### PR TITLE
[Fix] Increase speed of transform_points

### DIFF
--- a/kornia/geometry/linalg.py
+++ b/kornia/geometry/linalg.py
@@ -211,12 +211,12 @@ def transform_points(trans_01: torch.Tensor,
     points_1 = points_1.reshape(-1, points_1.shape[-2], points_1.shape[-1])
     trans_01 = trans_01.reshape(-1, trans_01.shape[-2], trans_01.shape[-1])
     # We expand trans_01 to match the dimensions needed for bmm
-    trans_01 = torch.repeat_interleave(trans_01, repeats=points_1.shape[0]//trans_01.shape[0], dim=0)
+    trans_01 = torch.repeat_interleave(trans_01, repeats=points_1.shape[0] // trans_01.shape[0], dim=0)
     # to homogeneous
     points_1_h = convert_points_to_homogeneous(points_1)  # BxNxD+1
     # transform coordinates
     points_0_h = torch.bmm(points_1_h,
-                           trans_01.permute(0,2,1))
+                           trans_01.permute(0, 2, 1))
     points_0_h = torch.squeeze(points_0_h, dim=-1)
     # to euclidean
     points_0 = convert_points_from_homogeneous(points_0_h)  # BxNxD
@@ -225,6 +225,7 @@ def transform_points(trans_01: torch.Tensor,
     shape_inp[-1] = points_0.shape[-1]
     points_0 = points_0.reshape(shape_inp)
     return points_0
+
 
 def transform_boxes(trans_mat: torch.Tensor, boxes: torch.Tensor, mode: str = "xyxy") -> torch.Tensor:
     r""" Function that applies a transformation matrix to a box or batch of boxes. Boxes must

--- a/kornia/geometry/linalg.py
+++ b/kornia/geometry/linalg.py
@@ -204,17 +204,27 @@ def transform_points(trans_01: torch.Tensor,
     if not trans_01.shape[0] == points_1.shape[0] and trans_01.shape[0] != 1:
         raise ValueError("Input batch size must be the same for both tensors or 1")
     if not trans_01.shape[-1] == (points_1.shape[-1] + 1):
-        raise ValueError("Last input dimensions must differe by one unit")
+        raise ValueError("Last input dimensions must differ by one unit")
+
+    # We reshape to BxNxD in case we get more dimensions, e.g., MxBxNxD
+    shape_inp = list(points_1.shape)
+    points_1 = points_1.reshape(-1, points_1.shape[-2], points_1.shape[-1])
+    trans_01 = trans_01.reshape(-1, trans_01.shape[-2], trans_01.shape[-1])
+    # We expand trans_01 to match the dimensions needed for bmm
+    trans_01 = torch.repeat_interleave(trans_01, repeats=points_1.shape[0]//trans_01.shape[0], dim=0)
     # to homogeneous
     points_1_h = convert_points_to_homogeneous(points_1)  # BxNxD+1
     # transform coordinates
-    points_0_h = torch.matmul(
-        trans_01.unsqueeze(1), points_1_h.unsqueeze(-1))
+    points_0_h = torch.bmm(points_1_h,
+                           trans_01.permute(0,2,1))
     points_0_h = torch.squeeze(points_0_h, dim=-1)
     # to euclidean
     points_0 = convert_points_from_homogeneous(points_0_h)  # BxNxD
+    # reshape to the input shape
+    shape_inp[-2] = points_0.shape[-2]
+    shape_inp[-1] = points_0.shape[-1]
+    points_0 = points_0.reshape(shape_inp)
     return points_0
-
 
 def transform_boxes(trans_mat: torch.Tensor, boxes: torch.Tensor, mode: str = "xyxy") -> torch.Tensor:
     r""" Function that applies a transformation matrix to a box or batch of boxes. Boxes must

--- a/test/augmentation/test_augmentation_mix.py
+++ b/test/augmentation/test_augmentation_mix.py
@@ -174,9 +174,9 @@ class TestRandomCutMix:
 
         assert_allclose(out_image, expected, rtol=1e-4, atol=1e-4)
         assert (out_label[0, :, 0] == label).all()
-        assert (out_label[0, :, 1] == torch.tensor([0, 1])).all()
+        assert (out_label[0, :, 1] == torch.tensor([0, 1], device=device, dtype=dtype)).all()
         # cut area = 4 / 12
-        assert_allclose(out_label[0, :, 2], torch.tensor([0.33333, 0.33333], dtype=dtype))
+        assert_allclose(out_label[0, :, 2], torch.tensor([0.33333, 0.33333], device=device, dtype=dtype))
 
     def test_random_mixup_num2(self, device, dtype):
         torch.manual_seed(76)

--- a/test/performance/test_project_points_speed.py
+++ b/test/performance/test_project_points_speed.py
@@ -1,0 +1,24 @@
+import pytest
+from time import time
+
+import torch
+import kornia as kornia
+
+
+points_shapes = [(64, 1024**2, 3), (8192, 8192, 3), (1024**2, 64, 3)]
+
+
+def test_performance_speed(device, dtype):
+    if device.type != 'cuda' or not torch.cuda.is_available():
+        pytest.skip("Cuda not available in system,")
+
+    print("Benchmarking project_points")
+    for input_shape in points_shapes:
+        BS = input_shape[0]
+        inpt = torch.rand(input_shape).to(device)
+        pose = torch.rand((1, 4, 4)).to(device)
+        torch.cuda.synchronize(device)
+        t = time()
+        kornia.geometry.transform_points(pose, inpt)
+        torch.cuda.synchronize(device)
+        print(f"inp={input_shape}, dev={device}, {time() - t}, sec")


### PR DESCRIPTION
### Description
The speed of the function `transform_points` in `linalg.py` is increased by using `torch.bmm` instead of `torch.matmul` as done in the corresponding function in Pytorch3d. As `torch.matmul` handles different shapes via broadcasting but `torch.bmm` does not, we need to include extra code to reshape the data. The increase in speed for some input sizes is:
Before:
```
Benchmarking project_points
inp=(64, 1048576, 3), dev=cuda:0, 0.6896541118621826, sec
inp=(8192, 8192, 3), dev=cuda:0, 0.49063897132873535, sec
inp=(1048576, 64, 3), dev=cuda:0, 0.5144214630126953, sec
```

After modification:
```
Benchmarking project_points
inp=(64, 1048576, 3), dev=cuda:0, 0.27915072441101074, sec
inp=(8192, 8192, 3), dev=cuda:0, 0.10534358024597168, sec
inp=(1048576, 64, 3), dev=cuda:0, 0.11871767044067383, sec
```
However, even though the new function passes all the tests, the results are not exactly the same as the original function. The new function matches the results given by Pytorch3d. This Colab notebook shows a quick example of that:
https://colab.research.google.com/drive/1dVHXicxHVPfUdyuYNdd4jOzx7JKtwqxb#scrollTo=ixEUsV33ofYE

Changes:
 - `transform_points` in `linalg.py` is changed to use `torch.bmm` instead of `torch.matmul`. Also added code to reshape data.
 - Added a new performance test, `test_project_points_speed.py`, to test the performance of `transform_points`.
 - Small non-related changes in `test_augmentation_mix.py` to fix some cuda tests crashing. Some `device` variables were missing.

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [X] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [X] Documentations: did you build documentation ? `make build-docs`
- [X] Implementation: is your code well commented and follow conventions ? `make lint`
- [X] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>