### PR TITLE
Correct docstrings to point to kornia.enhance

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -33,7 +33,7 @@ __all__ = [
 def adjust_saturation_raw(input: torch.Tensor, saturation_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust color saturation of an image. Expecting input to be in hsv format already.
 
-    See :class:`~kornia.color.AdjustSaturation` for details.
+    See :class:`~kornia.enhance.AdjustSaturation` for details.
     """
 
     if not torch.is_tensor(input):
@@ -69,7 +69,7 @@ def adjust_saturation_raw(input: torch.Tensor, saturation_factor: Union[float, t
 def adjust_saturation(input: torch.Tensor, saturation_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust color saturation of an image.
 
-    See :class:`~kornia.color.AdjustSaturation` for details.
+    See :class:`~kornia.enhance.AdjustSaturation` for details.
     """
 
     # convert the rgb image to hsv
@@ -87,7 +87,7 @@ def adjust_saturation(input: torch.Tensor, saturation_factor: Union[float, torch
 def adjust_hue_raw(input: torch.Tensor, hue_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust hue of an image. Expecting input to be in hsv format already.
 
-    See :class:`~kornia.color.AdjustHue` for details.
+    See :class:`~kornia.enhance.AdjustHue` for details.
     """
 
     if not torch.is_tensor(input):
@@ -124,7 +124,7 @@ def adjust_hue_raw(input: torch.Tensor, hue_factor: Union[float, torch.Tensor]) 
 def adjust_hue(input: torch.Tensor, hue_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust hue of an image.
 
-    See :class:`~kornia.color.AdjustHue` for details.
+    See :class:`~kornia.enhance.AdjustHue` for details.
     """
 
     # convert the rgb image to hsv
@@ -143,7 +143,7 @@ def adjust_gamma(input: torch.Tensor, gamma: Union[float, torch.Tensor],
                  gain: Union[float, torch.Tensor] = 1.) -> torch.Tensor:
     r"""Perform gamma correction on an image.
 
-    See :class:`~kornia.color.AdjustGamma` for details.
+    See :class:`~kornia.enhance.AdjustGamma` for details.
     """
 
     if not torch.is_tensor(input):
@@ -187,7 +187,7 @@ def adjust_contrast(input: torch.Tensor,
                     contrast_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust Contrast of an image.
 
-    See :class:`~kornia.color.AdjustContrast` for details.
+    See :class:`~kornia.enhance.AdjustContrast` for details.
     """
 
     if not torch.is_tensor(input):
@@ -221,7 +221,7 @@ def adjust_brightness(input: torch.Tensor,
                       brightness_factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust Brightness of an image.
 
-    See :class:`~kornia.color.AdjustBrightness` for details.
+    See :class:`~kornia.enhance.AdjustBrightness` for details.
     """
 
     if not torch.is_tensor(input):


### PR DESCRIPTION
Seems wrong? Saw this in docstring and confused me when trying to find correct doc :)

### Description
Small fix for docstrings in kornia.enhance

### Status
**Ready**

### Types of changes
- [x] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
