### PR TITLE
Add keepdim param to tensor_to_image function.

### DIFF
--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -93,7 +93,7 @@ def _to_bcdhw(tensor: torch.Tensor) -> torch.Tensor:
     return tensor
 
 
-def tensor_to_image(tensor: torch.Tensor) -> "np.ndarray":
+def tensor_to_image(tensor: torch.Tensor, keepdim: bool = False) -> "np.ndarray":
     """Converts a PyTorch tensor image to a numpy image.
 
     In case the tensor is in the GPU, it will be copied back to CPU.
@@ -101,13 +101,16 @@ def tensor_to_image(tensor: torch.Tensor) -> "np.ndarray":
     Args:
         tensor: image of the form :math:`(H, W)`, :math:`(C, H, W)` or
             :math:`(B, C, H, W)`.
+        keepdim: If ``False`` squeeze the input image to match the shape
+            :math:`(H, W, C)`.
+
 
     Returns:
         image of the form :math:`(H, W)`, :math:`(H, W, C)` or :math:`(B, H, W, C)`.
 
     """
     if not isinstance(tensor, torch.Tensor):
-        raise TypeError("Input type is not a torch.Tensor. Got {}".format(type(tensor)))
+        raise TypeError(f"Input type is not a torch.Tensor. Got {type(tensor)}")
 
     if len(tensor.shape) > 4 or len(tensor.shape) < 2:
         raise ValueError("Input size must be a two, three or four dimensional tensor")
@@ -128,12 +131,12 @@ def tensor_to_image(tensor: torch.Tensor) -> "np.ndarray":
     elif len(input_shape) == 4:
         # (B, C, H, W) -> (B, H, W, C)
         image = image.transpose(0, 2, 3, 1)
-        if input_shape[0] == 1:
+        if input_shape[0] == 1 and not keepdim:
             image = image.squeeze(0)
         if input_shape[1] == 1:
             image = image.squeeze(-1)
     else:
-        raise ValueError("Cannot process tensor with shape {}".format(input_shape))
+        raise ValueError(f"Cannot process tensor with shape {input_shape}")
 
     return image
 

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -102,7 +102,7 @@ def tensor_to_image(tensor: torch.Tensor, keepdim: bool = False) -> "np.ndarray"
         tensor: image of the form :math:`(H, W)`, :math:`(C, H, W)` or
             :math:`(B, C, H, W)`.
         keepdim: If ``False`` squeeze the input image to match the shape
-            :math:`(H, W, C)`.
+            :math:`(H, W, C)` or :math:`(H, W)`.
 
 
     Returns:

--- a/test/utils/test_image.py
+++ b/test/utils/test_image.py
@@ -36,6 +36,24 @@ def test_tensor_to_image(device, input_shape, expected):
 @pytest.mark.parametrize(
     "input_shape, expected",
     [
+        ((4, 4), (4, 4)),
+        ((1, 4, 4), (4, 4)),
+        ((1, 1, 4, 4), (1, 4, 4)),
+        ((3, 4, 4), (4, 4, 3)),
+        ((2, 3, 4, 4), (2, 4, 4, 3)),
+        ((1, 3, 4, 4), (1, 4, 4, 3)),
+    ],
+)
+def test_tensor_to_image_keepdim(device, input_shape, expected):
+    tensor = torch.ones(input_shape).to(device)
+    image = kornia.utils.tensor_to_image(tensor, keepdim=True)
+    assert image.shape == expected
+    assert isinstance(image, np.ndarray)
+
+
+@pytest.mark.parametrize(
+    "input_shape, expected",
+    [
         ((4, 4), (1, 1, 4, 4)),
         ((1, 4, 4), (1, 4, 1, 4)),
         ((2, 3, 4), (1, 4, 2, 3)),


### PR DESCRIPTION
### Description
Add keepdim param to tensor_to_image function to avoid squeezing tensor with batch_size = 1, #1003.

### Status
**Ready/Work in progress/Hold**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [x] **Pass all tests**: did you test in local ? `make test`
- [x] Unittests: did you add tests for your new functionality ?
- [x] Documentations: did you build documentation ? `make build-docs`
- [x] Implementation: is your code well commented and follow conventions ? `make lint`
- [x] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>

  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?

</details>
