### PR TITLE
return all learned modules by default in eval() mode

### DIFF
--- a/kornia/feature/affine_shape.py
+++ b/kornia/feature/affine_shape.py
@@ -183,6 +183,7 @@ class LAFAffNetShapeEstimator(nn.Module):
                 urls['affnet'], map_location=lambda storage, loc: storage
             )
             self.load_state_dict(pretrained_dict['state_dict'], strict=False)
+        self.eval()
 
     @staticmethod
     def _normalize_input(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:

--- a/kornia/feature/defmo.py
+++ b/kornia/feature/defmo.py
@@ -295,6 +295,7 @@ class DeFMO(nn.Module):
                 urls['defmo_rendering'], map_location=lambda storage, loc: storage
             )
             self.rendering.load_state_dict(pretrained_dict_ren, strict=True)
+        self.eval()
 
     def forward(self, input_data: torch.Tensor) -> torch.Tensor:
         latent = self.encoder(input_data)

--- a/kornia/feature/hardnet.py
+++ b/kornia/feature/hardnet.py
@@ -66,6 +66,7 @@ class HardNet(nn.Module):
                 urls['liberty_aug'], map_location=lambda storage, loc: storage
             )
             self.load_state_dict(pretrained_dict['state_dict'], strict=True)
+        self.eval()
 
     @staticmethod
     def _normalize_input(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
@@ -143,6 +144,7 @@ class HardNet8(nn.Module):
                 urls['hardnet8v2'], map_location=lambda storage, loc: storage
             )
             self.load_state_dict(pretrained_dict, strict=True)
+        self.eval()
 
     @staticmethod
     def weights_init(m):

--- a/kornia/feature/mkd.py
+++ b/kornia/feature/mkd.py
@@ -587,6 +587,7 @@ class MKDDescriptor(nn.Module):
                 whitening, whitening_model, in_dims=self.odims, output_dims=self.output_dims
             )
             self.odims = self.output_dims
+        self.eval()
 
     def forward(self, patches: torch.Tensor) -> torch.Tensor:
         if not isinstance(patches, torch.Tensor):

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -172,6 +172,7 @@ class OriNet(nn.Module):
                 urls['orinet'], map_location=lambda storage, loc: storage
             )
             self.load_state_dict(pretrained_dict['state_dict'], strict=False)
+        self.eval()
 
     @staticmethod
     def _normalize_input(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:

--- a/kornia/feature/sosnet.py
+++ b/kornia/feature/sosnet.py
@@ -59,7 +59,7 @@ class SOSNet(nn.Module):
         if pretrained:
             pretrained_dict = torch.hub.load_state_dict_from_url(urls['lib'], map_location=lambda storage, loc: storage)
             self.load_state_dict(pretrained_dict, strict=True)
-
+        self.eval()
         return
 
     def forward(self, input: torch.Tensor, eps: float = 1e-10) -> torch.Tensor:

--- a/kornia/feature/tfeat.py
+++ b/kornia/feature/tfeat.py
@@ -55,6 +55,7 @@ class TFeat(nn.Module):
                 urls['liberty'], map_location=lambda storage, loc: storage
             )
             self.load_state_dict(pretrained_dict, strict=True)
+        self.eval()
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         x = self.features(input)


### PR DESCRIPTION
#### Changes
Return all learned modules by default in eval() mode

Since the main usage of the kornia is inference and that users sometimes can forget to put the descriptor, or other module into eval() mode, it makes sense to create them in the `eval()` mode in the first place. 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [x] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
