### PR TITLE
Adds ImageToTensor module and resize for non-batched images

### DIFF
--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -10,6 +10,7 @@ from kornia.geometry.transform.projwarp import (
     warp_affine3d, get_projective_transform
 )
 from kornia.utils import _extract_device_dtype
+from kornia.utils.image import _to_bchw
 
 __all__ = [
     "affine",
@@ -544,15 +545,13 @@ def resize(input: torch.Tensor, size: Union[int, Tuple[int, int]],
         return input
 
     # TODO: find a proper way to handle this cases in the future
-    input_tmp = input
-    if len(input.shape) == 3:
-        input_tmp = input_tmp.unsqueeze(0)
+    input_tmp = _to_bchw(input)
 
     output = torch.nn.functional.interpolate(
         input_tmp, size=size, mode=interpolation, align_corners=align_corners)
 
-    if len(input.shape) == 3:
-        output = output.squeeze(0)
+    if len(input.shape) != len(output.shape):
+        output = output.squeeze()
 
     return output
 

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -543,7 +543,18 @@ def resize(input: torch.Tensor, size: Union[int, Tuple[int, int]],
     if size == input_size:
         return input
 
-    return torch.nn.functional.interpolate(input, size=size, mode=interpolation, align_corners=align_corners)
+    # TODO: find a proper way to handle this cases in the future
+    input_tmp = input
+    if len(input.shape) == 3:
+        input_tmp = input_tmp.unsqueeze(0)
+
+    output = torch.nn.functional.interpolate(
+        input_tmp, size=size, mode=interpolation, align_corners=align_corners)
+
+    if len(input.shape) == 3:
+        output = output.squeeze(0)
+
+    return output
 
 
 def rescale(

--- a/kornia/utils/__init__.py
+++ b/kornia/utils/__init__.py
@@ -1,6 +1,6 @@
 from .one_hot import one_hot
 from .grid import create_meshgrid, create_meshgrid3d
-from .image import tensor_to_image, image_to_tensor
+from .image import tensor_to_image, image_to_tensor, ImageToTensor
 from .pointcloud_io import save_pointcloud_ply, load_pointcloud_ply
 from .draw import draw_rectangle
 from .helpers import _extract_device_dtype
@@ -17,4 +17,5 @@ __all__ = [
     "load_pointcloud_ply",
     "draw_rectangle",
     "_extract_device_dtype",
+    "ImageToTensor",
 ]

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import numpy as np
 import torch
+import torch.nn as nn
 
 
 def image_to_tensor(image: np.ndarray, keepdim: bool = True) -> torch.Tensor:
@@ -141,3 +142,18 @@ def tensor_to_image(tensor: torch.Tensor) -> np.array:
             "Cannot process tensor with shape {}".format(input_shape))
 
     return image
+
+
+class ImageToTensor(nn.Module):
+    """Converts a numpy image to a PyTorch 4d tensor image.
+
+    Args:
+        keepdim (bool): If ``False`` unsqueeze the input image to match the shape
+            :math:`(B, H, W, C)`. Default: ``True``
+    """
+    def __init__(self, keepdim: bool = False):
+        super().__init__()
+        self.keepdim = keepdim
+
+    def forward(self, x: np.ndarray) -> torch.Tensor:
+        return image_to_tensor(x, keepdim=self.keepdim)

--- a/test/geometry/transform/test_affine.py
+++ b/test/geometry/transform/test_affine.py
@@ -13,6 +13,11 @@ class TestResize:
         out = kornia.resize(inp, (3, 4))
         assert_allclose(inp, out, atol=1e-4, rtol=1e-4)
 
+    def test_no_batch(self, device, dtype):
+        inp = torch.rand(3, 3, 4, device=device, dtype=dtype)
+        out = kornia.resize(inp, (2, 5))
+        assert out.shape == (3, 2, 5)
+
     def test_upsize(self, device, dtype):
         inp = torch.rand(1, 3, 3, 4, device=device, dtype=dtype)
         out = kornia.resize(inp, (6, 8))

--- a/test/utils/test_image.py
+++ b/test/utils/test_image.py
@@ -2,6 +2,8 @@ import pytest
 import numpy as np
 
 import torch
+from torch.testing import assert_allclose
+
 import kornia as kornia
 import kornia.testing as utils  # test utils
 
@@ -42,6 +44,9 @@ def test_image_to_tensor(input_shape, expected):
     tensor = kornia.utils.image_to_tensor(image, keepdim=False)
     assert tensor.shape == expected
     assert isinstance(tensor, torch.Tensor)
+
+    to_tensor = kornia.utils.ImageToTensor(keepdim=False)
+    assert_allclose(tensor, to_tensor(image))
 
 
 @pytest.mark.parametrize("input_shape, expected",


### PR DESCRIPTION
### Description

This PR implements resize to work with non batch and adds `ImageToTensor` module.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
