### PR TITLE
remove PIL dependency

### DIFF
--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -1,15 +1,12 @@
-from typing import Union
-from PIL import Image
-
 import numpy as np
 import torch
 
 
-def image_to_tensor(image: Union[np.ndarray, Image.Image], keepdim: bool = True) -> torch.Tensor:
-    """Converts a numpy or PIL image to a PyTorch 4d tensor image.
+def image_to_tensor(image: np.ndarray, keepdim: bool = True) -> torch.Tensor:
+    """Converts a numpy image to a PyTorch 4d tensor image.
 
     Args:
-        image (numpy.ndarray or PIL Image): image of the form :math:`(H, W, C)`, :math:`(H, W)` or
+        image (numpy.ndarray): image of the form :math:`(H, W, C)`, :math:`(H, W)` or
             :math:`(B, H, W, C)`.
         keepdim (bool): If ``False`` unsqueeze the input image to match the shape
             :math:`(B, H, W, C)`. Default: ``True``
@@ -19,12 +16,9 @@ def image_to_tensor(image: Union[np.ndarray, Image.Image], keepdim: bool = True)
             :math:`(C, H, W)` otherwise.
 
     """
-    if not isinstance(image, (np.ndarray, Image.Image)):
-        raise TypeError("Input type must be a numpy.ndarray or PIL Image. Got {}".format(
+    if not isinstance(image, (np.ndarray,)):
+        raise TypeError("Input type must be a numpy.ndarray. Got {}".format(
             type(image)))
-
-    if isinstance(image, Image.Image):
-        image = np.array(image)
 
     if len(image.shape) > 4 or len(image.shape) < 2:
         raise ValueError(


### PR DESCRIPTION
This PR removes PIL dependency since it's really needed in the core, and eventually can lead to security issues as informed github:

![image](https://user-images.githubusercontent.com/5157099/78979058-5ba38d00-7b1b-11ea-8270-47c654259e01.png)

-----------------------

One can simply achieve same behaviour from outside kornia:
```python
img: PIL.Image = Image(...)
timg: torch.Tensor = K.image_to_tensor(np.array(img))
```