### PR TITLE
fix _se_to_mask

### DIFF
--- a/kornia/morphology/basic_operators.py
+++ b/kornia/morphology/basic_operators.py
@@ -12,8 +12,8 @@ def _se_to_mask(se: torch.Tensor) -> torch.Tensor:
     num_feats = se_h * se_w
     out = torch.zeros(num_feats, 1, se_h, se_w, dtype=se.dtype, device=se.device)
     for i in range(num_feats):
-        y = i % se_h
-        x = i // se_h
+        y = i // se_w
+        x = i % se_w
         out[i, 0, y, x] = (se_flat[i] >= 0).float()
     return out
 

--- a/kornia/morphology/basic_operators.py
+++ b/kornia/morphology/basic_operators.py
@@ -107,7 +107,7 @@ def erosion(tensor: torch.Tensor, kernel: torch.Tensor) -> torch.Tensor:
 
     # pad
     se_h, se_w = kernel.shape
-    pad_e: List[int] = [se_h // 2, se_h // 2, se_w // 2, se_w // 2]
+    pad_e: List[int] = [se_w // 2, se_w // 2, se_h // 2, se_h // 2]
 
     output: torch.Tensor = tensor.view(
         tensor.shape[0] * tensor.shape[1], 1, tensor.shape[2], tensor.shape[3])

--- a/kornia/morphology/basic_operators.py
+++ b/kornia/morphology/basic_operators.py
@@ -107,7 +107,7 @@ def erosion(tensor: torch.Tensor, kernel: torch.Tensor) -> torch.Tensor:
 
     # pad
     se_h, se_w = kernel.shape
-    pad_e: List[int] = [se_h // 2, se_w // 2, se_h // 2, se_w // 2]
+    pad_e: List[int] = [se_h // 2, se_h // 2, se_w // 2, se_w // 2]
 
     output: torch.Tensor = tensor.view(
         tensor.shape[0] * tensor.shape[1], 1, tensor.shape[2], tensor.shape[3])

--- a/kornia/morphology/basic_operators.py
+++ b/kornia/morphology/basic_operators.py
@@ -14,7 +14,7 @@ def _se_to_mask(se: torch.Tensor) -> torch.Tensor:
     for i in range(num_feats):
         y = i % se_h
         x = i // se_h
-        out[i, 0, x, y] = (se_flat[i] >= 0).float()
+        out[i, 0, y, x] = (se_flat[i] >= 0).float()
     return out
 
 

--- a/test/morphology/test_dilation.py
+++ b/test/morphology/test_dilation.py
@@ -15,7 +15,7 @@ class TestDilate():
     @pytest.mark.parametrize(
         "shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 1), (3, 2, 5, 5)])
     @pytest.mark.parametrize(
-        "kernel", [(3, 3), (5, 5)])
+        "kernel", [(3, 3), (5, 5), (3, 5), (5, 3)])
     def test_cardinality(self, device, dtype, shape, kernel):
         img = torch.ones(shape, device=device, dtype=dtype)
         krnl = torch.ones(kernel, device=device, dtype=dtype)

--- a/test/morphology/test_erosion.py
+++ b/test/morphology/test_erosion.py
@@ -15,7 +15,7 @@ class TestErode():
     @pytest.mark.parametrize(
         "shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 1), (3, 2, 5, 5)])
     @pytest.mark.parametrize(
-        "kernel", [(3, 3), (5, 5), (5, 3), (3, 5)])
+        "kernel", [(3, 3), (5, 5), (3, 5), (5, 3)])
     def test_cardinality(self, device, dtype, shape, kernel):
         img = torch.ones(shape, device=device, dtype=dtype)
         krnl = torch.ones(kernel, device=device, dtype=dtype)

--- a/test/morphology/test_erosion.py
+++ b/test/morphology/test_erosion.py
@@ -15,7 +15,7 @@ class TestErode():
     @pytest.mark.parametrize(
         "shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 1), (3, 2, 5, 5)])
     @pytest.mark.parametrize(
-        "kernel", [(3, 3), (5, 5)])
+        "kernel", [(3, 3), (5, 5), (5, 3), (3, 5)])
     def test_cardinality(self, device, dtype, shape, kernel):
         img = torch.ones(shape, device=device, dtype=dtype)
         krnl = torch.ones(kernel, device=device, dtype=dtype)


### PR DESCRIPTION
### Description
_se_to_mask currently fails with rectangular strels because the coords are specified in the wrong order

btw can't erosion and dilation share code since their relationship is just f(x) and -f(-x)?

Edit: ended up fixing erosion padding as well.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
