### PR TITLE
Correct crop_and_resize on aspect ratio changes.

### DIFF
--- a/kornia/geometry/transform/crop.py
+++ b/kornia/geometry/transform/crop.py
@@ -20,9 +20,9 @@ def crop_and_resize(tensor: torch.Tensor, boxes: torch.Tensor,
         tensor (torch.Tensor): the reference tensor of shape BxCxHxW.
         boxes (torch.Tensor): a tensor containing the coordinates of the
           bounding boxes to be extracted. The tensor must have the shape
-          of Bx4x2, where each box is defined in the following order: top-left,
-          top-right, bottom-left and bottom-right. The coordinates order must
-          be in y, x respectively.
+          of Bx4x2, where each box is defined in the following (clockwise)
+          order: top-left, top-right, bottom-right and bottom-left. The
+          coordinates must be in the x, y order.
         size (Tuple[int, int]): a tuple with the height and width that will be
           used to resize the extracted patches.
 
@@ -62,18 +62,18 @@ def crop_and_resize(tensor: torch.Tensor, boxes: torch.Tensor,
     dst_h: torch.Tensor = torch.tensor(size[0])
     dst_w: torch.Tensor = torch.tensor(size[1])
 
-    # [y, x] origin
-    # top-left, top-right, bottom-left, bottom-right
+    # [x, y] origin
+    # top-left, top-right, bottom-right, bottom-left
     points_src: torch.Tensor = boxes.to(
         tensor.device).to(tensor.dtype)
 
-    # [y, x] destination
-    # top-left, top-right, bottom-left, bottom-right
+    # [x, y] destination
+    # top-left, top-right, bottom-right, bottom-left
     points_dst: torch.Tensor = torch.tensor([[
         [0, 0],
-        [0, dst_w - 1],
-        [dst_h - 1, 0],
-        [dst_h - 1, dst_w - 1],
+        [dst_w - 1, 0],
+        [dst_w - 1, dst_h - 1],
+        [0, dst_h - 1],
     ]]).repeat(points_src.shape[0], 1, 1).to(
         tensor.device).to(tensor.dtype)
 

--- a/test/geometry/transform/test_crop.py
+++ b/test/geometry/transform/test_crop.py
@@ -19,17 +19,17 @@ class TestCropAndResize:
             [13., 14., 15., 16.],
         ]])
 
-        height, width = 2, 2
+        height, width = 2, 3
         expected = torch.tensor([[
-            [6., 7.],
-            [10., 11.],
+            [6., 6.5, 7.],
+            [10., 10.5, 11.],
         ]])
 
         boxes = torch.tensor([[
             [1., 1.],
-            [1., 2.],
             [2., 1.],
             [2., 2.],
+            [1., 2.],
         ]])  # 1x4x2
 
         patches = kornia.crop_and_resize(inp, boxes, (height, width))
@@ -53,20 +53,20 @@ class TestCropAndResize:
             [6., 7.],
             [10., 11.],
         ]], [[
-            [11., 15.],
-            [12., 16.],
+            [7., 15.],
+            [8., 16.],
         ]]])
 
         boxes = torch.tensor([[
             [1., 1.],
-            [1., 2.],
             [2., 1.],
             [2., 2.],
+            [1., 2.],
         ], [
-            [2., 2.],
-            [2., 3.],
+            [1., 2.],
             [3., 2.],
             [3., 3.],
+            [1., 3.],
         ]])  # 2x4x2
 
         patches = kornia.crop_and_resize(inp, boxes, (height, width))
@@ -96,9 +96,9 @@ class TestCropAndResize:
 
         boxes = torch.tensor([[
             [1., 1.],
-            [1., 2.],
             [2., 1.],
             [2., 2.],
+            [1., 2.],
         ]])  # 1x4x2
 
         patches = kornia.crop_and_resize(inp, boxes, (height, width))
@@ -111,9 +111,9 @@ class TestCropAndResize:
 
         boxes = torch.tensor([[
             [1., 1.],
-            [1., 2.],
             [2., 1.],
             [2., 2.],
+            [1., 2.],
         ]])  # 1x4x2
         boxes = utils.tensor_to_gradcheck_var(
             boxes, requires_grad=False)  # to var
@@ -138,9 +138,9 @@ class TestCropAndResize:
         ]])
         boxes = torch.tensor([[
             [1., 1.],
-            [1., 2.],
             [2., 1.],
             [2., 2.],
+            [1., 2.],
         ]])  # 1x4x2
 
         crop_height, crop_width = 4, 2


### PR DESCRIPTION
Fixes #281 

I modified two of the existing tests (`test_crop` and `test_crop_batch`) to have some aspect ratio changes and to catch the now-fixed issue. Other tests had to be adapted as well to the changed interface of `crop_and_resize`.