### PR TITLE
Ananyamukh6/fix psnr doc

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 :github_url: https://github.com/arraiyopensource/kornia
-             
+
 Kornia Documentation
 ====================
 
@@ -23,6 +23,7 @@ Kornia Documentation
    filters
    geometry
    losses
+   morphology
    utils
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 :github_url: https://github.com/arraiyopensource/kornia
-
+             
 Kornia Documentation
 ====================
 
@@ -23,7 +23,6 @@ Kornia Documentation
    filters
    geometry
    losses
-   morphology
    utils
 
 Indices and tables

--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -5,7 +5,7 @@ kornia.losses
 
 .. autofunction:: dice_loss
 .. autofunction:: total_variation
-.. autofunction:: psnr
+.. autofunction:: psnr_loss
 .. autofunction:: tversky_loss
 .. autofunction:: focal_loss
 .. autofunction:: ssim
@@ -17,4 +17,4 @@ kornia.losses
 .. autoclass:: SSIM
 .. autoclass:: InverseDepthSmoothnessLoss
 .. autoclass:: TotalVariation
-.. autoclass:: PSNR
+.. autoclass:: PSNRLoss


### PR DESCRIPTION
During review https://github.com/kornia/kornia/pull/272 had changed `psnr` to `psnr_loss` and `PSNR` to `PSNRLoss`, but had forgotten to update the rst file.

Fixing the documentation bug in this PR