### PR TITLE
[TEST] Move test data to device in nms and sobel

### DIFF
--- a/test/feature/test_nms.py
+++ b/test/feature/test_nms.py
@@ -91,7 +91,7 @@ class TestNMS3d:
                                     [0., 0., 0., 0., 0.],
                                     [0., 0., 0., 0., 0.],
                                     [0., 0., 0., 0., 0.],
-                                    [0., 0., 0., 0., 0.]]]]])
+                                    [0., 0., 0., 0., 0.]]]]]).to(device)
         nms = kornia.feature.NonMaximaSuppression3d((3, 3, 3)).to(device)
         scores = nms(inp)
         assert_allclose(scores, expected, atol=1e-4, rtol=1e-3)

--- a/test/filters/test_sobel.py
+++ b/test/filters/test_sobel.py
@@ -226,6 +226,7 @@ class TestSpatialGradient3d:
                                      [0.0000, 0.0000, -0.5000, 0.0000, 0.0000],
                                      [0.0000, 0.0000, 0.0000, 0.0000, 0.0000]]]]]])
 
+        expected = expected.to(device)
         edges = kornia.filters.spatial_gradient3d(inp)
         assert_allclose(edges, expected)
 


### PR DESCRIPTION
- The following gpu tests fail because the tensors aren't moved to the gpu.
