### PR TITLE
fix variable name in dice loss error message (#982)

### DIFF
--- a/kornia/losses/dice.py
+++ b/kornia/losses/dice.py
@@ -58,7 +58,7 @@ def dice_loss(input: torch.Tensor, target: torch.Tensor, eps: float = 1e-8) -> t
 
     if not input.shape[-2:] == target.shape[-2:]:
         raise ValueError("input and target shapes must be the same. Got: {} and {}"
-                         .format(input.shape, input.shape))
+                         .format(input.shape, target.shape))
 
     if not input.device == target.device:
         raise ValueError(


### PR DESCRIPTION
### Description
Changes variable name in `dice_loss` error message to the correct variable as described in #982 

https://github.com/kornia/kornia/blob/5392651d0bc268da577fa0a49aa50f957289c7dd/kornia/losses/dice.py#L61
second `input.shape` is now corrected to `target.shape`

### Status
Ready

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our 
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [x] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>
  
  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if 
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?
 
</details>
