### PR TITLE
[Docs] Display both shapes in MeanIoU raise error

### DIFF
--- a/kornia/utils/metrics/mean_iou.py
+++ b/kornia/utils/metrics/mean_iou.py
@@ -35,7 +35,7 @@ def mean_iou(
                         "torch.int64 dtype. Got {}".format(type(target)))
     if not input.shape == target.shape:
         raise ValueError("Inputs input and target must have the same shape. "
-                         "Got: {}".format(input.shape, target.shape))
+                         "Got: {} and {}".format(input.shape, target.shape))
     if not input.device == target.device:
         raise ValueError("Inputs must be in the same device. "
                          "Got: {} - {}".format(input.device, target.device))


### PR DESCRIPTION
Currently the error message reads as e.g.:

`ValueError: Inputs input and target must have the same shape. Got: torch.Size([4, 7, 256, 360])`