### PR TITLE
revert torch.amin to torch.min

### DIFF
--- a/kornia/morphology/basic_operators.py
+++ b/kornia/morphology/basic_operators.py
@@ -86,6 +86,7 @@ def erosion(tensor: torch.Tensor, kernel: torch.Tensor) -> torch.Tensor:
         tensor.shape[0] * tensor.shape[1], 1, tensor.shape[2], tensor.shape[3])
     output = F.pad(output, pad_e, mode='constant', value=1.)
     output = F.conv2d(output, kernel_e) - se_e.view(1, -1, 1, 1)
-    output = output.amin(1)
+    # TODO: upgrade to: `output = torch.amin(output, dim=1)` after dropping pytorch 1.6 support
+    output = torch.min(output, dim=1)[0]
 
     return output.view_as(tensor)


### PR DESCRIPTION
### Description

reverts usage of `torch.amin` to `torch.min` again in `kornia.morphollogy` since `amin` does not have proper torchscript support in pytorch <1.7

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
