### PR TITLE
[Bug] Fix/random affine3 d throws an exception when used with scales

### DIFF
--- a/kornia/augmentation/augmentation3d.py
+++ b/kornia/augmentation/augmentation3d.py
@@ -203,11 +203,11 @@ class RandomAffine3D(AugmentationBase3D):
             If degrees is a list of tuple ((a, b), (m, n), (x, y)), then yaw, pitch, roll will be generated from
             (a, b), (m, n) and (x, y).
             Set to 0 to deactivate rotations.
-        translate (tuple, optional): tuple of maximum absolute fraction for depthical, horizontal
-            and vertical translations. For example translate=(a, b, c), then
-            depthical shift will be randomly sampled in the range -img_depth * a < dx < img_depth * a
-            horizontal shift will be randomly sampled in the range -img_width * b < dy < img_width * b.
+        translate (tuple, optional): tuple of maximum absolute fraction for horizontal, vertical and
+        depthical translations (dx,dy,dz). For example translate=(a, b, c), then
+            horizontal shift will be randomly sampled in the range -img_width * a < dx < img_width * a
             vertical shift will be randomly sampled in the range -img_height * b < dy < img_height * b.
+            depthical shift will be randomly sampled in the range -img_depth * c < dz < img_depth * c.
             Will not translate by default.
         scale (tuple, optional): scaling factor interval.
             If (a, b) represents isotropic scaling, the scale is randomly sampled from the range a <= scale <= b.

--- a/kornia/augmentation/functional3d.py
+++ b/kornia/augmentation/functional3d.py
@@ -241,8 +241,8 @@ def apply_affine3d(input: torch.Tensor, params: Dict[str, torch.Tensor]) -> torc
         input (torch.Tensor): Tensor to be transformed with shape (D, H, W), (C, D, H, W), (B, C, D, H, W).
         params (Dict[str, torch.Tensor]):
             - params['angles']: Degrees of rotation with the shape of :math: `(*, 3)` for yaw, pitch, roll.
-            - params['translations']: Depthical, Horizontal and vertical translations.
-            - params['center']: Rotation center.
+            - params['translations']: Horizontal, vertical and depthical translations (dx,dy,dz).
+            - params['center']: Rotation center (x,y,z).
             - params['scale']: Isotropic scaling params.
             - params['sxy']: Shear param toward x-y-axis.
             - params['sxz']: Shear param toward x-z-axis.
@@ -287,8 +287,8 @@ def compute_affine_transformation3d(input: torch.Tensor, params: Dict[str, torch
         input (torch.Tensor): Tensor to be transformed with shape (D, H, W), (C, D, H, W), (B, C, D, H, W).
         params (Dict[str, torch.Tensor]):
             - params['angles']: Degrees of rotation with the shape of :math: `(*, 3)` for yaw, pitch, roll.
-            - params['translations']: Depthical, Horizontal and vertical translations.
-            - params['center']: Rotation center.
+            - params['translations']: Horizontal, vertical and depthical translations (dx,dy,dz).
+            - params['center']: Rotation center (x,y,z).
             - params['scale']: Isotropic scaling params.
             - params['sxy']: Shear param toward x-y-axis.
             - params['sxz']: Shear param toward x-z-axis.

--- a/kornia/augmentation/random_generator3d.py
+++ b/kornia/augmentation/random_generator3d.py
@@ -86,7 +86,7 @@ def random_affine_generator3d(
     yaw = _adapted_uniform((batch_size,), degrees[0][0], degrees[0][1], same_on_batch)
     pitch = _adapted_uniform((batch_size,), degrees[1][0], degrees[1][1], same_on_batch)
     roll = _adapted_uniform((batch_size,), degrees[2][0], degrees[2][1], same_on_batch)
-    angles = torch.cat([yaw, pitch, roll], dim=-1).view((batch_size, -1))
+    angles = torch.stack([yaw, pitch, roll], dim=1)
 
     # compute tensor ranges
     if scale is not None:
@@ -109,13 +109,13 @@ def random_affine_generator3d(
             _adapted_uniform((batch_size,), -max_dx, max_dx, same_on_batch),
             _adapted_uniform((batch_size,), -max_dy, max_dy, same_on_batch),
             _adapted_uniform((batch_size,), -max_dz, max_dz, same_on_batch)
-        ], dim=-1)
+        ], dim=1)
     else:
         translations = torch.zeros(batch_size, 3)
 
     # center should be in x,y,z
     center: torch.Tensor = torch.tensor(
-        [width,height,depth], dtype=torch.float32).view(1, 3) / 2. - 0.5
+        [width, height, depth], dtype=torch.float32).view(1, 3) / 2. - 0.5
     center = center.expand(batch_size, -1)
 
     if shears is not None:

--- a/kornia/augmentation/random_generator3d.py
+++ b/kornia/augmentation/random_generator3d.py
@@ -64,7 +64,7 @@ def random_affine_generator3d(
         width (int): width of the image.
         degrees (torch.Tensor): Ranges of degrees with shape (3, 2) for yaw, pitch and roll.
         translate (torch.Tensor, optional):  maximum absolute fraction with shape (3,) for horizontal, vertical
-            and depthical translations. Will not translate by default.
+            and depthical translations (dx,dy,dz). Will not translate by default.
         scale (torch.Tensor, optional): scaling factor interval, e.g (a, b), then scale is
             randomly sampled from the range a <= scale <= b. Will keep original scale by default.
         shear (sequence or float, optional): Range of degrees to select from.
@@ -101,9 +101,9 @@ def random_affine_generator3d(
 
     if translate is not None:
         assert translate.shape == torch.Size([3]), f"'translate' must be the shape of (2). Got {translate.shape}."
-        max_dz: torch.Tensor = translate[0] * depth
+        max_dx: torch.Tensor = translate[0] * width
         max_dy: torch.Tensor = translate[1] * height
-        max_dx: torch.Tensor = translate[2] * width
+        max_dz: torch.Tensor = translate[2] * depth
         # translations should be in x,y,z
         translations = torch.stack([
             _adapted_uniform((batch_size,), -max_dx, max_dx, same_on_batch),

--- a/kornia/augmentation/random_generator3d.py
+++ b/kornia/augmentation/random_generator3d.py
@@ -59,7 +59,7 @@ def random_affine_generator3d(
 
     Args:
         batch_size (int): the tensor batch size.
-        depth (int) : height of the image.
+        depth (int) : depth of the image.
         height (int) : height of the image.
         width (int): width of the image.
         degrees (torch.Tensor): Ranges of degrees with shape (3, 2) for yaw, pitch and roll.
@@ -91,7 +91,7 @@ def random_affine_generator3d(
     # compute tensor ranges
     if scale is not None:
         assert scale.shape == torch.Size([3, 2]), f"'scale' must be the shape of (3, 2). Got {scale.shape}."
-        scale = torch.cat([
+        scale = torch.stack([
             _adapted_uniform((batch_size,), scale[0, 0], scale[0, 1], same_on_batch),
             _adapted_uniform((batch_size,), scale[1, 0], scale[1, 1], same_on_batch),
             _adapted_uniform((batch_size,), scale[2, 0], scale[2, 1], same_on_batch),
@@ -101,9 +101,10 @@ def random_affine_generator3d(
 
     if translate is not None:
         assert translate.shape == torch.Size([3]), f"'translate' must be the shape of (2). Got {translate.shape}."
-        max_dx: torch.Tensor = translate[0] * depth
-        max_dy: torch.Tensor = translate[1] * width
-        max_dz: torch.Tensor = translate[2] * height
+        max_dz: torch.Tensor = translate[0] * depth
+        max_dy: torch.Tensor = translate[1] * height
+        max_dx: torch.Tensor = translate[2] * width
+        # translations should be in x,y,z
         translations = torch.stack([
             _adapted_uniform((batch_size,), -max_dx, max_dx, same_on_batch),
             _adapted_uniform((batch_size,), -max_dy, max_dy, same_on_batch),
@@ -112,8 +113,9 @@ def random_affine_generator3d(
     else:
         translations = torch.zeros(batch_size, 3)
 
+    # center should be in x,y,z
     center: torch.Tensor = torch.tensor(
-        [depth, width, height], dtype=torch.float32).view(1, 3) / 2. - 0.5
+        [width,height,depth], dtype=torch.float32).view(1, 3) / 2. - 0.5
     center = center.expand(batch_size, -1)
 
     if shears is not None:

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -259,8 +259,8 @@ def rotate3d(tensor: torch.Tensor, yaw: torch.Tensor, pitch: torch.Tensor, roll:
     # compute the rotation matrix
     # TODO: add broadcasting to get_rotation_matrix2d for center
     yaw = yaw.expand(tensor.shape[0])
-    pitch = yaw.expand(tensor.shape[0])
-    roll = yaw.expand(tensor.shape[0])
+    pitch = pitch.expand(tensor.shape[0])
+    roll = roll.expand(tensor.shape[0])
     center = center.expand(tensor.shape[0], -1)
     rotation_matrix: torch.Tensor = _compute_rotation_matrix3d(yaw, pitch, roll, center)
 

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -47,9 +47,9 @@ def _compute_tensor_center3d(tensor: torch.Tensor) -> torch.Tensor:
     """Computes the center of tensor plane for (D, H, W), (C, D, H, W) and (B, C, D, H, W)."""
     assert 3 <= len(tensor.shape) <= 5, f"Must be a 3D tensor as DHW, CDHW and BCDHW. Got {tensor.shape}."
     depth, height, width = tensor.shape[-3:]
-    center_x: float = float(depth - 1) / 2
+    center_x: float = float(width - 1) / 2
     center_y: float = float(height - 1) / 2
-    center_z: float = float(width - 1) / 2
+    center_z: float = float(depth - 1) / 2
     center: torch.Tensor = torch.tensor(
         [center_x, center_y, center_z],
         device=tensor.device, dtype=tensor.dtype)

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -540,8 +540,8 @@ def get_affine_matrix3d(translations: torch.Tensor, center: torch.Tensor, scale:
     r"""Composes 3d affine matrix from the components.
 
     Args:
-        translations (torch.Tensor): tensor containing the translation vector with shape :math:`(B, 3)`.
-        center (torch.Tensor): tensor containing the center vector with shape :math:`(B, 3)`.
+        translations (torch.Tensor): tensor containing the translation vector (dx,dy,dz) with shape :math:`(B, 3)`.
+        center (torch.Tensor): tensor containing the center vector (x,y,z) with shape :math:`(B, 3)`.
         scale (torch.Tensor): tensor containing the scale factor with shape :math:`(B)`.
         sxy (torch.Tensor, optional): tensor containing the shear factor in the xy-direction with shape :math:`(B)`.
         sxz (torch.Tensor, optional): tensor containing the shear factor in the xz-direction with shape :math:`(B)`.

--- a/kornia/geometry/transform/projwarp.py
+++ b/kornia/geometry/transform/projwarp.py
@@ -93,7 +93,7 @@ def get_projective_transform(center: torch.Tensor, angles: torch.Tensor, scales:
     The function computes the projection matrix given the center and angles per axis.
 
     Args:
-        center (torch.Tensor): center of the rotation in the source with shape :math:`(B, 3)`.
+        center (torch.Tensor): center of the rotation (x,y,z) in the source with shape :math:`(B, 3)`.
         angles (torch.Tensor): angle axis vector containing the rotation angles in degrees in the form
             of (rx, ry, rz) with shape :math:`(B, 3)`. Internally it calls Rodrigues to compute
             the rotation matrix from axis-angle.


### PR DESCRIPTION
### Description
This PR fixes #674 .
Corrects some documentations about dimension orders.
Fixes randomrotation3D to return the correct transformation matrix.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
