### PR TITLE
Img to tensor

### DIFF
--- a/examples/color_conversions.py
+++ b/examples/color_conversions.py
@@ -20,7 +20,7 @@ img_bgr: np.ndarray = cv2.imread('./data/simba.png', cv2.IMREAD_COLOR)
 
 #############################
 # Convert the numpy array to torch
-x_bgr: torch.Tensor = kornia.image_to_tensor(img_bgr)
+x_bgr: torch.Tensor = kornia.image_to_tensor(img_bgr, keepdim=False)
 
 #############################
 # Using `kornia` we easily perform color transformation in batch mode.

--- a/examples/gaussian_blur.py
+++ b/examples/gaussian_blur.py
@@ -17,7 +17,7 @@ img: np.ndarray = cv2.imread('./data/lena.jpg')
 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
 # convert to torch tensor
-data: torch.tensor = kornia.image_to_tensor(img)  # BxCxHxW
+data: torch.tensor = kornia.image_to_tensor(img, keepdim=False)  # BxCxHxW
 
 # create the operator
 gauss = kornia.filters.GaussianBlur2d((11, 11), (10.5, 10.5))

--- a/examples/warp_affine.py
+++ b/examples/warp_affine.py
@@ -17,7 +17,7 @@ img: np.ndarray = cv2.imread('./data/bennett_aden.png')
 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
 # convert to torch tensor
-data: torch.tensor = kornia.image_to_tensor(img)  # BxCxHxW
+data: torch.tensor = kornia.image_to_tensor(img, keepdim=False)  # BxCxHxW
 
 # create transformation (rotation)
 alpha: float = 45.0  # in degrees

--- a/examples/warp_perspective.py
+++ b/examples/warp_perspective.py
@@ -17,7 +17,7 @@ img: np.ndarray = cv2.imread('./data/bruce.png')
 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
 # convert to torch tensor
-data: torch.tensor = kornia.image_to_tensor(img)  # BxCxHxW
+data: torch.tensor = kornia.image_to_tensor(img, keepdim=False)  # BxCxHxW
 
 # the source points are the region to crop corners
 points_src = torch.tensor([[

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -1,49 +1,56 @@
-from typing import Optional
+from typing import Union
+from PIL import Image
 
 import numpy as np
 import torch
 
 
-def image_to_tensor(image: np.array) -> torch.Tensor:
-    """Converts a numpy image to a PyTorch 4d tensor image.
+def image_to_tensor(image: Union[np.ndarray, Image.Image], keepdim: bool = True) -> torch.Tensor:
+    """Converts a numpy or PIL image to a PyTorch 4d tensor image.
 
     Args:
-        image (numpy.ndarray): image of the form :math:`(H, W)`,
-        math:`(H, W, C)`, or math:`(B, H, W, C)`.
+        image (numpy.ndarray or PIL Image): image of the form math:`(H, W, C)`, math: `(H, W)` or math:`(B, H, W, C)`.
+        keepdim (bool): If ``False`` unsqueeze the input image to match the shape
+        math: `(B, H, W, C)`. Default: ``True``
 
     Returns:
-        torch.Tensor: tensor of the form :math:`(H, W)`,
-        math:`(B, C, H, W)`.
+        torch.Tensor: tensor of the form math:`(B, C, H, W)` if keepdim is ``False``, math:`(C, H, W)` otherwise.
 
     """
-    if not isinstance(image, np.ndarray):
-        raise TypeError("Input type is not a numpy.ndarray. Got {}".format(
+    if not isinstance(image, (np.ndarray, Image.Image)):
+        raise TypeError("Input type must be a numpy.ndarray or PIL Image. Got {}".format(
             type(image)))
+
+    if isinstance(image, Image.Image):
+        image = np.array(image)
 
     if len(image.shape) > 4 or len(image.shape) < 2:
         raise ValueError(
             "Input size must be a two, three or four dimensional array")
 
     input_shape = image.shape
-    tensor: torch.Tensor = torch.from_numpy(image)
+    tensor: torch.Tensor = torch.from_numpy(image).to(torch.float)
+
     if len(input_shape) == 2:
-        # (H, W) -> (1, 1, H, W)
-        tensor = tensor.unsqueeze(0).unsqueeze(0)
+        # (H, W) -> (1, H, W)
+        tensor = tensor.unsqueeze(0)
     elif len(input_shape) == 3:
         # (H, W, C) -> (C, H, W)
-        tensor = tensor.permute(2, 0, 1).unsqueeze(0)
+        tensor = tensor.permute(2, 0, 1)
     elif len(input_shape) == 4:
         # (B, H, W, C) -> (B, C, H, W)
         tensor = tensor.permute(0, 3, 1, 2)
+        keepdim = True  # no need to unsqueeze
     else:
         raise ValueError(
             "Cannot process image with shape {}".format(input_shape))
-    return tensor
+
+    return tensor.unsqueeze(0) if not keepdim else tensor
 
 
 def tensor_to_image(tensor: torch.Tensor) -> np.array:
-    """Converts a PyTorch tensor image to a numpy image. In case the tensor is
-    in the GPU, it will be copied back to CPU.
+    """Converts a PyTorch tensor image to a numpy image. In case the tensor is in the GPU,
+    it will be copied back to CPU.
 
     Args:
         tensor (torch.Tensor): image of the form :math:`(H, W)`,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # core dependencies
 pytorch==1.3.0
+pillow==6.2.0
 
 # package
 setuptools==41.4.0

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ long_description = '\n'.join(readme.split('\n')[7:])
 
 requirements = [
     'torch>=1.0.0',
+    'pillow>=6.2.0',
 ]
 
 
@@ -74,7 +75,7 @@ if __name__ == '__main__':
 	long_description=long_description,
 	license='Apache License 2.0',
 	python_requires='>=3.6',
-	    
+
 	# Test
 	setup_requires=['pytest-runner'],
 	tests_require=['pytest'],

--- a/test/utils/test_image.py
+++ b/test/utils/test_image.py
@@ -29,6 +29,20 @@ def test_tensor_to_image(input_shape, expected):
                           ((1, 4, 4, 3), (1, 3, 4, 4)), ])
 def test_image_to_tensor(input_shape, expected):
     image = np.ones(input_shape)
-    tensor = kornia.utils.image_to_tensor(image)
+    tensor = kornia.utils.image_to_tensor(image, keepdim=False)
+    assert tensor.shape == expected
+    assert isinstance(tensor, torch.Tensor)
+
+
+@pytest.mark.parametrize("input_shape, expected",
+                         [((4, 4), (1, 4, 4)),
+                          ((1, 4, 4), (4, 1, 4)),
+                          ((2, 3, 4), (4, 2, 3)),
+                          ((4, 4, 3), (3, 4, 4)),
+                          ((2, 4, 4, 3), (2, 3, 4, 4)),
+                          ((1, 4, 4, 3), (1, 3, 4, 4)), ])
+def test_image_to_tensor_keepdim(input_shape, expected):
+    image = np.ones(input_shape)
+    tensor = kornia.utils.image_to_tensor(image, keepdim=True)
     assert tensor.shape == expected
     assert isinstance(tensor, torch.Tensor)


### PR DESCRIPTION
Allows img_to_tensor to take PIL images as inputs.