### PR TITLE
[Feature] Mask correspondences in motion_from_essential_choose_solution

### DIFF
--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -137,11 +137,13 @@ def motion_from_essential_choose_solution(
     x2: torch.Tensor,
     mask: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    r"""Recovers the relative camera rotation and the translation from an estimated essential matrix.
-    The method check the corresponding points in two images and also returns the triangulated
+    r"""Recover the relative camera rotation and the translation from an estimated essential matrix.
+
+    The method checks the corresponding points in two images and also returns the triangulated
     3d points. Internally uses :py:meth:`~kornia.geometry.epipolar.decompose_essential_matrix` and then chooses
     the best solution based on the combination that gives more 3d points in front of the camera plane from
     :py:meth:`~kornia.geometry.epipolar.triangulate_points`.
+
     Args:
         E_mat (torch.Tensor): The essential matrix in the form of :math:`(*, 3, 3)`.
         K1 (torch.Tensor): The camera matrix from first camera with shape :math:`(*, 3, 3)`.
@@ -151,11 +153,14 @@ def motion_from_essential_choose_solution(
         x2 (torch.Tensor): The set of points seen from the first camera frame in the camera plane
           coordinates with shape :math:`(*, N, 2)`.
         mask (torch.Tensor): A boolean mask which can be used to exclude some points from choosing
-          the best solution. This is useful for using this method with function with batched
-          sets of points of different cardinality. Mask is of shape :math:`(*, N)`.
+          the best solution. This is useful for using this function with sets of points of
+          different cardinality (for instance after filtering with RANSAC) while keeping batch
+          semantics. Mask is of shape :math:`(*, N)`.
+
     Returns:
         Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: The rotation and translation plus the
         3d triangulated points. The tuple is as following :math:`[(*, 3, 3), (*, 3, 1), (*, N, 3)]`.
+
     """
     assert len(E_mat.shape) >= 2 and E_mat.shape[-2:], E_mat.shape
     assert len(K1.shape) >= 2 and K1.shape[-2:] == (3, 3), K1.shape

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -201,11 +201,11 @@ def motion_from_essential_choose_solution(
     d2 = projection.depth(R2, t2, X)
 
     # verify the point values that have a postive depth value
-    if mask is None:
-        mask = ((d1 > 0.) & (d2 > 0.))
-    else:
-        mask = ((d1 > 0.) & (d2 > 0.)) & mask.unsqueeze(1)
-    mask_indices = torch.max(mask.sum(-1), dim=-1, keepdim=True)[1]
+    depth_mask = ((d1 > 0.) & (d2 > 0.))
+    if mask is not None:
+        depth_mask &= mask.unsqueeze(1)
+
+    mask_indices = torch.max(depth_mask.sum(-1), dim=-1, keepdim=True)[1]
 
     # get pose and points 3d and return
     R_out = Rs[:, mask_indices][:, 0, 0]

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -1,5 +1,5 @@
 """Module containing functionalities for the Essential matrix."""
-from typing import Tuple
+from typing import Tuple, Optional
 
 import torch
 

--- a/test/geometry/epipolar/test_essential.py
+++ b/test/geometry/epipolar/test_essential.py
@@ -292,6 +292,23 @@ class TestMotionFromEssentialChooseSolution:
         assert t.shape == (B, 3, 1)
         assert X.shape == (B, N, 3)
 
+    def test_masking(self, device, dtype):
+        E_mat = torch.rand(2, 3, 3, device=device, dtype=dtype)
+        K1 = torch.rand(2, 3, 3, device=device, dtype=dtype)
+        K2 = torch.rand(2, 3, 3, device=device, dtype=dtype)
+        x1 = torch.rand(2, 10, 2, device=device, dtype=dtype)
+        x2 = torch.rand(2, 10, 2, device=device, dtype=dtype)
+
+        R, t, X = epi.motion_from_essential_choose_solution(E_mat, K1, K2, x1[:, 1:-1, :], x2[:, 1:-1, :])
+
+        mask = torch.zeros(2, 10, dtype=torch.bool, device=device)
+        mask[:, 1:-1] = True
+        Rm, tm, Xm = epi.motion_from_essential_choose_solution(E_mat, K1, K2, x1, x2, mask=mask)
+
+        assert_allclose(R, Rm)
+        assert_allclose(t, tm)
+        assert_allclose(X, Xm[:, 1:-1, :])
+
     def test_two_view(self, device, dtype):
 
         scene = utils.generate_two_view_random_scene(device, dtype)


### PR DESCRIPTION
### Description
Currently, [motion_from_essential_choose_solution](https://kornia.readthedocs.io/en/latest/geometry.epipolar.html#kornia.geometry.epipolar.motion_from_essential_choose_solution) allows batching of inputs, but in the common scenario when the number of correspondences is different across different batch elements (for example because they were filtered with RANSAC) we still have to work with batch size of 1. This change adds an optional `mask` parameter which allows excluding some correspondences from being counted in the choose_solution step. This means that one can now pad the correspondences to a common length and mask out the padding, recovering the batch semantics.

Note: similarly to my other PR, this also has the annoying comming `125defb`. I have no clue where it is coming from in the git history and how to rectify that, I'll be happy to receive some guidance.
### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] New non-breaking functionality


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [x] **Pass all tests**: did you test in local ? `make test`
- [x] Unittests: did you add tests for your new functionality ?
- [x] Documentations: did you build documentation ? `make build-docs`
- [x] Implementation: is your code well commented and follow conventions ? `make lint`
- [x] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
