### PR TITLE
Add bbox V2 as discussed in #1142

### DIFF
--- a/docs/source/geometry.bbox_v2.rst
+++ b/docs/source/geometry.bbox_v2.rst
@@ -1,11 +1,28 @@
-kornia.geometry.bbox
-==========================
+kornia.geometry.bbox_v2
+=======================
+
+.. currentmodule:: kornia.geometry.bbox_v2
 
 Module with useful functionalities for 2D and 3D bounding boxes manipulation.
 
-Kornia bounding boxes format is defined as a a floating data type tensor of shape Nx4x2 or BxNx4x2 where each box is a `quadrilateral <https://en.wikipedia.org/wiki/Quadrilateral>`_ defined by it's 4 vertices coordinates (A, B, C, D). Coordinates must be in the x, y order. The height and width of a box is ``width = xmax - xmin`` and ``height = ymax - ymin``. Examples of `quadrilaterals <https://en.wikipedia.org/wiki/Quadrilateral>`_ are rectangles, rhombus and trapezoids.
+2D bounding boxes
+-----------------
+**Kornia 2D bounding boxes format** is defined as a floating data type tensor of shape ``Nx4x2`` or ``BxNx4x2`` where each box is a `quadrilateral <https://en.wikipedia.org/wiki/Quadrilateral>`_ defined by it's 4 vertices coordinates (A, B, C, D). Coordinates must be in ``x, y`` order. The height and width of a box is defined as ``width = xmax - xmin`` and ``height = ymax - ymin``. Examples of `quadrilaterals <https://en.wikipedia.org/wiki/Quadrilateral>`_ are rectangles, rhombus and trapezoids.
 
-Kornia 3D bounding boxes format is defined as a a floating data type tensor of shape Nx8x3 or BxNx8x3 where each box is a `hexahedron <https://en.wikipedia.org/wiki/Hexahedron>`_ defined by it's 8 vertices coordinates. Coordinates must be in the x, y, z order. The height, width and depth of a box is ``width = xmax - xmin``, ``height = ymax - ymin`` and ``depth = zmax - zmin``. Examples of `hexahedrons <https://en.wikipedia.org/wiki/Hexahedron>`_ are cubes and rhombohedrons.
+.. autofunction:: bbox_to_kornia_bbox
+.. autofunction:: bbox_to_mask
+.. autofunction:: infer_bbox_shape
+.. autofunction:: kornia_bbox_to_bbox
+.. autofunction:: transform_bbox
+.. autofunction:: validate_bbox
 
-.. automodule:: kornia.geometry.bbox
-    :members:
+3D bounding boxes
+-----------------
+**Kornia 3D bounding boxes format** is defined as a floating data type tensor of shape ``Nx8x3`` or ``BxNx8x3`` where each box is a `hexahedron <https://en.wikipedia.org/wiki/Hexahedron>`_ defined by it's 8 vertices coordinates. Coordinates must be in ``x, y, z`` order. The height, width and depth of a box is defined as ``width = xmax - xmin``, ``height = ymax - ymin`` and ``depth = zmax - zmin``. Examples of `hexahedrons <https://en.wikipedia.org/wiki/Hexahedron>`_ are cubes and rhombohedrons.
+
+.. autofunction:: bbox3d_to_kornia_bbox3d
+.. autofunction:: bbox3d_to_mask3d
+.. autofunction:: infer_bbox3d_shape
+.. autofunction:: kornia_bbox3d_to_bbox3d
+.. autofunction:: transform_bbox3d
+.. autofunction:: validate_bbox3d

--- a/docs/source/geometry.bbox_v2.rst
+++ b/docs/source/geometry.bbox_v2.rst
@@ -1,0 +1,11 @@
+kornia.geometry.bbox
+==========================
+
+Module with useful functionalities for 2D and 3D bounding boxes manipulation.
+
+Kornia bounding boxes format is defined as a a floating data type tensor of shape Nx4x2 or BxNx4x2 where each box is a `quadrilateral <https://en.wikipedia.org/wiki/Quadrilateral>`_ defined by it's 4 vertices coordinates (A, B, C, D). Coordinates must be in the x, y order. The height and width of a box is ``width = xmax - xmin`` and ``height = ymax - ymin``. Examples of `quadrilaterals <https://en.wikipedia.org/wiki/Quadrilateral>`_ are rectangles, rhombus and trapezoids.
+
+Kornia 3D bounding boxes format is defined as a a floating data type tensor of shape Nx8x3 or BxNx8x3 where each box is a `hexahedron <https://en.wikipedia.org/wiki/Hexahedron>`_ defined by it's 8 vertices coordinates. Coordinates must be in the x, y, z order. The height, width and depth of a box is ``width = xmax - xmin``, ``height = ymax - ymin`` and ``depth = zmax - zmin``. Examples of `hexahedrons <https://en.wikipedia.org/wiki/Hexahedron>`_ are cubes and rhombohedrons.
+
+.. automodule:: kornia.geometry.bbox
+    :members:

--- a/docs/source/geometry.rst
+++ b/docs/source/geometry.rst
@@ -7,6 +7,7 @@ kornia.geometry
    :maxdepth: 2
 
    geometry.bbox
+   geometry.bbox_v2
    geometry.calibration
    geometry.camera
    geometry.conversions

--- a/kornia/geometry/__init__.py
+++ b/kornia/geometry/__init__.py
@@ -1,4 +1,16 @@
 from kornia.geometry.bbox import *
+from kornia.geometry.bbox_v2 import bbox3d_to_kornia_bbox3d as bbox3d_to_kornia_bbox3d_v2
+from kornia.geometry.bbox_v2 import bbox3d_to_mask3d as bbox3d_to_mask3d_v2
+from kornia.geometry.bbox_v2 import bbox_to_kornia_bbox as bbox_to_kornia_bbox_v2
+from kornia.geometry.bbox_v2 import bbox_to_mask as bbox_to_mask_v2
+from kornia.geometry.bbox_v2 import infer_bbox3d_shape as infer_bbox3d_shape_v2
+from kornia.geometry.bbox_v2 import infer_bbox_shape as infer_bbox_shape_v2
+from kornia.geometry.bbox_v2 import kornia_bbox3d_to_bbox3d as kornia_bbox3d_to_bbox3d_v2
+from kornia.geometry.bbox_v2 import kornia_bbox_to_bbox as kornia_bbox_to_bbox_v2
+from kornia.geometry.bbox_v2 import transform_bbox as transform_bbox_v2
+from kornia.geometry.bbox_v2 import transform_bbox3d as transform_bbox3d_v2
+from kornia.geometry.bbox_v2 import validate_bbox as validate_bbox_v2
+from kornia.geometry.bbox_v2 import validate_bbox3d as validate_bbox3d_v2
 from kornia.geometry.calibration import *
 from kornia.geometry.camera import *
 from kornia.geometry.conversions import *

--- a/kornia/geometry/bbox_v2.py
+++ b/kornia/geometry/bbox_v2.py
@@ -1,0 +1,602 @@
+from typing import Tuple
+
+import torch
+
+import kornia
+
+
+def _check_bbox_dimensions(boxes: torch.Tensor):
+    if not (3 <= boxes.ndim <= 4 and boxes.shape[-2:] == (4, 2)):
+        raise ValueError(f"BBox shape must be (N, 4, 2) or (B, N, 4, 2). Got {boxes.shape}.")
+
+
+def _check_bbox3d_dimensions(boxes: torch.Tensor):
+    if not (3 <= boxes.ndim <= 4 and boxes.shape[-2:] == (8, 3)):
+        raise ValueError(f"3D bbox shape must be (N, 8, 3) or (B, N, 8, 3). Got {boxes.shape}.")
+
+
+@torch.jit.ignore
+def validate_bbox(boxes: torch.Tensor) -> bool:
+    """Validate if a 2D bounding box usable or not. This function checks if the boxes are rectangular or not.
+
+    Args:
+        boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have the shape
+            of Nx4x2 or BxNx4x2, where each box is defined in the following ``clockwise`` order: top-left, top-right,
+            bottom-right, ottom-left. The coordinates must be in the x, y order. The height and width of a box with
+            corners (x1, y1) and (x2, y2) is computed as ``width = x2 - x1`` and ``height = y2 - y1``.
+    """
+    _check_bbox_dimensions(boxes)
+    if not boxes.is_floating_point():
+        raise ValueError(f"Coordinates must be in floating point. Got {boxes.dtype}")
+
+    if not torch.allclose((boxes[..., 1, 0] - boxes[..., 0, 0]), (boxes[..., 2, 0] - boxes[..., 3, 0])):
+        raise ValueError(
+            "Boxes must have be rectangular, while get widths %s and %s"
+            % (str(boxes[..., 1, 0] - boxes[..., 0, 0]), str(boxes[..., 2, 0] - boxes[..., 3, 0]))
+        )
+
+    if not torch.allclose((boxes[..., 2, 1] - boxes[..., 0, 1]), (boxes[..., 3, 1] - boxes[..., 1, 1])):
+        raise ValueError(
+            "Boxes must have be rectangular, while get heights %s and %s"
+            % (str(boxes[..., 2, 1] - boxes[..., 0, 1]), str(boxes[..., 3, 1] - boxes[..., 1, 1]))
+        )
+
+    return True
+
+
+@torch.jit.ignore
+def validate_bbox3d(boxes: torch.Tensor) -> bool:
+    """Validate if a 3D bounding box usable or not. This function checks if the boxes are cube or not.
+
+    Args:
+        boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have the shape
+            of Nx8x3 or BxNx8x3, where each box is defined in the following ``clockwise`` order: front-top-left,
+            front-top-right, front-bottom-right, front-bottom-left, back-top-left, back-top-right, back-bottom-right,
+            back-bottom-left. The coordinates must be in the x, y, z order. The height, width and depth of a 3D box with
+            corners (x1, y1, z1) and (x2, y2, z2) is computed as ``width = x2 - x1``, ``height = y2 - y1`` and
+            ``depth = z2 - z1``.
+    """
+    _check_bbox3d_dimensions(boxes)
+    if not boxes.is_floating_point():
+        raise ValueError(f"Coordinates must be in floating point. Got {boxes.dtype}")
+
+    left = boxes[..., [1, 2, 5, 6], 0]
+    right = boxes[..., [0, 3, 4, 7], 0]
+    widths = left - right
+    if not torch.allclose(widths.permute(1, 0), widths[:, 0]):
+        raise ValueError(f"Boxes must have be cube, while get different widths {widths}.")
+
+    bottom = boxes[..., [2, 3, 6, 7], 1]
+    upper = boxes[..., [0, 1, 4, 5], 1]
+    heights = bottom - upper
+    if not torch.allclose(heights.permute(1, 0), heights[:, 0]):
+        raise ValueError(f"Boxes must have be cube, while get different heights {heights}.")
+
+    depths = boxes[..., 4:, 2] - boxes[..., :4, 2]
+    if not torch.allclose(depths.permute(1, 0), depths[:, 0]):
+        ValueError(f"Boxes must have be cube, while get different depths {depths}.")
+
+    return True
+
+
+def infer_bbox_shape(boxes: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Auto-infer the output sizes for the given 2D bounding boxes.
+
+    Args:
+        boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have the shape
+            of Nx4x2 or BxNx4x2, where each box is defined in the following ``clockwise`` order: top-left, top-right,
+            bottom-right, bottom-left. The coordinates must be in the x, y order. The height and width of a box with
+            corners (x1, y1) and (x2, y2) is computed as ``width = x2 - x1`` and ``height = y2 - y1``.
+
+    Returns:
+        - Bounding box heights, shape of :math:`(N,)` or :math:`(B,N)`.
+        - Boundingbox widths, shape of :math:`(N,)` or :math:`(B,N)`.
+
+    Example:
+        >>> boxes = torch.tensor([[[
+        ...     [1., 1.],
+        ...     [2., 1.],
+        ...     [2., 2.],
+        ...     [1., 2.],
+        ... ], [
+        ...     [1., 1.],
+        ...     [3., 1.],
+        ...     [3., 2.],
+        ...     [1., 2.],
+        ... ]]])  # 1x2x4x2
+        >>> infer_bbox_shape(boxes)
+        (tensor([[1., 1.]]), tensor([[1., 2.]]))
+    """
+    _check_bbox_dimensions(boxes)
+    width: torch.Tensor = boxes[..., 1, 0] - boxes[..., 0, 0]
+    height: torch.Tensor = boxes[..., 2, 1] - boxes[..., 0, 1]
+    return height, width
+
+
+def infer_bbox3d_shape(boxes: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    r"""Auto-infer the output sizes for the given 3D bounding boxes.
+
+    Args:
+        boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have the shape
+            of Nx8x3 or BxNx8x3, where each box is defined in the following ``clockwise`` order: front-top-left,
+            front-top-right, front-bottom-right, front-bottom-left, back-top-left, back-top-right, back-bottom-right,
+            back-bottom-left. The coordinates must be in the x, y, z order. The height, width and depth of a 3D box with
+            corners (x1, y1, z1) and (x2, y2, z2) is computed as ``width = x2 - x1``, ``height = y2 - y1`` and
+            ``depth = z2 - z1``.
+
+    Returns:
+        - Bounding box depths, shape of :math:`(N,)` or :math:`(B,)`.
+        - Bounding box heights, shape of :math:`(N,)` or :math:`(B,)`.
+        - Bounding box widths, shape of :math:`(N,)` or :math:`(B,)`.
+
+    Example:
+        >>> boxes = torch.tensor([[[ 0,  1,  2],
+        ...         [10,  1,  2],
+        ...         [10, 21,  2],
+        ...         [ 0, 21,  2],
+        ...         [ 0,  1, 32],
+        ...         [10,  1, 32],
+        ...         [10, 21, 32],
+        ...         [ 0, 21, 32]],
+        ...        [[ 3,  4,  5],
+        ...         [43,  4,  5],
+        ...         [43, 54,  5],
+        ...         [ 3, 54,  5],
+        ...         [ 3,  4, 65],
+        ...         [43,  4, 65],
+        ...         [43, 54, 65],
+        ...         [ 3, 54, 65]]]) # 2x8x3
+        >>> infer_bbox3d_shape(boxes)
+        (tensor([30, 60]), tensor([20, 50]), tensor([10, 40]))
+    """
+    _check_bbox3d_dimensions(boxes)
+
+    left = boxes[..., [1, 2, 5, 6], 0]
+    right = boxes[..., [0, 3, 4, 7], 0]
+    widths = left - right
+
+    bottom = boxes[..., [2, 3, 6, 7], 1]
+    upper = boxes[..., [0, 1, 4, 5], 1]
+    heights = bottom - upper
+
+    depths = boxes[..., 4:, 2] - boxes[..., :4, 2]
+    return depths[..., 0], heights[..., 0], widths[..., 0]
+
+
+def bbox_to_mask(boxes: torch.Tensor, width: int, height: int) -> torch.Tensor:
+    """Convert 2D bounding boxes to masks. Covered area is 1. and the remaining is 0.
+
+    Args:
+        boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have the shape
+            of Nx4x2 or BxNx4x2, where each box is defined in the following ``clockwise`` order: top-left, top-right,
+            bottom-right and bottom-left. The coordinates must be in the x, y order. The height and width of a box with
+            corners (x1, y1) and (x2, y2) is computed as ``width = x2 - x1`` and ``height = y2 - y1``.
+        width: width of the masked image/images.
+        height: height of the masked image/images.
+
+    Returns:
+        the output mask tensor, shape of :math:`(N, width, height)` or :math:`(B,N, width, height)` and dtype of boxes.
+
+    Note:
+        It is currently non-differentiable.
+
+    Examples:
+        >>> boxes = torch.tensor([[
+        ...        [1., 1.],
+        ...        [4., 1.],
+        ...        [4., 3.],
+        ...        [1., 3.],
+        ...   ]])  # 1x4x2
+        >>> bbox_to_mask(boxes, 5, 5)
+        tensor([[[0., 0., 0., 0., 0.],
+                 [0., 1., 1., 1., 0.],
+                 [0., 1., 1., 1., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.]]])
+    """
+    _check_bbox_dimensions(boxes)
+    mask = torch.zeros((*boxes.shape[:-2], height, width), dtype=boxes.dtype, device=boxes.device)
+
+    # Boxes coordinates can be outside the image size after transforms. Clamp values to the image size
+    clamped_boxes = boxes.detach().clone()
+    clamped_boxes[..., 0].clamp_(0, width)
+    clamped_boxes[..., 1].clamp_(0, height)
+
+    boxes_xyxy = kornia_bbox_to_bbox(boxes, mode='xyxy')
+    # Reshape mask to (BxN, H, W) and boxes to (BxN, 4) to iterate over all of them.
+    # Cast boxes coordinates to be integer to use them as indexes. Use round to handle decimal values.
+    for mask_channel, box_xyxy in zip(mask.view(-1, *mask.shape[-2:]), boxes_xyxy.view(-1, 4).round().int()):
+        # Mask channel dimensions: (height, width)
+        mask_channel[box_xyxy[1] : box_xyxy[3], box_xyxy[0] : box_xyxy[2]] = 1
+
+    return mask
+
+
+def bbox3d_to_mask3d(boxes: torch.Tensor, depth: int, width: int, height: int) -> torch.Tensor:
+    """Convert 3D bounding boxes to masks. Covered area is 1. and the remaining is 0.
+
+    Args:
+        boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have the shape
+            of Nx8x3 or BxNx8x3, where each box is defined in the following ``clockwise`` order: front-top-left,
+            front-top-right, ront-bottom-right, front-bottom-left, back-top-left, back-top-right, back-bottom-right,
+            back-bottom-left. The coordinates must be in the x, y, z order. The height, width and depth of a 3D box with
+            corners (x1, y1, z1) and (x2, y2, z2) is computed as ``width = x2 - x1``, ``height = y2 - y1`` and
+            ``depth = z2 - z1``.
+        width: width of the masked image/images.
+        height: height of the masked image/images.
+        depth: depth of the masked image/images.
+
+    Returns:
+        the output mask tensor, shape of :math:`(N, depth, width, height)` or :math:`(B,N, depth, width, height)` and
+         dtype of boxes.
+
+    Examples:
+        >>> boxes = torch.tensor([[
+        ...     [1., 1., 1.],
+        ...     [3., 1., 1.],
+        ...     [3., 3., 1.],
+        ...     [1., 3., 1.],
+        ...     [1., 1., 2.],
+        ...     [3., 1., 2.],
+        ...     [3., 3., 2.],
+        ...     [1., 3., 2.],
+        ... ]])  # 1x8x3
+        >>> bbox3d_to_mask3d(boxes, 4, 5, 5)
+        tensor([[[0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                [[0., 0., 0., 0., 0.],
+                 [0., 1., 1., 0., 0.],
+                 [0., 1., 1., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                [[0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                [[0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.]]])
+    """
+    _check_bbox3d_dimensions(boxes)
+
+    mask = torch.zeros((*boxes.shape[:-3], depth, height, width), dtype=boxes.dtype, device=boxes.device)
+
+    # Boxes coordinates can be outside the image size after transforms. Clamp values to the image size
+    clamped_boxes = boxes.detach().clone()
+    clamped_boxes[..., 0].clamp_(0, width)
+    clamped_boxes[..., 1].clamp_(0, height)
+    clamped_boxes[..., 2].clamp_(0, depth)
+
+    boxes_xyzxyz = kornia_bbox3d_to_bbox3d(boxes, mode='xyzxyz')
+    # Reshape mask to (BxN, D, H, W) and boxes to (BxN, 6) to iterate over all of them.
+    # Cast boxes coordinates to be integer to use them as indexes. Use round to handle decimal values.
+    for mask_channel, box_xyzxyz in zip(mask.view(-1, *mask.shape[-3:]), boxes_xyzxyz.view(-1, 6).round().int()):
+        # Mask channel dimensions: (depth, height, width)
+        mask_channel[box_xyzxyz[2] : box_xyzxyz[5], box_xyzxyz[1] : box_xyzxyz[4], box_xyzxyz[0] : box_xyzxyz[3]] = 1
+
+    return mask
+
+
+def bbox_to_kornia_bbox(boxes: torch.Tensor, mode: str = "xyxy") -> torch.Tensor:
+    r"""Convert 2D bounding boxes to kornia format according to the format in which the boxes are provided.
+
+    Kornia bounding boxes format is defined as a a floating data type tensor of shape Nx4x2 or BxNx4x2, where each box
+    is defined in the following ``clockwise`` order: top-left, top-right, bottom-right, bottom-left. The coordinates
+    must be in the x, y order. The height and width of a box with corners (x1, y1) and (x2, y2) is computed as
+    ``width = x2 - x1`` and ``height = y2 - y1``.
+
+    Args:
+        boxes: boxes to be transformed, shape of :math:`(N,4)` or :math:`(B,N,4)`.
+        mode: The format in which the boxes are provided.
+            - 'xyxy': boxes are assumed to be in the format ``xmin, ymin, xmax, ymax`` where ``width = xmax - xmin`` and
+                ``height = ymax - ymin``.
+            - 'xyxy_plus_1': like 'xyxy' where ``width = xmax - xmin + 1`` and  ``height = ymax - ymin + 1``.
+            - 'xywh': boxes are assumed to be in the format ``xmin, ymin, width, height`` where ``width = xmax - xmin``
+                and ``height = ymax - ymin``.
+            - 'xywh_plus_1': like 'xywh' where ``width = xmax - xmin + 1`` and  ``height = ymax - ymin + 1``.
+    Returns:
+        Bounding boxes tensor in kornia format, shape of :math:`(N, 4, 2)` or :math:`(B, N, 4, 2)` and dtype of
+            ``boxes`` if it's a floating point data type and ``float`` if not.
+
+    Examples:
+        >>> boxes_xyxy = torch.as_tensor([[0, 3, 1, 4], [5, 1, 8, 4]])
+        >>> bbox_to_kornia_bbox(boxes_xyxy, mode='xyxy')
+        tensor([[[0., 3.],
+                 [1., 3.],
+                 [1., 4.],
+                 [0., 4.]],
+        <BLANKLINE>
+                [[5., 1.],
+                 [8., 1.],
+                 [8., 4.],
+                 [5., 4.]]])
+
+    """
+    if not (2 <= boxes.ndim <= 3 and boxes.shape[-1] == 4):
+        raise ValueError(f"BBox shape must be (N, 4) or (B, N, 4). Got {boxes.shape}.")
+
+    boxes = boxes if boxes.is_floating_point() else boxes.float()
+
+    xmin, ymin = boxes[..., 0], boxes[..., 1]
+    if mode in ("xyxy", "xyxy_plus_1"):
+        height, width = boxes[..., 3] - boxes[..., 1], boxes[..., 2] - boxes[..., 0]
+    elif mode in ("xywh", "xywh_plus_1"):
+        height, width = boxes[..., 3], boxes[..., 2]
+    else:
+        raise ValueError(f"Unknown mode {mode}")
+
+    if "plus_1" in mode:
+        height -= 1
+        width -= 1
+
+    # Create (B,N,4,2) or (N,4,2) with all points in top left position of the bounding box
+    kornia_boxes = torch.zeros((*boxes.shape[:-1], 4, 2), device=boxes.device, dtype=boxes.dtype)
+    kornia_boxes[..., 0] = xmin.unsqueeze(-1)
+    kornia_boxes[..., 1] = ymin.unsqueeze(-1)
+    # Shift top-right, bottom-right, bottom-left points to the right coordinates
+    kornia_boxes[..., 1, 0] += width  # Top right
+    kornia_boxes[..., 2, 0] += width  # Bottom right
+    kornia_boxes[..., 2, 1] += height  # Bottom right
+    kornia_boxes[..., 3, 1] += height  # Bottom left
+
+    return kornia_boxes
+
+
+def bbox3d_to_kornia_bbox3d(boxes: torch.Tensor, mode: str = "xyzxyz") -> torch.Tensor:
+    r"""Convert 3D bounding boxes to kornia format according to the format in which the boxes are provided.
+
+    Kornia 3D bounding boxes format is defined as a floating data type tensor of shape Nx8x3 or BxNx8x3, where each 3D
+    box is defined in the following ``clockwise`` order: front-top-left, front-top-right, ront-bottom-right,
+    front-bottom-left, ack-top-left, back-top-right, back-bottom-right, back-bottom-left. The coordinates must be in
+    the x, y, z order. The height, width and depth of a 3D box with corners (x1, y1, z1) and (x2, y2, z2) is computed as
+    ``width = x2 - x1``, ``height = y2 - y1`` and ``depth = z2 - z1``.
+
+    Args:
+        boxes: 3D boxes to be transformed, shape of :math:`(N,6)` or :math:`(B,N,6)`.
+        mode: The format in which the boxes are provided.
+            - 'xyzxyz': boxes are assumed to be in the format ``xmin, ymin, zmin, xmax, ymax, zmax`` where
+                ``width = xmax - xmin``, ``height = ymax - ymin`` and ``depth = zmax - zmin``.
+            - 'xyzxyz_plus_1': like 'xyzxyz' where ``width = xmax - xmin + 1``, ``height = ymax - ymin + 1`` and
+                ``depth = zmax - zmin + 1``.
+            - 'xyzwhd': boxes are assumed to be in the format ``xmin, ymin, zmin, width, height, depth`` where
+                ``width = xmax - xmin``, ``height = ymax - ymin`` and ``depth = zmax - zmin``.
+            - 'xyzwhd_plus_1': like 'xyzwhd' where ``width = xmax - xmin + 1``, ``height = ymax - ymin + 1`` and
+                ``depth = zmax - zmin + 1``.
+    Returns:
+        3D bounding boxes tensor in kornia format, shape of :math:`(N, 8, 3)` or :math:`(B, N, 8, 3)` and dtype of
+            ``boxes`` if it's a floating point data type and ``float`` if not.
+
+    Examples:
+        >>> boxes_xyzxyz = torch.as_tensor([[0, 3, 6, 1, 4, 8], [5, 1, 3, 8, 4, 9]])
+        >>> bbox3d_to_kornia_bbox3d(boxes_xyzxyz, mode='xyzxyz')
+        tensor([[[0., 3., 6.],
+                 [1., 3., 6.],
+                 [1., 4., 6.],
+                 [0., 4., 6.],
+                 [0., 3., 8.],
+                 [1., 3., 8.],
+                 [1., 4., 8.],
+                 [0., 4., 8.]],
+        <BLANKLINE>
+                [[5., 1., 3.],
+                 [8., 1., 3.],
+                 [8., 4., 3.],
+                 [5., 4., 3.],
+                 [5., 1., 9.],
+                 [8., 1., 9.],
+                 [8., 4., 9.],
+                 [5., 4., 9.]]])
+    """
+    if not (2 <= boxes.ndim <= 3 and boxes.shape[-1] == 6):
+        raise ValueError(f"BBox shape must be (N, 6) or (B, N, 6). Got {boxes.shape}.")
+
+    boxes = boxes if boxes.is_floating_point() else boxes.float()
+
+    xmin, ymin, zmin = boxes[..., 0], boxes[..., 1], boxes[..., 2]
+    if mode in ("xyzxyz", "xyzxyz_plus_1"):
+        width = boxes[..., 3] - boxes[..., 0]
+        height = boxes[..., 4] - boxes[..., 1]
+        depth = boxes[..., 5] - boxes[..., 2]
+    elif mode in ("xyzwhd", "xyzwhd_plus_1"):
+        depth, height, width = boxes[4], boxes[..., 3], boxes[5]
+    else:
+        raise ValueError(f"Unknown mode {mode}")
+
+    if "plus_1" in mode:
+        height -= 1
+        width -= 1
+        depth -= 1
+
+    # Front
+    # Create (B,N,4,3) or (N,4,3) with all points in top left position of the bounding box
+    kornia_front_boxes = torch.zeros((*boxes.shape[:-1], 4, 3), device=boxes.device, dtype=boxes.dtype)
+    kornia_front_boxes[..., 0] = xmin.unsqueeze(-1)
+    kornia_front_boxes[..., 1] = ymin.unsqueeze(-1)
+    kornia_front_boxes[..., 2] = zmin.unsqueeze(-1)
+    # Shift front-top-right, front-bottom-right, front-bottom-left points to the right coordinates
+    kornia_front_boxes[..., 1, 0] += width  # Top right
+    kornia_front_boxes[..., 2, 0] += width  # Bottom right
+    kornia_front_boxes[..., 2, 1] += height  # Bottom right
+    kornia_front_boxes[..., 3, 1] += height  # Bottom left
+
+    # Back
+    kornia_back_boxes = kornia_front_boxes.clone()
+    kornia_back_boxes[..., 2] += depth.unsqueeze(-1)
+
+    return torch.cat([kornia_front_boxes, kornia_back_boxes], dim=-1)
+
+
+def kornia_bbox_to_bbox(kornia_boxes: torch.Tensor, mode: str = "xyxy") -> torch.Tensor:
+    r"""Convert 2D bounding boxes in kornia format to the format specified by ``mode``.
+
+    Kornia bounding boxes format is defined as a a floating data type tensor of shape Nx4x2 or BxNx4x2, where each box
+    is defined in the following ``clockwise`` order: top-left, top-right, bottom-right, bottom-left. The coordinates
+    must be in the x, y order. The height and width of a box with corners (x1, y1) and (x2, y2) is computed as
+    ``width = x2 - x1`` and ``height = y2 - y1``.
+
+    Args:
+        kornia_boxes: boxes to be transformed, shape of :math:`(N, 4, 2)` or :math:`(B, N, 4, 2)`.
+        mode: The format in which the boxes are provided.
+            - 'xyxy': boxes are assumed to be in the format ``xmin, ymin, xmax, ymax`` where ``width = xmax - xmin`` and
+                ``height = ymax - ymin``.
+            - 'xyxy_plus_1': like 'xyxy' where ``width = xmax - xmin + 1`` and  ``height = ymax - ymin + 1``.
+            - 'xywh': boxes are assumed to be in the format ``xmin, ymin, width, height`` where ``width = xmax - xmin``
+                and ``height = ymax - ymin``.
+            - 'xywh_plus_1': like 'xywh' where ``width = xmax - xmin + 1`` and  ``height = ymax - ymin + 1``.
+    Returns:
+        Bounding boxes tensor the ``mode`` format, shape of :math:`(N, 4, 2)` or :math:`(B, N, 4, 2)`.
+
+    Examples:
+        >>> boxes_xyxy = torch.as_tensor([[0, 3, 1, 4], [5, 1, 8, 4]])
+        >>> kornia_bbox = bbox_to_kornia_bbox(boxes_xyxy, mode='xyxy')
+        >>> assert (kornia_bbox_to_bbox(kornia_bbox, mode='xyxy') == boxes_xyxy).all()
+    """
+    _check_bbox_dimensions(kornia_boxes)
+
+    boxes = torch.stack([kornia_boxes.min(dim=-2).values, kornia_boxes.max(dim=-2).values], dim=1).view(
+        *kornia_boxes.shape[:-2], 4
+    )
+
+    if mode in ("xyxy", "xyxy_plus_1"):
+        pass
+    elif mode in ("xywh", "xywh_plus_1"):
+        height, width = boxes[..., 3] - boxes[..., 1], boxes[..., 2] - boxes[..., 0]
+        boxes[..., 2] = width
+        boxes[..., 3] = height
+    else:
+        raise ValueError(f"Unknown mode {mode}")
+
+    if "plus_1" in mode:
+        offset = torch.as_tensor([0, 0, 1, 1], device=boxes.device, dtype=boxes.dtype)
+        boxes = boxes + offset
+
+    return boxes
+
+
+def kornia_bbox3d_to_bbox3d(kornia_boxes: torch.Tensor, mode: str = "xyzxyz") -> torch.Tensor:
+    r"""Convert 3D bounding boxes in kornia format according to the format specified by ``mode``.
+
+    Kornia 3D bounding boxes format is defined as a floating data type tensor of shape Nx8x3 or BxNx8x3, where each 3D
+    box is defined in the following ``clockwise`` order: front-top-left, front-top-right, ront-bottom-right,
+    front-bottom-left, ack-top-left, back-top-right, back-bottom-right, back-bottom-left. The coordinates must be in
+    the x, y, z order. The height, width and depth of a 3D box with corners (x1, y1, z1) and (x2, y2, z2) is computed as
+    ``width = x2 - x1``, ``height = y2 - y1`` and ``depth = z2 - z1``.
+
+    Args:
+        kornia_boxes: 3D boxes to be transformed, shape of :math:`(N, 8, 3)` or :math:`(B, N, 8, 3)`.
+        mode: The format in which the boxes are provided.
+            - 'xyzxyz': boxes are assumed to be in the format ``xmin, ymin, zmin, xmax, ymax, zmax`` where
+                ``width = xmax - xmin``, ``height = ymax - ymin`` and ``depth = zmax - zmin``.
+            - 'xyzxyz_plus_1': like 'xyzxyz' where ``width = xmax - xmin + 1``, ``height = ymax - ymin + 1`` and
+                ``depth = zmax - zmin + 1``.
+            - 'xyzwhd': boxes are assumed to be in the format ``xmin, ymin, zmin, width, height, depth`` where
+                ``width = xmax - xmin``, ``height = ymax - ymin`` and ``depth = zmax - zmin``.
+            - 'xyzwhd_plus_1': like 'xyzwhd' where ``width = xmax - xmin + 1``, ``height = ymax - ymin + 1`` and
+                ``depth = zmax - zmin + 1``.
+    Returns:
+        3D bounding boxes tensor the ``mode`` format, shape of :math:`(N, 6)` or :math:`(B, N, 6)`.
+
+
+    Examples:
+        >>> boxes_xyzxyz = torch.as_tensor([[0, 3, 6, 1, 4, 8], [5, 1, 3, 8, 4, 9]])
+        >>> kornia_bbox = bbox3d_to_kornia_bbox3d(boxes_xyzxyz, mode='xyzxyz')
+        >>> assert (kornia_bbox3d_to_bbox3d(kornia_bbox, mode='xyzxyz') == boxes_xyzxyz).all()
+    """
+    _check_bbox3d_dimensions(kornia_boxes)
+    boxes = torch.stack([kornia_boxes.min(dim=-2).values, kornia_boxes.max(dim=-2).values], dim=1).view(
+        *kornia_boxes.shape[:-2], 6
+    )
+
+    if mode in ("xyzxyz", "xyzxyz_plus_1"):
+        pass
+    elif mode in ("xyzwhd", "xyzwhd_plus_1"):
+        width = boxes[..., 3] - boxes[..., 0]
+        height = boxes[..., 4] - boxes[..., 1]
+        depth = boxes[..., 5] - boxes[..., 2]
+        boxes[..., 3] = width
+        boxes[..., 4] = height
+        boxes[..., 5] = depth
+    else:
+        raise ValueError(f"Unknown mode {mode}")
+
+    if "plus_1" in mode:
+        offset = torch.as_tensor([0, 0, 0, 1, 1, 1], device=boxes.device, dtype=boxes.dtype)
+        boxes = boxes + offset
+
+    return boxes
+
+
+def _transform_bbox(boxes: torch.Tensor, M: torch.Tensor) -> torch.Tensor:
+    """Transforms 3D and 2D in kornia format by applying the transformation matrix M. Boxes and the transformation matrix
+    could be batched or not.
+
+    Args:
+        boxes: 2D or 3D boxes in kornia format.
+        M: the transformation matrix of shape :math:`(3, 3)` or :math:`(B, 3, 3)` for 2D and :math:`(4, 4)` or
+            :math:`(B, 4, 4)` for 3D boxes.
+    """
+    boxes = boxes if boxes.is_floating_point() else boxes.float()
+    M = M if M.is_floating_point() else M.float()
+
+    # Work with batch as kornia.transform_points only supports a batch of points.
+    boxes_per_batch, n_points_per_box, coordinates_dimension = boxes.shape[-3:]
+    points = boxes.view(-1, n_points_per_box * boxes_per_batch, coordinates_dimension)
+    M = M if M.ndim == 3 else M.unsqueeze(0)
+
+    if points.shape[0] != M.shape[0]:
+        raise ValueError(
+            f"Batch size mismatch. Got {points.shape[0]} for boxes, {M.shape[0]} for the transformation matrix."
+        )
+
+    transformed_boxes: torch.Tensor = kornia.transform_points(M, points)
+    transformed_boxes = transformed_boxes.view_as(boxes)
+    return transformed_boxes
+
+
+def transform_bbox(boxes: torch.Tensor, M: torch.Tensor) -> torch.Tensor:
+    r"""Function that applies a transformation matrix to boxes or a batch of boxes in kornia format. That it's, a
+    floating data type tensor of shape Nx4x2 or BxNx4x2, where each box is defined in the following ``clockwise`` order:
+    top-left, top-right, bottom-right and bottom-left. The coordinates must be in the x, y order. The height and width
+    of a box with corners (x1, y1) and (x2, y2) is computed as ``width = x2 - x1`` and ``height = y2 - y1``.
+
+    Args:
+        boxes: The boxes to be transformed. It must be a tensor of shape :math:`(N, 4, 2)` or :math:`(B, N, 4, 2)`.
+        M: The transformation matrix to be applied, shape of :math:`(3, 3)` or :math:`(B, 3, 3)`.
+    Returns:
+        A tensor of shape :math:`(N, 4, 2)` or :math:`(B, N, 4, 2)` with the transformed boxes in kornia format.
+    """
+    _check_bbox_dimensions(boxes)
+    if not 2 <= M.ndim <= 3 or M.shape[-2:] != (3, 3):
+        raise ValueError(f"The transformation matrix shape must be (3, 3) or (B, 3, 3). Got {M.shape}.")
+
+    return _transform_bbox(boxes, M)
+
+
+def transform_bbox3d(boxes: torch.Tensor, M: torch.Tensor) -> torch.Tensor:
+    r"""Function that applies a transformation matrix to 3D boxes or a batch of 3D boxes in kornia format. That it's, a
+    floating data type tensor of shape Nx8x3 or BxNx8x3, where each box is defined in the following ``clockwise`` order:
+    front-top-left, front-top-right, front-bottom-right, front-bottom-left, back-top-left, back-top-right,
+    back-bottom-right,back-bottom-left. The coordinates must be in the x, y, z order. The height, width and depth of a
+    3D box with corners (x1, y1, z1) and (x2, y2, z2) is computed as ``width = x2 - x1``, ``height = y2 - y1`` and
+    ``depth = z2 - z1``.
+
+    Args:
+        boxes: The 3D boxes to be transformed. It must be a tensor of shape :math:`(N, 8, 3)` or :math:`(B, N, 8, 3)`.
+        M: The transformation matrix to be applied, shape of :math:`(4, 4)` or :math:`(B, 4, 4)`.
+    Returns:
+        A tensor of shape :math:`(N, 8, 3)` or :math:`(B, N, 8, 3)` with the transformed 3D boxes in kornia format.
+    """
+    _check_bbox3d_dimensions(boxes)
+    if not 2 <= M.ndim <= 3 or M.shape[-2:] != (4, 4):
+        raise ValueError(f"The transformation matrix shape must be (4, 4) or (B, 4, 4). Got {M.shape}.")
+
+    return _transform_bbox(boxes, M)

--- a/kornia/geometry/bbox_v2.py
+++ b/kornia/geometry/bbox_v2.py
@@ -58,7 +58,7 @@ def _boxes3d_to_polygons3d(
     back_vertices = front_vertices.clone()
     back_vertices[..., 2] += depth.unsqueeze(-1)
 
-    polygons3d = torch.cat([front_vertices, back_vertices], dim=-1)
+    polygons3d = torch.cat([front_vertices, back_vertices], dim=-2)
     return polygons3d
 
 
@@ -401,7 +401,7 @@ def bbox3d_to_kornia_bbox3d(boxes: torch.Tensor, mode: str = "xyzxyz") -> torch.
         height = boxes[..., 4] - boxes[..., 1]
         depth = boxes[..., 5] - boxes[..., 2]
     elif mode in ("xyzwhd", "xyzwhd_plus_1"):
-        depth, height, width = boxes[4], boxes[..., 3], boxes[5]
+        depth, height, width = boxes[..., 4], boxes[..., 3], boxes[..., 5]
     else:
         raise ValueError(f"Unknown mode {mode}")
 

--- a/test/geometry/test_bbox_v2.py
+++ b/test/geometry/test_bbox_v2.py
@@ -5,14 +5,18 @@ import torch
 from torch.autograd import gradcheck
 from torch.testing import assert_allclose
 
-import kornia
 import kornia.testing as utils
 from kornia.geometry.bbox_v2 import (
+    bbox3d_to_kornia_bbox3d,
+    bbox3d_to_mask3d,
     bbox_to_kornia_bbox,
     bbox_to_mask,
+    infer_bbox3d_shape,
     infer_bbox_shape,
+    kornia_bbox3d_to_bbox3d,
     kornia_bbox_to_bbox,
     transform_bbox,
+    transform_bbox3d,
     validate_bbox,
     validate_bbox3d,
 )
@@ -34,33 +38,41 @@ class TestBbox2D:
             bbox[0, 3, 1] = points[0][3]
             return bbox
 
-        bbox = _create_bbox()
         # Validate
-        assert validate_bbox(bbox)
-
-        # Batch od 2 samples
-        batched_bbox = torch.stack([_create_bbox(), _create_bbox()])
+        assert validate_bbox(_create_bbox())  # Validate 1 box
+        two_boxes = torch.cat([_create_bbox(), _create_bbox()])  # 2 boxes without batching (N, 4, 2) where N=2
+        assert validate_bbox(two_boxes)
+        batched_bbox = torch.stack([_create_bbox(), _create_bbox()])  # 2 boxes in batch (B, 1, 4, 2) where B=2
         assert validate_bbox(batched_bbox)
 
     def test_bounding_boxes_dim_inferring(self, device, dtype):
-        box = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
+        box = torch.tensor([[[1.0, 1.0], [3.0, 2.0], [1.0, 2.0], [3.0, 1.0]]], device=device, dtype=dtype)
         boxes = torch.tensor(
-            [[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]], [[2.0, 2.0], [5.0, 2.0], [5.0, 4.0], [2.0, 4.0]]],
+            [[[1.0, 1.0], [3.0, 1.0], [1.0, 2.0], [3.0, 2.0]], [[5.0, 4.0], [2.0, 2.0], [5.0, 2.0], [2.0, 4.0]]],
             device=device,
             dtype=dtype,
-        )
+        )  # (2, 4, 2)
+        boxes_batch = boxes[None]  # (1, 2, 4, 2)
 
+        # Single box
         h, w = infer_bbox_shape(box)
         assert (h.item(), w.item()) == (1, 2)
 
+        # Boxes
         h, w = infer_bbox_shape(boxes)
         assert h.ndim == 1 and w.ndim == 1
         assert len(h) == 2 and len(w) == 2
         assert (h == torch.as_tensor([1.0, 2.0])).all() and (w == torch.as_tensor([2.0, 3.0])).all()
 
+        # Box batch
+        h, w = infer_bbox_shape(boxes_batch)
+        assert h.ndim == 2 and w.ndim == 2
+        assert h.shape == (1, 2) and w.shape == (1, 2)
+        assert (h == torch.as_tensor([[1.0, 2.0]])).all() and (w == torch.as_tensor([[2.0, 3.0]])).all()
+
     def test_bounding_boxes_dim_inferring_batch(self, device, dtype):
-        box1 = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
-        box2 = torch.tensor([[[2.0, 2.0], [5.0, 2.0], [5.0, 4.0], [2.0, 4.0]]], device=device, dtype=dtype)
+        box1 = torch.tensor([[[1.0, 1.0], [3.0, 2.0], [3.0, 1.0], [1.0, 2.0]]], device=device, dtype=dtype)
+        box2 = torch.tensor([[[5.0, 2.0], [2.0, 2.0], [5.0, 4.0], [2.0, 4.0]]], device=device, dtype=dtype)
         batched_boxes = torch.stack([box1, box2])
 
         h, w = infer_bbox_shape(batched_boxes)
@@ -96,17 +108,22 @@ class TestBbox2D:
 
     @pytest.mark.parametrize('shape', [(1, 4), (1, 1, 4)])
     def test_bounding_boxes_convert_from_kornia(self, shape: Tuple[int], device, dtype):
-        box = torch.as_tensor([[[1, 2], [3, 2], [3, 4], [1, 4]]], device=device, dtype=dtype).view(*shape, 2)
+        # Quadrilater with randommized vertices to reflect possible transforms.
+        box = torch.as_tensor([[[3, 2], [3, 4], [1, 4], [1, 2]]], device=device, dtype=dtype).view(*shape, 2)
 
         expected_box_xyxy = torch.as_tensor([[1, 2, 3, 4]], device=device, dtype=dtype).view(*shape)
         expected_box_xyxy_plus_1 = torch.as_tensor([[1, 2, 4, 5]], device=device, dtype=dtype).view(*shape)
         expected_box_xywh = torch.as_tensor([[1, 2, 2, 2]], device=device, dtype=dtype).view(*shape)
         expected_box_xywh_plus_1 = torch.as_tensor([[1, 2, 3, 3]], device=device, dtype=dtype).view(*shape)
+        expected_vertices = torch.as_tensor([[[1, 2], [3, 2], [3, 4], [1, 4]]], device=device, dtype=dtype).view(
+            *shape, 2
+        )
 
         kornia_xyxy = kornia_bbox_to_bbox(box, mode='xyxy')
         kornia_xyxy_plus_1 = kornia_bbox_to_bbox(box, mode='xyxy_plus_1')
         kornia_xywh = kornia_bbox_to_bbox(box, mode='xywh')
         kornia_xywh_plus_1 = kornia_bbox_to_bbox(box, mode='xywh_plus_1')
+        kornia_vertices = kornia_bbox_to_bbox(box, mode='vertices')
 
         assert kornia_xyxy.shape == expected_box_xyxy.shape
         assert_allclose(kornia_xyxy, expected_box_xyxy)
@@ -120,11 +137,73 @@ class TestBbox2D:
         assert kornia_xywh_plus_1.shape == expected_box_xywh_plus_1.shape
         assert_allclose(kornia_xywh_plus_1, expected_box_xywh_plus_1)
 
+        assert kornia_vertices.shape == expected_vertices.shape
+        assert_allclose(kornia_vertices, expected_vertices)
+
+    def test_bbox_to_mask(self, device, dtype):
+        box1 = torch.tensor([[[1.0, 1.0], [4.0, 1.0], [4.0, 3.0], [1.0, 3.0]]], device=device, dtype=dtype)  # (1, 4, 2)
+        box2 = torch.tensor([[[2.0, 2.0], [5.0, 2.0], [5.0, 6.0], [5.0, 2.0]]], device=device, dtype=dtype)  # (1, 4, 2)
+        two_boxes = torch.cat([box1, box2])  # (2, 4, 2)
+        batched_boxes = torch.stack([box1, box2])  # (2, 1, 4, 2)
+
+        height, width = 7, 5
+
+        expected_mask1 = torch.tensor(
+            [
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        expected_mask2 = torch.tensor(
+            [
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 1],
+                    [0, 0, 1, 1, 1],
+                    [0, 0, 1, 1, 1],
+                    [0, 0, 1, 1, 1],
+                    [0, 0, 0, 0, 0],
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        expected_two_masks = torch.cat([expected_mask1, expected_mask2])
+        expected_batched_masks = torch.stack([expected_mask1, expected_mask2])
+
+        mask1 = bbox_to_mask(box1, height, width)
+        mask2 = bbox_to_mask(box2, height, width)
+        two_masks = bbox_to_mask(two_boxes, height, width)
+        batched_masks = bbox_to_mask(batched_boxes, height, width)
+
+        assert mask1.shape == expected_mask1.shape
+        assert_allclose(mask1, expected_mask1)
+
+        assert mask2.shape == expected_mask2.shape
+        assert_allclose(mask2, expected_mask2)
+
+        assert two_masks.shape == expected_two_masks.shape
+        assert_allclose(two_masks, expected_two_masks)
+
+        assert batched_masks.shape == expected_batched_masks.shape
+        assert_allclose(batched_masks, expected_batched_masks)
+
     def test_gradcheck(self, device, dtype):
         boxes1 = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
+
         boxes1 = utils.tensor_to_gradcheck_var(boxes1)
         boxes2 = utils.tensor_to_gradcheck_var(boxes1.detach().clone())
-
         boxes_xyxy = torch.tensor([[1.0, 3.0, 5.0, 6.0]])
 
         assert gradcheck(infer_bbox_shape, (boxes1,), raise_exception=True)
@@ -171,22 +250,21 @@ class TestBbox2D:
 
 class TestTransformBoxes2D:
     def test_transform_boxes(self, device, dtype):
+        # Define boxes in XYXY format for simplicity.
+        boxes_xyxy = torch.tensor([[139.2640, 103.0150, 397.3120, 410.5225]], device=device, dtype=dtype)
+        expected_boxes_xyxy = torch.tensor([[372.7360, 103.0150, 114.6880, 410.5225]], device=device, dtype=dtype)
 
-        boxes = bbox_to_kornia_bbox(
-            torch.tensor([[139.2640, 103.0150, 397.3120, 410.5225]], device=device, dtype=dtype)
-        )
-
-        expected = bbox_to_kornia_bbox(
-            torch.tensor([[372.7360, 103.0150, 114.6880, 410.5225]], device=device, dtype=dtype)
-        )
+        boxes = bbox_to_kornia_bbox(boxes_xyxy)
+        expected_boxes = bbox_to_kornia_bbox(expected_boxes_xyxy)
 
         trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
 
-        out = transform_bbox(boxes, trans_mat)
-        assert_allclose(out, expected, atol=1e-4, rtol=1e-4)
+        transformed_boxes = transform_bbox(boxes, trans_mat)
+        assert_allclose(transformed_boxes, expected_boxes, atol=1e-4, rtol=1e-4)
 
     def test_transform_multiple_boxes(self, device, dtype):
-        boxes = torch.tensor(
+        # Define boxes in XYXY format for simplicity.
+        boxes_xyxy = torch.tensor(
             [
                 [139.2640, 103.0150, 397.3120, 410.5225],
                 [1.0240, 80.5547, 512.0000, 512.0000],
@@ -195,11 +273,11 @@ class TestTransformBoxes2D:
             ],
             device=device,
             dtype=dtype,
-        )
+        ).repeat(
+            2, 1, 1
+        )  # 2 x 4 x 4 two images 4 boxes each
 
-        boxes = boxes.repeat(2, 1, 1)  # 2 x 4 x 4 two images 4 boxes each
-
-        expected = torch.tensor(
+        expected_boxes_xyxy = torch.tensor(
             [
                 [
                     [372.7360, 103.0150, 114.6880, 410.5225],
@@ -227,15 +305,15 @@ class TestTransformBoxes2D:
             dtype=dtype,
         )
 
-        kornia_bboxes = bbox_to_kornia_bbox(boxes)
-        expected_kornia_bboxes = bbox_to_kornia_bbox(expected)
+        boxes = bbox_to_kornia_bbox(boxes_xyxy)
+        expected_boxes = bbox_to_kornia_bbox(expected_boxes_xyxy)
 
-        out = transform_bbox(kornia_bboxes, trans_mat)
-        assert_allclose(out, expected_kornia_bboxes, atol=1e-4, rtol=1e-4)
+        out = transform_bbox(boxes, trans_mat)
+        assert_allclose(out, expected_boxes, atol=1e-4, rtol=1e-4)
 
     def test_gradcheck(self, device, dtype):
-
-        boxes = torch.tensor(
+        # Define boxes in XYXY format for simplicity.
+        boxes_xyxy = torch.tensor(
             [
                 [139.2640, 103.0150, 258.0480, 307.5075],
                 [1.0240, 80.5547, 510.9760, 431.4453],
@@ -245,89 +323,468 @@ class TestTransformBoxes2D:
             device=device,
             dtype=dtype,
         )
+        boxes = bbox_to_kornia_bbox(boxes_xyxy)
 
         trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
 
         trans_mat = utils.tensor_to_gradcheck_var(trans_mat)
-        boxes = utils.tensor_to_gradcheck_var(bbox_to_kornia_bbox(boxes))
+        boxes = utils.tensor_to_gradcheck_var(boxes)
 
         assert gradcheck(transform_bbox, (boxes, trans_mat), raise_exception=True)
 
     def test_jit(self, device, dtype):
-        boxes = torch.tensor([[139.2640, 103.0150, 258.0480, 307.5075]], device=device, dtype=dtype)
+        boxes_xyxy = torch.tensor([[139.2640, 103.0150, 258.0480, 307.5075]], device=device, dtype=dtype)
         trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
-        args = (trans_mat, bbox_to_kornia_bbox(boxes))
-        op = kornia.geometry.transform_points
+        args = (bbox_to_kornia_bbox(boxes_xyxy), trans_mat)
+        op = transform_bbox
         op_jit = torch.jit.script(op)
         assert_allclose(op(*args), op_jit(*args))
 
 
 class TestBbox3D:
     def test_smoke(self, device, dtype):
-        # Sample two points of the 3d rect
-        points = torch.rand(1, 6, device=device, dtype=dtype)
+        def _create_bbox():
+            # Sample two points of the 3d rect
+            points = torch.rand(1, 6, device=device, dtype=dtype)
 
-        # Fill acording missing points
-        bbox = torch.zeros(1, 8, 3, device=device, dtype=dtype)
-        bbox[0, 0] = points[0][:3]
-        bbox[0, 1, 0] = points[0][3]
-        bbox[0, 1, 1] = points[0][1]
-        bbox[0, 1, 2] = points[0][2]
-        bbox[0, 2, 0] = points[0][3]
-        bbox[0, 2, 1] = points[0][4]
-        bbox[0, 2, 2] = points[0][2]
-        bbox[0, 3, 0] = points[0][0]
-        bbox[0, 3, 1] = points[0][4]
-        bbox[0, 3, 2] = points[0][2]
-        bbox[0, 4, 0] = points[0][0]
-        bbox[0, 4, 1] = points[0][1]
-        bbox[0, 4, 2] = points[0][5]
-        bbox[0, 5, 0] = points[0][3]
-        bbox[0, 5, 1] = points[0][1]
-        bbox[0, 5, 2] = points[0][5]
-        bbox[0, 6] = points[0][3:]
-        bbox[0, 7, 0] = points[0][0]
-        bbox[0, 7, 1] = points[0][4]
-        bbox[0, 7, 2] = points[0][5]
+            # Fill acording missing points
+            bbox = torch.zeros(1, 8, 3, device=device, dtype=dtype)
+            bbox[0, 0] = points[0][:3]
+            bbox[0, 1, 0] = points[0][3]
+            bbox[0, 1, 1] = points[0][1]
+            bbox[0, 1, 2] = points[0][2]
+            bbox[0, 2, 0] = points[0][3]
+            bbox[0, 2, 1] = points[0][4]
+            bbox[0, 2, 2] = points[0][2]
+            bbox[0, 3, 0] = points[0][0]
+            bbox[0, 3, 1] = points[0][4]
+            bbox[0, 3, 2] = points[0][2]
+            bbox[0, 4, 0] = points[0][0]
+            bbox[0, 4, 1] = points[0][1]
+            bbox[0, 4, 2] = points[0][5]
+            bbox[0, 5, 0] = points[0][3]
+            bbox[0, 5, 1] = points[0][1]
+            bbox[0, 5, 2] = points[0][5]
+            bbox[0, 6] = points[0][3:]
+            bbox[0, 7, 0] = points[0][0]
+            bbox[0, 7, 1] = points[0][4]
+            bbox[0, 7, 2] = points[0][5]
+            return bbox
 
         # Validate
-        assert validate_bbox3d(bbox)
+        assert validate_bbox3d(_create_bbox())  # Validate 1 box
+        two_boxes = torch.cat([_create_bbox(), _create_bbox()])  # 2 boxes without batching (N, 8, 3) where N=2
+        assert validate_bbox3d(two_boxes)
+        batched_bbox = torch.stack([_create_bbox(), _create_bbox()])  # 2 boxes in batch (B, 1, 8, 3) where B=2
+        assert validate_bbox3d(batched_bbox)
 
     def test_bounding_boxes_dim_inferring(self, device, dtype):
+        box = torch.tensor(
+            [[[0, 1, 2], [0, 1, 32], [10, 21, 2], [0, 21, 2], [10, 1, 32], [10, 21, 32], [10, 1, 2], [0, 21, 32]]],
+            device=device,
+            dtype=dtype,
+        )  # 1x8x3
         boxes = torch.tensor(
             [
-                [[0, 1, 2], [10, 1, 2], [10, 21, 2], [0, 21, 2], [0, 1, 32], [10, 1, 32], [10, 21, 32], [0, 21, 32]],
-                [[3, 4, 5], [43, 4, 5], [43, 54, 5], [3, 54, 5], [3, 4, 65], [43, 4, 65], [43, 54, 65], [3, 54, 65]],
+                [[0, 21, 32], [0, 1, 2], [10, 1, 2], [0, 21, 2], [0, 1, 32], [10, 21, 2], [10, 1, 32], [10, 21, 32]],
+                [[3, 4, 5], [3, 4, 65], [43, 54, 5], [3, 54, 5], [43, 4, 5], [43, 4, 65], [43, 54, 65], [3, 54, 65]],
             ],
             device=device,
             dtype=dtype,
         )  # 2x8x3
-        d, h, w = infer_bbox_shape3d(boxes)
+        boxes_batch = boxes[None]  # (1, 2, 8, 3)
 
-        assert_allclose(d, torch.tensor([31.0, 61.0], device=device, dtype=dtype))
-        assert_allclose(h, torch.tensor([21.0, 51.0], device=device, dtype=dtype))
-        assert_allclose(w, torch.tensor([11.0, 41.0], device=device, dtype=dtype))
+        # Single box
+        d, h, w = infer_bbox3d_shape(box)
+        assert (d.item(), h.item(), w.item()) == (30.0, 20.0, 10.0)
+
+        # Boxes
+        d, h, w = infer_bbox3d_shape(boxes)
+        assert h.ndim == 1 and w.ndim == 1
+        assert len(d) == 2 and len(h) == 2 and len(w) == 2
+        assert (
+            (d == torch.as_tensor([30.0, 60.0])).all()
+            and (h == torch.as_tensor([20.0, 50.0])).all()
+            and (w == torch.as_tensor([10.0, 40.0])).all()
+        )
+
+        # Box batch
+        d, h, w = infer_bbox3d_shape(boxes_batch)
+        assert h.ndim == 2 and w.ndim == 2
+        assert h.shape == (1, 2) and w.shape == (1, 2)
+        assert (
+            (d == torch.as_tensor([[30.0, 60.0]])).all()
+            and (h == torch.as_tensor([[20.0, 50.0]])).all()
+            and (w == torch.as_tensor([[10.0, 40.0]])).all()
+        )
+
+    @pytest.mark.parametrize('shape', [(1, 6), (1, 1, 6)])
+    def test_bounding_boxes_convert_to_kornia(self, shape: Tuple[int], device, dtype):
+        box_xyzxyz = torch.as_tensor([[1, 2, 3, 4, 5, 6]], device=device, dtype=dtype).view(*shape)
+        box_xyzxyz_plus_1 = torch.as_tensor([[1, 2, 3, 5, 6, 7]], device=device, dtype=dtype).view(*shape)
+        box_xyzwhd = torch.as_tensor([[1, 2, 3, 3, 3, 3]], device=device, dtype=dtype).view(*shape)
+        box_xyzwhd_plus_1 = torch.as_tensor([[1, 2, 3, 4, 4, 4]], device=device, dtype=dtype).view(*shape)
+
+        expected_box = torch.as_tensor(
+            [[[1, 2, 3], [4, 2, 3], [4, 5, 3], [1, 5, 3], [1, 2, 6], [4, 2, 6], [4, 5, 6], [1, 5, 6]]],  # Front  # Back
+            device=device,
+            dtype=dtype,
+        ).view(*shape[:-1], 8, 3)
+
+        kornia_xyzxyz = bbox3d_to_kornia_bbox3d(box_xyzxyz, mode='xyzxyz')
+        kornia_xyzxyz_plus_1 = bbox3d_to_kornia_bbox3d(box_xyzxyz_plus_1, mode='xyzxyz_plus_1')
+        kornia_xyzwhd = bbox3d_to_kornia_bbox3d(box_xyzwhd, mode='xyzwhd')
+        kornia_xyzwhd_plus_1 = bbox3d_to_kornia_bbox3d(box_xyzwhd_plus_1, mode='xyzwhd_plus_1')
+
+        assert kornia_xyzxyz.shape == expected_box.shape
+        assert_allclose(kornia_xyzxyz, expected_box)
+
+        assert kornia_xyzxyz_plus_1.shape == expected_box.shape
+        assert_allclose(kornia_xyzxyz_plus_1, expected_box)
+
+        assert kornia_xyzwhd.shape == expected_box.shape
+        assert_allclose(kornia_xyzwhd, expected_box)
+
+        assert kornia_xyzwhd_plus_1.shape == expected_box.shape
+        assert_allclose(kornia_xyzwhd_plus_1, expected_box)
+
+    @pytest.mark.parametrize('shape', [(1, 6), (1, 1, 6)])
+    def test_bounding_boxes_convert_from_kornia(self, shape: Tuple[int], device, dtype):
+        # Hexahedron with randommized vertices to reflect possible transforms.
+        box = torch.as_tensor(
+            [[[3, 2, 1], [1, 2, 1], [3, 4, 3], [1, 4, 3], [3, 2, 3], [1, 4, 1], [3, 4, 1], [1, 2, 3]]],
+            device=device,
+            dtype=dtype,
+        ).view(*shape[:-1], 8, 3)
+
+        expected_box_xyzxyz = torch.as_tensor([[1, 2, 1, 3, 4, 3]], device=device, dtype=dtype).view(*shape)
+        expected_box_xyzxyz_plus_1 = torch.as_tensor([[1, 2, 1, 4, 5, 4]], device=device, dtype=dtype).view(*shape)
+        expected_box_xyzwhd = torch.as_tensor([[1, 2, 1, 2, 2, 2]], device=device, dtype=dtype).view(*shape)
+        expected_box_xyzwhd_plus_1 = torch.as_tensor([[1, 2, 1, 3, 3, 3]], device=device, dtype=dtype).view(*shape)
+        expected_vertices = torch.as_tensor(
+            [[[1, 2, 1], [3, 2, 1], [3, 4, 1], [1, 4, 1], [1, 2, 3], [3, 2, 3], [3, 4, 3], [1, 4, 3]]],  # Front  # Back
+            device=device,
+            dtype=dtype,
+        ).view(*shape[:-1], 8, 3)
+
+        kornia_xyzxyz = kornia_bbox3d_to_bbox3d(box, mode='xyzxyz')
+        kornia_xyzxyz_plus_1 = kornia_bbox3d_to_bbox3d(box, mode='xyzxyz_plus_1')
+        kornia_xyzwhd = kornia_bbox3d_to_bbox3d(box, mode='xyzwhd')
+        kornia_xyzwhd_plus_1 = kornia_bbox3d_to_bbox3d(box, mode='xyzwhd_plus_1')
+        kornia_vertices = kornia_bbox3d_to_bbox3d(box, mode='vertices')
+
+        assert kornia_xyzxyz.shape == expected_box_xyzxyz.shape
+        assert_allclose(kornia_xyzxyz, expected_box_xyzxyz)
+
+        assert kornia_xyzxyz_plus_1.shape == expected_box_xyzxyz_plus_1.shape
+        assert_allclose(kornia_xyzxyz_plus_1, expected_box_xyzxyz_plus_1)
+
+        assert kornia_xyzwhd.shape == expected_box_xyzwhd.shape
+        assert_allclose(kornia_xyzwhd, expected_box_xyzwhd)
+
+        assert kornia_xyzwhd_plus_1.shape == expected_box_xyzwhd_plus_1.shape
+        assert_allclose(kornia_xyzwhd_plus_1, expected_box_xyzwhd_plus_1)
+
+        assert kornia_vertices.shape == expected_vertices.shape
+        assert_allclose(kornia_vertices, expected_vertices)
+
+    def test_bbox_to_mask(self, device, dtype):
+        box1 = torch.tensor(
+            [
+                [
+                    [1.0, 1.0, 1.0],
+                    [4.0, 1.0, 1.0],
+                    [4.0, 3.0, 1.0],
+                    [1.0, 3.0, 1.0],  # Front
+                    [1.0, 1.0, 3.0],
+                    [4.0, 1.0, 3.0],
+                    [4.0, 3.0, 3.0],
+                    [1.0, 3.0, 3.0],  # Back
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )  # (1, 4, 2)
+        box2 = torch.tensor(
+            [
+                [
+                    [2.0, 2.0, 1.0],
+                    [5.0, 2.0, 1.0],
+                    [5.0, 6.0, 1.0],
+                    [5.0, 2.0, 1.0],  # Front
+                    [2.0, 2.0, 2.0],
+                    [5.0, 2.0, 2.0],
+                    [5.0, 6.0, 2.0],
+                    [5.0, 2.0, 2.0],  # Back
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )  # (1, 4, 2)
+        two_boxes = torch.cat([box1, box2])  # (2, 4, 2)
+        batched_boxes = torch.stack([box1, box2])  # (2, 1, 4, 2)
+
+        depth, height, width = 3, 7, 5
+
+        expected_mask1 = torch.tensor(
+            [
+                [
+                    [  # Depth 0
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                    ],
+                    [  # Depth 1
+                        [0, 0, 0, 0, 0],
+                        [0, 1, 1, 1, 0],
+                        [0, 1, 1, 1, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                    ],
+                    [  # Depth 2
+                        [0, 0, 0, 0, 0],
+                        [0, 1, 1, 1, 0],
+                        [0, 1, 1, 1, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                    ],
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        expected_mask2 = torch.tensor(
+            [
+                [
+                    [  # Depth 0
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                    ],
+                    [  # Depth 1
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 1, 1, 1],
+                        [0, 0, 1, 1, 1],
+                        [0, 0, 1, 1, 1],
+                        [0, 0, 1, 1, 1],
+                        [0, 0, 0, 0, 0],
+                    ],
+                    [  # Depth 2
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0],
+                    ],
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        expected_two_masks = torch.cat([expected_mask1, expected_mask2])
+        expected_batched_masks = torch.stack([expected_mask1, expected_mask2])
+
+        mask1 = bbox3d_to_mask3d(box1, depth, height, width)
+        mask2 = bbox3d_to_mask3d(box2, depth, height, width)
+        two_masks = bbox3d_to_mask3d(two_boxes, depth, height, width)
+        batched_masks = bbox3d_to_mask3d(batched_boxes, depth, height, width)
+
+        assert mask1.shape == expected_mask1.shape
+        assert_allclose(mask1, expected_mask1)
+
+        assert mask2.shape == expected_mask2.shape
+        assert_allclose(mask2, expected_mask2)
+
+        assert two_masks.shape == expected_two_masks.shape
+        assert_allclose(two_masks, expected_two_masks)
+
+        assert batched_masks.shape == expected_batched_masks.shape
+        assert_allclose(batched_masks, expected_batched_masks)
 
     def test_gradcheck(self, device, dtype):
-        boxes = torch.tensor(
+        boxes1 = torch.tensor(
             [[[0, 1, 2], [10, 1, 2], [10, 21, 2], [0, 21, 2], [0, 1, 32], [10, 1, 32], [10, 21, 32], [0, 21, 32]]],
             device=device,
             dtype=dtype,
         )
-        boxes = utils.tensor_to_gradcheck_var(boxes)
-        assert gradcheck(infer_bbox_shape3d, (boxes,), raise_exception=True)
 
-    def test_jit(self, device, dtype):
+        boxes1 = utils.tensor_to_gradcheck_var(boxes1)
+        boxes2 = utils.tensor_to_gradcheck_var(boxes1.detach().clone())
+        boxes_xyzxyz = torch.tensor([[1.0, 3.0, 8.0, 5.0, 6.0, 12.0]])
+
+        assert gradcheck(infer_bbox3d_shape, (boxes1,), raise_exception=True)
+        assert gradcheck(kornia_bbox3d_to_bbox3d, (boxes2,), raise_exception=True)
+        assert gradcheck(bbox3d_to_kornia_bbox3d, (boxes_xyzxyz,), raise_exception=True)
+
+    @pytest.mark.parametrize('op', [validate_bbox3d, infer_bbox3d_shape, kornia_bbox3d_to_bbox3d])
+    def test_jit(self, op: Callable, device, dtype):
         # Define script
-        op = infer_bbox_shape3d
         op_script = torch.jit.script(op)
-
+        # Define input
         boxes = torch.tensor(
             [[[0, 0, 1], [3, 0, 1], [3, 2, 1], [0, 2, 1], [0, 0, 3], [3, 0, 3], [3, 2, 3], [0, 2, 3]]],
             device=device,
             dtype=dtype,
         )  # 1x8x3
-
-        actual = op_script(boxes)
+        # Run
         expected = op(boxes)
+        actual = op_script(boxes)
+        # Compare
         assert_allclose(actual, expected)
+
+    def test_jit_bbox3d_to_mask3d(self, device, dtype):
+        # Define script
+        op = bbox3d_to_mask3d
+        op_script = torch.jit.script(op)
+        # Define input
+        boxes = torch.tensor(
+            [[[0, 0, 1], [3, 0, 1], [3, 2, 1], [0, 2, 1], [0, 0, 3], [3, 0, 3], [3, 2, 3], [0, 2, 3]]],
+            device=device,
+            dtype=dtype,
+        )  # 1x8x3
+        depth, height, width = 7, 5, 10
+        # Run
+        expected = op(boxes, depth, height, width)
+        actual = op_script(boxes, depth, height, width)
+        # Compare
+        assert_allclose(actual, expected)
+
+    def test_jit_convert_to_kornia_format(self, device, dtype):
+        # Define script
+        op = bbox3d_to_kornia_bbox3d
+        op_script = torch.jit.script(op)
+        # Define input
+        boxes = torch.tensor([[1, 2, 3, 4, 5, 6]], device=device, dtype=dtype)
+        # Run
+        expected = op(boxes)
+        actual = op_script(boxes)
+        # Compare
+        assert_allclose(actual, expected)
+
+
+class TestTransformBoxes3D:
+    def test_transform_boxes(self, device, dtype):
+        # Define boxes in XYZXYZ format for simplicity.
+        boxes_xyzxyz = torch.tensor(
+            [[139.2640, 103.0150, 283.162, 397.3120, 410.5225, 453.185]], device=device, dtype=dtype
+        )
+        expected_boxes_xyzxyz = torch.tensor(
+            [[372.7360, 103.0150, 567.324, 114.6880, 410.5225, 907.37]], device=device, dtype=dtype
+        )
+
+        boxes = bbox3d_to_kornia_bbox3d(boxes_xyzxyz)
+        expected_boxes = bbox3d_to_kornia_bbox3d(expected_boxes_xyzxyz)
+
+        trans_mat = torch.tensor(
+            [[[-1.0, 0.0, 0.0, 512.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
+        )
+
+        transformed_boxes = transform_bbox3d(boxes, trans_mat)
+        assert_allclose(transformed_boxes, expected_boxes, atol=1e-4, rtol=1e-4)
+
+    def test_transform_multiple_boxes(self, device, dtype):
+        # Define boxes in XYZXYZ format for simplicity.
+        boxes_xyzxyz = torch.tensor(
+            [
+                [139.2640, 103.0150, 283.162, 397.3120, 410.5225, 453.185],
+                [1.0240, 80.5547, 469.50, 512.0000, 512.0000, 512.0],
+                [165.2053, 262.1440, 42.98, 510.6347, 508.9280, 784.443],
+                [119.8080, 144.2067, 234.21, 257.0240, 410.1292, 86.14],
+            ],
+            device=device,
+            dtype=dtype,
+        ).repeat(
+            2, 1, 1
+        )  # 2 x 4 x 4 two images 4 boxes each
+
+        expected_boxes_xyzxyz = torch.tensor(
+            [
+                [
+                    [372.7360, 103.0150, 567.324, 114.6880, 410.5225, 907.37],
+                    [510.9760, 80.5547, 940.0, 0.0000, 512.0000, 1025.0],
+                    [346.7947, 262.1440, 86.96, 1.3653, 508.9280, 1569.886],
+                    [392.1920, 144.2067, 469.42, 254.9760, 410.1292, 173.28],
+                ],
+                [
+                    [139.2640, 103.0150, 283.162, 397.3120, 410.5225, 453.185],
+                    [1.0240, 80.5547, 469.50, 512.0000, 512.0000, 512.0],
+                    [165.2053, 262.1440, 42.98, 510.6347, 508.9280, 784.443],
+                    [119.8080, 144.2067, 234.21, 257.0240, 410.1292, 86.14],
+                ],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        trans_mat = torch.tensor(
+            [
+                [[-1.0, 0.0, 0.0, 512.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]],
+                [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        boxes = bbox3d_to_kornia_bbox3d(boxes_xyzxyz)
+        expected_boxes = bbox3d_to_kornia_bbox3d(expected_boxes_xyzxyz)
+
+        out = transform_bbox3d(boxes, trans_mat)
+        assert_allclose(out, expected_boxes, atol=1e-4, rtol=1e-4)
+
+    def test_gradcheck(self, device, dtype):
+        # Define boxes in XYZXYZ format for simplicity.
+        boxes_xyzxyz = torch.tensor(
+            [
+                [139.2640, 103.0150, 283.162, 397.3120, 410.5225, 453.185],
+                [1.0240, 80.5547, 469.50, 512.0000, 512.0000, 512.0],
+                [165.2053, 262.1440, 42.98, 510.6347, 508.9280, 784.443],
+                [119.8080, 144.2067, 234.21, 257.0240, 410.1292, 86.14],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        boxes = bbox3d_to_kornia_bbox3d(boxes_xyzxyz)
+
+        trans_mat = torch.tensor(
+            [[[-1.0, 0.0, 0.0, 512.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
+        )
+
+        trans_mat = utils.tensor_to_gradcheck_var(trans_mat)
+        boxes = utils.tensor_to_gradcheck_var(boxes)
+
+        assert gradcheck(transform_bbox3d, (boxes, trans_mat), raise_exception=True)
+
+    def test_jit(self, device, dtype):
+        boxes_xyzxyz = torch.tensor(
+            [[[139.2640, 103.0150, 283.162, 397.3120, 410.5225, 453.185]]], device=device, dtype=dtype
+        )
+
+        trans_mat = torch.tensor(
+            [[[-1.0, 0.0, 0.0, 512.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
+        )
+        args = (bbox3d_to_kornia_bbox3d(boxes_xyzxyz), trans_mat)
+        op = transform_bbox3d
+        op_jit = torch.jit.script(op)
+        assert_allclose(op(*args), op_jit(*args))

--- a/test/geometry/test_bbox_v2.py
+++ b/test/geometry/test_bbox_v2.py
@@ -1,0 +1,323 @@
+from typing import Callable, Tuple
+
+import pytest
+import torch
+from torch.autograd import gradcheck
+from torch.testing import assert_allclose
+
+import kornia
+import kornia.testing as utils
+from kornia.geometry.bbox_v2 import (
+    bbox_to_kornia_bbox,
+    bbox_to_mask,
+    infer_bbox_shape,
+    kornia_bbox_to_bbox,
+    transform_bbox,
+    validate_bbox,
+    validate_bbox3d,
+)
+
+
+class TestBbox2D:
+    def test_smoke(self, device, dtype):
+        def _create_bbox():
+            # Sample two points of the rectangle
+            points = torch.rand(1, 4, device=device, dtype=dtype)
+
+            # Fill according missing points
+            bbox = torch.zeros(1, 4, 2, device=device, dtype=dtype)
+            bbox[0, 0] = points[0][:2]
+            bbox[0, 1, 0] = points[0][2]
+            bbox[0, 1, 1] = points[0][1]
+            bbox[0, 2] = points[0][2:]
+            bbox[0, 3, 0] = points[0][0]
+            bbox[0, 3, 1] = points[0][3]
+            return bbox
+
+        bbox = _create_bbox()
+        # Validate
+        assert validate_bbox(bbox)
+
+        # Batch od 2 samples
+        batched_bbox = torch.stack([_create_bbox(), _create_bbox()])
+        assert validate_bbox(batched_bbox)
+
+    def test_bounding_boxes_dim_inferring(self, device, dtype):
+        box = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
+        boxes = torch.tensor(
+            [[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]], [[2.0, 2.0], [5.0, 2.0], [5.0, 4.0], [2.0, 4.0]]],
+            device=device,
+            dtype=dtype,
+        )
+
+        h, w = infer_bbox_shape(box)
+        assert (h.item(), w.item()) == (1, 2)
+
+        h, w = infer_bbox_shape(boxes)
+        assert h.ndim == 1 and w.ndim == 1
+        assert len(h) == 2 and len(w) == 2
+        assert (h == torch.as_tensor([1, 2])).all() and (w == torch.as_tensor([2, 3])).all()
+
+    def test_bounding_boxes_dim_inferring_batch(self, device, dtype):
+        box1 = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
+        box2 = torch.tensor([[[2.0, 2.0], [5.0, 2.0], [5.0, 4.0], [2.0, 4.0]]], device=device, dtype=dtype)
+        batched_boxes = torch.stack([box1, box2])
+
+        h, w = infer_bbox_shape(batched_boxes)
+        assert h.ndim == 2 and w.ndim == 2
+        assert h.shape == (2, 1) and w.shape == (2, 1)
+        assert (h == torch.as_tensor([[1], [2]])).all() and (w == torch.as_tensor([[2], [3]])).all()
+
+    @pytest.mark.parametrize('shape', [(1, 4), (1, 1, 4)])
+    def test_bounding_boxes_convert_to_kornia(self, shape: Tuple[int], device, dtype):
+        box_xyxy = torch.as_tensor([[1, 2, 3, 4]], device=device, dtype=dtype).view(*shape)
+        box_xyxy_plus_1 = torch.as_tensor([[1, 2, 4, 5]], device=device, dtype=dtype).view(*shape)
+        box_xywh = torch.as_tensor([[1, 2, 2, 2]], device=device, dtype=dtype).view(*shape)
+        box_xywh_plus_1 = torch.as_tensor([[1, 2, 3, 3]], device=device, dtype=dtype).view(*shape)
+
+        expected_box = torch.as_tensor([[[1, 2], [3, 2], [3, 4], [1, 4]]], device=device, dtype=dtype).view(*shape, 2)
+
+        kornia_xyxy = bbox_to_kornia_bbox(box_xyxy, mode='xyxy')
+        kornia_xyxy_plus_1 = bbox_to_kornia_bbox(box_xyxy_plus_1, mode='xyxy_plus_1')
+        kornia_xywh = bbox_to_kornia_bbox(box_xywh, mode='xywh')
+        kornia_xywh_plus_1 = bbox_to_kornia_bbox(box_xywh_plus_1, mode='xywh_plus_1')
+
+        assert kornia_xyxy.shape == expected_box.shape
+        assert_allclose(kornia_xyxy, expected_box)
+
+        assert kornia_xyxy_plus_1.shape == expected_box.shape
+        assert_allclose(kornia_xyxy_plus_1, expected_box)
+
+        assert kornia_xywh.shape == expected_box.shape
+        assert_allclose(kornia_xywh, expected_box)
+
+        assert kornia_xywh_plus_1.shape == expected_box.shape
+        assert_allclose(kornia_xywh_plus_1, expected_box)
+
+    @pytest.mark.parametrize('shape', [(1, 4), (1, 1, 4)])
+    def test_bounding_boxes_convert_from_kornia(self, shape: Tuple[int], device, dtype):
+        box = torch.as_tensor([[[1, 2], [3, 2], [3, 4], [1, 4]]], device=device, dtype=dtype).view(*shape, 2)
+
+        expected_box_xyxy = torch.as_tensor([[1, 2, 3, 4]], device=device, dtype=dtype).view(*shape)
+        expected_box_xyxy_plus_1 = torch.as_tensor([[1, 2, 4, 5]], device=device, dtype=dtype).view(*shape)
+        expected_box_xywh = torch.as_tensor([[1, 2, 2, 2]], device=device, dtype=dtype).view(*shape)
+        expected_box_xywh_plus_1 = torch.as_tensor([[1, 2, 3, 3]], device=device, dtype=dtype).view(*shape)
+
+        kornia_xyxy = kornia_bbox_to_bbox(box, mode='xyxy')
+        kornia_xyxy_plus_1 = kornia_bbox_to_bbox(box, mode='xyxy_plus_1')
+        kornia_xywh = kornia_bbox_to_bbox(box, mode='xywh')
+        kornia_xywh_plus_1 = kornia_bbox_to_bbox(box, mode='xywh_plus_1')
+
+        assert kornia_xyxy.shape == expected_box_xyxy.shape
+        assert_allclose(kornia_xyxy, expected_box_xyxy)
+
+        assert kornia_xyxy_plus_1.shape == expected_box_xyxy_plus_1.shape
+        assert_allclose(kornia_xyxy_plus_1, expected_box_xyxy_plus_1)
+
+        assert kornia_xywh.shape == expected_box_xywh.shape
+        assert_allclose(kornia_xywh, expected_box_xywh)
+
+        assert kornia_xywh_plus_1.shape == expected_box_xywh_plus_1.shape
+        assert_allclose(kornia_xywh_plus_1, expected_box_xywh_plus_1)
+
+    def test_gradcheck(self, device, dtype):
+        boxes1 = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
+        boxes1 = utils.tensor_to_gradcheck_var(boxes1)
+        boxes2 = utils.tensor_to_gradcheck_var(boxes1.detach().clone())
+
+        boxes_xyxy = torch.tensor([[1.0, 3.0, 5.0, 6.0]])
+
+        assert gradcheck(infer_bbox_shape, (boxes1,), raise_exception=True)
+        assert gradcheck(kornia_bbox_to_bbox, (boxes2,), raise_exception=True)
+        assert gradcheck(bbox_to_kornia_bbox, (boxes_xyxy,), raise_exception=True)
+
+    @pytest.mark.parametrize(
+        'op', [validate_bbox, infer_bbox_shape, bbox_to_mask, bbox_to_kornia_bbox, kornia_bbox_to_bbox]
+    )
+    def test_jit(self, op: Callable, device, dtype):
+        # Define script
+        op_script = torch.jit.script(op)
+        # Define input
+        boxes = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
+        # Run
+        expected = op(boxes)
+        actual = op_script(boxes)
+        # Compare
+        assert_allclose(actual, expected)
+
+    def test_jit_convert_to_kornia_format(self, device, dtype):
+        # Define script
+        op = bbox_to_kornia_bbox
+        op_script = torch.jit.script(op)
+        # Define input
+        boxes = torch.tensor([[1, 2, 3, 4]], device=device, dtype=dtype)
+        # Run
+        expected = op(boxes)
+        actual = op_script(boxes)
+        # Compare
+        assert_allclose(actual, expected)
+
+
+class TestTransformBoxes2D:
+    def test_transform_boxes(self, device, dtype):
+
+        boxes = bbox_to_kornia_bbox(
+            torch.tensor([[139.2640, 103.0150, 397.3120, 410.5225]], device=device, dtype=dtype)
+        )
+
+        expected = bbox_to_kornia_bbox(
+            torch.tensor([[372.7360, 103.0150, 114.6880, 410.5225]], device=device, dtype=dtype)
+        )
+
+        trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
+
+        out = transform_bbox(boxes, trans_mat)
+        assert_allclose(out, expected, atol=1e-4, rtol=1e-4)
+
+    def test_transform_multiple_boxes(self, device, dtype):
+
+        boxes = torch.tensor(
+            [
+                [139.2640, 103.0150, 397.3120, 410.5225],
+                [1.0240, 80.5547, 512.0000, 512.0000],
+                [165.2053, 262.1440, 510.6347, 508.9280],
+                [119.8080, 144.2067, 257.0240, 410.1292],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        boxes = boxes.repeat(2, 1, 1)  # 2 x 4 x 4 two images 4 boxes each
+
+        expected = torch.tensor(
+            [
+                [
+                    [372.7360, 103.0150, 114.6880, 410.5225],
+                    [510.9760, 80.5547, 0.0000, 512.0000],
+                    [346.7947, 262.1440, 1.3653, 508.9280],
+                    [392.1920, 144.2067, 254.9760, 410.1292],
+                ],
+                [
+                    [139.2640, 103.0150, 397.3120, 410.5225],
+                    [1.0240, 80.5547, 512.0000, 512.0000],
+                    [165.2053, 262.1440, 510.6347, 508.9280],
+                    [119.8080, 144.2067, 257.0240, 410.1292],
+                ],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        trans_mat = torch.tensor(
+            [
+                [[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        kornia_bboxes = bbox_to_kornia_bbox(boxes)
+        expected_kornia_bboxes = bbox_to_kornia_bbox(expected)
+
+        out = transform_bbox(kornia_bboxes, trans_mat)
+        assert_allclose(out, expected_kornia_bboxes, atol=1e-4, rtol=1e-4)
+
+    def test_gradcheck(self, device, dtype):
+
+        boxes = torch.tensor(
+            [
+                [139.2640, 103.0150, 258.0480, 307.5075],
+                [1.0240, 80.5547, 510.9760, 431.4453],
+                [165.2053, 262.1440, 345.4293, 246.7840],
+                [119.8080, 144.2067, 137.2160, 265.9225],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
+
+        trans_mat = utils.tensor_to_gradcheck_var(trans_mat)
+        boxes = utils.tensor_to_gradcheck_var(bbox_to_kornia_bbox(boxes))
+
+        assert gradcheck(transform_bbox, (boxes, trans_mat), raise_exception=True)
+
+    def test_jit(self, device, dtype):
+        boxes = torch.tensor([[139.2640, 103.0150, 258.0480, 307.5075]], device=device, dtype=dtype)
+        trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
+        args = (trans_mat, bbox_to_kornia_bbox(boxes))
+        op = kornia.geometry.transform_points
+        op_jit = torch.jit.script(op)
+        assert_allclose(op(*args), op_jit(*args))
+
+
+class TestBbox3D:
+    def test_smoke(self, device, dtype):
+        # Sample two points of the 3d rect
+        points = torch.rand(1, 6, device=device, dtype=dtype)
+
+        # Fill acording missing points
+        bbox = torch.zeros(1, 8, 3, device=device, dtype=dtype)
+        bbox[0, 0] = points[0][:3]
+        bbox[0, 1, 0] = points[0][3]
+        bbox[0, 1, 1] = points[0][1]
+        bbox[0, 1, 2] = points[0][2]
+        bbox[0, 2, 0] = points[0][3]
+        bbox[0, 2, 1] = points[0][4]
+        bbox[0, 2, 2] = points[0][2]
+        bbox[0, 3, 0] = points[0][0]
+        bbox[0, 3, 1] = points[0][4]
+        bbox[0, 3, 2] = points[0][2]
+        bbox[0, 4, 0] = points[0][0]
+        bbox[0, 4, 1] = points[0][1]
+        bbox[0, 4, 2] = points[0][5]
+        bbox[0, 5, 0] = points[0][3]
+        bbox[0, 5, 1] = points[0][1]
+        bbox[0, 5, 2] = points[0][5]
+        bbox[0, 6] = points[0][3:]
+        bbox[0, 7, 0] = points[0][0]
+        bbox[0, 7, 1] = points[0][4]
+        bbox[0, 7, 2] = points[0][5]
+
+        # Validate
+        assert validate_bbox3d(bbox)
+
+    def test_bounding_boxes_dim_inferring(self, device, dtype):
+        boxes = torch.tensor(
+            [
+                [[0, 1, 2], [10, 1, 2], [10, 21, 2], [0, 21, 2], [0, 1, 32], [10, 1, 32], [10, 21, 32], [0, 21, 32]],
+                [[3, 4, 5], [43, 4, 5], [43, 54, 5], [3, 54, 5], [3, 4, 65], [43, 4, 65], [43, 54, 65], [3, 54, 65]],
+            ],
+            device=device,
+            dtype=dtype,
+        )  # 2x8x3
+        d, h, w = infer_bbox_shape3d(boxes)
+
+        assert_allclose(d, torch.tensor([31.0, 61.0], device=device, dtype=dtype))
+        assert_allclose(h, torch.tensor([21.0, 51.0], device=device, dtype=dtype))
+        assert_allclose(w, torch.tensor([11.0, 41.0], device=device, dtype=dtype))
+
+    def test_gradcheck(self, device, dtype):
+        boxes = torch.tensor(
+            [[[0, 1, 2], [10, 1, 2], [10, 21, 2], [0, 21, 2], [0, 1, 32], [10, 1, 32], [10, 21, 32], [0, 21, 32]]],
+            device=device,
+            dtype=dtype,
+        )
+        boxes = utils.tensor_to_gradcheck_var(boxes)
+        assert gradcheck(infer_bbox_shape3d, (boxes,), raise_exception=True)
+
+    def test_jit(self, device, dtype):
+        # Define script
+        op = infer_bbox_shape3d
+        op_script = torch.jit.script(op)
+
+        boxes = torch.tensor(
+            [[[0, 0, 1], [3, 0, 1], [3, 2, 1], [0, 2, 1], [0, 0, 3], [3, 0, 3], [3, 2, 3], [0, 2, 3]]],
+            device=device,
+            dtype=dtype,
+        )  # 1x8x3
+
+        actual = op_script(boxes)
+        expected = op(boxes)
+        assert_allclose(actual, expected)


### PR DESCRIPTION
### Description
Add bbox V2 as discussed in #1142. I think that code is practically finished. See TODO section below for the missing bits. They could be tackle in other PRs. Also, I think I won't have much free time until the end of the summer. So, I open this PR so others contributors can continue this work during the summer if they want.

There are several new functions. I'm not sure if their names follows kornia convention. I tried as best as I could.

### Status
Ready to review

 # Differences from `kornia.geometry.bbox`:
General:
- Batch support.
- Change bbox format to remove +1
- Docs updated.
- Fix support for dtype and device. Now, results will always match with dtype and device of the original boxes. The only exception is with bbox_to_kornia_bbox* when original boxes are integer. They will be cast to float.
- Remove boxes validation inside bbox_to_mask* and infer_bbox_shape* to match with transform_bbox. I think it should be up to the user to do it or use the future Boxes structure.  Only a basic shape check is done now.
- Renamed bbox_generator* to bbox_to_kornia_bbox* and changed its arguments. 
- Created kornia_bbox_to_bbox* that converts boxes in kornia format into a more standard format like xyxy, etc.
   - I'm not sure if I can make it differentiable for cases of xywh and xyzwhd.
- transform_bbox: align to transform wrap convention: first pass boxes, then the transformation matrix.
- boxes_to_mask & boxes_to_mask3d: 
  - probably, it could be made differentiable with a performance penalty to remove inplace modifications.
  - Simplified.
  
Boxes 3D:
- Renamed bbox_to_mask3d to bbox3d_to_mask3d to keep the convention of bbox3d.
- Replace `index_fill` with tensor regular indexing (ex: t[:, 4, 5])
- Add transform_bbox3d for consistency.
 - Code has been simplified.
 - Changed bbox_to_mask3d signature to accept depth, width and height instead of size. Now, it matches 2D convention and bbox_generator3d.

Tests:
  - Lots of new tests. Now, there is 100% coverage. 
   - Grad checks. Current kornia.geometry.bbox wouldn't pass them either. So, I don't know if this new code is expected to pass.

TODO to do in future PRs):
- Port kornia containers to use them. At least, expose bbox_v2. Care should be taken since transforms assumes +1 convention. At least, it happens with random flips. Check [this article](https://ppwwyyxx.com/blog/2021/Where-are-Pixels/).


### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Breaking change (fix or new feature that would cause existing functionality to change)
- [x] New tests added to cover the changes
- [x] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [x] Did you discuss the functionality or any breaking changes before ?
- [x] **Pass all tests**: did you test in local ? `make test`
- [x] Unittests: did you add tests for your new functionality ?
- [x] Documentations: did you build documentation ? `make build-docs`
- [x]  Implementation: is your code well commented and follow conventions ? `make lint`
- [x] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [x] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>

  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?

</details>
