### PR TITLE
Add tensor support to Hue, Saturation and Gamma

### DIFF
--- a/kornia/color/adjust.py
+++ b/kornia/color/adjust.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from kornia.color.hsv import rgb_to_hsv, hsv_to_rgb
 
 
-def adjust_saturation(input: torch.Tensor, saturation_factor: float) -> torch.Tensor:
+def adjust_saturation(input: torch.Tensor, saturation_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust color saturation of an image.
 
     See :class:`~kornia.color.AdjustSaturation` for details.
@@ -15,8 +15,20 @@ def adjust_saturation(input: torch.Tensor, saturation_factor: float) -> torch.Te
     if not torch.is_tensor(input):
         raise TypeError(f"Input type is not a torch.Tensor. Got {type(input)}")
 
-    if not isinstance(saturation_factor, float):
-        raise TypeError(f"The saturation_factor should be a float number.")
+    if not isinstance(saturation_factor, (float, torch.Tensor,)):
+        raise TypeError(f"The saturation_factor should be a float number or torch.Tensor."
+                        f"Got {type(saturation_factor)}")
+
+    if isinstance(saturation_factor, float):
+        saturation_factor = torch.tensor([saturation_factor])
+
+    saturation_factor = saturation_factor.to(input.device).to(input.dtype)
+
+    if (saturation_factor < 0).any():
+        raise ValueError(f"Saturation factor must be non-negative. Got {saturation_factor}")
+
+    for _ in input.shape[1:]:
+        saturation_factor = torch.unsqueeze(saturation_factor, dim=-1)
 
     # convert the rgb image to hsv
     x_hsv: torch.Tensor = rgb_to_hsv(input)
@@ -36,7 +48,7 @@ def adjust_saturation(input: torch.Tensor, saturation_factor: float) -> torch.Te
     return out
 
 
-def adjust_hue(input: torch.Tensor, hue_factor: float) -> torch.Tensor:
+def adjust_hue(input: torch.Tensor, hue_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust hue of an image.
 
     See :class:`~kornia.color.AdjustHue` for details.
@@ -45,9 +57,23 @@ def adjust_hue(input: torch.Tensor, hue_factor: float) -> torch.Tensor:
     if not torch.is_tensor(input):
         raise TypeError(f"Input type is not a torch.Tensor. Got {type(input)}")
 
-    if not isinstance(hue_factor, float) and -0.5 < hue_factor < 0.5:
-        raise TypeError(f"The hue_factor should be a float number in the range between"
+    if not isinstance(hue_factor, (float, torch.Tensor)):
+        raise TypeError(f"The hue_factor should be a float number or torch.Tensor in the range between"
                         f" [-0.5, 0.5]. Got {type(hue_factor)}")
+
+    if isinstance(hue_factor, torch.Tensor):
+        hue_factor = torch.tensor([hue_factor])
+
+    if isinstance(hue_factor, float):
+        hue_factor = torch.tensor([hue_factor])
+
+    hue_factor = hue_factor.to(input.device).to(input.dtype)
+
+    if ((hue_factor < -0.5) | (hue_factor > 0.5)).any():
+        raise ValueError(f"Hue-factor must be in the range [-0.5, 0.5]. Got {hue_factor}")
+
+    for _ in input.shape[1:]:
+        hue_factor = torch.unsqueeze(hue_factor, dim=-1)
 
     # convert the rgb image to hsv
     x_hsv: torch.Tensor = rgb_to_hsv(input)
@@ -56,7 +82,7 @@ def adjust_hue(input: torch.Tensor, hue_factor: float) -> torch.Tensor:
     h, s, v = torch.chunk(x_hsv, chunks=3, dim=-3)
 
     # transform the hue value and appl module
-    h_out: torch.Tensor = torch.frac(h * hue_factor)
+    h_out: torch.Tensor = torch.frac(h + hue_factor)
 
     # pack back back the corrected hue
     x_adjusted: torch.Tensor = torch.cat([h_out, s, v], dim=-3)
@@ -67,7 +93,8 @@ def adjust_hue(input: torch.Tensor, hue_factor: float) -> torch.Tensor:
     return out
 
 
-def adjust_gamma(input: torch.Tensor, gamma: float, gain: float = 1.) -> torch.Tensor:
+def adjust_gamma(input: torch.Tensor, gamma: Union[float, torch.Tensor],
+                 gain: Union[float, torch.Tensor] = 1.) -> torch.Tensor:
     r"""Perform gamma correction on an image.
 
     See :class:`~kornia.color.AdjustGamma` for details.
@@ -76,11 +103,30 @@ def adjust_gamma(input: torch.Tensor, gamma: float, gain: float = 1.) -> torch.T
     if not torch.is_tensor(input):
         raise TypeError(f"Input type is not a torch.Tensor. Got {type(input)}")
 
-    if not isinstance(gamma, float) and gamma > 0.:
-        raise TypeError(f"The gamma should be a positive a float. Got {type(gamma)}")
+    if not isinstance(gamma, (float, torch.Tensor)):
+        raise TypeError(f"The gamma should be a positive float or torch.Tensor. Got {type(gamma)}")
 
-    if not isinstance(gain, float) and gain >= 1.:
-        raise TypeError(f"The gamma should be a positive a float. Got {type(gain)}")
+    if not isinstance(gain, (float, torch.Tensor)):
+        raise TypeError(f"The gain should be a positive float or torch.Tensor. Got {type(gain)}")
+
+    if isinstance(gamma, float):
+        gamma = torch.tensor([gamma])
+
+    if isinstance(gain, float):
+        gain = torch.tensor([gain])
+
+    gamma = gamma.to(input.device).to(input.dtype)
+    gain = gain.to(input.device).to(input.dtype)
+
+    if (gamma < 0.0).any():
+        raise ValueError(f"Gamma must be non-negative. Got {gamma}")
+
+    if (gain < 0.0).any():
+        raise ValueError(f"Gain must be non-negative. Got {gain}")
+
+    for _ in input.shape[1:]:
+        gamma = torch.unsqueeze(gamma, dim=-1)
+        gain = torch.unsqueeze(gain, dim=-1)
 
     # Apply the gamma correction
     x_adjust: torch.Tensor = gain * torch.pow(input, gamma)

--- a/kornia/color/adjust.py
+++ b/kornia/color/adjust.py
@@ -61,9 +61,6 @@ def adjust_hue(input: torch.Tensor, hue_factor: Union[float, torch.Tensor]) -> t
         raise TypeError(f"The hue_factor should be a float number or torch.Tensor in the range between"
                         f" [-0.5, 0.5]. Got {type(hue_factor)}")
 
-    if isinstance(hue_factor, torch.Tensor):
-        hue_factor = torch.tensor([hue_factor])
-
     if isinstance(hue_factor, float):
         hue_factor = torch.tensor([hue_factor])
 

--- a/test/color/test_adjust.py
+++ b/test/color/test_adjust.py
@@ -24,6 +24,29 @@ class TestAdjustSaturation:
         f = kornia.color.AdjustSaturation(1.)
         assert_allclose(f(data), expected)
 
+    def test_saturation_one_batch(self):
+        data = torch.tensor([[[[.5, .5],
+                               [.5, .5]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]],
+
+                             [[[.5, .5],
+                               [.5, .5]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]]])  # 2x3x2x2
+
+        expected = data
+        f = kornia.color.AdjustSaturation(torch.ones(2))
+        assert_allclose(f(data), expected)
+
 
 class TestAdjustHue:
     def test_hue_one(self):
@@ -37,8 +60,54 @@ class TestAdjustHue:
                               [.25, .25]]])  # 3x2x2
 
         expected = data
-        f = kornia.color.AdjustHue(1.)
+        f = kornia.color.AdjustHue(0.)
         assert_allclose(f(data), expected)
+
+    def test_hue_one_batch(self):
+        data = torch.tensor([[[[.5, .5],
+                               [.5, .5]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]],
+
+                             [[[.5, .5],
+                               [.5, .5]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]]])  # 2x3x2x2
+
+        expected = data
+        f = kornia.color.AdjustHue(torch.tensor([0, 0]))
+        assert_allclose(f(data), expected)
+
+    def test_hue_flip_batch(self):
+        data = torch.tensor([[[[.5, .5],
+                               [.5, .5]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]],
+
+                             [[[.5, .5],
+                               [.5, .5]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]]])  # 2x3x2x2
+
+        f = kornia.color.AdjustHue(torch.tensor([-.5, .5]))
+        result = f(data)
+        assert_allclose(result, result.flip(0))
 
 
 class TestAdjustGamma:
@@ -112,6 +181,46 @@ class TestAdjustGamma:
                                   [.0625, .0625]]])  # 3x2x2
 
         f = kornia.color.AdjustGamma(2.)
+        assert_allclose(f(data), expected)
+
+    def test_gamma_two_batch(self):
+        data = torch.tensor([[[[1., 1.],
+                               [1., 1.]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]],
+
+                             [[[1., 1.],
+                               [1., 1.]],
+
+                              [[.5, .5],
+                               [.5, .5]],
+
+                              [[.25, .25],
+                               [.25, .25]]]])  # 2x3x2x2
+
+        expected = torch.tensor([[[[1., 1.],
+                                   [1., 1.]],
+
+                                  [[.25, .25],
+                                   [.25, .25]],
+
+                                  [[.0625, .0625],
+                                   [.0625, .0625]]],
+
+                                 [[[1., 1.],
+                                   [1., 1.]],
+
+                                  [[.25, .25],
+                                   [.25, .25]],
+
+                                  [[.0625, .0625],
+                                   [.0625, .0625]]]])  # 2x3x2x2
+
+        f = kornia.color.AdjustGamma(torch.tensor([2., 2.]), gain=torch.ones(2))
         assert_allclose(f(data), expected)
 
     def test_gradcheck(self):


### PR DESCRIPTION
Now, the hue, saturation and gamma factors can recieve a tensor of same size as batch.

#290 I've also corrected the Hue implementation to add instead of multiply.