### PR TITLE
Mark long description as content type markdown in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ if __name__ == '__main__':
         url='https://github.com/kornia/kornia',
         description='Open Source Differentiable Computer Vision Library for PyTorch',
         long_description=long_description,
+        long_description_content_type='text/markdown',
         license='Apache License 2.0',
         python_requires='>=3.6',
 


### PR DESCRIPTION
Python assumes restructured text by default. While they are similar, they are not compatible and you'll run into PyPI problems without.

See
https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata
for details.

(I looked into this after chatting with @edgarriba)