### PR TITLE
Fixed divide by zero bug

### DIFF
--- a/kornia/geometry/warp/homography_warper.py
+++ b/kornia/geometry/warp/homography_warper.py
@@ -288,16 +288,17 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
     Returns:
         torch.Tensor: normalized transform with shape :math:`(1, 3, 3)`.
     """
+    # prevent divide by zero bugs
+    width = 1e-14 if width == 1 else width - 1.0
+    height = 1e-14 if height == 1 else height - 1.0
+
     tr_mat = torch.tensor([[1.0, 0.0, -1.0],
                            [0.0, 1.0, -1.0],
                            [0.0, 0.0, 1.0]])  # 3x3
 
-    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / (width - 1.0)
-    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / (height - 1.0)
+    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width
+    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height
 
-    # in the case that height or width is 1, prevent divide by zero bug
-    # torch.finfo(torch.float32).max
-    tr_mat[torch.isinf(tr_mat)] = 3.40282e+38
     return tr_mat.unsqueeze(0)  # 1x3x3
 
 
@@ -312,18 +313,20 @@ def normal_transform_pixel3d(depth: int, height: int, width: int) -> torch.Tenso
     Returns:
         Tensor: normalized transform with shape :math:`(1, 4, 4)`.
     """
+    # prevent divide by zero bugs
+    width = 1e-14 if width == 1 else width - 1.0
+    height = 1e-14 if height == 1 else height - 1.0
+    depth = 1e-14 if depth == 1 else depth - 1.0
+
     tr_mat = torch.tensor([[1.0, 0.0, 0.0, -1.0],
                            [0.0, 1.0, 0.0, -1.0],
                            [0.0, 0.0, 1.0, -1.0],
                            [0.0, 0.0, 0.0, 1.0]])  # 4x4
 
-    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / (width - 1.0)
-    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / (height - 1.0)
-    tr_mat[2, 2] = tr_mat[2, 2] * 2.0 / (depth - 1.0)
+    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width
+    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height
+    tr_mat[2, 2] = tr_mat[2, 2] * 2.0 / depth
 
-    # in the case that height, width, or depth is 1, prevent divide by zero bug
-    # torch.finfo(torch.float32).max
-    tr_mat[torch.isinf(tr_mat)] = 3.40282e+38
     return tr_mat.unsqueeze(0)  # 1x4x4
 
 

--- a/kornia/geometry/warp/homography_warper.py
+++ b/kornia/geometry/warp/homography_warper.py
@@ -284,7 +284,6 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
     Args:
         height (int): image height.
         width (int): image width.
-        eps (float): epsilon to prevent divide by zero
 
     Returns:
         torch.Tensor: normalized transform with shape :math:`(1, 3, 3)`.
@@ -299,7 +298,6 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
     # in the case that height or width is 1, prevent divide by zero bug
     # torch.finfo(torch.float32).max
     tr_mat[torch.isinf(tr_mat)] = 3.40282e+38
-
     return tr_mat.unsqueeze(0)  # 1x3x3
 
 
@@ -326,7 +324,6 @@ def normal_transform_pixel3d(depth: int, height: int, width: int) -> torch.Tenso
     # in the case that height, width, or depth is 1, prevent divide by zero bug
     # torch.finfo(torch.float32).max
     tr_mat[torch.isinf(tr_mat)] = 3.40282e+38
-
     return tr_mat.unsqueeze(0)  # 1x4x4
 
 

--- a/kornia/geometry/warp/homography_warper.py
+++ b/kornia/geometry/warp/homography_warper.py
@@ -8,7 +8,6 @@ from kornia.utils import create_meshgrid, create_meshgrid3d
 from kornia.geometry.linalg import transform_points
 from kornia.testing import check_is_tensor
 
-
 __all__ = [
     "HomographyWarper",
     "homography_warp",
@@ -109,7 +108,7 @@ def homography_warp(patch_src: torch.Tensor,
     if not src_homo_dst.device == patch_src.device:
         raise TypeError("Patch and homography must be on the same device. \
                          Got patch.device: {} src_H_dst.device: {}.".format(
-                        patch_src.device, src_homo_dst.device))
+            patch_src.device, src_homo_dst.device))
 
     height, width = dsize
     grid = create_meshgrid(height, width, normalized_coordinates=normalized_coordinates)
@@ -155,7 +154,7 @@ def homography_warp3d(patch_src: torch.Tensor,
     if not src_homo_dst.device == patch_src.device:
         raise TypeError("Patch and homography must be on the same device. \
                          Got patch.device: {} src_H_dst.device: {}.".format(
-                        patch_src.device, src_homo_dst.device))
+            patch_src.device, src_homo_dst.device))
 
     depth, height, width = dsize
     grid = create_meshgrid3d(depth, height, width, normalized_coordinates=normalized_coordinates,
@@ -266,7 +265,7 @@ class HomographyWarper(nn.Module):
                                  Got patch.device: {} warped_grid.device: {}. Wheter \
                                  recall precompute_warp_grid() with the correct device \
                                  for the homograhy or change the patch device.".format(
-                                patch_src.device, _warped_grid.device))
+                    patch_src.device, _warped_grid.device))
             warped_patch = F.grid_sample(
                 patch_src, _warped_grid, mode=self.mode, padding_mode=self.padding_mode,
                 align_corners=self.align_corners)
@@ -278,12 +277,13 @@ class HomographyWarper(nn.Module):
         return warped_patch
 
 
-def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
+def normal_transform_pixel(height: int, width: int, eps: float = 1e-14) -> torch.Tensor:
     r"""Compute the normalization matrix from image size in pixels to [-1, 1].
 
     Args:
         height (int): image height.
         width (int): image width.
+        eps (float): epsilon to prevent divide-by-zero errors
 
     Returns:
         torch.Tensor: normalized transform with shape :math:`(1, 3, 3)`.
@@ -293,8 +293,8 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
                            [0.0, 0.0, 1.0]])  # 3x3
 
     # prevent divide by zero bugs
-    width_denom: float = 1e-14 if width == 1 else width - 1.0
-    height_denom: float = 1e-14 if height == 1 else height - 1.0
+    width_denom: float = eps if width == 1 else width - 1.0
+    height_denom: float = eps if height == 1 else height - 1.0
 
     tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width_denom
     tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height_denom
@@ -302,13 +302,14 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
     return tr_mat.unsqueeze(0)  # 1x3x3
 
 
-def normal_transform_pixel3d(depth: int, height: int, width: int) -> torch.Tensor:
+def normal_transform_pixel3d(depth: int, height: int, width: int, eps: float = 1e-14) -> torch.Tensor:
     r"""Compute the normalization matrix from image size in pixels to [-1, 1].
 
     Args:
         depth (int): image depth.
         height (int): image height.
         width (int): image width.
+        eps (float): epsilon to prevent divide-by-zero errors
 
     Returns:
         Tensor: normalized transform with shape :math:`(1, 4, 4)`.
@@ -319,9 +320,9 @@ def normal_transform_pixel3d(depth: int, height: int, width: int) -> torch.Tenso
                            [0.0, 0.0, 0.0, 1.0]])  # 4x4
 
     # prevent divide by zero bugs
-    width_denom: float = 1e-14 if width == 1 else width - 1.0
-    height_denom: float = 1e-14 if height == 1 else height - 1.0
-    depth_denom: float = 1e-14 if depth == 1 else depth - 1.0
+    width_denom: float = eps if width == 1 else width - 1.0
+    height_denom: float = eps if height == 1 else height - 1.0
+    depth_denom: float = eps if depth == 1 else depth - 1.0
 
     tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width_denom
     tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height_denom

--- a/kornia/geometry/warp/homography_warper.py
+++ b/kornia/geometry/warp/homography_warper.py
@@ -284,6 +284,7 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
     Args:
         height (int): image height.
         width (int): image width.
+        eps (float): epsilon to prevent divide by zero
 
     Returns:
         torch.Tensor: normalized transform with shape :math:`(1, 3, 3)`.
@@ -294,6 +295,10 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
 
     tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / (width - 1.0)
     tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / (height - 1.0)
+
+    # in the case that height or width is 1, prevent divide by zero bug
+    # torch.finfo(torch.float32).max
+    tr_mat[torch.isinf(tr_mat)] = 3.40282e+38
 
     return tr_mat.unsqueeze(0)  # 1x3x3
 
@@ -317,6 +322,10 @@ def normal_transform_pixel3d(depth: int, height: int, width: int) -> torch.Tenso
     tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / (width - 1.0)
     tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / (height - 1.0)
     tr_mat[2, 2] = tr_mat[2, 2] * 2.0 / (depth - 1.0)
+
+    # in the case that height, width, or depth is 1, prevent divide by zero bug
+    # torch.finfo(torch.float32).max
+    tr_mat[torch.isinf(tr_mat)] = 3.40282e+38
 
     return tr_mat.unsqueeze(0)  # 1x4x4
 

--- a/kornia/geometry/warp/homography_warper.py
+++ b/kornia/geometry/warp/homography_warper.py
@@ -288,16 +288,16 @@ def normal_transform_pixel(height: int, width: int) -> torch.Tensor:
     Returns:
         torch.Tensor: normalized transform with shape :math:`(1, 3, 3)`.
     """
-    # prevent divide by zero bugs
-    width = 1e-14 if width == 1 else width - 1.0
-    height = 1e-14 if height == 1 else height - 1.0
-
     tr_mat = torch.tensor([[1.0, 0.0, -1.0],
                            [0.0, 1.0, -1.0],
                            [0.0, 0.0, 1.0]])  # 3x3
 
-    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width
-    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height
+    # prevent divide by zero bugs
+    width_denom: float = 1e-14 if width == 1 else width - 1.0
+    height_denom: float = 1e-14 if height == 1 else height - 1.0
+
+    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width_denom
+    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height_denom
 
     return tr_mat.unsqueeze(0)  # 1x3x3
 
@@ -313,19 +313,19 @@ def normal_transform_pixel3d(depth: int, height: int, width: int) -> torch.Tenso
     Returns:
         Tensor: normalized transform with shape :math:`(1, 4, 4)`.
     """
-    # prevent divide by zero bugs
-    width = 1e-14 if width == 1 else width - 1.0
-    height = 1e-14 if height == 1 else height - 1.0
-    depth = 1e-14 if depth == 1 else depth - 1.0
-
     tr_mat = torch.tensor([[1.0, 0.0, 0.0, -1.0],
                            [0.0, 1.0, 0.0, -1.0],
                            [0.0, 0.0, 1.0, -1.0],
                            [0.0, 0.0, 0.0, 1.0]])  # 4x4
 
-    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width
-    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height
-    tr_mat[2, 2] = tr_mat[2, 2] * 2.0 / depth
+    # prevent divide by zero bugs
+    width_denom: float = 1e-14 if width == 1 else width - 1.0
+    height_denom: float = 1e-14 if height == 1 else height - 1.0
+    depth_denom: float = 1e-14 if depth == 1 else depth - 1.0
+
+    tr_mat[0, 0] = tr_mat[0, 0] * 2.0 / width_denom
+    tr_mat[1, 1] = tr_mat[1, 1] * 2.0 / height_denom
+    tr_mat[2, 2] = tr_mat[2, 2] * 2.0 / depth_denom
 
     return tr_mat.unsqueeze(0)  # 1x4x4
 

--- a/test/geometry/warp/test_homography_warper.py
+++ b/test/geometry/warp/test_homography_warper.py
@@ -256,13 +256,21 @@ class TestHomographyWarper:
 
 
 class TestHomographyNormalTransform:
-
     def test_transform2d(self):
         height, width = 2, 5
         output = kornia.normal_transform_pixel(height, width)
         expected = torch.tensor([[
             [0.5, 0.0, -1.],
             [0.0, 2.0, -1.],
+            [0.0, 0.0, 1.]]])
+        assert_allclose(output, expected)
+
+        # check to ensure it handles case where a dimension == 1
+        height = 1
+        output = kornia.normal_transform_pixel(height, width)
+        expected = torch.tensor([[
+            [0.5, 0.0, -1.],
+            [0.0, 2e14, -1.],
             [0.0, 0.0, 1.]]])
         assert_allclose(output, expected)
 
@@ -280,6 +288,17 @@ class TestHomographyNormalTransform:
         expected = torch.tensor([[
             [0.4, 0.0, 0.0, -1.],
             [0.0, 2.0, 0.0, -1.],
+            [0.0, 0.0, 0.6667, -1.],
+            [0.0, 0.0, 0.0, 1.],
+        ]])
+        assert_allclose(output, expected)
+
+        # check to ensure it handles case where a dimension == 1
+        height, width, depth = 1, 6, 4
+        output = kornia.normal_transform_pixel3d(depth, height, width)
+        expected = torch.tensor([[
+            [0.4, 0.0, 0.0, -1.],
+            [0.0, 2e14, 0.0, -1.],
             [0.0, 0.0, 0.6667, -1.],
             [0.0, 0.0, 0.0, 1.],
         ]])

--- a/test/geometry/warp/test_homography_warper.py
+++ b/test/geometry/warp/test_homography_warper.py
@@ -9,7 +9,6 @@ from torch.testing import assert_allclose
 
 
 class TestHomographyWarper:
-
     num_tests = 10
     threshold = 0.1
 
@@ -256,23 +255,44 @@ class TestHomographyWarper:
 
 
 class TestHomographyNormalTransform:
-    def test_transform2d(self):
-        height, width = 2, 5
+    expected_2d_0 = torch.tensor([[
+        [0.5, 0.0, -1.],
+        [0.0, 2.0, -1.],
+        [0.0, 0.0, 1.]]])
+
+    expected_2d_1 = torch.tensor([[
+        [0.5, 0.0, -1.],
+        [0.0, 2e14, -1.],
+        [0.0, 0.0, 1.]]])
+
+    expected_3d_0 = expected = torch.tensor([[
+        [0.4, 0.0, 0.0, -1.],
+        [0.0, 2.0, 0.0, -1.],
+        [0.0, 0.0, 0.6667, -1.],
+        [0.0, 0.0, 0.0, 1.],
+    ]])
+
+    expected_3d_1 = torch.tensor([[
+        [0.4, 0.0, 0.0, -1.],
+        [0.0, 2e14, 0.0, -1.],
+        [0.0, 0.0, 0.6667, -1.],
+        [0.0, 0.0, 0.0, 1.],
+    ]])
+
+    @pytest.mark.parametrize("height,width,expected", [
+        (2, 5, expected_2d_0),
+        (1, 5, expected_2d_1)
+    ])
+    def test_transform2d(self, height, width, expected):
         output = kornia.normal_transform_pixel(height, width)
-        expected = torch.tensor([[
-            [0.5, 0.0, -1.],
-            [0.0, 2.0, -1.],
-            [0.0, 0.0, 1.]]])
+
         assert_allclose(output, expected)
 
-        # check to ensure it handles case where a dimension == 1
-        height = 1
+    @pytest.mark.parametrize("height", [1, 2, 5])
+    @pytest.mark.parametrize("width", [1, 2, 5])
+    def test_divide_by_zero2d(self, height, width):
         output = kornia.normal_transform_pixel(height, width)
-        expected = torch.tensor([[
-            [0.5, 0.0, -1.],
-            [0.0, 2e14, -1.],
-            [0.0, 0.0, 1.]]])
-        assert_allclose(output, expected)
+        assert torch.isinf(output).sum().item() == 0
 
     def test_transform2d_apply(self):
         height, width = 2, 5
@@ -282,27 +302,20 @@ class TestHomographyNormalTransform:
         output = kornia.transform_points(transform, input)
         assert_allclose(output, expected)
 
-    def test_transform3d(self):
-        height, width, depth = 2, 6, 4
+    @pytest.mark.parametrize("height,width,depth,expected", [
+        (2, 6, 4, expected_3d_0),
+        (1, 6, 4, expected_3d_1)
+    ])
+    def test_transform3d(self, height, width, depth, expected):
         output = kornia.normal_transform_pixel3d(depth, height, width)
-        expected = torch.tensor([[
-            [0.4, 0.0, 0.0, -1.],
-            [0.0, 2.0, 0.0, -1.],
-            [0.0, 0.0, 0.6667, -1.],
-            [0.0, 0.0, 0.0, 1.],
-        ]])
         assert_allclose(output, expected)
 
-        # check to ensure it handles case where a dimension == 1
-        height, width, depth = 1, 6, 4
+    @pytest.mark.parametrize("height", [1, 2, 5])
+    @pytest.mark.parametrize("width", [1, 2, 5])
+    @pytest.mark.parametrize("depth", [1, 2, 5])
+    def test_divide_by_zero3d(self, height, width, depth):
         output = kornia.normal_transform_pixel3d(depth, height, width)
-        expected = torch.tensor([[
-            [0.4, 0.0, 0.0, -1.],
-            [0.0, 2e14, 0.0, -1.],
-            [0.0, 0.0, 0.6667, -1.],
-            [0.0, 0.0, 0.0, 1.],
-        ]])
-        assert_allclose(output, expected)
+        assert torch.isinf(output).sum().item() == 0
 
     def test_transform3d_apply(self):
         depth, height, width = 3, 2, 5
@@ -314,7 +327,6 @@ class TestHomographyNormalTransform:
 
 
 class TestHomographyWarper3D:
-
     num_tests = 10
     threshold = 0.1
 


### PR DESCRIPTION
### Description
In `normal_transform_pixel` and `normal_transform_pixel3d`, having a `height`, `width`, (or `depth`) of 1 resulted in `inf`, which results in a `nan` in `normalize_homography`

In particular, I'm using this to rotate video data. Sometimes my number of frames is `1`, which in the 3D case means that `depth=1`. When you rotate an image with depth=1, it just results in zeros. 

`print(batch.shape) # torch.Size([64, 3, 1, 224, 224])`
Input image batch: 
![image (3)](https://user-images.githubusercontent.com/17788259/100917668-7315f880-34a5-11eb-83ac-c300e63957d6.png)

Code to reproduce bug:
```python
import kornia.augmentation as K

aug = K.RandomRotation3D((0,0,10), p=1.0)
inp = batch.clone()
out = aug(inp)
print(out.min(), out.mean(), out.max())
```
Just a bunch of zeros: 
`# tensor(0.) tensor(0.) tensor(0.)`

After fix: 
![image (5)](https://user-images.githubusercontent.com/17788259/100918048-fa636c00-34a5-11eb-9759-83a41ca19062.png)

Note, I called this a work in progress because I'm not sure if we want to add tests to make sure that this is caught in the future. 

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [x ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [x] Documentations: did you build documentation ? `make build-docs`
- [x] Implementation: is your code well commented and follow conventions ? `make lint`
- [x] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
