### PR TITLE
wrong param name fixed

### DIFF
--- a/kornia/augmentation/augmentation3d.py
+++ b/kornia/augmentation/augmentation3d.py
@@ -258,7 +258,7 @@ class RandomAffine3D(AugmentationBase3D):
             If (a, b) represents isotropic scaling, the scale is randomly sampled from the range a <= scale <= b.
             If ((a, b), (c, d), (e, f)), the scale is randomly sampled from the range a <= scale_x <= b,
             c <= scale_y <= d, e <= scale_z <= f. Will keep original scale by default.
-        shear: Range of degrees to select from.
+        shears: Range of degrees to select from.
             If shear is a number, a shear to the 6 facets in the range (-shear, +shear) will be applied.
             If shear is a tuple of 2 values, a shear to the 6 facets in the range (shear[0], shear[1]) will be applied.
             If shear is a tuple of 6 values, a shear to the i-th facet in the range (-shear[i], shear[i])


### PR DESCRIPTION
### Description
Wrong param name fixed for RandomAffine3D()
shear -> shears

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x] Docstrings/Documentation updated
