### PR TITLE
Resize regardless of number of dims, considering the last two dims as image

### DIFF
--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -5,6 +5,8 @@ import torch.nn as nn
 
 from math import ceil
 
+from functools import wraps
+
 import kornia
 from kornia.geometry.transform.imgwarp import (warp_affine, get_rotation_matrix2d, get_affine_matrix2d)
 from kornia.geometry.transform.projwarp import (warp_affine3d, get_projective_transform)
@@ -524,6 +526,7 @@ def _side_to_image_size(side_size: int, aspect_ratio: float, side: str = "short"
 
 
 def _reshape_perform_reshape(f):
+    @wraps(f)
     def _wrapper(input, *args, **kwargs):
         dont_care_shape = input.shape[:-3]
         input = input.view(-1, input.shape[-3], input.shape[-2], input.shape[-1])

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -11,7 +11,7 @@ import kornia
 from kornia.geometry.transform.imgwarp import (warp_affine, get_rotation_matrix2d, get_affine_matrix2d)
 from kornia.geometry.transform.projwarp import (warp_affine3d, get_projective_transform)
 from kornia.utils import _extract_device_dtype
-from kornia.utils.image import _to_bchw
+from kornia.utils.image import perform_keep_shape
 
 __all__ = [
     "affine",
@@ -525,28 +525,7 @@ def _side_to_image_size(side_size: int, aspect_ratio: float, side: str = "short"
         return int(side_size / aspect_ratio), side_size
 
 
-def _reshape_perform_reshape(f):
-    """TODO: where can we put this?"""
-
-    @wraps(f)
-    def _wrapper(input, *args, **kwargs):
-        input_shape = input.shape
-        if len(input_shape) == 2:
-            input = input[None]
-
-        dont_care_shape = input.shape[:-3]
-        input = input.view(-1, input.shape[-3], input.shape[-2], input.shape[-1])
-
-        output = f(input, *args, **kwargs)
-        output = output.view(*(dont_care_shape + output.shape[-3:]))
-        if len(input_shape) == 2:
-            output = output[0]
-        return output
-
-    return _wrapper
-
-
-@_reshape_perform_reshape
+@perform_keep_shape
 def resize(
     input: torch.Tensor,
     size: Union[int, Tuple[int, int]],

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -527,6 +527,7 @@ def _side_to_image_size(side_size: int, aspect_ratio: float, side: str = "short"
 
 def _reshape_perform_reshape(f):
     """TODO: where can we put this?"""
+
     @wraps(f)
     def _wrapper(input, *args, **kwargs):
         input_shape = input.shape

--- a/test/geometry/transform/test_affine.py
+++ b/test/geometry/transform/test_affine.py
@@ -14,21 +14,57 @@ class TestResize:
         out = kornia.resize(inp, (3, 4))
         assert_allclose(inp, out, atol=1e-4, rtol=1e-4)
 
-    def test_no_batch(self, device, dtype):
+        # 2D
+        inp = torch.rand(3, 4, device=device, dtype=dtype)
+        out = kornia.resize(inp, (3, 4))
+        assert_allclose(inp, out, atol=1e-4, rtol=1e-4)
+
+        # 3D
         inp = torch.rand(3, 3, 4, device=device, dtype=dtype)
-        out = kornia.resize(inp, (2, 5))
-        assert out.shape == (3, 2, 5)
+        out = kornia.resize(inp, (3, 4))
+        assert_allclose(inp, out, atol=1e-4, rtol=1e-4)
+
+        # arbitrary dim
+        inp = torch.rand(1, 2, 3, 2, 1, 3, 3, 4, device=device, dtype=dtype)
+        out = kornia.resize(inp, (3, 4))
+        assert_allclose(inp, out, atol=1e-4, rtol=1e-4)
 
     def test_upsize(self, device, dtype):
         inp = torch.rand(1, 3, 3, 4, device=device, dtype=dtype)
         out = kornia.resize(inp, (6, 8))
         assert out.shape == (1, 3, 6, 8)
 
+        # 2D
+        inp = torch.rand(3, 4, device=device, dtype=dtype)
+        out = kornia.resize(inp, (6, 8))
+        assert out.shape == (6, 8)
+
+        # 3D
+        inp = torch.rand(3, 3, 4, device=device, dtype=dtype)
+        out = kornia.resize(inp, (6, 8))
+        assert out.shape == (3, 6, 8)
+
+        # arbitrary dim
+        inp = torch.rand(1, 2, 3, 2, 1, 3, 3, 4, device=device, dtype=dtype)
+        out = kornia.resize(inp, (6, 8))
+        assert out.shape == (1, 2, 3, 2, 1, 3, 6, 8)
+
     def test_downsize(self, device, dtype):
         inp = torch.rand(1, 3, 5, 2, device=device, dtype=dtype)
         out = kornia.resize(inp, (3, 1))
         assert out.shape == (1, 3, 3, 1)
 
+        # 2D
+        inp = torch.rand(5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, (3, 1))
+        assert out.shape == (3, 1)
+
+        # 3D
+        inp = torch.rand(3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, (3, 1))
+        assert out.shape == (3, 3, 1)
+
+        # arbitrary dim
         inp = torch.rand(1, 2, 3, 2, 1, 3, 5, 2, device=device, dtype=dtype)
         out = kornia.resize(inp, (3, 1))
         assert out.shape == (1, 2, 3, 2, 1, 3, 3, 1)
@@ -38,22 +74,97 @@ class TestResize:
         out = kornia.resize(inp, (5, 3), antialias=True)
         assert out.shape == (1, 3, 5, 3)
 
+        # 2D
+        inp = torch.rand(10, 8, device=device, dtype=dtype)
+        out = kornia.resize(inp, (5, 3), antialias=True)
+        assert out.shape == (5, 3)
+
+        # 3D
+        inp = torch.rand(3, 10, 8, device=device, dtype=dtype)
+        out = kornia.resize(inp, (5, 3), antialias=True)
+        assert out.shape == (3, 5, 3)
+
+        # arbitrary dim
+        inp = torch.rand(1, 2, 3, 2, 1, 3, 10, 8, device=device, dtype=dtype)
+        out = kornia.resize(inp, (5, 3), antialias=True)
+        assert out.shape == (1, 2, 3, 2, 1, 3, 5, 3)
+
     def test_one_param(self, device, dtype):
         inp = torch.rand(1, 3, 5, 2, device=device, dtype=dtype)
         out = kornia.resize(inp, 10)
         assert out.shape == (1, 3, 25, 10)
+
+        # 2D
+        inp = torch.rand(5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10)
+        assert out.shape == (25, 10)
+
+        # 3D
+        inp = torch.rand(3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10)
+        assert out.shape == (3, 25, 10)
+
+        # arbitrary dim
+        inp = torch.rand(1, 2, 3, 2, 1, 3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10)
+        assert out.shape == (1, 2, 3, 2, 1, 3, 25, 10)
 
     def test_one_param_long(self, device, dtype):
         inp = torch.rand(1, 3, 5, 2, device=device, dtype=dtype)
         out = kornia.resize(inp, 10, side="long")
         assert out.shape == (1, 3, 10, 4)
 
+        # 2D
+        inp = torch.rand(5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="long")
+        assert out.shape == (10, 4)
+
+        # 3D
+        inp = torch.rand(3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="long")
+        assert out.shape == (3, 10, 4)
+
+        # arbitrary dim
+        inp = torch.rand(1, 2, 3, 2, 1, 3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="long")
+        assert out.shape == (1, 2, 3, 2, 1, 3, 10, 4)
+
     def test_one_param_vert(self, device, dtype):
         inp = torch.rand(1, 3, 5, 2, device=device, dtype=dtype)
         out = kornia.resize(inp, 10, side="vert")
         assert out.shape == (1, 3, 10, 4)
 
+        # 2D
+        inp = torch.rand(5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="vert")
+        assert out.shape == (10, 4)
+
+        # 3D
+        inp = torch.rand(3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="vert")
+        assert out.shape == (3, 10, 4)
+
+        # arbitrary dim
+        inp = torch.rand(1, 2, 3, 2, 1, 3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="vert")
+        assert out.shape == (1, 2, 3, 2, 1, 3, 10, 4)
+
     def test_one_param_horz(self, device, dtype):
+        inp = torch.rand(1, 3, 2, 5, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="horz")
+        assert out.shape == (1, 3, 4, 10)
+
+        # 2D
+        inp = torch.rand(1, 3, 2, 5, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="horz")
+        assert out.shape == (1, 3, 4, 10)
+
+        # 3D
+        inp = torch.rand(1, 3, 2, 5, device=device, dtype=dtype)
+        out = kornia.resize(inp, 10, side="horz")
+        assert out.shape == (1, 3, 4, 10)
+
+        # arbitrary dim
         inp = torch.rand(1, 3, 2, 5, device=device, dtype=dtype)
         out = kornia.resize(inp, 10, side="horz")
         assert out.shape == (1, 3, 4, 10)

--- a/test/geometry/transform/test_affine.py
+++ b/test/geometry/transform/test_affine.py
@@ -29,6 +29,10 @@ class TestResize:
         out = kornia.resize(inp, (3, 1))
         assert out.shape == (1, 3, 3, 1)
 
+        inp = torch.rand(1, 2, 3, 2, 1, 3, 5, 2, device=device, dtype=dtype)
+        out = kornia.resize(inp, (3, 1))
+        assert out.shape == (1, 2, 3, 2, 1, 3, 3, 1)
+
     def test_downsizeAA(self, device, dtype):
         inp = torch.rand(1, 3, 10, 8, device=device, dtype=dtype)
         out = kornia.resize(inp, (5, 3), antialias=True)


### PR DESCRIPTION
### Description
Hi. I propose to change the behavior of `kornia.geometry.transform.resize` to support any dimensional images as discussed [here](https://kornia.slack.com/archives/CV71WGN8H/p1622448371002400). The last two dims will be considered as image height and width. I wrote a test to serve as an example. If this is approved I will work on the rest.

### Status
**Work in progress**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [x] Did you discuss the functionality or any breaking changes before ?
- [x] **Pass all tests**: did you test in local ? `make test`
- [x] Unittests: did you add tests for your new functionality ?
- [x] Documentations: did you build documentation ? `make build-docs`
- [x] Implementation: is your code well commented and follow conventions ? `make lint`
- [x] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>

  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?

</details>
