### PR TITLE
[feat] Added mix augmentations in containers

### DIFF
--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -1879,8 +1879,12 @@ class GaussianBlur(RandomGaussianBlur):
         p: float = 0.5,
     ) -> None:
         super(GaussianBlur, self).__init__(
-            kernel_size=kernel_size, sigma=sigma, border_type=border_type, return_transform=return_transform,
-            same_on_batch=same_on_batch, p=p
+            kernel_size=kernel_size,
+            sigma=sigma,
+            border_type=border_type,
+            return_transform=return_transform,
+            same_on_batch=same_on_batch,
+            p=p,
         )
         warnings.warn(
             "GaussianBlur is no longer maintained and will be removed from the future versions. "

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -4,7 +4,7 @@ from typing import cast, Dict, List, Optional, Tuple, Union
 import torch
 from torch.nn.functional import pad
 
-from kornia.augmentation.base import GeometricAugmentationBase2D, IntensityAugmentationBase2D, TensorWithTransMat
+from kornia.augmentation.base import GeometricAugmentationBase2D, IntensityAugmentationBase2D, TensorWithTransformMat
 from kornia.color import rgb_to_grayscale
 from kornia.constants import BorderType, pi, Resample, SamplePadding
 from kornia.enhance import (
@@ -1119,7 +1119,7 @@ class RandomCrop(GeometricAugmentationBase2D):
 
     def inverse(
         self,
-        input: TensorWithTransMat,
+        input: TensorWithTransformMat,
         params: Optional[Dict[str, torch.Tensor]] = None,
         size: Optional[Tuple[int, int]] = None,
         **kwargs,
@@ -1136,10 +1136,10 @@ class RandomCrop(GeometricAugmentationBase2D):
 
     def forward(
         self,
-        input: TensorWithTransMat,
+        input: TensorWithTransformMat,
         params: Optional[Dict[str, torch.Tensor]] = None,
         return_transform: Optional[bool] = None,
-    ) -> TensorWithTransMat:
+    ) -> TensorWithTransformMat:
         if isinstance(input, (tuple, list)):
             input_temp = _transform_input(input[0])
             input_pad = self.compute_padding(input[0].shape)
@@ -1903,7 +1903,7 @@ class RandomInvert(IntensityAugmentationBase2D):
 
     def __init__(
         self,
-        max_val: torch.Tensor = torch.tensor(1.0),
+        max_val: Union[float, torch.Tensor] = torch.tensor(1.0),
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -1911,6 +1911,7 @@ class RandomInvert(IntensityAugmentationBase2D):
         super(RandomInvert, self).__init__(
             p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0
         )
+        self.max_val = max_val
 
     def __repr__(self) -> str:
         return self.__class__.__name__ + f"({super().__repr__()})"
@@ -1918,7 +1919,7 @@ class RandomInvert(IntensityAugmentationBase2D):
     def apply_transform(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], transform: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
-        return invert(input)
+        return invert(input, torch.as_tensor(self.max_val, device=input.device, dtype=input.dtype))
 
 
 class RandomChannelShuffle(IntensityAugmentationBase2D):

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -4,7 +4,7 @@ from typing import cast, Dict, List, Optional, Tuple, Union
 import torch
 from torch.nn.functional import pad
 
-from kornia.augmentation.base import GeometricAugmentationBase2D, IntensityAugmentationBase2D
+from kornia.augmentation.base import GeometricAugmentationBase2D, IntensityAugmentationBase2D, TensorWithTransMat
 from kornia.color import rgb_to_grayscale
 from kornia.constants import BorderType, pi, Resample, SamplePadding
 from kornia.enhance import (
@@ -1119,7 +1119,7 @@ class RandomCrop(GeometricAugmentationBase2D):
 
     def inverse(
         self,
-        input: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        input: TensorWithTransMat,
         params: Optional[Dict[str, torch.Tensor]] = None,
         size: Optional[Tuple[int, int]] = None,
         **kwargs,
@@ -1136,10 +1136,10 @@ class RandomCrop(GeometricAugmentationBase2D):
 
     def forward(
         self,
-        input: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        input: TensorWithTransMat,
         params: Optional[Dict[str, torch.Tensor]] = None,
         return_transform: Optional[bool] = None,
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    ) -> TensorWithTransMat:
         if isinstance(input, (tuple, list)):
             input_temp = _transform_input(input[0])
             input_pad = self.compute_padding(input[0].shape)

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -1869,11 +1869,24 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
 
 
 class GaussianBlur(RandomGaussianBlur):
-    warnings.warn(
-        "GaussianBlur is no longer maintained and will be removed from the future versions. "
-        "Please use RandomGaussianBlur instead.",
-        category=DeprecationWarning,
-    )
+    def __init__(
+        self,
+        kernel_size: Tuple[int, int],
+        sigma: Tuple[float, float],
+        border_type: str = 'reflect',
+        return_transform: bool = False,
+        same_on_batch: bool = False,
+        p: float = 0.5,
+    ) -> None:
+        super(RandomGaussianBlur, self).__init__(
+            kernel_size=kernel_size, sigma=sigma, border_type=border_type, return_transform=return_transform,
+            same_on_batch=same_on_batch, p=p
+        )
+        warnings.warn(
+            "GaussianBlur is no longer maintained and will be removed from the future versions. "
+            "Please use RandomGaussianBlur instead.",
+            category=DeprecationWarning,
+        )
 
 
 class RandomInvert(IntensityAugmentationBase2D):

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -1878,7 +1878,7 @@ class GaussianBlur(RandomGaussianBlur):
         same_on_batch: bool = False,
         p: float = 0.5,
     ) -> None:
-        super(RandomGaussianBlur, self).__init__(
+        super(GaussianBlur, self).__init__(
             kernel_size=kernel_size, sigma=sigma, border_type=border_type, return_transform=return_transform,
             same_on_batch=same_on_batch, p=p
         )

--- a/kornia/augmentation/augmentation3d.py
+++ b/kornia/augmentation/augmentation3d.py
@@ -19,7 +19,7 @@ from kornia.geometry.transform.affwarp import _compute_rotation_matrix3d, _compu
 from kornia.utils import _extract_device_dtype
 
 from . import random_generator as rg
-from .base import AugmentationBase3D, TensorWithTransMat
+from .base import AugmentationBase3D, TensorWithTransformMat
 from .utils import _range_bound, _singular_range_check, _tuple_range_reader
 
 
@@ -900,10 +900,10 @@ class RandomCrop3D(AugmentationBase3D):
 
     def forward(  # type: ignore
         self,
-        input: TensorWithTransMat,
+        input: TensorWithTransformMat,
         params: Optional[Dict[str, torch.Tensor]] = None,
         return_transform: Optional[bool] = None,
-    ) -> TensorWithTransMat:
+    ) -> TensorWithTransformMat:
         if type(input) is tuple:
             input = (self.precrop_padding(input[0]), input[1])
         else:

--- a/kornia/augmentation/augmentation3d.py
+++ b/kornia/augmentation/augmentation3d.py
@@ -19,7 +19,7 @@ from kornia.geometry.transform.affwarp import _compute_rotation_matrix3d, _compu
 from kornia.utils import _extract_device_dtype
 
 from . import random_generator as rg
-from .base import AugmentationBase3D
+from .base import AugmentationBase3D, TensorWithTransMat
 from .utils import _range_bound, _singular_range_check, _tuple_range_reader
 
 
@@ -900,10 +900,10 @@ class RandomCrop3D(AugmentationBase3D):
 
     def forward(  # type: ignore
         self,
-        input: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        input: TensorWithTransMat,
         params: Optional[Dict[str, torch.Tensor]] = None,
         return_transform: Optional[bool] = None,
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    ) -> TensorWithTransMat:
         if type(input) is tuple:
             input = (self.precrop_padding(input[0]), input[1])
         else:

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -112,9 +112,7 @@ class _BasicAugmentationBase(nn.Module):
         _params['batch_prob'] = to_apply
         return _params
 
-    def apply_func(
-        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
-    ) -> TensorWithTransMat:
+    def apply_func(self, input: torch.Tensor, params: Dict[str, torch.Tensor]) -> TensorWithTransMat:
         input = self.transform_tensor(input)
         return self.apply_transform(input, params)
 
@@ -509,8 +507,10 @@ class MixAugmentationBase(_BasicAugmentationBase):
         return output, label
 
     def forward(  # type: ignore
-        self, input: TensorWithTransMat, label: Optional[torch.Tensor] = None,
-        params: Optional[Dict[str, torch.Tensor]] = None
+        self,
+        input: TensorWithTransMat,
+        label: Optional[torch.Tensor] = None,
+        params: Optional[Dict[str, torch.Tensor]] = None,
     ) -> Tuple[TensorWithTransMat, torch.Tensor]:
         in_tensor, in_trans = self.__unpack_input__(input)
         ori_shape = in_tensor.shape

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -104,7 +104,7 @@ class _BasicAugmentationBase(nn.Module):
             batch_prob = batch_prob.repeat(batch_shape[0])
         return batch_prob
 
-    def forward_parameters(self, batch_shape):
+    def forward_parameters(self, batch_shape) -> Dict[str, torch.Tensor]:
         to_apply = self.__batch_prob_generator__(batch_shape, self.p, self.p_batch, self.same_on_batch)
         _params = self.generate_parameters(torch.Size((int(to_apply.sum().item()), *batch_shape[1:])))
         if _params is None:

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -517,7 +517,11 @@ class MixAugmentationBase(_BasicAugmentationBase):
         in_tensor = self.transform_tensor(in_tensor)
         # If label is not provided, it would output the indices instead.
         if label is None:
-            label = torch.arange(0, in_tensor.size(0))
+            if isinstance(input, (tuple, list)):
+                device = input[0].device
+            else:
+                device = input.device
+            label = torch.arange(0, in_tensor.size(0), device=device, dtype=torch.long)
         if params is None:
             batch_shape = in_tensor.shape
             params = self.forward_parameters(batch_shape)

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -509,11 +509,15 @@ class MixAugmentationBase(_BasicAugmentationBase):
         return output, label
 
     def forward(  # type: ignore
-        self, input: TensorWithTransMat, label: torch.Tensor, params: Optional[Dict[str, torch.Tensor]] = None
+        self, input: TensorWithTransMat, label: Optional[torch.Tensor] = None,
+        params: Optional[Dict[str, torch.Tensor]] = None
     ) -> Tuple[TensorWithTransMat, torch.Tensor]:
         in_tensor, in_trans = self.__unpack_input__(input)
         ori_shape = in_tensor.shape
         in_tensor = self.transform_tensor(in_tensor)
+        # If label is not provided, it would output the indices instead.
+        if label is None:
+            label = torch.arange(0, in_tensor.size(0))
         if params is None:
             batch_shape = in_tensor.shape
             params = self.forward_parameters(batch_shape)

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -324,7 +324,7 @@ class AugmentationSequential(ImageSequential):
         self.clear_state()
         outputs = []
         named_modules = list(self.get_forward_sequence(params))
-        self.return_label = self.get_mix_augmentation_indices(iter(named_modules))
+        self.return_label = len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
 
         for input, dcate in zip(args, data_keys):
             # use the parameter if the first round has been finished.

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -6,11 +6,11 @@ import torch
 import torch.nn as nn
 
 from kornia.augmentation.base import (
-    MixAugmentationBase,
-    TensorWithTransMat,
     _AugmentationBase,
     GeometricAugmentationBase2D,
-    IntensityAugmentationBase2D
+    IntensityAugmentationBase2D,
+    MixAugmentationBase,
+    TensorWithTransMat,
 )
 from kornia.constants import DataKey
 from kornia.geometry.bbox import transform_bbox
@@ -292,8 +292,10 @@ class AugmentationSequential(ImageSequential):
     def __packup_output__(  # type: ignore
         self, output: List[TensorWithTransMat], label: Optional[torch.Tensor] = None
     ) -> Union[
-        TensorWithTransMat, Tuple[TensorWithTransMat, Optional[torch.Tensor]],
-        List[TensorWithTransMat], Tuple[List[TensorWithTransMat], Optional[torch.Tensor]]
+        TensorWithTransMat,
+        Tuple[TensorWithTransMat, Optional[torch.Tensor]],
+        List[TensorWithTransMat],
+        Tuple[List[TensorWithTransMat], Optional[torch.Tensor]],
     ]:
         if len(output) == 1 and self.has_mix_augmentation:
             return output[0], label
@@ -311,8 +313,10 @@ class AugmentationSequential(ImageSequential):
         params: Optional[List[ParamItem]] = None,
         data_keys: Optional[List[Union[str, int, DataKey]]] = None,
     ) -> Union[
-        TensorWithTransMat, Tuple[TensorWithTransMat, Optional[torch.Tensor]],
-        List[TensorWithTransMat], Tuple[List[TensorWithTransMat], Optional[torch.Tensor]]
+        TensorWithTransMat,
+        Tuple[TensorWithTransMat, Optional[torch.Tensor]],
+        List[TensorWithTransMat],
+        Tuple[List[TensorWithTransMat], Optional[torch.Tensor]],
     ]:
         """Compute multiple tensors simultaneously according to ``self.data_keys``."""
         if data_keys is None:

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -295,12 +295,11 @@ class AugmentationSequential(ImageSequential):
     ]:
         if len(output) == 1 and self.return_label:
             return output[0], label
-        elif len(output) == 1:
+        if len(output) == 1:
             return output[0]
-        elif self.return_label:
+        if self.return_label:
             return output, label
-        else:
-            return output
+        return output
 
     def forward(  # type: ignore
         self,

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -339,9 +339,9 @@ class AugmentationSequential(ImageSequential):
             params = self._params if params is None or len(params) == 0 else params
             for param, (name, module) in zip_longest(params, named_modules):
                 if dcate == DataKey.INPUT:
-                    input, label = self.apply_to_input(input, label, name, module, param)
+                    input, label = self.apply_to_input(input, label, str(name), module, param)
                 elif isinstance(module, GeometricAugmentationBase2D) and dcate in DataKey:
-                    input, label = self.apply_by_key(input, label, name, module, param, dcate)
+                    input, label = self.apply_by_key(input, label, str(name), module, param, dcate)
                 elif isinstance(module, IntensityAugmentationBase2D) and dcate in DataKey:
                     pass  # Do nothing
                 elif isinstance(module, PatchSequential) and module.is_intensity_only() and dcate in DataKey:

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -288,9 +288,12 @@ class AugmentationSequential(ImageSequential):
 
         return outputs
 
-    def __packup_output__(
-        self, output: TensorWithTransMat, label: Optional[torch.Tensor] = None
-    ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
+    def __packup_output__(  # type: ignore
+        self, output: List[TensorWithTransMat], label: Optional[torch.Tensor] = None
+    ) -> Union[
+        TensorWithTransMat, Tuple[TensorWithTransMat, Optional[torch.Tensor]],
+        List[TensorWithTransMat], Tuple[List[TensorWithTransMat], Optional[torch.Tensor]]
+    ]:
         if len(output) == 1 and self.has_mix_augmentations:
             return output[0], label
         elif len(output) == 1:
@@ -318,8 +321,8 @@ class AugmentationSequential(ImageSequential):
             data_keys
         ), f"The number of inputs must align with the number of data_keys. Got {len(args)} and {len(data_keys)}."
 
+        self.clear_state()
         outputs = []
-        self._params = []
         named_modules = list(self.get_forward_sequence(params))
         for input, dcate in zip(args, data_keys):
             # use the parameter if the first round has been finished.

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -9,7 +9,6 @@ from kornia.augmentation.base import (
     _AugmentationBase,
     GeometricAugmentationBase2D,
     IntensityAugmentationBase2D,
-    MixAugmentationBase,
     TensorWithTransformMat,
 )
 from kornia.constants import DataKey
@@ -48,12 +47,9 @@ class AugmentationSequential(ImageSequential):
             If True, the whole list of args will be processed as a sequence in a random order.
             If False, the whole list of args will be processed as a sequence in original order.
 
-    Return:
-        the tensor (, and the transformation matrix) has been sequentially modified by the args.
-
     Note:
         Mix augmentations (e.g. RandomMixUp, RandomCutMix) can only be working with "input" data key.
-        It is not clear how to deal with the conversions of the other data keys.
+        It is not clear how to deal with the conversions of masks, bounding boxes and keypoints.
 
     Examples:
         >>> import kornia
@@ -324,7 +320,7 @@ class AugmentationSequential(ImageSequential):
         self.clear_state()
         outputs = []
         named_modules = list(self.get_forward_sequence(params))
-        self.return_label = len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
+        self.return_label = label is not None or len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
 
         for input, dcate in zip(args, data_keys):
             # use the parameter if the first round has been finished.

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -4,7 +4,6 @@ from itertools import zip_longest
 from typing import cast, Dict, List, Optional, Tuple, Union
 
 import torch
-from torch.autograd.grad_mode import F
 import torch.nn as nn
 
 from kornia.augmentation.base import (
@@ -164,8 +163,7 @@ class AugmentationSequential(ImageSequential):
         dcate: Union[str, int, DataKey] = DataKey.INPUT,
     ) -> Tuple[TensorWithTransformMat, Optional[torch.Tensor]]:
         if module is None:
-            # TODO (jian): double check why typing is crashing
-            module = self.get_submodule(param.name)  # type: ignore
+            module = self.get_submodule(param.name)
         if DataKey.get(dcate) in [DataKey.INPUT]:
             return self.apply_to_input(input, label, module=module, param=param)
         if DataKey.get(dcate) in [DataKey.MASK]:
@@ -294,7 +292,7 @@ class AugmentationSequential(ImageSequential):
     ]:
         if len(output) == 1 and isinstance(output, (tuple, list,)) and self.return_label:
             return output[0], label
-        if len(output) == 1 and isinstance(output, (tuple, list,)) :
+        if len(output) == 1 and isinstance(output, (tuple, list,)):
             return output[0]
         if self.return_label:
             return output, label

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -1,4 +1,3 @@
-from kornia.augmentation.container.base import SequentialBase
 import warnings
 from itertools import zip_longest
 from typing import cast, Dict, List, Optional, Tuple, Union
@@ -12,6 +11,7 @@ from kornia.augmentation.base import (
     IntensityAugmentationBase2D,
     TensorWithTransformMat,
 )
+from kornia.augmentation.container.base import SequentialBase
 from kornia.constants import DataKey
 from kornia.geometry.bbox import transform_bbox
 from kornia.geometry.linalg import transform_points
@@ -184,23 +184,18 @@ class AugmentationSequential(ImageSequential):
             return self.apply_to_keypoints(input, module, param), None
         raise NotImplementedError(f"input type of {dcate} is not implemented.")
 
-    def inverse_input(
-        self, input: torch.Tensor, module: nn.Module, param: Optional[ParamItem] = None
-    ) -> torch.Tensor:
+    def inverse_input(self, input: torch.Tensor, module: nn.Module, param: Optional[ParamItem] = None) -> torch.Tensor:
         if isinstance(module, GeometricAugmentationBase2D):
             input = module.inverse(input, None if param is None else cast(Dict, param.data))
         return input
 
     def inverse_bbox(
-        self,
-        input: torch.Tensor,
-        module: nn.Module,
-        param: Optional[ParamItem] = None,
-        mode: str = "xyxy",
+        self, input: torch.Tensor, module: nn.Module, param: Optional[ParamItem] = None, mode: str = "xyxy"
     ) -> torch.Tensor:
         if isinstance(module, GeometricAugmentationBase2D):
             transform = module.compute_inverse_transformation(
-                module.get_transformation_matrix(input, None if param is None else cast(Dict, param.data)))
+                module.get_transformation_matrix(input, None if param is None else cast(Dict, param.data))
+            )
             input = transform_bbox(torch.as_tensor(transform, device=input.device, dtype=input.dtype), input, mode)
         return input
 
@@ -209,7 +204,8 @@ class AugmentationSequential(ImageSequential):
     ) -> torch.Tensor:
         if isinstance(module, GeometricAugmentationBase2D):
             transform = module.compute_inverse_transformation(
-                module.get_transformation_matrix(input, None if param is None else cast(Dict, param.data)))
+                module.get_transformation_matrix(input, None if param is None else cast(Dict, param.data))
+            )
             input = transform_points(torch.as_tensor(transform, device=input.device, dtype=input.dtype), input)
         return input
 
@@ -277,7 +273,7 @@ class AugmentationSequential(ImageSequential):
                     raise NotImplementedError(f"data_key {dcate} is not implemented for {module}.")
             outputs.append(input)
 
-        if len(outputs) == 1 and isinstance(outputs, (tuple, list,)):
+        if len(outputs) == 1 and isinstance(outputs, (tuple, list)):
             return outputs[0]
 
         return outputs
@@ -290,9 +286,9 @@ class AugmentationSequential(ImageSequential):
         List[TensorWithTransformMat],
         Tuple[List[TensorWithTransformMat], Optional[torch.Tensor]],
     ]:
-        if len(output) == 1 and isinstance(output, (tuple, list,)) and self.return_label:
+        if len(output) == 1 and isinstance(output, (tuple, list)) and self.return_label:
             return output[0], label
-        if len(output) == 1 and isinstance(output, (tuple, list,)):
+        if len(output) == 1 and isinstance(output, (tuple, list)):
             return output[0]
         if self.return_label:
             return output, label
@@ -323,7 +319,7 @@ class AugmentationSequential(ImageSequential):
         if params is None:
             if DataKey.INPUT in data_keys:
                 _input = args[data_keys.index(DataKey.INPUT)]
-                if isinstance(_input, (tuple, list,)):
+                if isinstance(_input, (tuple, list)):
                     params = self.forward_parameters(_input[0].shape)
                 else:
                     params = self.forward_parameters(_input.shape)

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -52,6 +52,46 @@ class SequentialBase(nn.Sequential):
                 if return_transform is not None:
                     mod.return_transform = return_transform
 
+    def get_submodule(self, target: str) -> nn.Module:
+        """Get submodule.
+
+        This code is taken from torch 1.9.0 since it is not introduced
+        back to torch 1.7.1. We included this for maintaining more
+        backward torch versions.
+
+        Args:
+            target: The fully-qualified string name of the submodule
+                to look for. (See above example for how to specify a
+                fully-qualified string.)
+
+        Returns:
+            torch.nn.Module: The submodule referenced by ``target``
+
+        Raises:
+            AttributeError: If the target string references an invalid
+                path or resolves to something that is not an
+                ``nn.Module``
+        """
+        if target == "":
+            return self
+
+        atoms: List[str] = target.split(".")
+        mod: torch.nn.Module = self
+
+        for item in atoms:
+
+            if not hasattr(mod, item):
+                raise AttributeError(mod._get_name() + " has no "
+                                     "attribute `" + item + "`")
+
+            mod = getattr(mod, item)
+
+            if not isinstance(mod, torch.nn.Module):
+                raise AttributeError("`" + item + "` is not "
+                                     "an nn.Module")
+
+        return mod
+
     @property
     def same_on_batch(self) -> Optional[bool]:
         return self._same_on_batch

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -15,6 +15,17 @@ class ParamItem(NamedTuple):
 
 
 class SequentialBase(nn.Sequential):
+    r"""SequentialBase for creating kornia modulized processing pipeline.
+
+    Args:
+        *args : a list of kornia augmentation and image operation modules.
+        same_on_batch: apply the same transformation across the batch.
+            If None, it will not overwrite the function-wise settings.
+        return_transform: if ``True`` return the matrix describing the transformation
+            applied to each. If None, it will not overwrite the function-wise settings.
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+            to the batch form (False). If None, it will not overwrite the function-wise settings.
+    """
     def __init__(
         self,
         *args: nn.Module,
@@ -121,6 +132,10 @@ class SequentialBase(nn.Sequential):
 
     def clear_state(self) -> None:
         self._params = []
+
+    # TODO: Implement this for all submodules.
+    def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
+        raise NotImplementedError
 
     def get_children_by_indices(self, indices: torch.Tensor) -> Iterator[Tuple[str, nn.Module]]:
         modules = list(self.named_children())

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -1,0 +1,101 @@
+from typing import Iterator, Optional, Union, Tuple, NamedTuple, List, Any
+from collections import OrderedDict
+
+import torch
+import torch.nn as nn
+
+from kornia.augmentation.base import MixAugmentationBase, _AugmentationBase
+
+__all__ = [
+    "SequentialBase",
+    "ParamItem",
+]
+
+
+class ParamItem(NamedTuple):
+    name: str
+    data: Optional[Union[dict, list]]
+
+
+class SequentialBase(nn.Sequential):
+    def __init__(
+        self,
+        *args: nn.Module,
+        same_on_batch: Optional[bool] = None,
+        return_transform: Optional[bool] = None,
+        keepdim: Optional[bool] = None,
+    ) -> None:
+        # To name the modules properly
+        _args = OrderedDict()
+        for idx, mod in enumerate(args):
+            if not isinstance(mod, nn.Module):
+                raise NotImplementedError(f"Only nn.Module are supported at this moment. Got {mod}.")
+            _args.update({f"{mod.__class__.__name__}_{idx}": mod})
+        super().__init__(_args)
+        self._same_on_batch = same_on_batch
+        self._return_transform = return_transform
+        self._keepdim = keepdim
+        self._params: List[Any] = []
+        self.update_attribute(same_on_batch, return_transform, keepdim)
+
+    def update_attribute(
+        self,
+        same_on_batch: Optional[bool] = None,
+        return_transform: Optional[bool] = None,
+        keepdim: Optional[bool] = None,
+    ) -> None:
+        for mod in self.children():
+            # MixAugmentation does not have return transform
+            if isinstance(mod, _AugmentationBase) or isinstance(mod, MixAugmentationBase):
+                if same_on_batch is not None:
+                    mod.same_on_batch = same_on_batch
+                if keepdim is not None:
+                    mod.keepdim = keepdim
+            if isinstance(mod, _AugmentationBase):
+                if return_transform is not None:
+                    mod.return_transform = return_transform
+
+    @property
+    def same_on_batch(self) -> Optional[bool]:
+        return self._same_on_batch
+
+    @same_on_batch.setter
+    def same_on_batch(self, same_on_batch: Optional[bool]) -> None:
+        self._same_on_batch = same_on_batch
+        self.update_attribute(same_on_batch=same_on_batch)
+
+    @property
+    def return_transform(self) -> Optional[bool]:
+        return self._return_transform
+
+    @return_transform.setter
+    def return_transform(self, return_transform: Optional[bool]) -> None:
+        self._return_transform = return_transform
+        self.update_attribute(return_transform=return_transform)
+
+    @property
+    def keepdim(self) -> Optional[bool]:
+        return self._keepdim
+
+    @keepdim.setter
+    def keepdim(self, keepdim: Optional[bool]) -> None:
+        self._keepdim = keepdim
+        self.update_attribute(keepdim=keepdim)
+
+    def clear_state(self) -> None:
+        self._params = []
+
+    def get_children_by_indices(self, indices: torch.Tensor) -> Iterator[Tuple[str, nn.Module]]:
+        modules = list(self.named_children())
+        for idx in indices:
+            yield modules[idx]
+
+    def get_children_by_params(self, params: List[ParamItem]) -> Iterator[Tuple[str, nn.Module]]:
+        modules = list(self.named_children())
+        for param in params:
+            yield modules[list(dict(self.named_children()).keys()).index(param.name)]
+
+    def get_params_by_module(self, named_modules: Iterator[Tuple[str, nn.Module]]) -> Iterator[ParamItem]:
+        # This will not take module._params
+        for name, _ in named_modules:
+            yield ParamItem(name, None)

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -44,7 +44,7 @@ class SequentialBase(nn.Sequential):
         self._same_on_batch = same_on_batch
         self._return_transform = return_transform
         self._keepdim = keepdim
-        self._params: List[Any] = []
+        self._params: Optional[List[Any]] = None
         self.update_attribute(same_on_batch, return_transform, keepdim)
 
     def update_attribute(
@@ -130,7 +130,13 @@ class SequentialBase(nn.Sequential):
         self.update_attribute(keepdim=keepdim)
 
     def clear_state(self) -> None:
-        self._params = []
+        self._params = None
+
+    def update_params(self, param: Any) -> None:
+        if self._params is None:
+            self._params = [param]
+        else:
+            self._params.append(param)
 
     # TODO: Implement this for all submodules.
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
@@ -150,3 +156,6 @@ class SequentialBase(nn.Sequential):
         # This will not take module._params
         for name, _ in named_modules:
             yield ParamItem(name, None)
+
+    def contains_label_operations(self, params: List) -> bool:
+        raise NotImplementedError

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -1,15 +1,12 @@
-from typing import Iterator, Optional, Union, Tuple, NamedTuple, List, Any
 from collections import OrderedDict
+from typing import Any, Iterator, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
-from kornia.augmentation.base import MixAugmentationBase, _AugmentationBase
+from kornia.augmentation.base import _AugmentationBase, MixAugmentationBase
 
-__all__ = [
-    "SequentialBase",
-    "ParamItem",
-]
+__all__ = ["SequentialBase", "ParamItem"]
 
 
 class ParamItem(NamedTuple):

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -26,6 +26,7 @@ class SequentialBase(nn.Sequential):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
             to the batch form (False). If None, it will not overwrite the function-wise settings.
     """
+
     def __init__(
         self,
         *args: nn.Module,
@@ -54,7 +55,7 @@ class SequentialBase(nn.Sequential):
     ) -> None:
         for mod in self.children():
             # MixAugmentation does not have return transform
-            if isinstance(mod, (_AugmentationBase, MixAugmentationBase,)):
+            if isinstance(mod, (_AugmentationBase, MixAugmentationBase)):
                 if same_on_batch is not None:
                     mod.same_on_batch = same_on_batch
                 if keepdim is not None:
@@ -92,14 +93,12 @@ class SequentialBase(nn.Sequential):
         for item in atoms:
 
             if not hasattr(mod, item):
-                raise AttributeError(mod._get_name() + " has no "
-                                     "attribute `" + item + "`")
+                raise AttributeError(mod._get_name() + " has no " "attribute `" + item + "`")
 
             mod = getattr(mod, item)
 
             if not isinstance(mod, torch.nn.Module):
-                raise AttributeError("`" + item + "` is not "
-                                     "an nn.Module")
+                raise AttributeError("`" + item + "` is not " "an nn.Module")
 
         return mod
 

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -43,7 +43,7 @@ class SequentialBase(nn.Sequential):
     ) -> None:
         for mod in self.children():
             # MixAugmentation does not have return transform
-            if isinstance(mod, _AugmentationBase) or isinstance(mod, MixAugmentationBase):
+            if isinstance(mod, (_AugmentationBase, MixAugmentationBase,)):
                 if same_on_batch is not None:
                     mod.same_on_batch = same_on_batch
                 if keepdim is not None:

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -31,9 +31,9 @@ class ImageSequential(SequentialBase):
             If True, the whole list of args will be processed as a sequence in a random order.
             If False, the whole list of args will be processed as a sequence in original order.
 
-    Returns:
-        TensorWithTransformMat: the tensor (, and the transformation matrix)
-            has been sequentially modified by the args.
+    Note:
+        Transformation matrix returned only considers the transformation applied in ``kornia.augmentation`` module.
+        Those transformations in ``kornia.geometry`` will not be taken into account.
 
     Examples:
         >>> _ = torch.manual_seed(77)
@@ -61,10 +61,6 @@ class ImageSequential(SequentialBase):
         >>> out2, lab2 = aug_list(input, label=label, params=aug_list._params)
         >>> torch.equal(out[0], out2[0]), torch.equal(out[1], out2[1]), torch.equal(lab[1], lab2[1])
         (True, True, True)
-
-    Note:
-        Transformation matrix returned only considers the transformation applied in ``kornia.augmentation`` module.
-        Those transformations in ``kornia.geometry`` will not be taken into account.
     """
 
     def __init__(
@@ -212,7 +208,7 @@ class ImageSequential(SequentialBase):
         named_modules = list(self.get_forward_sequence(params))
         if params is None:
             params = list(self.get_params_by_module(iter(named_modules)))
-        self.return_label = len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
+        self.return_label = label is not None or len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
         for (_, module), param in zip_longest(named_modules, params):
             input, label = self.apply_to_input(input, label, module=module, param=param)
         return self.__packup_output__(input, label)

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -212,15 +212,14 @@ class ImageSequential(SequentialBase):
     ) -> Union[TensorWithTransformMat, Tuple[TensorWithTransformMat, torch.Tensor]]:
         self.clear_state()
         if params is None:
-            if isinstance(input, (tuple, list,)):
+            if isinstance(input, (tuple, list)):
                 params = self.forward_parameters(input[0].shape)
             else:
                 params = self.forward_parameters(input.shape)
         self.return_label = label is not None or self.contains_label_operations(params)
         for param in params:
             module = self.get_submodule(param.name)
-            input, label = self.apply_to_input(  # type: ignore
-                input, label, module, param=param)
+            input, label = self.apply_to_input(input, label, module, param=param)  # type: ignore
             if isinstance(module, (_AugmentationBase, MixAugmentationBase, SequentialBase)):
                 param = ParamItem(param.name, module._params)
             else:

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -1,5 +1,3 @@
-from itertools import zip_longest
-from sys import modules
 from typing import Iterator, List, Optional, Tuple, Union
 
 import torch

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -134,29 +134,29 @@ class ImageSequential(nn.Sequential):
                     arg.keepdim = keepdim
 
     @property
-    def same_on_batch(self):
+    def same_on_batch(self) -> None:
         return self._same_on_batch
 
     @property
-    def return_transform(self):
+    def return_transform(self) -> None:
         return self._return_transform
 
     @property
-    def keepdim(self):
+    def keepdim(self) -> None:
         return self._keepdim
 
     @same_on_batch.setter
-    def same_on_batch(self, same_on_batch: Optional[bool]):
+    def same_on_batch(self, same_on_batch: Optional[bool]) -> None:
         self._same_on_batch = same_on_batch
         self.update_attribute(same_on_batch=same_on_batch)
 
     @return_transform.setter
-    def return_transform(self, return_transform: Optional[bool]):
+    def return_transform(self, return_transform: Optional[bool]) -> None:
         self._return_transform = return_transform
         self.update_attribute(return_transform=return_transform)
 
     @keepdim.setter
-    def keepdim(self, keepdim: Optional[bool]):
+    def keepdim(self, keepdim: Optional[bool]) -> None:
         self._keepdim = keepdim
         self.update_attribute(keepdim=keepdim)
 

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -4,8 +4,9 @@ from typing import Iterator, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 
-from .base import SequentialBase, ParamItem
 from kornia.augmentation.base import _AugmentationBase, MixAugmentationBase, TensorWithTransformMat
+
+from .base import ParamItem, SequentialBase
 
 __all__ = ["ImageSequential"]
 
@@ -75,7 +76,8 @@ class ImageSequential(SequentialBase):
         random_apply: Union[int, bool, Tuple[int, int]] = False,
     ) -> None:
         super(ImageSequential, self).__init__(
-            *args, same_on_batch=same_on_batch, return_transform=return_transform, keepdim=keepdim)
+            *args, same_on_batch=same_on_batch, return_transform=return_transform, keepdim=keepdim
+        )
 
         self.random_apply: Union[Tuple[int, int], bool] = self._read_random_apply(random_apply, len(args))
 
@@ -159,11 +161,7 @@ class ImageSequential(SequentialBase):
         return named_modules
 
     def _apply_operation(
-        self,
-        input: TensorWithTransformMat,
-        label: Optional[torch.Tensor],
-        module: nn.Module,
-        param: ParamItem,
+        self, input: TensorWithTransformMat, label: Optional[torch.Tensor], module: nn.Module, param: ParamItem
     ) -> Tuple[TensorWithTransformMat, Optional[torch.Tensor], ParamItem]:
         if isinstance(module, (MixAugmentationBase,)):
             input, label = module(input, label, params=param.data)
@@ -172,8 +170,7 @@ class ImageSequential(SequentialBase):
             input = module(input, params=param.data)
             out_param = ParamItem(param.name, module._params)
         else:
-            assert param.data is None, \
-                f"Non-augmentaion operation {param.name} require empty parameters. Got {param}."
+            assert param.data is None, f"Non-augmentaion operation {param.name} require empty parameters. Got {param}."
             # In case of return_transform = True
             if isinstance(input, (tuple, list)):
                 input = (module(input[0]), input[1])
@@ -206,8 +203,10 @@ class ImageSequential(SequentialBase):
         return output
 
     def forward(  # type: ignore
-        self, input: TensorWithTransformMat, label: Optional[torch.Tensor] = None,
-        params: Optional[List[ParamItem]] = None
+        self,
+        input: TensorWithTransformMat,
+        label: Optional[torch.Tensor] = None,
+        params: Optional[List[ParamItem]] = None,
     ) -> Union[TensorWithTransformMat, Tuple[TensorWithTransformMat, torch.Tensor]]:
         self.clear_state()
         named_modules = list(self.get_forward_sequence(params))

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -13,8 +13,8 @@ __all__ = ["ImageSequential"]
 
 class ParamItem(NamedTuple):
     name: str
-    data: Union[dict, list]
-
+    data: Optional[Union[dict, list]
+]
 
 # TODO: Add forward_parameters for ImageSequential
 class ImageSequential(nn.Sequential):

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -1,23 +1,17 @@
-import warnings
-from collections import OrderedDict
 from itertools import zip_longest
-from typing import Any, Iterator, List, NamedTuple, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
-from kornia.augmentation.base import _AugmentationBase, MixAugmentationBase, TensorWithTransMat
+from .base import SequentialBase, ParamItem
+from kornia.augmentation.base import _AugmentationBase, MixAugmentationBase, TensorWithTransformMat
 
 __all__ = ["ImageSequential"]
 
 
-class ParamItem(NamedTuple):
-    name: str
-    data: Optional[Union[dict, list]]
-
-
 # TODO: Add forward_parameters for ImageSequential
-class ImageSequential(nn.Sequential):
+class ImageSequential(SequentialBase):
     r"""Sequential for creating kornia image processing pipeline.
 
     Args:
@@ -37,7 +31,7 @@ class ImageSequential(nn.Sequential):
             If False, the whole list of args will be processed as a sequence in original order.
 
     Returns:
-        TensorWithTransMat: the tensor (, and the transformation matrix)
+        TensorWithTransformMat: the tensor (, and the transformation matrix)
             has been sequentially modified by the args.
 
     Examples:
@@ -79,122 +73,45 @@ class ImageSequential(nn.Sequential):
         return_transform: Optional[bool] = None,
         keepdim: Optional[bool] = None,
         random_apply: Union[int, bool, Tuple[int, int]] = False,
-        validate_args: bool = True,
     ) -> None:
-        self._same_on_batch = same_on_batch
-        self._return_transform = return_transform
-        self._keepdim = keepdim
-        # To name the modules properly
-        _args = OrderedDict()
-        for idx, arg in enumerate(args):
-            if not isinstance(arg, nn.Module):
-                raise NotImplementedError(f"Only nn.Module are supported at this moment. Got {arg}.")
-            _args.update({f"{arg.__class__.__name__}_{idx}": arg})
-        super(ImageSequential, self).__init__(_args)
-        self.update_attribute(same_on_batch, return_transform, keepdim)
+        super(ImageSequential, self).__init__(
+            *args, same_on_batch=same_on_batch, return_transform=return_transform, keepdim=keepdim)
 
-        self._params: List[Any] = []
-        self.random_apply: Union[Tuple[int, int], bool]
-        if random_apply:
-            if isinstance(random_apply, (bool,)) and random_apply is True:
-                self.random_apply = (len(args), len(args) + 1)
-            elif isinstance(random_apply, (int,)):
-                self.random_apply = (random_apply, random_apply + 1)
-            elif (
-                isinstance(random_apply, (tuple,))
-                and len(random_apply) == 2
-                and isinstance(random_apply[0], (int,))
-                and isinstance(random_apply[1], (int,))
-            ):
-                self.random_apply = (random_apply[0], random_apply[1] + 1)
-            elif isinstance(random_apply, (tuple,)) and len(random_apply) == 1 and isinstance(random_apply[0], (int,)):
-                self.random_apply = (random_apply[0], len(args) + 1)
-            else:
-                raise ValueError(f"Non-readable random_apply. Got {random_apply}.")
-            assert (
-                isinstance(self.random_apply, (tuple,))
-                and len(self.random_apply) == 2
-                and isinstance(self.random_apply[0], (int,))
-                and isinstance(self.random_apply[0], (int,))
-            ), f"Expect a tuple of (int, int). Got {self.random_apply}."
+        self.random_apply: Union[Tuple[int, int], bool] = self._read_random_apply(random_apply, len(args))
+
+    def _read_random_apply(
+        self, random_apply: Union[int, bool, Tuple[int, int]], max_length: int
+    ) -> Union[Tuple[int, int], bool]:
+        if isinstance(random_apply, (bool,)) and random_apply is False:
+            random_apply = False
+        elif isinstance(random_apply, (bool,)) and random_apply is True:
+            random_apply = (max_length, max_length + 1)
+        elif isinstance(random_apply, (int,)):
+            random_apply = (random_apply, random_apply + 1)
+        elif (
+            isinstance(random_apply, (tuple,))
+            and len(random_apply) == 2
+            and isinstance(random_apply[0], (int,))
+            and isinstance(random_apply[1], (int,))
+        ):
+            random_apply = (random_apply[0], random_apply[1] + 1)
+        elif isinstance(random_apply, (tuple,)) and len(random_apply) == 1 and isinstance(random_apply[0], (int,)):
+            random_apply = (random_apply[0], max_length + 1)
         else:
-            self.random_apply = False
-        self._validate_mix_augmentation(*args, validate_args=validate_args)
-        self.has_mix_augmentation = len(self.__get_mix_indices__(iter(args))) > 0
+            raise ValueError(f"Non-readable random_apply. Got {random_apply}.")
+        assert (
+            isinstance(random_apply, (tuple,))
+            and len(random_apply) == 2
+            and isinstance(random_apply[0], (int,))
+            and isinstance(random_apply[0], (int,))
+        ), f"Expect a tuple of (int, int). Got {random_apply}."
+        return random_apply
 
-    def update_attribute(
-        self,
-        same_on_batch: Optional[bool] = None,
-        return_transform: Optional[bool] = None,
-        keepdim: Optional[bool] = None,
-    ) -> None:
-        for arg in self.children():
-            if isinstance(arg, _AugmentationBase):
-                if same_on_batch is not None:
-                    arg.same_on_batch = same_on_batch
-                if return_transform is not None:
-                    arg.return_transform = return_transform
-                if keepdim is not None:
-                    arg.keepdim = keepdim
-
-    @property
-    def same_on_batch(self) -> Optional[bool]:
-        return self._same_on_batch
-
-    @same_on_batch.setter
-    def same_on_batch(self, same_on_batch: Optional[bool]) -> None:
-        self._same_on_batch = same_on_batch
-        self.update_attribute(same_on_batch=same_on_batch)
-
-    @property
-    def return_transform(self) -> Optional[bool]:
-        return self._return_transform
-
-    @return_transform.setter
-    def return_transform(self, return_transform: Optional[bool]) -> None:
-        self._return_transform = return_transform
-        self.update_attribute(return_transform=return_transform)
-
-    @property
-    def keepdim(self) -> Optional[bool]:
-        return self._keepdim
-
-    @keepdim.setter
-    def keepdim(self, keepdim: Optional[bool]) -> None:
-        self._keepdim = keepdim
-        self.update_attribute(keepdim=keepdim)
-
-    def clear_state(self) -> None:
-        self._params = []
-
-    def _validate_mix_augmentation(self, *args: nn.Module, validate_args: bool = True):
-        mix_count = 0
-        for arg in args:
-            if isinstance(arg, (MixAugmentationBase,)):
-                mix_count += 1
-        if self.random_apply is False and mix_count > 1 and validate_args:
-            raise ValueError(
-                f"Multiple mix augmentation is prohibited without enabling random_apply. Detected {mix_count}."
-            )
-        if mix_count > 1 and validate_args:
-            warnings.warn(
-                f"Multiple ({mix_count}) mix augmentation detected and at most one mix augmenation can"
-                "be applied at each forward. To silence this warning, please set `validate_args` to False.",
-                category=UserWarning,
-            )
-
-    def __get_mix_indices__(self, args: Iterator) -> List[int]:
-        mix_indices = []
-        for i, child in enumerate(args):
-            if isinstance(child, (MixAugmentationBase,)):
-                mix_indices.append(i)
-        return mix_indices
-
-    def __sample_forward_indices__(self, with_mix: bool = True) -> Tuple[Iterator[Tuple[str, nn.Module]], bool]:
+    def get_random_forward_sequence(self, with_mix: bool = True) -> Tuple[Iterator[Tuple[str, nn.Module]], bool]:
         num_samples = int(torch.randint(*self.random_apply, (1,)).item())  # type: ignore
         multinomial_weights = torch.ones((len(self),))
         # Mix augmentation can only be applied once per forward
-        mix_indices = self.__get_mix_indices__(self.children())
+        mix_indices = self.get_mix_augmentation_indices(self.named_children())
         # kick out the mix augmentations
         multinomial_weights[mix_indices] = 0
         indices = torch.multinomial(
@@ -212,114 +129,97 @@ class ImageSequential(nn.Sequential):
                 indices = indices[torch.randperm(len(indices))]
                 mix_added = True
 
-        return self._get_children_by_indices(indices), mix_added
+        return self.get_children_by_indices(indices), mix_added
 
-    def _get_child_sequence(self) -> Iterator[Tuple[str, nn.Module]]:
-        # Mix augmentation can only be applied once per forward
-        mix_indices = self.__get_mix_indices__(self.children())
-
-        if self.random_apply:
-            return self.__sample_forward_indices__()[0]
-
-        if len(mix_indices) > 1:
-            raise ValueError(
-                "Multiple mix augmentation is prohibited without enabling random_apply." f"Detected {len(mix_indices)}."
-            )
-
-        return self.named_children()
-
-    def contains_mix_augmentation(self, params: List[ParamItem]) -> bool:
-        for param in params:
-            if param.name.startswith("RandomMixUP") or param.name.startswith("RandomCutMix"):
-                return True
-        return False
-
-    def _get_children_by_indices(self, indices: torch.Tensor) -> Iterator[Tuple[str, nn.Module]]:
-        modules = list(self.named_children())
-        for idx in indices:
-            yield modules[idx]
-
-    def _get_children_by_module_names(self, names: List[str]) -> Iterator[Tuple[str, nn.Module]]:
-        modules = list(self.named_children())
-        for name in names:
-            yield modules[list(dict(self.named_children()).keys()).index(name)]
+    def get_mix_augmentation_indices(self, named_modules: Iterator[Tuple[str, nn.Module]]) -> List[int]:
+        indices = []
+        for idx, (_, child) in enumerate(named_modules):
+            if isinstance(child, (MixAugmentationBase,)):
+                indices.append(idx)
+        return indices
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
         if params is None:
-            named_modules = self._get_child_sequence()
+            # Mix augmentation can only be applied once per forward
+            mix_indices = self.get_mix_augmentation_indices(self.named_children())
+
+            if self.random_apply:
+                return self.get_random_forward_sequence()[0]
+
+            if len(mix_indices) > 1:
+                raise ValueError(
+                    "Multiple mix augmentation is prohibited without enabling random_apply."
+                    f"Detected {len(mix_indices)}."
+                )
+
+            return self.named_children()
         else:
-            named_modules = self._get_children_by_module_names([p.name for p in params])
+            named_modules = self.get_children_by_params(params)
         return named_modules
 
     def _apply_operation(
         self,
-        input: TensorWithTransMat,
+        input: TensorWithTransformMat,
         label: Optional[torch.Tensor],
-        module_name: str,
         module: nn.Module,
-        param: Optional[Union[dict, list]],
-    ) -> Tuple[TensorWithTransMat, Optional[torch.Tensor], ParamItem]:
+        param: ParamItem,
+    ) -> Tuple[TensorWithTransformMat, Optional[torch.Tensor], ParamItem]:
         if isinstance(module, (MixAugmentationBase,)) and param is None:
             input, label = module(input, label)
-            out_param = ParamItem(module_name, module._params)
+            out_param = ParamItem(param.name, module._params)
         elif isinstance(module, (MixAugmentationBase,)) and param is not None:
             input, label = module(input, label, params=param)
-            out_param = ParamItem(module_name, param)
+            out_param = ParamItem(param.name, param.data)
         elif isinstance(module, (_AugmentationBase, ImageSequential)) and param is None:
             input = module(input)
-            out_param = ParamItem(module_name, module._params)
+            out_param = ParamItem(param.name, module._params)
         elif isinstance(module, (_AugmentationBase, ImageSequential)) and param is not None:
             input = module(input, params=param)
-            out_param = ParamItem(module_name, param)
+            out_param = ParamItem(param.name, param.data)
         else:
             assert (
                 param == {} or param is None
-            ), f"Non-augmentaion operation {module_name} require empty parameters. Got {param}."
+            ), f"Non-augmentaion operation {param.name} require empty parameters. Got {param}."
             # In case of return_transform = True
             if isinstance(input, (tuple, list)):
                 input = (module(input[0]), input[1])
             else:
                 input = module(input)
-            out_param = ParamItem(module_name, {})
+            out_param = ParamItem(param.name, None)
         return input, label, out_param
 
     def apply_to_input(
         self,
-        input: TensorWithTransMat,
+        input: TensorWithTransformMat,
         label: Optional[torch.Tensor],
-        module_name: str,
-        module: Optional[nn.Module] = None,
-        param: Optional[ParamItem] = None,
-    ) -> Tuple[TensorWithTransMat, Optional[torch.Tensor]]:
+        module: Optional[nn.Module],
+        param: ParamItem,
+    ) -> Tuple[TensorWithTransformMat, Optional[torch.Tensor]]:
         if module is None:
-            # TODO (jian): double check why typing is crashing
-            module = self.get_submodule(module_name)  # type: ignore
-        if param is not None:
-            assert module_name == param.name
-            _param = param.data
-        else:
-            _param = None  # type: ignore
+            module = self.get_submodule(param.name)
 
-        input, label, out_param = self._apply_operation(input, label, module_name, module, _param)
+        input, label, out_param = self._apply_operation(input, label, module, param)
         self._params.append(out_param)
 
         return input, label
 
     def __packup_output__(
-        self, output: TensorWithTransMat, label: Optional[torch.Tensor] = None
-    ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
-        if self.has_mix_augmentation:
+        self, output: TensorWithTransformMat, label: Optional[torch.Tensor] = None
+    ) -> Union[TensorWithTransformMat, Tuple[TensorWithTransformMat, torch.Tensor]]:
+        if self.return_label:
             return output, label  # type: ignore
             # Implicitly indicating the label cannot be optional since there is a mix aug
         return output
 
     def forward(  # type: ignore
-        self, input: TensorWithTransMat, label: Optional[torch.Tensor] = None, params: Optional[List[ParamItem]] = None
-    ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
+        self, input: TensorWithTransformMat, label: Optional[torch.Tensor] = None,
+        params: Optional[List[ParamItem]] = None
+    ) -> Union[TensorWithTransformMat, Tuple[TensorWithTransformMat, torch.Tensor]]:
         self.clear_state()
         named_modules = self.get_forward_sequence(params)
-        params = [] if params is None else params
-        self.has_mix_augmentation = self.contains_mix_augmentation(params)
-        for (name, module), param in zip_longest(named_modules, [] if params is None else params):
-            input, label = self.apply_to_input(input, label, name, module, param=param)
+        if params is None:
+            params = list(self.get_params_by_module(named_modules))
+        self.return_label = self.get_mix_augmentation_indices(named_modules)
+        for (_, module), param in zip_longest(named_modules, params):
+            input, label = self.apply_to_input(input, label, module=module, param=param)
         return self.__packup_output__(input, label)

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -80,6 +80,7 @@ class ImageSequential(SequentialBase):
         )
 
         self.random_apply: Union[Tuple[int, int], bool] = self._read_random_apply(random_apply, len(args))
+        self.return_label: Optional[bool] = None
 
     def _read_random_apply(
         self, random_apply: Union[int, bool, Tuple[int, int]], max_length: int
@@ -156,9 +157,8 @@ class ImageSequential(SequentialBase):
                 )
 
             return self.named_children()
-        else:
-            named_modules = self.get_children_by_params(params)
-        return named_modules
+
+        return self.get_children_by_params(params)
 
     def _apply_operation(
         self, input: TensorWithTransformMat, label: Optional[torch.Tensor], module: nn.Module, param: ParamItem

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -120,9 +120,10 @@ class ImageSequential(nn.Sequential):
         else:
             self.random_apply = False
         self.has_mix_augmentations = self._validate_mix_augmentation(*args, validate_args=validate_args)
-    
+
     def update_attribute(
-        self, same_on_batch: Optional[bool] = None, return_transform: Optional[bool] = None, keepdim: Optional[bool] = None
+        self, same_on_batch: Optional[bool] = None, return_transform: Optional[bool] = None,
+        keepdim: Optional[bool] = None
     ) -> None:
         for arg in self.children():
             if isinstance(arg, _AugmentationBase):
@@ -134,26 +135,26 @@ class ImageSequential(nn.Sequential):
                     arg.keepdim = keepdim
 
     @property
-    def same_on_batch(self) -> None:
+    def same_on_batch(self) -> Optional[bool]:
         return self._same_on_batch
-
-    @property
-    def return_transform(self) -> None:
-        return self._return_transform
-
-    @property
-    def keepdim(self) -> None:
-        return self._keepdim
 
     @same_on_batch.setter
     def same_on_batch(self, same_on_batch: Optional[bool]) -> None:
         self._same_on_batch = same_on_batch
         self.update_attribute(same_on_batch=same_on_batch)
 
+    @property
+    def return_transform(self) -> Optional[bool]:
+        return self._return_transform
+
     @return_transform.setter
     def return_transform(self, return_transform: Optional[bool]) -> None:
         self._return_transform = return_transform
         self.update_attribute(return_transform=return_transform)
+
+    @property
+    def keepdim(self) -> Optional[bool]:
+        return self._keepdim
 
     @keepdim.setter
     def keepdim(self, keepdim: Optional[bool]) -> None:
@@ -300,7 +301,6 @@ class ImageSequential(nn.Sequential):
     ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
         self.clear_state()
         named_modules = self.get_forward_sequence(params)
-        params = [] if params is None else params
-        for (name, module), param in zip_longest(named_modules, params):
+        for (name, module), param in zip_longest(named_modules, [] if params is None else params):
             input, label = self.apply_to_input(input, label, name, module, param=param)
         return self.__packup_output__(input, label)

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -126,6 +126,9 @@ class ImageSequential(nn.Sequential):
             self.random_apply = False
         self.has_mix_augmentations = self._validate_mix_augmentation(*args, validate_args=validate_args)
 
+    def clear_state(self) -> None:
+        self._params = []
+
     def _validate_mix_augmentation(self, *args: nn.Module, validate_args: bool = True) -> bool:
         mix_count = 0
         for arg in args:
@@ -241,7 +244,7 @@ class ImageSequential(nn.Sequential):
         self, output: TensorWithTransMat, label: Optional[torch.Tensor] = None
     ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
         if self.has_mix_augmentations:
-            return output, label
+            return output, label  # type: ignore
         return output
 
     def forward(  # type: ignore
@@ -250,7 +253,7 @@ class ImageSequential(nn.Sequential):
         label: Optional[torch.Tensor] = None,
         params: Optional[List[ParamItem]] = None,
     ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
-        self._params = []
+        self.clear_state()
         named_modules = self.get_forward_sequence(params)
         params = [] if params is None else params
         for (name, module), param in zip_longest(named_modules, params):

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -1,12 +1,12 @@
+import warnings
 from collections import OrderedDict
 from itertools import zip_longest
 from typing import Any, Iterator, List, NamedTuple, Optional, Tuple, Union
-import warnings
 
 import torch
 import torch.nn as nn
 
-from kornia.augmentation.base import MixAugmentationBase, TensorWithTransMat, _AugmentationBase
+from kornia.augmentation.base import _AugmentationBase, MixAugmentationBase, TensorWithTransMat
 
 __all__ = ["ImageSequential"]
 
@@ -123,8 +123,10 @@ class ImageSequential(nn.Sequential):
         self.has_mix_augmentation = len(self.__get_mix_indices__(iter(args))) > 0
 
     def update_attribute(
-        self, same_on_batch: Optional[bool] = None, return_transform: Optional[bool] = None,
-        keepdim: Optional[bool] = None
+        self,
+        same_on_batch: Optional[bool] = None,
+        return_transform: Optional[bool] = None,
+        keepdim: Optional[bool] = None,
     ) -> None:
         for arg in self.children():
             if isinstance(arg, _AugmentationBase):
@@ -172,12 +174,13 @@ class ImageSequential(nn.Sequential):
                 mix_count += 1
         if self.random_apply is False and mix_count > 1 and validate_args:
             raise ValueError(
-                f"Multiple mix augmentation is prohibited without enabling random_apply. Detected {mix_count}.")
+                f"Multiple mix augmentation is prohibited without enabling random_apply. Detected {mix_count}."
+            )
         if mix_count > 1 and validate_args:
             warnings.warn(
                 f"Multiple ({mix_count}) mix augmentation detected and at most one mix augmenation can"
                 "be applied at each forward. To silence this warning, please set `validate_args` to False.",
-                category=UserWarning
+                category=UserWarning,
             )
 
     def __get_mix_indices__(self, args: Iterator) -> List[int]:
@@ -195,9 +198,10 @@ class ImageSequential(nn.Sequential):
         # kick out the mix augmentations
         multinomial_weights[mix_indices] = 0
         indices = torch.multinomial(
-            multinomial_weights, num_samples,
+            multinomial_weights,
+            num_samples,
             # enable replacement if non-mix augmentation is less than required
-            replacement=True if num_samples > multinomial_weights.sum() else False
+            replacement=True if num_samples > multinomial_weights.sum() else False,
         )
 
         mix_added = False
@@ -219,8 +223,7 @@ class ImageSequential(nn.Sequential):
 
         if len(mix_indices) > 1:
             raise ValueError(
-                "Multiple mix augmentation is prohibited without enabling random_apply."
-                f"Detected {len(mix_indices)}."
+                "Multiple mix augmentation is prohibited without enabling random_apply." f"Detected {len(mix_indices)}."
             )
 
         return self.named_children()
@@ -297,8 +300,7 @@ class ImageSequential(nn.Sequential):
         else:
             _param = None  # type: ignore
 
-        input, label, out_param = self._apply_operation(
-            input, label, module_name, module, _param)
+        input, label, out_param = self._apply_operation(input, label, module_name, module, _param)
         self._params.append(out_param)
 
         return input, label
@@ -312,10 +314,7 @@ class ImageSequential(nn.Sequential):
         return output
 
     def forward(  # type: ignore
-        self,
-        input: TensorWithTransMat,
-        label: Optional[torch.Tensor] = None,
-        params: Optional[List[ParamItem]] = None,
+        self, input: TensorWithTransMat, label: Optional[torch.Tensor] = None, params: Optional[List[ParamItem]] = None
     ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
         self.clear_state()
         named_modules = self.get_forward_sequence(params)

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -52,8 +52,8 @@ class ImageSequential(SequentialBase):
         ... )
         >>> out, lab = aug_list(input, label=label)
         >>> lab
-        tensor([[0.0000, 0.0000, 0.2746],
-                [1.0000, 1.0000, 0.1576]])
+        tensor([[0.0000, 1.0000, 0.1214],
+                [1.0000, 0.0000, 0.1214]])
         >>> out[0].shape, out[1].shape
         (torch.Size([2, 3, 5, 6]), torch.Size([2, 3, 3]))
 
@@ -212,7 +212,7 @@ class ImageSequential(SequentialBase):
         named_modules = list(self.get_forward_sequence(params))
         if params is None:
             params = list(self.get_params_by_module(iter(named_modules)))
-        self.return_label = self.get_mix_augmentation_indices(iter(named_modules))
+        self.return_label = len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
         for (_, module), param in zip_longest(named_modules, params):
             input, label = self.apply_to_input(input, label, module=module, param=param)
         return self.__packup_output__(input, label)

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -1,13 +1,10 @@
-from typing import Iterator, List, Optional, Tuple, Union, NamedTuple
 from itertools import cycle, islice
+from typing import Iterator, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
-from kornia.augmentation.base import (
-    TensorWithTransMat,
-    IntensityAugmentationBase2D
-)
+from kornia.augmentation.base import IntensityAugmentationBase2D, TensorWithTransMat
 from kornia.contrib.extract_patches import extract_tensor_patches
 
 from .image import ImageSequential, ParamItem
@@ -239,8 +236,7 @@ class PatchSequential(ImageSequential):
         else:
             params = self.get_parameter_sequence(batch_shape[1])
             indices = torch.arange(0, batch_shape[0] * batch_shape[1], step=batch_shape[1])
-            [out_param.append(PatchParamItem((indices + i).numpy().tolist(), p))  # type: ignore
-                for p, i in params]
+            [out_param.append(PatchParamItem((indices + i).numpy().tolist(), p)) for p, i in params]  # type: ignore
             # "append" of "list" does not return a value
         return out_param
 
@@ -285,7 +281,8 @@ class PatchSequential(ImageSequential):
             _label = label
 
         output, out_label, out_param = self._apply_operation(
-            _input, _label, params.param.name, self.get_submodule(params.param.name), params.param.data)
+            _input, _label, params.param.name, self.get_submodule(params.param.name), params.param.data
+        )
 
         if isinstance(output, (tuple,)) and isinstance(input, (tuple,)):
             input[0][params.indices] = output[0]
@@ -318,10 +315,7 @@ class PatchSequential(ImageSequential):
         return input, label, PatchParamItem(params.indices, param=out_param)
 
     def forward_by_params(
-        self,
-        input: torch.Tensor,
-        label: Optional[torch.Tensor],
-        params: List[PatchParamItem],
+        self, input: torch.Tensor, label: Optional[torch.Tensor], params: List[PatchParamItem]
     ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, Optional[torch.Tensor]]]:
         p = []
         _input: TensorWithTransMat
@@ -342,10 +336,7 @@ class PatchSequential(ImageSequential):
         return _input, label
 
     def forward(  # type: ignore
-        self,
-        input: torch.Tensor,
-        label: Optional[torch.Tensor] = None,
-        params: Optional[List[PatchParamItem]] = None,
+        self, input: torch.Tensor, label: Optional[torch.Tensor] = None, params: Optional[List[PatchParamItem]] = None
     ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
         """Input transformation will be returned if input is a tuple."""
         self.clear_state()

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 
 from kornia.augmentation.augmentation import ColorJitter
-from kornia.augmentation.base import _AugmentationBase, IntensityAugmentationBase2D
+from kornia.augmentation.base import TensorWithTransMat, _AugmentationBase, IntensityAugmentationBase2D
 from kornia.contrib.extract_patches import extract_tensor_patches
 
 from .image import ImageSequential, ParamItem
@@ -42,7 +42,8 @@ class PatchSequential(ImageSequential):
             If ``False``, the whole list of args will be processed in original order.
 
     Return:
-        the tensor (, and the transformation matrix) has been sequentially modified by the args.
+        List[TensorWithTransMat]: the tensor (, and the transformation matrix)
+            has been sequentially modified by the args.
 
     Examples:
         >>> import kornia.augmentation as K
@@ -279,9 +280,10 @@ class PatchSequential(ImageSequential):
 
     def forward(  # type: ignore
         self,
-        input: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        input: TensorWithTransMat,
+        label: Optional[torch.Tensor] = None,
         params: Optional[Union[List[ParamItem], List[List[ParamItem]]]] = None,
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:  # NOTE: return_transform is always False here.
+    ) -> Union[TensorWithTransMat, Tuple[TensorWithTransMat, torch.Tensor]]:
         """Input transformation will be returned if input is a tuple."""
         # BCHW -> B(patch)CHW
         if isinstance(input, (tuple,)):

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -97,7 +97,8 @@ class PatchSequential(ImageSequential):
         elif patchwise_apply and random_apply is False:
             assert len(args) == grid_size[0] * grid_size[1], (
                 "The number of processing modules must be equal with grid size."
-                f"Got {len(args)} and {grid_size[0] * grid_size[1]}. Or set random_apply = True."
+                f"Got {len(args)} and {grid_size[0] * grid_size[1]}. "
+                "Please set random_apply = True or patchwise_apply = False."
             )
             _random_apply = random_apply
         elif patchwise_apply and isinstance(random_apply, (int, tuple)):
@@ -157,7 +158,7 @@ class PatchSequential(ImageSequential):
 
         Example:
             >>> import kornia.augmentation as K
-            >>> pas = PatchSequential(K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0))
+            >>> pas = PatchSequential(K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), patchwise_apply=False)
             >>> pas.extract_patches(torch.arange(16).view(1, 1, 4, 4), grid_size=(2, 2))
             tensor([[[[[ 0,  1],
                        [ 4,  5]]],
@@ -203,7 +204,7 @@ class PatchSequential(ImageSequential):
 
         Example:
             >>> import kornia.augmentation as K
-            >>> pas = PatchSequential(K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0))
+            >>> pas = PatchSequential(K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), patchwise_apply=False)
             >>> out = pas.extract_patches(torch.arange(16).view(1, 1, 4, 4), grid_size=(2, 2))
             >>> pas.restore_from_patches(out, grid_size=(2, 2))
             tensor([[[[ 0,  1,  2,  3],
@@ -298,17 +299,21 @@ class PatchSequential(ImageSequential):
         _label = None
         if label is not None and out_label is not None:
             if len(out_label.shape) == 1:
-                _label = torch.ones((in_shape[0] * in_shape[1],)) * -1
+                _label = torch.ones(
+                    (in_shape[0] * in_shape[1],), device=out_label.device, out_label=label.dtype) * -1
                 _label = label
             else:
-                _label = torch.ones((in_shape[0], *out_label.shape[1:])) * -1
+                _label = torch.ones(
+                    (in_shape[0], *out_label.shape[1:]), device=out_label.device, dtype=out_label.dtype) * -1
                 _label[:, 0] = label
             label[params.indices] = out_label
         elif label is None and out_label is not None:
             if len(out_label.shape) == 1:
-                _label = torch.ones((in_shape[0] * in_shape[1],)) * -1
+                _label = torch.ones(
+                    (in_shape[0] * in_shape[1],), device=out_label.device, dtype=out_label.dtype) * -1
             else:
-                _label = torch.ones((in_shape[0], *out_label.shape[1:])) * -1
+                _label = torch.ones(
+                    (in_shape[0], *out_label.shape[1:]), device=out_label.device, dtype=out_label.dtype) * -1
             _label[params.indices] = out_label
 
         return input, label, PatchParamItem(params.indices, param=out_param)

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -47,8 +47,9 @@ class PatchSequential(ImageSequential):
             If ``False`` and ``patchwise_apply``, the whole list of args will be processed in original order
             location-wisely.
 
-    Return:
-        the tensor (, and the transformation matrix) has been sequentially modified by the args.
+    Note:
+        Transformation matrix returned only considers the transformation applied in ``kornia.augmentation`` module.
+        Those transformations in ``kornia.geometry`` will not be taken into account.
 
     Examples:
         >>> import kornia.augmentation as K
@@ -300,20 +301,20 @@ class PatchSequential(ImageSequential):
         if label is not None and out_label is not None:
             if len(out_label.shape) == 1:
                 _label = torch.ones(
-                    (in_shape[0] * in_shape[1],), device=out_label.device, out_label=label.dtype) * -1
+                    in_shape[0] * in_shape[1], device=out_label.device, out_label=label.dtype) * -1
                 _label = label
             else:
                 _label = torch.ones(
-                    (in_shape[0], *out_label.shape[1:]), device=out_label.device, dtype=out_label.dtype) * -1
+                    in_shape[0], *out_label.shape[1:], device=out_label.device, dtype=out_label.dtype) * -1
                 _label[:, 0] = label
             label[params.indices] = out_label
         elif label is None and out_label is not None:
             if len(out_label.shape) == 1:
                 _label = torch.ones(
-                    (in_shape[0] * in_shape[1],), device=out_label.device, dtype=out_label.dtype) * -1
+                    in_shape[0] * in_shape[1], device=out_label.device, dtype=out_label.dtype) * -1
             else:
                 _label = torch.ones(
-                    (in_shape[0], *out_label.shape[1:]), device=out_label.device, dtype=out_label.dtype) * -1
+                    in_shape[0], *out_label.shape[1:], device=out_label.device, dtype=out_label.dtype) * -1
             _label[params.indices] = out_label
 
         return input, label, PatchParamItem(params.indices, param=out_param)
@@ -354,7 +355,7 @@ class PatchSequential(ImageSequential):
         if params is None:
             params = self.forward_parameters(input.shape)
 
-        self.return_label = self.contains_mix_augmentation(params)
+        self.return_label = label is not None or self.contains_mix_augmentation(params)
 
         _input, label = self.forward_by_params(input, label, params)
 

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -346,7 +346,7 @@ class PatchSequential(ImageSequential):
         self.clear_state()
         # BCHW -> B(patch)CHW
         if isinstance(input, (tuple,)):
-            raise ValueError(f"tuple input is not currently supported.")
+            raise ValueError("tuple input is not currently supported.")
         _input: TensorWithTransformMat
 
         pad = self.compute_padding(input, self.padding)

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -349,7 +349,7 @@ class PatchSequential(ImageSequential):
         if params is None:
             params = self.forward_parameters(input.shape)
 
-        self.has_mix_augmentation = self.contains_mix_augmentation(params)
+        self.return_label = self.contains_mix_augmentation(params)
 
         _input, label = self.forward_by_params(input, label, params)
 

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -300,21 +300,21 @@ class PatchSequential(ImageSequential):
         _label = None
         if label is not None and out_label is not None:
             if len(out_label.shape) == 1:
-                _label = torch.ones(
-                    in_shape[0] * in_shape[1], device=out_label.device, out_label=label.dtype) * -1
+                _label = torch.ones(in_shape[0] * in_shape[1], device=out_label.device, out_label=label.dtype) * -1
                 _label = label
             else:
-                _label = torch.ones(
-                    in_shape[0], *out_label.shape[1:], device=out_label.device, dtype=out_label.dtype) * -1
+                _label = (
+                    torch.ones(in_shape[0], *out_label.shape[1:], device=out_label.device, dtype=out_label.dtype) * -1
+                )
                 _label[:, 0] = label
             label[params.indices] = out_label
         elif label is None and out_label is not None:
             if len(out_label.shape) == 1:
-                _label = torch.ones(
-                    in_shape[0] * in_shape[1], device=out_label.device, dtype=out_label.dtype) * -1
+                _label = torch.ones(in_shape[0] * in_shape[1], device=out_label.device, dtype=out_label.dtype) * -1
             else:
-                _label = torch.ones(
-                    in_shape[0], *out_label.shape[1:], device=out_label.device, dtype=out_label.dtype) * -1
+                _label = (
+                    torch.ones(in_shape[0], *out_label.shape[1:], device=out_label.device, dtype=out_label.dtype) * -1
+                )
             _label[params.indices] = out_label
 
         return input, label, PatchParamItem(params.indices, param=out_param)

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 
 import kornia
-from kornia.augmentation.base import MixAugmentationBase, TensorWithTransMat, _AugmentationBase
+from kornia.augmentation.base import _AugmentationBase, MixAugmentationBase, TensorWithTransMat
 
 from .image import ImageSequential, ParamItem
 

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 
 import kornia
-from kornia.augmentation.base import _AugmentationBase
+from kornia.augmentation.base import TensorWithTransMat, _AugmentationBase
 
 from .image import ImageSequential, ParamItem
 
@@ -126,7 +126,7 @@ class VideoSequential(ImageSequential):
 
     def forward(  # type: ignore
         self, input: torch.Tensor, params: Optional[List[ParamItem]] = None
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    ) -> TensorWithTransMat:
         """Define the video computation performed."""
         assert len(input.shape) == 5, f"Input must be a 5-dim tensor. Got {input.shape}."
         self._params = []

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -1,6 +1,5 @@
 from itertools import zip_longest
 from typing import cast, List, Optional, Tuple, Union
-from kornia.color import lab
 
 import torch
 import torch.nn as nn
@@ -13,7 +12,6 @@ from .image import ImageSequential, ParamItem
 __all__ = ["VideoSequential"]
 
 
-# TODO: Rewrite this to support inverse operation by having a generic AugmentationSequential.
 class VideoSequential(ImageSequential):
     r"""VideoSequential for processing 5-dim video data like (B, T, C, H, W) and (B, C, T, H, W).
 
@@ -151,15 +149,9 @@ class VideoSequential(ImageSequential):
         self.clear_state()
 
         named_modules = self.get_forward_sequence(params)
-        if params is not None:
-            self.has_mix_augmentation = self.contains_mix_augmentation(params)
-        else:
-            self.has_mix_augmentation = False
-            for name, child in enumerate(named_modules):
-                if isinstance(child, (MixAugmentationBase,)):
-                    self.has_mix_augmentation = True
-                    break
+
         params = [] if params is None else params
+        self.has_mix_augmentation = self.contains_mix_augmentation(params)
 
         # Size of T
         frame_num = input.size(self._temporal_channel)

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -148,10 +148,10 @@ class VideoSequential(ImageSequential):
         assert len(input.shape) == 5, f"Input must be a 5-dim tensor. Got {input.shape}."
         self.clear_state()
 
-        named_modules = self.get_forward_sequence(params)
+        named_modules = list(self.get_forward_sequence(params))
         if params is None:
-            params = list(self.get_params_by_module(named_modules))
-        self.return_label = self.get_mix_augmentation_indices(named_modules)
+            params = list(self.get_params_by_module(iter(named_modules)))
+        self.return_label = self.get_mix_augmentation_indices(iter(named_modules))
 
         # Size of T
         frame_num = input.size(self._temporal_channel)
@@ -163,7 +163,7 @@ class VideoSequential(ImageSequential):
             batch_shape = input.shape
 
         for (name, module), param in zip_longest(named_modules, params):
-            if param is None and isinstance(module, (_AugmentationBase, MixAugmentationBase)):
+            if param.data is None and isinstance(module, (_AugmentationBase, MixAugmentationBase)):
                 mod_param = module.forward_parameters(batch_shape)
                 if self.same_on_frame:
                     for k, v in mod_param.items():
@@ -172,7 +172,7 @@ class VideoSequential(ImageSequential):
                             mod_param.update({k: self.__repeat_param_across_channels__(v, frame_num)})
                 param = ParamItem(name, mod_param)
 
-            input, label = self.apply_to_input(input, label, name, module, param=param)  # type: ignore
+            input, label = self.apply_to_input(input, label, module, param=param)  # type: ignore
 
         if isinstance(input, (tuple, list)):
             input[0], label = self._input_shape_convert_back(input[0], label, frame_num)

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -1,4 +1,3 @@
-from kornia.augmentation.container.base import SequentialBase
 from typing import cast, List, Optional, Tuple, Union
 
 import torch
@@ -6,6 +5,7 @@ import torch.nn as nn
 
 import kornia
 from kornia.augmentation.base import _AugmentationBase, MixAugmentationBase, TensorWithTransformMat
+from kornia.augmentation.container.base import SequentialBase
 
 from .image import ImageSequential, ParamItem
 
@@ -164,7 +164,7 @@ class VideoSequential(ImageSequential):
                 if self.same_on_frame:
                     raise ValueError("Sequential is currently unsupported for ``same_on_frame``.")
                 param = ParamItem(name, seq_param)
-            elif isinstance(module, (_AugmentationBase, MixAugmentationBase,)):
+            elif isinstance(module, (_AugmentationBase, MixAugmentationBase)):
                 mod_param = module.forward_parameters(batch_shape)
                 if self.same_on_frame:
                     for k, v in mod_param.items():

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -31,6 +31,10 @@ class VideoSequential(ImageSequential):
             If (a, b), x number of transformations (a <= x <= b) will be selected.
             If None, the whole list of args will be processed as a sequence.
 
+    Note:
+        Transformation matrix returned only considers the transformation applied in ``kornia.augmentation`` module.
+        Those transformations in ``kornia.geometry`` will not be taken into account.
+
     Example:
         If set `same_on_frame` to True, we would expect the same augmentation has been applied to each
         timeframe.
@@ -154,7 +158,7 @@ class VideoSequential(ImageSequential):
         named_modules = list(self.get_forward_sequence(params))
         if params is None:
             params = list(self.get_params_by_module(iter(named_modules)))
-        self.return_label = len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
+        self.return_label = label is not None or len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
 
         # Size of T
         frame_num = input.size(self._temporal_channel)

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -151,6 +151,14 @@ class VideoSequential(ImageSequential):
         self.clear_state()
 
         named_modules = self.get_forward_sequence(params)
+        if params is not None:
+            self.has_mix_augmentation = self.contains_mix_augmentation(params)
+        else:
+            self.has_mix_augmentation = False
+            for name, child in enumerate(named_modules):
+                if isinstance(child, (MixAugmentationBase,)):
+                    self.has_mix_augmentation = True
+                    break
         params = [] if params is None else params
 
         # Size of T

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -154,7 +154,7 @@ class VideoSequential(ImageSequential):
         named_modules = list(self.get_forward_sequence(params))
         if params is None:
             params = list(self.get_params_by_module(iter(named_modules)))
-        self.return_label = self.get_mix_augmentation_indices(iter(named_modules))
+        self.return_label = len(self.get_mix_augmentation_indices(iter(named_modules))) > 0
 
         # Size of T
         frame_num = input.size(self._temporal_channel)

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -61,7 +61,7 @@ class VideoSequential(ImageSequential):
         ...     kornia.augmentation.RandomMixUp(p=1.0),
         ... data_format="BCTHW",
         ... same_on_frame=False)
-        >>> output, lab = aug_list(input, label)
+        >>> output, lab = aug_list(input)
         >>> output.shape, lab.shape
         (torch.Size([2, 3, 4, 5, 6]), torch.Size([2, 4, 3]))
         >>> (output[0, :, 0] == output[0, :, 1]).all()

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -117,14 +117,17 @@ class VideoSequential(ImageSequential):
         if self.data_format == "BTCHW":
             pass
 
-        if label is not None and label.shape == input.shape[:2]:
-            # if label is provided as (B, T)
-            label = label.view(-1)
-        elif label is not None and label.shape == input.shape[:1]:
-            label = label[..., None].repeat(1, frame_num).view(-1)
-        elif label is not None and torch.Size([input.shape[0] * input.shape[1]]):
-            # Skip the conversion if label is provided as (B * T,)
-            pass
+        if label is not None:
+            if label.shape == input.shape[:2]:
+                # if label is provided as (B, T)
+                label = label.view(-1)
+            elif label.shape == input.shape[:1]:
+                label = label[..., None].repeat(1, frame_num).view(-1)
+            elif label.shape == torch.Size([input.shape[0] * input.shape[1]]):
+                # Skip the conversion if label is provided as (B * T,)
+                pass
+            else:
+                raise NotImplementedError(f"Invalid label shape of {label.shape}.")
         input = input.reshape(-1, *input.shape[2:])
         return input, label
 

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -1,4 +1,3 @@
-from itertools import zip_longest
 from kornia.augmentation.container.base import SequentialBase
 from typing import cast, List, Optional, Tuple, Union
 

--- a/kornia/augmentation/mix_augmentation.py
+++ b/kornia/augmentation/mix_augmentation.py
@@ -104,7 +104,7 @@ class RandomMixUp(MixAugmentationBase):
         return rg.random_mixup_generator(batch_shape[0], self.p, lambda_val, same_on_batch=self.same_on_batch)
 
     def apply_transform(  # type: ignore
-        self, input: torch.Tensor, label: torch.Tensor, params: Dict[str, torch.Tensor]  # type: ignore
+        self, input: torch.Tensor, label: torch.Tensor, params: Dict[str, torch.Tensor]
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         input_permute = input.index_select(dim=0, index=params['mixup_pairs'].to(input.device))
         labels_permute = label.index_select(dim=0, index=params['mixup_pairs'].to(label.device))

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -94,7 +94,7 @@ class TestVideoSequential:
         if data_format == 'BCTHW':
             input = torch.randn(2, 3, 1, 5, 6, device=device, dtype=dtype).repeat(1, 1, 4, 1, 1)
             output = aug_list(input)
-            if aug_list.has_mix_augmentation:
+            if aug_list.return_label:
                 output, label = output
             assert (output[:, :, 0] == output[:, :, 1]).all()
             assert (output[:, :, 1] == output[:, :, 2]).all()
@@ -102,7 +102,7 @@ class TestVideoSequential:
         if data_format == 'BTCHW':
             input = torch.randn(2, 1, 3, 5, 6, device=device, dtype=dtype).repeat(1, 4, 1, 1, 1)
             output = aug_list(input)
-            if aug_list.has_mix_augmentation:
+            if aug_list.return_label:
                 output, label = output
             assert (output[:, 0] == output[:, 1]).all()
             assert (output[:, 1] == output[:, 2]).all()
@@ -160,7 +160,7 @@ class TestSequential:
             random_apply=random_apply,
         )
         c = 0
-        for a in aug._get_child_sequence():
+        for a in aug.get_forward_sequence():
             if isinstance(a, (MixAugmentationBase,)):
                 c += 1
         assert c < 2
@@ -179,7 +179,7 @@ class TestSequential:
             random_apply=random_apply,
         )
         out = aug(inp)
-        if aug.has_mix_augmentation:
+        if aug.return_label:
             out, label = out
         if isinstance(out, (tuple,)):
             assert out[0].shape == inp.shape
@@ -208,7 +208,7 @@ class TestAugmentationSequential:
             random_apply=random_apply,
         )
         out = aug(inp)
-        if aug.has_mix_augmentation:
+        if aug.return_label:
             out, label = out
         assert out.shape == inp.shape
         reproducibility_test(inp, aug)
@@ -398,7 +398,7 @@ class TestPatchSequential:
 
         input = torch.randn(*shape, device=device, dtype=dtype)
         out = seq(input)
-        if seq.has_mix_augmentation:
+        if seq.return_label:
             out, label = out
         assert out.shape[-3:] == input.shape[-3:]
 

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -397,17 +397,10 @@ class TestPatchSequential:
             return
 
         input = torch.randn(*shape, device=device, dtype=dtype)
-        trans = torch.randn(shape[0], 3, 3, device=device, dtype=dtype)
         out = seq(input)
         if seq.has_mix_augmentation:
             out, label = out
         assert out.shape[-3:] == input.shape[-3:]
-
-        out = seq((input, trans))
-        if seq.has_mix_augmentation:
-            out, label = out
-        assert out[0].shape[-3:] == input.shape[-3:]
-        assert out[1].shape == trans.shape
 
         reproducibility_test(input, seq)
 

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -80,7 +80,7 @@ class TestVideoSequential:
             [K.RandomAffine(360, p=1.0), kornia.color.BgrToRgb()],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.0), K.RandomAffine(360, p=0.0)],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.0)],
-            [K.RandomAffine(360, p=0.0)],
+            [K.RandomAffine(360, p=0.0), K.ImageSequential(K.RandomAffine(360, p=0.0))],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0), K.RandomMixUp(p=1.0)],
         ],
     )
@@ -164,6 +164,14 @@ class TestSequential:
             if isinstance(a, (MixAugmentationBase,)):
                 c += 1
         assert c < 2
+        aug.same_on_batch = True
+        aug.return_transform = True
+        aug.keepdim = True
+        for m in aug.children():
+            assert m.same_on_batch is True, m.same_on_batch
+            if not isinstance(m, (MixAugmentationBase,)):
+                assert m.return_transform is True, m.return_transform
+            assert m.keepdim is True, m.keepdim
 
     @pytest.mark.parametrize("return_transform", [True, False, None])
     @pytest.mark.parametrize('random_apply', [1, (2, 2), (1, 2), (2,), 10, True, False])
@@ -197,8 +205,9 @@ class TestAugmentationSequential:
         with pytest.raises(Exception):  # AssertError and NotImplementedError
             K.AugmentationSequential(augmentation_list, data_keys=data_keys)
 
+    @pytest.mark.parametrize('return_transform', [True, False])
     @pytest.mark.parametrize('random_apply', [1, (2, 2), (1, 2), (2,), 10, True, False])
-    def test_mixup(self, random_apply, device, dtype):
+    def test_mixup(self, return_transform, random_apply, device, dtype):
         inp = torch.randn(1, 3, 1000, 500, device=device, dtype=dtype)
         aug = K.AugmentationSequential(
             K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0),
@@ -206,15 +215,19 @@ class TestAugmentationSequential:
             K.RandomMixUp(p=1.0),
             data_keys=["input"],
             random_apply=random_apply,
+            return_transform=return_transform,
         )
         out = aug(inp)
         if aug.return_label:
             out, label = out
+        if return_transform and isinstance(out, (tuple, list,)):
+            out = out[0]
         assert out.shape == inp.shape
         reproducibility_test(inp, aug)
 
     @pytest.mark.parametrize('random_apply', [1, (2, 2), (1, 2), (2,), 10, True, False])
-    def test_forward_and_inverse(self, random_apply, device, dtype):
+    @pytest.mark.parametrize('return_transform', [True, False])
+    def test_forward_and_inverse(self, random_apply, return_transform, device, dtype):
         inp = torch.randn(1, 3, 1000, 500, device=device, dtype=dtype)
         bbox = torch.tensor([[[355, 10], [660, 10], [660, 250], [355, 250]]], device=device, dtype=dtype)
         keypoints = torch.tensor([[[465, 115], [545, 116]]], device=device, dtype=dtype)
@@ -226,9 +239,13 @@ class TestAugmentationSequential:
             K.RandomAffine(360, p=1.0),
             data_keys=["input", "mask", "bbox", "keypoints"],
             random_apply=random_apply,
+            return_transform=return_transform
         )
         out = aug(inp, mask, bbox, keypoints)
-        assert out[0].shape == inp.shape
+        if return_transform and isinstance(out, (tuple, list,)):
+            assert out[0][0].shape == inp.shape
+        else:
+            assert out[0].shape == inp.shape
         assert out[1].shape == mask.shape
         assert out[2].shape == bbox.shape
         assert out[3].shape == keypoints.shape
@@ -366,11 +383,7 @@ class TestPatchSequential:
         torch.manual_seed(11)
         try:  # skip wrong param settings.
             seq = K.PatchSequential(
-                K.ImageSequential(
-                    K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.5),
-                    K.RandomPerspective(0.2, p=0.5),
-                    K.RandomSolarize(0.1, 0.1, p=0.5),
-                ),
+                kornia.color.RgbToBgr(),
                 K.ColorJitter(0.1, 0.1, 0.1, 0.1),
                 K.ImageSequential(
                     K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.5),

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -94,7 +94,7 @@ class TestVideoSequential:
         if data_format == 'BCTHW':
             input = torch.randn(2, 3, 1, 5, 6, device=device, dtype=dtype).repeat(1, 1, 4, 1, 1)
             output = aug_list(input)
-            if aug_list.has_mix_augmentations:
+            if aug_list.has_mix_augmentation:
                 output, label = output
             assert (output[:, :, 0] == output[:, :, 1]).all()
             assert (output[:, :, 1] == output[:, :, 2]).all()
@@ -102,7 +102,7 @@ class TestVideoSequential:
         if data_format == 'BTCHW':
             input = torch.randn(2, 1, 3, 5, 6, device=device, dtype=dtype).repeat(1, 4, 1, 1, 1)
             output = aug_list(input)
-            if aug_list.has_mix_augmentations:
+            if aug_list.has_mix_augmentation:
                 output, label = output
             assert (output[:, 0] == output[:, 1]).all()
             assert (output[:, 1] == output[:, 2]).all()
@@ -179,7 +179,7 @@ class TestSequential:
             random_apply=random_apply,
         )
         out = aug(inp)
-        if aug.has_mix_augmentations:
+        if aug.has_mix_augmentation:
             out, label = out
         if isinstance(out, (tuple,)):
             assert out[0].shape == inp.shape
@@ -208,7 +208,7 @@ class TestAugmentationSequential:
             random_apply=random_apply,
         )
         out = aug(inp)
-        if aug.has_mix_augmentations:
+        if aug.has_mix_augmentation:
             out, label = out
         assert out.shape == inp.shape
         reproducibility_test(inp, aug)
@@ -399,12 +399,12 @@ class TestPatchSequential:
         input = torch.randn(*shape, device=device, dtype=dtype)
         trans = torch.randn(shape[0], 3, 3, device=device, dtype=dtype)
         out = seq(input)
-        if seq.has_mix_augmentations:
+        if seq.has_mix_augmentation:
             out, label = out
         assert out.shape[-3:] == input.shape[-3:]
 
         out = seq((input, trans))
-        if seq.has_mix_augmentations:
+        if seq.has_mix_augmentation:
             out, label = out
         assert out[0].shape[-3:] == input.shape[-3:]
         assert out[1].shape == trans.shape

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -371,6 +371,7 @@ class TestPatchSequential:
     @pytest.mark.parametrize('keepdim', [True, False, None])
     @pytest.mark.parametrize('random_apply', [1, (2, 2), (1, 2), (2,), 10, True, False])
     def test_forward(self, shape, padding, patchwise_apply, same_on_batch, keepdim, random_apply, device, dtype):
+        torch.manual_seed(11)
         try:  # skip wrong param settings.
             seq = K.PatchSequential(
                 K.ImageSequential(

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -257,15 +257,11 @@ class TestAugmentationSequential:
         assert aug(inp, data_keys=['input'])[0].shape == inp.shape
         aug = K.AugmentationSequential(K.RandomAffine(360, p=1.0, return_transform=False))
         assert aug(inp, data_keys=['input']).shape == inp.shape
-        assert aug(mask, data_keys=['mask']).shape == mask.shape
+        assert aug(mask, data_keys=['mask'], params=aug._params).shape == mask.shape
 
-        aug = K.AugmentationSequential(K.RandomAffine(360, p=1.0, return_transform=True))
         assert aug.inverse(inp, data_keys=['input']).shape == inp.shape
-        aug = K.AugmentationSequential(K.RandomAffine(360, p=1.0, return_transform=True))
         assert aug.inverse(bbox, data_keys=['bbox']).shape == bbox.shape
-        aug = K.AugmentationSequential(K.RandomAffine(360, p=1.0, return_transform=True))
         assert aug.inverse(keypoints, data_keys=['keypoints']).shape == keypoints.shape
-        aug = K.AugmentationSequential(K.RandomAffine(360, p=1.0, return_transform=True))
         assert aug.inverse(mask, data_keys=['mask']).shape == mask.shape
 
     @pytest.mark.parametrize('random_apply', [2, (1, 1), (2,), 10, True, False])
@@ -310,12 +306,8 @@ class TestAugmentationSequential:
             data_keys=["input", "mask", "bbox", "keypoints"],
             random_apply=random_apply,
         )
-
-        out_inv = aug.inverse(inp, mask, bbox, keypoints)
-        assert out_inv[0].shape == inp.shape
-        assert out_inv[1].shape == mask.shape
-        assert out_inv[2].shape == bbox.shape
-        assert out_inv[3].shape == keypoints.shape
+        with pytest.raises(Exception):  # No parameters avaliable for inversing.
+            aug.inverse(inp, mask, bbox, keypoints)
 
         out = aug(inp, mask, bbox, keypoints)
         assert out[0][0].shape == inp.shape

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -80,7 +80,7 @@ class TestVideoSequential:
             [K.RandomAffine(360, p=1.0), kornia.color.BgrToRgb()],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.0), K.RandomAffine(360, p=0.0)],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.0)],
-            [K.RandomAffine(360, p=0.0), K.ImageSequential(K.RandomAffine(360, p=0.0))],
+            [K.RandomAffine(360, p=0.0)],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0), K.RandomMixUp(p=1.0)],
         ],
     )
@@ -110,7 +110,11 @@ class TestVideoSequential:
         reproducibility_test(input, aug_list)
 
     @pytest.mark.parametrize(
-        'augmentations', [[K.RandomAffine(360, p=1.0)], [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0)]]
+        'augmentations', [
+            [K.RandomAffine(360, p=1.0)],
+            [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0)],
+            [K.RandomAffine(360, p=0.0), K.ImageSequential(K.RandomAffine(360, p=0.0))],
+        ]
     )
     @pytest.mark.parametrize('data_format', ["BCTHW", "BTCHW"])
     def test_against_sequential(self, augmentations, data_format, device, dtype):

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -1,9 +1,9 @@
-from kornia.augmentation.base import MixAugmentationBase
 import pytest
 import torch
 
 import kornia
 import kornia.augmentation as K
+from kornia.augmentation.base import MixAugmentationBase
 from kornia.constants import BorderType
 from kornia.geometry.bbox import bbox_to_mask
 from kornia.testing import assert_close
@@ -81,7 +81,7 @@ class TestVideoSequential:
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.0), K.RandomAffine(360, p=0.0)],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=0.0)],
             [K.RandomAffine(360, p=0.0)],
-            [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0), K.RandomMixUp(p=1.)],
+            [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0), K.RandomMixUp(p=1.0)],
         ],
     )
     @pytest.mark.parametrize('data_format', ["BCTHW", "BTCHW"])
@@ -153,7 +153,7 @@ class TestSequential:
         aug = K.ImageSequential(
             K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0),
             K.RandomAffine(360, p=1.0),
-            K.RandomMixUp(p=1.),
+            K.RandomMixUp(p=1.0),
             same_on_batch=same_on_batch,
             return_transform=return_transform,
             keepdim=keepdim,
@@ -174,7 +174,7 @@ class TestSequential:
             kornia.filters.MedianBlur((3, 3)),
             K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0, return_transform=True),
             K.RandomAffine(360, p=1.0),
-            K.RandomMixUp(p=1.),
+            K.RandomMixUp(p=1.0),
             return_transform=return_transform,
             random_apply=random_apply,
         )

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -110,11 +110,12 @@ class TestVideoSequential:
         reproducibility_test(input, aug_list)
 
     @pytest.mark.parametrize(
-        'augmentations', [
+        'augmentations',
+        [
             [K.RandomAffine(360, p=1.0)],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0)],
             [K.RandomAffine(360, p=0.0), K.ImageSequential(K.RandomAffine(360, p=0.0))],
-        ]
+        ],
     )
     @pytest.mark.parametrize('data_format', ["BCTHW", "BTCHW"])
     def test_against_sequential(self, augmentations, data_format, device, dtype):
@@ -224,7 +225,7 @@ class TestAugmentationSequential:
         out = aug(inp)
         if aug.return_label:
             out, label = out
-        if return_transform and isinstance(out, (tuple, list,)):
+        if return_transform and isinstance(out, (tuple, list)):
             out = out[0]
         assert out.shape == inp.shape
         reproducibility_test(inp, aug)
@@ -243,10 +244,10 @@ class TestAugmentationSequential:
             K.RandomAffine(360, p=1.0),
             data_keys=["input", "mask", "bbox", "keypoints"],
             random_apply=random_apply,
-            return_transform=return_transform
+            return_transform=return_transform,
         )
         out = aug(inp, mask, bbox, keypoints)
-        if return_transform and isinstance(out, (tuple, list,)):
+        if return_transform and isinstance(out, (tuple, list)):
             assert out[0][0].shape == inp.shape
         else:
             assert out[0].shape == inp.shape


### PR DESCRIPTION
This PR enabled mix augmentations in containers.

In order to process labels correctly, I forced to apply only one mix augmentation at the time.

Sorry for the delay that I have refactored many times to get a decent API. The whole general structure is more or less fixed, and I will update the internal mess shortly.

\cc @LinShiqi047