### PR TITLE
Fix docstrings, enhance docs and change an assertion

### DIFF
--- a/docs/source/geometry.camera.pinhole.rst
+++ b/docs/source/geometry.camera.pinhole.rst
@@ -38,16 +38,16 @@ or
     \end{bmatrix}
 
 where:
-    * :math:`M'` is a 3D point in space with coordinates :math:`[X,Y,Z]^T` expressed in a Euclidean coordinate system.
+    * :math:`M'` is a 3D point in space with coordinates :math:`[X,Y,Z]^T` expressed in an Euclidean coordinate frame known as the *world coordinate system*.
     * :math:`m'` is the projection of the 3D point :math:`M'` onto the *image plane* with coordinates :math:`[u,v]^T` expressed in pixel units.
-    * :math:`K` is the *camera calibration matrix*, also referred as the intrinsics parameters matrix.
+    * :math:`K` is the *camera calibration matrix*, also referred as the intrinsic matrix.
     * :math:`C` is the *principal point offset* with coordinates :math:`[u_0, v_0]^T` at the origin in the image plane.
     * :math:`fx, fy` are the focal lengths expressed in pixel units.
 
-The camera rotation and translation are expressed in terms of Euclidean coordinate frame, also known as the *world coordinates system*. This terms are usually expressed by the joint rotation-translation matrix :math:`[R|t]`, or also called as the extrinsics parameters matrix. It is used to describe the camera pose around a static scene and translates the coordinates of a 3D point :math:`(X,Y,Z)` to a coordinate system respect to the camera.
+The camera rotation and translation are expressed in terms of an Euclidean coordinate frame known as the *world coordinate system*. These terms are usually expressed by the joint rotation-translation matrix :math:`[R|t]` which is also known as the extrinsic matrix. It is used to describe the camera pose around a static scene and transforms the coordinates of a 3D point :math:`(X,Y,Z)` from the *world coordinate system* to the *camera coordinate system*.
 
-The :class:`PinholeCamera` expects the *intrinsics parameters matrix* and the *extrensics parameters matrix*
-to  be of shape `(B, 4, 4)` such that each *intrinsics parameters matrix* has the following format:
+The :class:`PinholeCamera` expects the *intrinsic matrices* and the *extrinsic matrices*
+to be of shape `(B, 4, 4)` such that each *intrinsic matrix* has the following format:
 
 .. math::
     \begin{bmatrix}
@@ -57,7 +57,7 @@ to  be of shape `(B, 4, 4)` such that each *intrinsics parameters matrix* has th
     0 & 0 & 0 & 1
     \end{bmatrix}
 
-And each *extrensics parameters matrix* has the following format:
+And each *extrinsic matrix* has the following format:
 
 .. math::
     \begin{bmatrix}

--- a/docs/source/geometry.epipolar.rst
+++ b/docs/source/geometry.epipolar.rst
@@ -3,7 +3,7 @@ kornia.geometry.epipolar
 
 .. currentmodule:: kornia.geometry.epipolar
 
-Module to with useful functionalities for epipolar geometry used by Structure from Motion
+Module with useful functionalities for epipolar geometry used by Structure from Motion
 
 .. image:: data/epipolar_geometry.svg.png
 

--- a/kornia/geometry/epipolar/numeric.py
+++ b/kornia/geometry/epipolar/numeric.py
@@ -37,7 +37,7 @@ def eye_like(n: int, input: torch.Tensor) -> torch.Tensor:
           The expected shape is :math:`(B, *)`.
 
     Returns:
-       The identity matrix with same size as input :math:`(*, N, N)`.
+       The identity matrix with same size as input :math:`(B, N, N)`.
 
     """
     if n <= 0:
@@ -58,7 +58,7 @@ def vec_like(n, tensor):
           The expected shape is :math:`(B, *)`.
 
     Returns:
-        The vector with same size as input :math:`(*, N, 1)`.
+        The vector with same size as input :math:`(B, N, 1)`.
 
     """
     if n <= 0:

--- a/kornia/geometry/epipolar/projection.py
+++ b/kornia/geometry/epipolar/projection.py
@@ -181,13 +181,13 @@ def projections_from_fundamental(F_mat: torch.Tensor) -> torch.Tensor:
     r"""Get the projection matrices from the Fundamental Matrix.
 
     Args:
-       F_mat: the fundamental matrix with the shape :math:`(*, 3, 3)`.
+       F_mat: the fundamental matrix with the shape :math:`(B, 3, 3)`.
 
     Returns:
-        The projection matrices with shape :math:`(*, 4, 4, 2)`.
+        The projection matrices with shape :math:`(B, 3, 4, 2)`.
 
     """
-    if len(F_mat.shape) < 2:
+    if len(F_mat.shape) != 3:
         raise AssertionError(F_mat.shape)
     if F_mat.shape[-2:] != (3, 3):
         raise AssertionError(F_mat.shape)


### PR DESCRIPTION
### Description
- Fixed docstring in `projections_from_fundamental` so that #996 and #997 can be closed.
- Fixed docstrings in `eye_like` and `vec_like`. 
- Changed an assertion in the function `projections_from_fundamental` so that the shape is checked properly (that's why I selected breaking change in the types of changes below. Do let me know if this is not considered a breaking change).
- Enhanced some documentation.

I ran the following tests:
1. `pytest -sv test/geometry/epipolar/test_projection.py  --device all --dtype float32`: All passed with 1 warning (explained below)
2. `pytest -sv test/geometry/epipolar/test_projection.py  --device all --dtype float64`: All passed with 1 warning (explained below)
3. `pytest -sv test/geometry/epipolar/test_numeric.py  --device all --dtype float32`: All passed
4. `pytest -sv test/geometry/epipolar/test_numeric.py  --device all --dtype float64`: All passed
5. `make build-docs`: Build succeeded with 2 warnings (the usual name 'np' is not defined warnings)

The warning obtained for `test_projection.py` for both dtypes tested were similar. The warnings summary obtained when dtype was `float64` was:

```
=================================================================== warnings summary ====================================================================
test/geometry/epipolar/test_projection.py::TestProjectionFromKRt::test_krt_from_projection[cpu-float64]
  /kornia/kornia/geometry/epipolar/projection.py:134: UserWarning: torch.qr is deprecated in favor of torch.linalg.qr and will be removed in a future PyTorch release.
  The boolean parameter 'some' has been replaced with a string parameter 'mode'.
  Q, R = torch.qr(A, some)
  should be replaced with
  Q, R = torch.linalg.qr(A, 'reduced' if some else 'complete') (Triggered internally at  /opt/conda/conda-bld/pytorch_1623448224956/work/aten/src/ATen/native/BatchLinearAlgebra.cpp:1940.)
    ortho_mat, upper_mat = torch.qr(submat_3x3)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

Perhaps someone can address the warning in a separate PR later. 

Also, I got some fails in `make test` since I kept running out of CUDA memory (my laptop has only 2GB GPU memory). It's odd cause when I was submitting an older PR I was able to run `make test` just fine without the above memory issue. Not sure why it's running out of memory now (maybe because of any changes/additions to tests since last PR or maybe because of some issue in my laptop). Have to check running `make test` with more GPU memory somewhere else sometime. Anyway, just wanted to mention this.

Do let me know if I have to make any changes to this PR. Thanks!

### Status
**Ready**

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or new feature that would cause existing functionality to change)
- [ ] New tests added to cover the changes
- [x] Docstrings/Documentation updated


## PR Checklist
### PR Implementer
This is a small checklist for the implementation details of this PR.

If there are any questions regarding code style or other conventions check out our
[summary](https://github.com/kornia/kornia/blob/master/CONTRIBUTING.rst).

- [ ] Did you discuss the functionality or any breaking changes before ?
- [ ] **Pass all tests**: did you test in local ? `make test`
- [ ] Unittests: did you add tests for your new functionality ?
- [x] Documentations: did you build documentation ? `make build-docs`
- [ ] Implementation: is your code well commented and follow conventions ? `make lint`
- [ ] Docstrings & Typing: has your code documentation and typing ? `make mypy`
- [ ] Update notebooks & documentation if necessary

### KorniaTeam
<details>
  <summary>KorniaTeam workflow</summary>

  - [ ] Assign correct label
  - [ ] Assign PR to a reviewer
  - [ ] Does this PR close an Issue? (add `closes #IssueNumber` at the bottom if
        not already in description)

</details>

### Reviewer
<details>
  <summary>Reviewer workflow</summary>

  - [ ] Do all tests pass? (Unittests, Typing, Linting, Documentation, Environment)
  - [ ] Does the implementation follow `kornia` design conventions?
  - [ ] Is the documentation complete enough ?
  - [ ] Are the tests covering simple and corner cases ?

</details>
