### PR TITLE
[WIP] Parametrize device and dtype fixtures using CLI options

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,15 @@
 import pytest
 
 
+def pytest_generate_tests(metafunc):
+    if 'device_type' in metafunc.fixturenames:
+        raw_value = metafunc.config.getoption('--typetest')
+        metafunc.parametrize('device_type', raw_value.split(','))
+    if 'dtype_name' in metafunc.fixturenames:
+        raw_value = metafunc.config.getoption('--dtypetest')
+        metafunc.parametrize('dtype_name', raw_value.split(','))
+
+
 def pytest_addoption(parser):
     parser.addoption('--typetest', action="store", default="cpu")
     parser.addoption('--dtypetest', action="store", default="float32")

--- a/test/common.py
+++ b/test/common.py
@@ -38,12 +38,10 @@ TEST_DTYPES: Dict[str, torch.dtype] = get_test_dtypes()
 
 
 @pytest.fixture()
-def device(request) -> torch.device:
-    _device_type: str = request.config.getoption('--typetest')
-    return TEST_DEVICES[_device_type]
+def device(device_type) -> torch.device:
+    return TEST_DEVICES[device_type]
 
 
 @pytest.fixture()
-def dtype(request) -> torch.dtype:
-    _dtype_name: str = request.config.getoption('--dtypetest')
-    return TEST_DTYPES[_dtype_name]
+def dtype(dtype_name) -> torch.dtype:
+    return TEST_DTYPES[dtype_name]


### PR DESCRIPTION
### Description
Configure PyTest tests so that they can run for multiple combinations of dtypes/devices in one invocation.

### Status
**Work in progress**


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
