### PR TITLE
added tensor device conversion for solarize params

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -251,6 +251,8 @@ def _solarize(input: torch.Tensor, thresholds: Union[float, torch.Tensor] = 0.5)
         # TODO: I am not happy about this line, but no easy to do batch-wise operation
         thresholds = torch.stack([x.expand(*input.shape[1:]) for x in thresholds])
 
+    thresholds = thresholds.to(input.device).to(input.dtype)
+
     return torch.where(input < thresholds, input, 1.0 - input)
 
 
@@ -296,6 +298,8 @@ def solarize(input: torch.Tensor, thresholds: Union[float, torch.Tensor] = 0.5,
                 f"additions must be a 1-d vector of shape ({input.size(0)},). Got {additions}"
             # TODO: I am not happy about this line, but no easy to do batch-wise operation
             additions = torch.stack([x.expand(*input.shape[1:]) for x in additions])
+
+        additions = additions.to(input.device).to(input.dtype)
 
         input = input + additions
         input = input.clamp(0., 1.)

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -250,8 +250,7 @@ def _solarize(input: torch.Tensor, thresholds: Union[float, torch.Tensor] = 0.5)
             f"threshholds must be a 1-d vector of shape ({input.size(0)},). Got {thresholds}"
         # TODO: I am not happy about this line, but no easy to do batch-wise operation
         thresholds = torch.stack([x.expand(*input.shape[1:]) for x in thresholds])
-
-    thresholds = thresholds.to(input.device).to(input.dtype)
+        thresholds = thresholds.to(input.device).to(input.dtype)
 
     return torch.where(input < thresholds, input, 1.0 - input)
 

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -296,10 +296,8 @@ def solarize(input: torch.Tensor, thresholds: Union[float, torch.Tensor] = 0.5,
             assert input.size(0) == len(additions) and len(additions.shape) == 1, \
                 f"additions must be a 1-d vector of shape ({input.size(0)},). Got {additions}"
             # TODO: I am not happy about this line, but no easy to do batch-wise operation
+            additions = additions.to(input.device).to(input.dtype)
             additions = torch.stack([x.expand(*input.shape[1:]) for x in additions])
-
-        additions = additions.to(input.device).to(input.dtype)
-
         input = input + additions
         input = input.clamp(0., 1.)
 

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -249,8 +249,8 @@ def _solarize(input: torch.Tensor, thresholds: Union[float, torch.Tensor] = 0.5)
         assert input.size(0) == len(thresholds) and len(thresholds.shape) == 1, \
             f"threshholds must be a 1-d vector of shape ({input.size(0)},). Got {thresholds}"
         # TODO: I am not happy about this line, but no easy to do batch-wise operation
-        thresholds = torch.stack([x.expand(*input.shape[1:]) for x in thresholds])
         thresholds = thresholds.to(input.device).to(input.dtype)
+        thresholds = torch.stack([x.expand(*input.shape[1:]) for x in thresholds])
 
     return torch.where(input < thresholds, input, 1.0 - input)
 


### PR DESCRIPTION
### Description
Resolves issue #622 
([Bug] Solarize transform breaks with cuda input tensors)

Added statements to force solarize params to same device and type as input tensor.

### Status
**Ready**

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
