### PR TITLE
Moves _check_and_bound to augmentation.utils

### DIFF
--- a/kornia/augmentation/random_generator.py
+++ b/kornia/augmentation/random_generator.py
@@ -5,7 +5,10 @@ import math
 import torch
 
 from kornia.constants import Resample
-from kornia.augmentation.utils import _adapted_uniform
+from kornia.augmentation.utils import (
+    _adapted_uniform,
+    _check_and_bound
+)
 
 from .types import (
     TupleFloat,
@@ -34,51 +37,7 @@ def random_color_jitter_generator(batch_size: int, brightness: FloatUnionType = 
     See :class:`~kornia.augmentation.ColorJitter` for details.
     """
 
-    def _check_and_bound(factor: FloatUnionType, name: str, center: float = 0.,
-                         bounds: Tuple[float, float] = (0, float('inf'))) -> torch.Tensor:
-        r"""Check inputs and compute the corresponding factor bounds
-        """
-
-        if isinstance(factor, float):
-
-            if factor < 0:
-                raise ValueError(f"If {name} is a single number number, it must be non negative. Got {factor}")
-
-            factor_bound = torch.tensor([center - factor, center + factor], dtype=torch.float32)
-            factor_bound = torch.clamp(factor_bound, bounds[0], bounds[1])
-
-        elif (isinstance(factor, torch.Tensor) and factor.dim() == 0):
-
-            if factor < 0:
-                raise ValueError(f"If {name} is a single number number, it must be non negative. Got {factor}")
-
-            factor_bound = torch.tensor(
-                [torch.tensor(center) - factor, torch.tensor(center) + factor], dtype=torch.float32)
-            factor_bound = torch.clamp(factor_bound, bounds[0], bounds[1])
-
-        elif isinstance(factor, (tuple, list)) and len(factor) == 2:
-
-            if not bounds[0] <= factor[0] <= factor[1] <= bounds[1]:
-                raise ValueError(f"{name}[0] should be smaller than {name}[1] got {factor}")
-
-            factor_bound = torch.tensor(factor, dtype=torch.float32)
-
-        elif isinstance(factor, torch.Tensor) and factor.shape[0] == 2 and factor.dim() == 1:
-
-            if not bounds[0] <= factor[0] <= factor[1] <= bounds[1]:
-                raise ValueError(f"{name}[0] should be smaller than {name}[1] got {factor}")
-
-            factor_bound = factor
-
-        else:
-
-            raise TypeError(
-                f"The {name} should be a float number or a tuple with length 2 whose values move between {bounds}.")
-
-        return factor_bound
-
-    brightness_bound: torch.Tensor = _check_and_bound(
-        brightness, 'brightness', center=1., bounds=(0, 2))
+    brightness_bound: torch.Tensor = _check_and_bound(brightness, 'brightness', center=1., bounds=(0, 2))
     contrast_bound: torch.Tensor = _check_and_bound(contrast, 'contrast', center=1.)
     saturation_bound: torch.Tensor = _check_and_bound(saturation, 'saturation', center=1.)
     hue_bound: torch.Tensor = _check_and_bound(hue, 'hue', bounds=(-0.5, 0.5))


### PR DESCRIPTION
A small refactor that moved ```_check_and_bound``` to utils to clean up the mess inside the ```random_color_jitter_generator```