### PR TITLE
optimized version of hls_to_rgb() and rgb_to_hls()

### DIFF
--- a/kornia/color/hls.py
+++ b/kornia/color/hls.py
@@ -4,7 +4,13 @@ import torch
 import torch.nn as nn
 
 
-def rgb_to_hls(image: torch.Tensor) -> torch.Tensor:
+# tricks to speed up a little bit the conversions by presetting some small tensors
+# (in the functions they are moved to the device)
+_HLS2RGB: torch.Tensor = torch.tensor([[[0.]], [[8.]], [[4.]]])  # 3x1x1
+_RGB2HSL_IDX: torch.Tensor = torch.tensor([[[0.]], [[1.]], [[2.]]])  # 3x1x1
+
+
+def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     r"""Convert a RGB image to HLS.
 
     .. image:: _static/img/rgb_to_hls.png
@@ -13,6 +19,7 @@ def rgb_to_hls(image: torch.Tensor) -> torch.Tensor:
 
     Args:
         image: RGB image to be converted to HLS with shape :math:`(*, 3, H, W)`.
+        eps: epsilon value to avoid div by zero.
 
     Returns:
         HLS version of the image with shape :math:`(*, 3, H, W)`.
@@ -26,40 +33,42 @@ def rgb_to_hls(image: torch.Tensor) -> torch.Tensor:
 
     if len(image.shape) < 3 or image.shape[-3] != 3:
         raise ValueError("Input size must have a shape of (*, 3, H, W). Got {}".format(image.shape))
+    global _RGB2HSL_IDX
+    _RGB2HSL_IDX = _RGB2HSL_IDX.to(image)
 
-    r: torch.Tensor = image[..., 0, :, :]
-    g: torch.Tensor = image[..., 1, :, :]
-    b: torch.Tensor = image[..., 2, :, :]
-
-    maxc: torch.Tensor = image.max(-3)[0]
+    maxc: torch.Tensor
+    imax: torch.Tensor
+    maxc, imax = image.max(-3)
     minc: torch.Tensor = image.min(-3)[0]
 
-    imax: torch.Tensor = image.max(-3)[1]
+    # define the resulting image to avoid the torch.stack([h, l, s])
+    image_hls: torch.Tensor = torch.empty_like(image)
+    h: torch.Tensor = torch.select(image_hls, -3, 0)
+    l: torch.Tensor = torch.select(image_hls, -3, 1)
+    s: torch.Tensor = torch.select(image_hls, -3, 2)
+    torch.add(maxc, minc, out=l)  # l = max + min
+    torch.sub(maxc, minc, out=s)  # s = max - min
 
-    l: torch.Tensor = (maxc + minc) / 2  # luminance
+    # precompute image / (max - min)
+    im: torch.Tensor = image / (s + eps).unsqueeze(-3)
 
-    deltac: torch.Tensor = maxc - minc
+    # epsilon cannot be inside the torch.where to avoid precision issues
+    s /= torch.where(l < 1., l, 2.0 - l) + eps  # saturation
+    l /= 2  # luminance
 
-    s: torch.Tensor = torch.where(
-        l < 0.5, deltac / (maxc + minc), deltac / (torch.tensor(2.0) - (maxc + minc))
-    )  # saturation
-
-    hi: torch.Tensor = torch.zeros_like(deltac)
-
-    hi[imax == 0] = (((g - b) / deltac) % 6)[imax == 0]
-    hi[imax == 1] = (((b - r) / deltac) + 2)[imax == 1]
-    hi[imax == 2] = (((r - g) / deltac) + 4)[imax == 2]
-
-    h: torch.Tensor = 2.0 * math.pi * (60.0 * hi) / 360.0  # hue [0, 2*pi]
-
-    image_hls: torch.Tensor = torch.stack([h, l, s], dim=-3)
-
-    # JIT indexing is not supported before 1.6.0 https://github.com/pytorch/pytorch/issues/38962
-    # image_hls[torch.isnan(image_hls)] = 0.
-    image_hls = torch.where(
-        torch.isnan(image_hls), torch.tensor(0.0, device=image_hls.device, dtype=image_hls.dtype), image_hls
-    )
-
+    # note that r,g and b were previously div by (max - min)
+    r: torch.Tensor = torch.select(im, -3, 0)
+    g: torch.Tensor = torch.select(im, -3, 1)
+    b: torch.Tensor = torch.select(im, -3, 2)
+    # h[imax == 0] = (((g - b) / (max - min)) % 6)[imax == 0]
+    # h[imax == 1] = (((b - r) / (max - min)) + 2)[imax == 1]
+    # h[imax == 2] = (((r - g) / (max - min)) + 4)[imax == 2]
+    cond: torch.Tensor = imax.unsqueeze(-3) == _RGB2HSL_IDX
+    torch.mul((g - b) % 6, torch.select(cond, -3, 0), out=h)
+    h += torch.add(b - r, 2) * torch.select(cond, -3, 1)
+    h += torch.add(r - g, 4) * torch.select(cond, -3, 2)
+    # h = 2.0 * math.pi * (60.0 * h) / 360.0
+    h *= (math.pi / 3.0)  # hue [0, 2*pi]
     return image_hls
 
 
@@ -84,30 +93,24 @@ def hls_to_rgb(image: torch.Tensor) -> torch.Tensor:
     if len(image.shape) < 3 or image.shape[-3] != 3:
         raise ValueError("Input size must have a shape of (*, 3, H, W). Got {}".format(image.shape))
 
-    h: torch.Tensor = image[..., 0, :, :] * 360 / (2 * math.pi)
-    l: torch.Tensor = image[..., 1, :, :]
-    s: torch.Tensor = image[..., 2, :, :]
+    global _HLS2RGB
+    _HLS2RGB = _HLS2RGB.to(image)
 
-    kr = (0 + h / 30) % 12
-    kg = (8 + h / 30) % 12
-    kb = (4 + h / 30) % 12
-    a = s * torch.min(l, torch.tensor(1.0) - l)
+    im: torch.Tensor = image.unsqueeze(-4)
+    h: torch.Tensor = torch.select(im, -3, 0)
+    l: torch.Tensor = torch.select(im, -3, 1)
+    s: torch.Tensor = torch.select(im, -3, 2)
+    h = h * (6 / math.pi)  # h * 360 / (2 * math.pi) / 30
+    a = s * torch.min(l, 1.0 - l)
 
-    ones_k = torch.ones_like(kr)
+    # kr = (0 + h) % 12
+    # kg = (8 + h) % 12
+    # kb = (4 + h) % 12
+    k: torch.Tensor = (h + _HLS2RGB) % 12
 
-    fr: torch.Tensor = l - a * torch.max(
-        torch.min(torch.min(kr - torch.tensor(3.0), torch.tensor(9.0) - kr), ones_k), -1 * ones_k
-    )
-    fg: torch.Tensor = l - a * torch.max(
-        torch.min(torch.min(kg - torch.tensor(3.0), torch.tensor(9.0) - kg), ones_k), -1 * ones_k
-    )
-    fb: torch.Tensor = l - a * torch.max(
-        torch.min(torch.min(kb - torch.tensor(3.0), torch.tensor(9.0) - kb), ones_k), -1 * ones_k
-    )
-
-    out: torch.Tensor = torch.stack([fr, fg, fb], dim=-3)
-
-    return out
+    # l - a * max(min(min(k - 3.0, 9.0 - k), 1), -1)
+    mink = torch.min(k - 3.0, 9.0 - k)
+    return torch.addcmul(l, a, mink.clamp_(min=-1.0, max=1.0), value=-1)
 
 
 class RgbToHls(nn.Module):

--- a/kornia/color/hls.py
+++ b/kornia/color/hls.py
@@ -34,8 +34,8 @@ def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
         # weird way to use globals compiling with JIT even in the code not used by JIT...
         # __setattr__ can be removed if pytorch version is > 1.6.0 and then use:
         # rgb_to_hls.RGB2HSL_IDX = hls_to_rgb.RGB2HSL_IDX.to(image.device)
-        rgb_to_hls.__setattr__('RGB2HSL_IDX', rgb_to_hls.RGB2HSL_IDX.to(image))
-        _RGB2HSL_IDX = rgb_to_hls.RGB2HSL_IDX
+        rgb_to_hls.__setattr__('RGB2HSL_IDX', rgb_to_hls.RGB2HSL_IDX.to(image))  # type: ignore
+        _RGB2HSL_IDX: torch.Tensor = rgb_to_hls.RGB2HSL_IDX  # type: ignore
     else:
         _RGB2HSL_IDX = torch.tensor([[[0.0]], [[1.0]], [[2.0]]], device=image.device, dtype=image.dtype)  # 3x1x1
 
@@ -120,8 +120,8 @@ def hls_to_rgb(image: torch.Tensor) -> torch.Tensor:
         # weird way to use globals compiling with JIT even in the code not used by JIT...
         # __setattr__ can be removed if pytorch version is > 1.6.0 and then use:
         # hls_to_rgb.HLS2RGB = hls_to_rgb.HLS2RGB.to(image.device)
-        hls_to_rgb.__setattr__('HLS2RGB', hls_to_rgb.HLS2RGB.to(image))
-        _HLS2RGB = hls_to_rgb.HLS2RGB
+        hls_to_rgb.__setattr__('HLS2RGB', hls_to_rgb.HLS2RGB.to(image))  # type: ignore
+        _HLS2RGB: torch.Tensor = hls_to_rgb.HLS2RGB  # type: ignore
     else:
         _HLS2RGB = torch.tensor([[[0.0]], [[8.0]], [[4.0]]], device=image.device, dtype=image.dtype)  # 3x1x1
 

--- a/kornia/color/hls.py
+++ b/kornia/color/hls.py
@@ -33,7 +33,7 @@ def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
         rgb_to_hls.RGB2HSL_IDX = rgb_to_hls.RGB2HSL_IDX.to(image.device)  # type: ignore
         _RGB2HSL_IDX = rgb_to_hls.RGB2HSL_IDX  # type: ignore
     else:
-        _RGB2HSL_IDX = torch.tensor([[[0.]], [[1.]], [[2.]]], device=image.device)  # 3x1x1
+        _RGB2HSL_IDX = torch.tensor([[[0.0]], [[1.0]], [[2.0]]], device=image.device)  # 3x1x1
 
     # maxc: torch.Tensor  # not supported by JIT
     # imax: torch.Tensor  # not supported by JIT
@@ -61,7 +61,7 @@ def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     im: torch.Tensor = image / (s + eps).unsqueeze(-3)
 
     # epsilon cannot be inside the torch.where to avoid precision issues
-    s /= torch.where(l < 1., l, 2.0 - l) + eps  # saturation
+    s /= torch.where(l < 1.0, l, 2.0 - l) + eps  # saturation
     l /= 2  # luminance
 
     # note that r,g and b were previously div by (max - min)
@@ -79,7 +79,7 @@ def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     h += torch.add(b - r, 2) * torch.select(cond, -3, 1)
     h += torch.add(r - g, 4) * torch.select(cond, -3, 2)
     # h = 2.0 * math.pi * (60.0 * h) / 360.0
-    h *= (math.pi / 3.0)  # hue [0, 2*pi]
+    h *= math.pi / 3.0  # hue [0, 2*pi]
 
     if image.requires_grad:
         return torch.stack([h, l, s], dim=-3)
@@ -113,7 +113,7 @@ def hls_to_rgb(image: torch.Tensor) -> torch.Tensor:
         hls_to_rgb.HLS2RGB = hls_to_rgb.HLS2RGB.to(image.device)  # type: ignore
         _HLS2RGB = hls_to_rgb.HLS2RGB  # type: ignore
     else:
-        _HLS2RGB = torch.tensor([[[0.]], [[8.]], [[4.]]], device=image.device)  # 3x1x1
+        _HLS2RGB = torch.tensor([[[0.0]], [[8.0]], [[4.0]]], device=image.device)  # 3x1x1
 
     im: torch.Tensor = image.unsqueeze(-4)
     h: torch.Tensor = torch.select(im, -3, 0)
@@ -134,8 +134,8 @@ def hls_to_rgb(image: torch.Tensor) -> torch.Tensor:
 
 # tricks to speed up a little bit the conversions by presetting small tensors
 # (in the functions they are moved to the proper device)
-hls_to_rgb.HLS2RGB = torch.tensor([[[0.]], [[8.]], [[4.]]])  # type:ignore  # 3x1x1
-rgb_to_hls.RGB2HSL_IDX = torch.tensor([[[0.]], [[1.]], [[2.]]])  # type: ignore # 3x1x1
+hls_to_rgb.HLS2RGB = torch.tensor([[[0.0]], [[8.0]], [[4.0]]])  # type:ignore  # 3x1x1
+rgb_to_hls.RGB2HSL_IDX = torch.tensor([[[0.0]], [[1.0]], [[2.0]]])  # type: ignore # 3x1x1
 
 
 class RgbToHls(nn.Module):

--- a/test/color/test_hls.py
+++ b/test/color/test_hls.py
@@ -247,6 +247,14 @@ class TestHlsToRgb(BaseTester):
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
+        if version.parse(torch.__version__) < version.parse('1.7.0'):
+            warnings.warn(
+                "This test is not compatible with pytorch < 1.7.0. This message will be removed as soon as we do not "
+                "support pytorch 1.6.0. `hls_to_rgb()` method for pytorch < 1.7.0 version cannot be compiled with JIT.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
         op = kornia.color.hls_to_rgb

--- a/test/color/test_hls.py
+++ b/test/color/test_hls.py
@@ -1,4 +1,6 @@
 import math
+from packaging import version
+import warnings
 
 import pytest
 import torch
@@ -118,6 +120,14 @@ class TestRgbToHls(BaseTester):
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
+        if version.parse(torch.__version__) < version.parse('1.7.0'):
+            warnings.warn(
+                "This test is not compatible with pytorch < 1.7.0. This message will be removed as soon as we do not "
+                "support pytorch 1.6.0. `rgb_to_hls()` method for pytorch < 1.7.0 version cannot be compiled with JIT.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
         op = kornia.color.rgb_to_hls

--- a/test/color/test_hls.py
+++ b/test/color/test_hls.py
@@ -1,5 +1,4 @@
 import math
-from packaging import version
 import warnings
 
 import pytest
@@ -8,6 +7,7 @@ from torch.autograd import gradcheck
 
 import kornia
 from kornia.testing import assert_close, BaseTester
+from packaging import version
 
 
 class TestRgbToHls(BaseTester):

--- a/test/color/test_hls.py
+++ b/test/color/test_hls.py
@@ -103,8 +103,12 @@ class TestRgbToHls(BaseTester):
             ],
             dim=1,
         )
-
         assert_close(kornia.color.rgb_to_hls(data), expected)
+
+    def test_nan_random_extreme_values(self, device, dtype):
+        # generate extreme colors randomly
+        ext_rand_slice = (torch.rand((1, 3, 32, 32), dtype=dtype, device=device) >= 0.5).float()
+        assert not kornia.color.rgb_to_hls(ext_rand_slice).isnan().any()
 
     @pytest.mark.grad
     def test_gradcheck(self, device, dtype):

--- a/test/color/test_hls.py
+++ b/test/color/test_hls.py
@@ -94,6 +94,15 @@ class TestRgbToHls(BaseTester):
         assert_close(kornia.color.rgb_to_hls(data), expected)
 
     def test_nan_rgb_to_hls(self, device, dtype):
+        if device != torch.device('cpu') and version.parse(torch.__version__) < version.parse('1.7.0'):
+            warnings.warn(
+                "This test is not compatible with pytorch < 1.7.0. This message will be removed as soon as we do not "
+                "support pytorch 1.6.0. `torch.max()` have a problem in pytorch < 1.7.0 then we cannot get the correct "
+                "result. https://github.com/pytorch/pytorch/issues/41781",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return
         data = torch.ones(2, 3, 5, 5, device=device, dtype=dtype)
 
         # OpenCV


### PR DESCRIPTION
### Description

in colab I got this speed up (the ones with the _ are the optimized ones):

![Screenshot 2021-07-11 at 16 05 48](https://user-images.githubusercontent.com/7938375/125198475-4c514900-e262-11eb-9b5b-4feaa99195ca.png)

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [ ] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [ ] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>

  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?

</details>
