### PR TITLE
[DOCS] fix import problem and fix docs for LuvToRgb and PSNR

### DIFF
--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -29,5 +29,5 @@ Kornia relation to Other Computer Vision Projects
 
 The project mimics some of the functionalities found in OpenCV. Eventhough
 the project is backed up by the `OpenCV.org <www.opencv.org/>`_, there is no
-intention at all to merge in any form both projects. *Kornia* is ment to
+intention at all to merge in any form both projects. *Kornia* is meant to
 provide differentiable operators to train nets, while *OpenCV* scope is inference.

--- a/kornia/color/__init__.py
+++ b/kornia/color/__init__.py
@@ -69,7 +69,7 @@ __all__ = [
     "RgbToXyz",
     "XyzToRgb",
     "RgbToLuv",
-    "LuvToRbg",
+    "LuvToRgb",
     "Normalize",
     "Denormalize",
     "AdjustBrightness",

--- a/kornia/color/xyz.py
+++ b/kornia/color/xyz.py
@@ -23,7 +23,7 @@ class RgbToXyz(nn.Module):
         >>> input = torch.rand(2, 3, 4, 5)
         >>> xyz = kornia.color.RgbToXyz()
         >>> output = xyz(input)  # 2x3x4x5
-        
+
     Reference:
         [1] https://docs.opencv.org/4.0.1/de/d25/imgproc_color_conversions.html
     """

--- a/kornia/color/xyz.py
+++ b/kornia/color/xyz.py
@@ -11,15 +11,19 @@ class RgbToXyz(nn.Module):
 
     args:
         image (torch.Tensor): RGB image to be converted to XYZ.
+
     returns:
         torch.Tensor: XYZ version of the image.
+
     shape:
         - image: :math:`(*, 3, H, W)`
         - output: :math:`(*, 3, H, W)`
+
     Examples:
         >>> input = torch.rand(2, 3, 4, 5)
         >>> xyz = kornia.color.RgbToXyz()
         >>> output = xyz(input)  # 2x3x4x5
+        
     Reference:
         [1] https://docs.opencv.org/4.0.1/de/d25/imgproc_color_conversions.html
     """
@@ -36,15 +40,19 @@ class XyzToRgb(nn.Module):
 
     args:
         image (torch.Tensor): XYZ image to be converted to RGB.
+
     returns:
         torch.Tensor: RGB version of the image.
+
     shape:
         - image: :math:`(*, 3, H, W)`
         - output: :math:`(*, 3, H, W)`
+
     Examples:
         >>> input = torch.rand(2, 3, 4, 5)
         >>> rgb = kornia.color.XyzToRgb()
         >>> output = rgb(input)  # 2x3x4x5
+
     Reference:
         [1] https://docs.opencv.org/4.0.1/de/d25/imgproc_color_conversions.html
     """

--- a/kornia/color/yuv.py
+++ b/kornia/color/yuv.py
@@ -8,6 +8,7 @@ from typing import Tuple
 class RgbToYuv(nn.Module):
     r"""Convert image from RGB to YUV
     The image data is assumed to be in the range of (0, 1).
+
     args:
         image (torch.Tensor): RGB image to be converted to YUV.
     returns:
@@ -34,6 +35,7 @@ class RgbToYuv(nn.Module):
 def rgb_to_yuv(input: torch.Tensor) -> torch.Tensor:
     r"""Convert an RGB image to YUV
     The image data is assumed to be in the range of (0, 1).
+
     Args:
         input (torch.Tensor): RGB Image to be converted to YUV.
     Returns:
@@ -59,6 +61,7 @@ def rgb_to_yuv(input: torch.Tensor) -> torch.Tensor:
 class YuvToRgb(nn.Module):
     r"""Convert image from YUV to RGB
     The image data is assumed to be in the range of (0, 1).
+
     args:
         image (torch.Tensor): YUV image to be converted to RGB.
     returns:
@@ -83,6 +86,7 @@ class YuvToRgb(nn.Module):
 def yuv_to_rgb(input: torch.Tensor) -> torch.Tensor:
     r"""Convert an YUV image to RGB
     The image data is assumed to be in the range of (0, 1).
+    
     Args:
         input (torch.Tensor): YUV Image to be converted to RGB.
     Returns:

--- a/kornia/color/yuv.py
+++ b/kornia/color/yuv.py
@@ -86,7 +86,7 @@ class YuvToRgb(nn.Module):
 def yuv_to_rgb(input: torch.Tensor) -> torch.Tensor:
     r"""Convert an YUV image to RGB
     The image data is assumed to be in the range of (0, 1).
-    
+
     Args:
         input (torch.Tensor): YUV Image to be converted to RGB.
     Returns:

--- a/kornia/losses/psnr.py
+++ b/kornia/losses/psnr.py
@@ -4,9 +4,21 @@ from torch.nn.functional import mse_loss
 
 
 class PSNRLoss(nn.Module):
-    r"""Creates a criterion that calculates the PSNR between 2 images. Given an m x n image,
+    r"""Creates a criterion that calculates the PSNR between 2 images. Given an m x n image, the PSNR is:
+
     .. math::
-    \text{MSE}(I,T) = \frac{1}{m\,n}\sum_{i=0}^{m-1}\sum_{j=0}^{n-1} [I(i,j) - T(i,j)]^2
+
+        \text{PSNR} = 10 \log_{10} \bigg(\frac{\text{MAX}_I^2}{MSE(I,T)}\bigg)
+
+    where
+
+    .. math::
+
+        \text{MSE}(I,T) = \frac{1}{mn}\sum_{i=0}^{m-1}\sum_{j=0}^{n-1} [I(i,j) - T(i,j)]^2
+
+    and :math:`\text{MAX}_I` is the maximum possible input value
+    (e.g for floating point images :math:`\text{MAX}_I=1`).
+
 
     Arguments:
         max_val (float): Maximum value of input


### PR DESCRIPTION
- I realized that I typoed LuvToRgb in the __ all __ of colors which would cause an import problem.
- I noticed that documentation RGB to YUV wasn't rendering correctly online
- Edited docstring for RGB<-> XYZ in order remove the doc build warnings caused by the lack of newline.
- Fixed minor typo in FAQs
- Fixed math rendering in psnr and completed the description