### PR TITLE
use alpha channel in rgba_to_rgb

### DIFF
--- a/kornia/color/rgb.py
+++ b/kornia/color/rgb.py
@@ -120,11 +120,12 @@ def bgr_to_rgba(image: torch.Tensor, alpha_val: Union[float, torch.Tensor]) -> t
     return rgb_to_rgba(x_rgb, alpha_val)
 
 
-def rgba_to_rgb(image: torch.Tensor) -> torch.Tensor:
+def rgba_to_rgb(image: torch.Tensor, bg_rgb: Tuple = (0, 0, 0)) -> torch.Tensor:
     r"""Convert an image from RGBA to RGB.
 
     Args:
         image: RGBA Image to be converted to RGB of shape :math:`(*,4,H,W)`.
+        bg_rgb: background RGB.
 
     Returns:
         RGB version of the image with shape :math:`(*,3,H,W)`.
@@ -141,14 +142,15 @@ def rgba_to_rgb(image: torch.Tensor) -> torch.Tensor:
 
     # unpack channels
     r, g, b, a = torch.chunk(image, image.shape[-3], dim=-3)
+    r_bg, g_bg, b_bg = bg_rgb
 
     # compute new channels
     a_one = torch.tensor(1.0) - a
-    r_new: torch.Tensor = a_one * r + a * r
-    g_new: torch.Tensor = a_one * g + a * g
-    b_new: torch.Tensor = a_one * b + a * b
+    r_new: torch.Tensor = a_one * r_bg + a * r
+    g_new: torch.Tensor = a_one * g_bg + a * g
+    b_new: torch.Tensor = a_one * b_bg + a * b
 
-    return torch.cat([r, g, b], dim=-3)
+    return torch.cat([r_new, g_new, b_new], dim=-3)
 
 
 def rgba_to_bgr(image: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
### Description
Current implementation of `rgba_to_rgb` does not use alpha channel. 
The updated implementation overlays input RGBA image with a background RGB image (`(0, 0, 0)` by default). 

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>

  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?

</details>
