### PR TITLE
fix documentation of angle_axis_to_rotation_matrix

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -127,7 +127,7 @@ def angle_axis_to_rotation_matrix(angle_axis: torch.Tensor) -> torch.Tensor:
         angle_axis (torch.Tensor): tensor of 3d vector of axis-angle rotations.
 
     Returns:
-        torch.Tensor: tensor of 4x4 rotation matrices.
+        torch.Tensor: tensor of 3x3 rotation matrices.
 
     Shape:
         - Input: :math:`(N, 3)`


### PR DESCRIPTION
return value was claimed to be `4x4` instead of the correct `3x3`