### PR TITLE
Added tests, fixed docstrings and made some other changes

### DIFF
--- a/test/geometry/test_pinhole.py
+++ b/test/geometry/test_pinhole.py
@@ -1,7 +1,259 @@
 import torch
-
+import pytest
 import kornia
-from kornia.testing import assert_close
+
+from torch.autograd import gradcheck
+from kornia.testing import assert_close, tensor_to_gradcheck_var
+
+
+class TestCam2Pixel:
+
+    def _create_intrinsics(self, batch_size, fx, fy, cx, cy, device, dtype):
+        temp = torch.eye(4, device=device, dtype=dtype)
+        temp[0, 0], temp[0, 2] = fx, cx
+        temp[1, 1], temp[1, 2] = fy, cy
+        intrinsics = temp.expand(batch_size, -1, -1)
+        return intrinsics
+
+    def _create_intrinsics_inv(self, batch_size, fx, fy, cx, cy, device, dtype):
+        temp = torch.eye(4, device=device, dtype=dtype)
+        temp[0, 0], temp[0, 2] = 1 / fx, -cx / fx
+        temp[1, 1], temp[1, 2] = 1 / fy, -cy / fy
+        intrinsics_inv = temp.expand(batch_size, -1, -1)
+        return intrinsics_inv
+
+    def _get_samples(self, shape, low, high, device, dtype):
+        """Returns a tensor having the given shape and whose values are in the range [low, high)"""
+        return ((high - low) * torch.rand(shape, device=device, dtype=dtype)) + low
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_smoke(self, batch_size, device, dtype):
+        H, W = 250, 500
+        fx, fy = W, H
+        cx, cy = W / 2, H / 2
+        eps = 1e-12
+        seed = 77
+        low, high = -500, 500
+
+        intrinsics = self._create_intrinsics(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        )
+
+        # Setting the projection matrix to the intrinsic matrix for
+        # simplicity (i.e. assuming that the RT matrix is an identity matrix)
+        proj_mat = intrinsics
+
+        torch.manual_seed(seed)
+        cam_coords_src = self._get_samples((batch_size, H, W, 3), low, high, device, dtype)
+
+        pixel_coords_dst = kornia.cam2pixel(
+            cam_coords_src=cam_coords_src,
+            dst_proj_src=proj_mat,
+            eps=eps
+        )
+        assert pixel_coords_dst.shape == (batch_size, H, W, 2)
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_consistency(self, batch_size, device, dtype):
+        H, W = 250, 500
+        fx, fy = W, H
+        cx, cy = W / 2, H / 2
+        eps = 1e-12
+        seed = 77
+        low, high = -500, 500
+
+        intrinsics = self._create_intrinsics(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        )
+        intrinsics_inv = self._create_intrinsics_inv(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        )
+
+        # Setting the projection matrix to the intrinsic matrix for
+        # simplicity (i.e. assuming that the RT matrix is an identity matrix)
+        proj_mat = intrinsics
+
+        torch.manual_seed(seed)
+        cam_coords_input = self._get_samples((batch_size, H, W, 3), low, high, device, dtype)
+
+        pixel_coords_output = kornia.cam2pixel(
+            cam_coords_src=cam_coords_input,
+            dst_proj_src=proj_mat,
+            eps=eps,
+        )
+
+        last_ch = torch.ones((batch_size, H, W, 1), device=device, dtype=dtype)
+        pixel_coords_concat = torch.cat([pixel_coords_output, last_ch], axis=-1)
+
+        depth = cam_coords_input[..., 2:3].permute(0, 3, 1, 2).contiguous()
+        cam_coords_output = kornia.pixel2cam(
+            depth=depth, intrinsics_inv=intrinsics_inv,
+            pixel_coords=pixel_coords_concat,
+        )
+
+        assert_close(cam_coords_output, cam_coords_input, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_gradcheck(self, batch_size, device, dtype):
+        H, W = 10, 20
+        fx, fy = W, H
+        cx, cy = W / 2, H / 2
+        eps = 1e-12
+        seed = 77
+        low, high = -500, 500
+        atol, rtol = 1e-5, 1e-3
+
+        # Different tolerances for the below case.
+        if (device.type == "cuda") and ((dtype == "float64") or (dtype == torch.float64)):
+            atol, rtol = 1e-4, 1e-2
+
+        # If contiguous() is not called, gradcheck fails
+        intrinsics = self._create_intrinsics(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        ).contiguous()
+
+        # Setting the projection matrix to the intrinsic matrix for
+        # simplicity (i.e. assuming that the RT matrix is an identity matrix)
+        proj_mat = intrinsics
+
+        torch.manual_seed(seed)
+        cam_coords_src = self._get_samples((batch_size, H, W, 3), low, high, device, dtype)
+
+        cam_coords_src = tensor_to_gradcheck_var(cam_coords_src)
+        proj_mat = tensor_to_gradcheck_var(proj_mat)
+
+        assert gradcheck(
+            kornia.geometry.cam2pixel,
+            (cam_coords_src, proj_mat, eps), raise_exception=True,
+            atol=atol, rtol=rtol,
+        )
+
+
+class TestPixel2Cam:
+
+    def _create_intrinsics(self, batch_size, fx, fy, cx, cy, device, dtype):
+        temp = torch.eye(4, device=device, dtype=dtype)
+        temp[0, 0], temp[0, 2] = fx, cx
+        temp[1, 1], temp[1, 2] = fy, cy
+        intrinsics = temp.expand(batch_size, -1, -1)
+        return intrinsics
+
+    def _create_intrinsics_inv(self, batch_size, fx, fy, cx, cy, device, dtype):
+        temp = torch.eye(4, device=device, dtype=dtype)
+        temp[0, 0], temp[0, 2] = 1 / fx, -cx / fx
+        temp[1, 1], temp[1, 2] = 1 / fy, -cy / fy
+        intrinsics_inv = temp.expand(batch_size, -1, -1)
+        return intrinsics_inv
+
+    def _get_samples(self, shape, low, high, device, dtype):
+        """Returns a tensor having the given shape and whose values are in the range [low, high)"""
+        return ((high - low) * torch.rand(shape, device=device, dtype=dtype)) + low
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_smoke(self, batch_size, device, dtype):
+        H, W = 250, 500
+        fx, fy = W, H
+        cx, cy = W / 2, H / 2
+        seed = 77
+        low_1, high_1 = -500, 500
+        low_2, high_2 = -(max(W, H) * 3), (max(W, H) * 3)
+
+        torch.manual_seed(seed)
+        depth = self._get_samples((batch_size, 1, H, W), low_1, high_1, device, dtype)
+        pixel_coords = self._get_samples((batch_size, H, W, 2), low_2, high_2, device, dtype)
+
+        last_ch = torch.ones((batch_size, H, W, 1), device=device, dtype=dtype)
+        pixel_coords_input = torch.cat([pixel_coords, last_ch], axis=-1)
+
+        intrinsics_inv = self._create_intrinsics_inv(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        )
+
+        output = kornia.pixel2cam(
+            depth=depth, intrinsics_inv=intrinsics_inv,
+            pixel_coords=pixel_coords_input,
+        )
+
+        assert output.shape == (batch_size, H, W, 3)
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_consistency(self, batch_size, device, dtype):
+        H, W = 250, 500
+        fx, fy = W, H
+        cx, cy = W / 2, H / 2
+        eps = 1e-12
+        seed = 77
+        low_1, high_1 = -500, 500
+        low_2, high_2 = -(max(W, H) * 3), (max(W, H) * 3)
+
+        torch.manual_seed(seed)
+        depth = self._get_samples((batch_size, 1, H, W), low_1, high_1, device, dtype)
+        pixel_coords = self._get_samples((batch_size, H, W, 2), low_2, high_2, device, dtype)
+
+        last_ch = torch.ones((batch_size, H, W, 1), device=device, dtype=dtype)
+        pixel_coords_input = torch.cat([pixel_coords, last_ch], axis=-1)
+
+        intrinsics = self._create_intrinsics(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        )
+        intrinsics_inv = self._create_intrinsics_inv(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        )
+
+        cam_coords = kornia.pixel2cam(
+            depth=depth, intrinsics_inv=intrinsics_inv,
+            pixel_coords=pixel_coords_input,
+        )
+
+        # Setting the projection matrix to the intrinsic matrix for
+        # simplicity (i.e. assuming that the RT matrix is an identity matrix)
+        proj_mat = intrinsics
+        pixel_coords_output = kornia.cam2pixel(
+            cam_coords_src=cam_coords,
+            dst_proj_src=proj_mat,
+            eps=eps
+        )
+        pixel_coords_concat = torch.cat([pixel_coords_output, last_ch], axis=-1)
+
+        assert_close(pixel_coords_concat, pixel_coords_input, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_gradcheck(self, batch_size, device, dtype):
+        H, W = 10, 20
+        fx, fy = W, H
+        cx, cy = W / 2, H / 2
+        seed = 77
+        low_1, high_1 = -500, 500
+        low_2, high_2 = -(max(W, H) * 3), (max(W, H) * 3)
+
+        torch.manual_seed(seed)
+        depth = self._get_samples((batch_size, 1, H, W), low_1, high_1, device, dtype)
+        pixel_coords = self._get_samples((batch_size, H, W, 2), low_2, high_2, device, dtype)
+
+        last_ch = torch.ones((batch_size, H, W, 1), device=device, dtype=dtype)
+        pixel_coords_input = torch.cat([pixel_coords, last_ch], axis=-1)
+
+        # If contiguous() is not called, gradcheck fails
+        intrinsics_inv = self._create_intrinsics_inv(
+            batch_size, fx, fy, cx, cy,
+            device=device, dtype=dtype
+        ).contiguous()
+
+        depth = tensor_to_gradcheck_var(depth)
+        intrinsics_inv = tensor_to_gradcheck_var(intrinsics_inv)
+        pixel_coords_input = tensor_to_gradcheck_var(pixel_coords_input)
+
+        assert gradcheck(
+            kornia.geometry.pixel2cam,
+            (depth, intrinsics_inv, pixel_coords_input), raise_exception=True
+        )
 
 
 class TestPinholeCamera:

--- a/test/geometry/test_pinhole.py
+++ b/test/geometry/test_pinhole.py
@@ -1,13 +1,12 @@
-import torch
 import pytest
-import kornia
-
+import torch
 from torch.autograd import gradcheck
+
+import kornia
 from kornia.testing import assert_close, tensor_to_gradcheck_var
 
 
 class TestCam2Pixel:
-
     def _create_intrinsics(self, batch_size, fx, fy, cx, cy, device, dtype):
         temp = torch.eye(4, device=device, dtype=dtype)
         temp[0, 0], temp[0, 2] = fx, cx
@@ -35,10 +34,7 @@ class TestCam2Pixel:
         seed = 77
         low, high = -500, 500
 
-        intrinsics = self._create_intrinsics(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
-        )
+        intrinsics = self._create_intrinsics(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
 
         # Setting the projection matrix to the intrinsic matrix for
         # simplicity (i.e. assuming that the RT matrix is an identity matrix)
@@ -47,11 +43,7 @@ class TestCam2Pixel:
         torch.manual_seed(seed)
         cam_coords_src = self._get_samples((batch_size, H, W, 3), low, high, device, dtype)
 
-        pixel_coords_dst = kornia.cam2pixel(
-            cam_coords_src=cam_coords_src,
-            dst_proj_src=proj_mat,
-            eps=eps
-        )
+        pixel_coords_dst = kornia.cam2pixel(cam_coords_src=cam_coords_src, dst_proj_src=proj_mat, eps=eps)
         assert pixel_coords_dst.shape == (batch_size, H, W, 2)
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
@@ -63,14 +55,8 @@ class TestCam2Pixel:
         seed = 77
         low, high = -500, 500
 
-        intrinsics = self._create_intrinsics(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
-        )
-        intrinsics_inv = self._create_intrinsics_inv(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
-        )
+        intrinsics = self._create_intrinsics(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
+        intrinsics_inv = self._create_intrinsics_inv(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
 
         # Setting the projection matrix to the intrinsic matrix for
         # simplicity (i.e. assuming that the RT matrix is an identity matrix)
@@ -79,19 +65,14 @@ class TestCam2Pixel:
         torch.manual_seed(seed)
         cam_coords_input = self._get_samples((batch_size, H, W, 3), low, high, device, dtype)
 
-        pixel_coords_output = kornia.cam2pixel(
-            cam_coords_src=cam_coords_input,
-            dst_proj_src=proj_mat,
-            eps=eps,
-        )
+        pixel_coords_output = kornia.cam2pixel(cam_coords_src=cam_coords_input, dst_proj_src=proj_mat, eps=eps)
 
         last_ch = torch.ones((batch_size, H, W, 1), device=device, dtype=dtype)
         pixel_coords_concat = torch.cat([pixel_coords_output, last_ch], axis=-1)
 
         depth = cam_coords_input[..., 2:3].permute(0, 3, 1, 2).contiguous()
         cam_coords_output = kornia.pixel2cam(
-            depth=depth, intrinsics_inv=intrinsics_inv,
-            pixel_coords=pixel_coords_concat,
+            depth=depth, intrinsics_inv=intrinsics_inv, pixel_coords=pixel_coords_concat
         )
 
         assert_close(cam_coords_output, cam_coords_input, atol=1e-4, rtol=1e-4)
@@ -111,10 +92,7 @@ class TestCam2Pixel:
             atol, rtol = 1e-4, 1e-2
 
         # If contiguous() is not called, gradcheck fails
-        intrinsics = self._create_intrinsics(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
-        ).contiguous()
+        intrinsics = self._create_intrinsics(batch_size, fx, fy, cx, cy, device=device, dtype=dtype).contiguous()
 
         # Setting the projection matrix to the intrinsic matrix for
         # simplicity (i.e. assuming that the RT matrix is an identity matrix)
@@ -127,14 +105,11 @@ class TestCam2Pixel:
         proj_mat = tensor_to_gradcheck_var(proj_mat)
 
         assert gradcheck(
-            kornia.geometry.cam2pixel,
-            (cam_coords_src, proj_mat, eps), raise_exception=True,
-            atol=atol, rtol=rtol,
+            kornia.geometry.cam2pixel, (cam_coords_src, proj_mat, eps), raise_exception=True, atol=atol, rtol=rtol
         )
 
 
 class TestPixel2Cam:
-
     def _create_intrinsics(self, batch_size, fx, fy, cx, cy, device, dtype):
         temp = torch.eye(4, device=device, dtype=dtype)
         temp[0, 0], temp[0, 2] = fx, cx
@@ -169,15 +144,9 @@ class TestPixel2Cam:
         last_ch = torch.ones((batch_size, H, W, 1), device=device, dtype=dtype)
         pixel_coords_input = torch.cat([pixel_coords, last_ch], axis=-1)
 
-        intrinsics_inv = self._create_intrinsics_inv(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
-        )
+        intrinsics_inv = self._create_intrinsics_inv(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
 
-        output = kornia.pixel2cam(
-            depth=depth, intrinsics_inv=intrinsics_inv,
-            pixel_coords=pixel_coords_input,
-        )
+        output = kornia.pixel2cam(depth=depth, intrinsics_inv=intrinsics_inv, pixel_coords=pixel_coords_input)
 
         assert output.shape == (batch_size, H, W, 3)
 
@@ -198,28 +167,15 @@ class TestPixel2Cam:
         last_ch = torch.ones((batch_size, H, W, 1), device=device, dtype=dtype)
         pixel_coords_input = torch.cat([pixel_coords, last_ch], axis=-1)
 
-        intrinsics = self._create_intrinsics(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
-        )
-        intrinsics_inv = self._create_intrinsics_inv(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
-        )
+        intrinsics = self._create_intrinsics(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
+        intrinsics_inv = self._create_intrinsics_inv(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
 
-        cam_coords = kornia.pixel2cam(
-            depth=depth, intrinsics_inv=intrinsics_inv,
-            pixel_coords=pixel_coords_input,
-        )
+        cam_coords = kornia.pixel2cam(depth=depth, intrinsics_inv=intrinsics_inv, pixel_coords=pixel_coords_input)
 
         # Setting the projection matrix to the intrinsic matrix for
         # simplicity (i.e. assuming that the RT matrix is an identity matrix)
         proj_mat = intrinsics
-        pixel_coords_output = kornia.cam2pixel(
-            cam_coords_src=cam_coords,
-            dst_proj_src=proj_mat,
-            eps=eps
-        )
+        pixel_coords_output = kornia.cam2pixel(cam_coords_src=cam_coords, dst_proj_src=proj_mat, eps=eps)
         pixel_coords_concat = torch.cat([pixel_coords_output, last_ch], axis=-1)
 
         assert_close(pixel_coords_concat, pixel_coords_input, atol=1e-4, rtol=1e-4)
@@ -242,18 +198,14 @@ class TestPixel2Cam:
 
         # If contiguous() is not called, gradcheck fails
         intrinsics_inv = self._create_intrinsics_inv(
-            batch_size, fx, fy, cx, cy,
-            device=device, dtype=dtype
+            batch_size, fx, fy, cx, cy, device=device, dtype=dtype
         ).contiguous()
 
         depth = tensor_to_gradcheck_var(depth)
         intrinsics_inv = tensor_to_gradcheck_var(intrinsics_inv)
         pixel_coords_input = tensor_to_gradcheck_var(pixel_coords_input)
 
-        assert gradcheck(
-            kornia.geometry.pixel2cam,
-            (depth, intrinsics_inv, pixel_coords_input), raise_exception=True
-        )
+        assert gradcheck(kornia.geometry.pixel2cam, (depth, intrinsics_inv, pixel_coords_input), raise_exception=True)
 
 
 class TestPinholeCamera:


### PR DESCRIPTION
Hey everyone, this PR provides the following contributions:

### Contributions:

1. Fixed the docstring issue mentioned in #1170.
2. Wrote tests for shape check, gradcheck and consistency check for cam2pixel and pixel2cam (please refer to the code for more details).
3. Changed the default value of the `eps` argument in `cam2pixel` to `1e-12` from `1e-6` to prevent a test from failing (more info is provided below).
4. A comment in the function `cam2pixel` seemed to imply that the variable `pixel_coords_dst` will have shape `(BxN)xHxWx2`. However, it has shape `BxHxWx2`. The comment has been corrected in this PR.
5. Some minor docstring refactoring and enhancement.

I have a few questions as well, which I have mentioned after the Additional Information section. Could anyone provide their answers/thoughts on those questions?

### Additional Information:

1. To run the tests for just `test_pinhole.py`, I used `pytest -sv test/geometry/test_pinhole.py --device all --dtype float32` and also `pytest -sv test/geometry/test_pinhole.py --device all --dtype float64`. Those tests passed.

2. Running `make test` had two failures, but the failures were in `test/augmentation/test_random_generator.py`. I do not think those fails are related to this PR. I have attached the short summary here:
```
=================================================================== short test summary info ===================================================================
FAILED test/augmentation/test_random_generator.py::TestColorJitterGen::test_random_gen[cuda-float32] - AssertionError: Tensors are not close!
FAILED test/augmentation/test_random_generator.py::TestColorJitterGen::test_random_gen[cuda-float64] - AssertionError: Tensors are not close!
============================== 2 failed, 39774 passed, 592 skipped, 59 xfailed, 37 xpassed, 1171 warnings in 1009.34s (0:16:49) ===============================
```

For sanity, I also ran `make test` in the `master` branch. Got the same failures in the short summary: 
```
=================================================================== short test summary info ===================================================================
FAILED test/augmentation/test_random_generator.py::TestColorJitterGen::test_random_gen[cuda-float32] - AssertionError: Tensors are not close!
FAILED test/augmentation/test_random_generator.py::TestColorJitterGen::test_random_gen[cuda-float64] - AssertionError: Tensors are not close!
============================== 2 failed, 39702 passed, 592 skipped, 61 xfailed, 35 xpassed, 1170 warnings in 1024.99s (0:17:04) ===============================
```

3.  The function `cam2pixel` had a default `eps` value of `1e-6`. While running `pytest -sv test/geometry/test_pinhole.py --device all --dtype float32` with eps value for `cam2pixel` as `1e-6`, I noticed that five tests failed. In particular, the test `TestCam2Pixel.test_consistency[cuda-float32-5]` (the `5` here is `batch_size`) with `eps` value of `1e-6` for `cam2pixel`, the following error was obtained:
```
E           AssertionError: Tensors are not close!
E           
E           Mismatched elements: 16 / 1875000 (0.0%)
E           Greatest absolute difference: 0.7143402099609375 at (4, 140, 113, 1) (up to 0.0001 allowed)
E           Greatest relative difference: 0.004112850818986882 at (4, 140, 113, 0) (up to 0.0001 allowed)
```
The absolute difference mentioned above seems too high (it is comparing points in xyz camera coordinates). When you change the `eps` value to `1e-12`, all tests succeed. Due to the rather high error with `eps` as `1e-6`, I thought it might be better to change the default `eps` value in `cam2pixel` instead of just passing a smaller value for the tests. 

4. The gradcheck tests `test/geometry/test_pinhole.py::TestCam2Pixel::test_gradcheck[cuda-float64-2]` and  `test/geometry/test_pinhole.py::TestCam2Pixel::test_gradcheck[cuda-float64-5]` failed for the default `atol` and `rtol` values (`atol` default is `1e-5` and `rtol` default is `1e-3`). Both tests got the error `torch.autograd.gradcheck.GradcheckError: Jacobian mismatch for output 0 with respect to input 1`. However, if I change `atol` to `1e-4` and `rtol` to `1e-2`, the tests succeed. Hence, in the function, if dtype is float64 and if device is cuda, then I have used `atol` as `1e-4` and `rtol` as `1e-2`. 

5. Interestingly, if I change the `eps` value input to `cam2pixel` to a rather high value of `1e-1`, the gradcheck tests mentioned in point 4 above pass with even the default `atol` and `rtol` values of the gradcheck function. However, I don't think such a large `eps` value should be used. 

### Questions:

1. As mentioned in point 3 of Additional Information above, I have changed the default `eps` value in `cam2pixel`. Is this fine? Or should I do something else?

2. As mentioned in point 4 of Additional Information above, I have used a different `atol` and `rtol` for gradcheck if dtype is float64 and if device is cuda. Is this fine? Or should I do something else?

3. In the function `test_gradcheck` in TestCam2Pixel, I have not used `tensor_to_gradcheck_var` on `eps` since `eps` is a float value and the function `cam2pixel` also takes `eps` as float. So, in this code block:
```
gradcheck(
    kornia.geometry.cam2pixel,
    (cam_coords_src, proj_mat, eps), raise_exception=True,
    atol=atol, rtol=rtol,
)
```
I have passed `eps` directly without using `tensor_to_gradcheck_var` since it is of type `float`. Is this fine?

Do let me know if I have to make any changes. Thanks!

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>

  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?

</details>
