### PR TITLE
[BUG] RandomResizedCrop throws runtime error when called with p=0

### DIFF
--- a/kornia/augmentation/random_generator/random_generator.py
+++ b/kornia/augmentation/random_generator/random_generator.py
@@ -354,6 +354,9 @@ def random_crop_size_generator(
     _joint_range_check(scale, "scale")
     _joint_range_check(ratio, "ratio")
 
+    if batch_size == 0:
+        return dict(size=torch.zeros([0, 2]))
+
     # 10 trails for each element
     area = _adapted_uniform(
         (batch_size, 10), scale[0] * size[0] * size[1], scale[1] * size[0] * size[1], same_on_batch)


### PR DESCRIPTION
### Description
This PR fixes the issue that RandomResizedCrop throws runtime error when called with p=0

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
