### PR TITLE
[Fix] Zca inverse transform fix

### DIFF
--- a/kornia/enhance/zca.py
+++ b/kornia/enhance/zca.py
@@ -260,7 +260,7 @@ def zca_mean(inp: torch.Tensor, dim: int = 0,
 
     T_inv: Optional[torch.Tensor] = None
     if return_inverse:
-        T_inv = (U).mm(torch.sqrt(S) * U.t())
+        T_inv = (U).mm(torch.sqrt(S + eps) * U.t())
 
     return T, mean, T_inv
 

--- a/test/enhance/test_zca.py
+++ b/test/enhance/test_zca.py
@@ -58,8 +58,8 @@ class TestZCA:
 
         assert_allclose(actual, expected)
 
-    @pytest.mark.parametrize("input_shape", [(15, 2, 2, 2), (10, 4), (20, 3, 2, 2)])
-    def test_identity(self, input_shape, device):
+    @pytest.mark.parametrize("input_shape,eps", [((15, 2, 2, 2), 1e-6), ((10, 4), .1), ((20, 3, 2, 2), 1e-3)])
+    def test_identity(self, input_shape, eps, device):
         """
 
         Assert that data can be recovered by the inverse transform
@@ -68,7 +68,7 @@ class TestZCA:
 
         data = torch.randn(*input_shape, dtype=torch.float32).to(device)
 
-        zca = kornia.enhance.ZCAWhitening(compute_inv=True).fit(data)
+        zca = kornia.enhance.ZCAWhitening(compute_inv=True, eps=eps).fit(data)
 
         data_w = zca(data)
 


### PR DESCRIPTION
### Description
I noticed that I forgot to include the regularization (epsilon) in computing the inverse ZCA transform. I updated the test to include different epsilon values.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [x] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
