### PR TITLE
Add mode parameter to elastic_transform_2d

### DIFF
--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -15,7 +15,8 @@ def elastic_transform2d(image: torch.Tensor,
                         kernel_size: Tuple[int, int] = (3, 3),
                         sigma: Tuple[float, float] = (4., 4.),
                         alpha: Tuple[float, float] = (32., 32.),
-                        align_corners: bool = False) -> torch.Tensor:
+                        align_corners: bool = False,
+                        mode: str = 'bilinear') -> torch.Tensor:
     r"""Applies elastic transform of images as described in :cite:`Simard2003BestPF`.
 
     Args:
@@ -29,6 +30,7 @@ def elastic_transform2d(image: torch.Tensor,
         alpha (Tuple[float, float]): The scaling factor that controls the intensity of the deformation
           in the y and x directions, respectively. Default: 32.
         align_corners (bool): Interpolation flag used by `grid_sample`. Default: False.
+        mode (str): Interpolation mode used by `grid_sample`. Either 'bilinear' or 'nearest'. Default: 'bilinear'.
 
     .. note:
         `sigma` and `alpha` can also be a `torch.Tensor`. However, you could not torchscript
@@ -85,6 +87,6 @@ def elastic_transform2d(image: torch.Tensor,
     b, c, h, w = image.shape
     grid = kornia.utils.create_meshgrid(h, w, device=image.device).to(image.dtype)
     warped = F.grid_sample(
-        image, (grid + disp).clamp(-1, 1), align_corners=align_corners)
+        image, (grid + disp).clamp(-1, 1), align_corners=align_corners, mode=mode)
 
     return warped


### PR DESCRIPTION
### Description

This PR adds the parameter `mode` to `elastic_parameters_2d`, which is passed to `grid_sample`. This enables elastic transformations with nearest interpolation (by passing `mode=nearest`).  This is useful, e.g. to apply the elastic deformation to label masks.

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
