### PR TITLE
Convert docstrings to active tense

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,7 @@ def get_test_devices() -> Dict[str, torch.device]:
 
 
 def get_test_dtypes() -> Dict[str, torch.dtype]:
-    """Creates a dictionary with the dtypes the source code.
+    """Create a dictionary with the dtypes the source code.
 
     Return:
         dict(str, torch.dtype): list with dtype names.

--- a/examples/depth_regression/main.py
+++ b/examples/depth_regression/main.py
@@ -39,7 +39,7 @@ def load_depth(file_name):
 
 
 def load_camera_data(file_name):
-    """Loads the camera data using the sintel SDK and converts to torch.Tensor."""
+    """Load the camera data using the sintel SDK and converts to torch.Tensor."""
     if not os.path.isfile(file_name):
         raise AssertionError(f"Invalid file {file_name}")
     import sintel_io

--- a/examples/depth_warper/main.py
+++ b/examples/depth_warper/main.py
@@ -19,7 +19,7 @@ def load_depth(file_name):
 
 
 def load_camera_data(file_name):
-    """Loads the camera data using the syntel SDK and converts to torch.Tensor."""
+    """Load the camera data using the syntel SDK and converts to torch.Tensor."""
     if not os.path.isfile(file_name):
         raise AssertionError(f"Invalid file {file_name}")
     import sintel_io

--- a/examples/homography_regression/main.py
+++ b/examples/homography_regression/main.py
@@ -12,7 +12,7 @@ import kornia as dgm
 
 
 def load_homography(file_name):
-    """Loads an homography from text file."""
+    """Load a homography from text file."""
     if not os.path.isfile(file_name):
         raise AssertionError(f"Invalid file {file_name}")
     return torch.from_numpy(np.loadtxt(file_name)).float()

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -45,7 +45,7 @@ from .utils import _range_bound, _transform_input
 
 
 class RandomHorizontalFlip(GeometricAugmentationBase2D):
-    r"""Applies a random horizontal flip to a tensor image or a batch of tensor images with a given probability.
+    r"""Apply a random horizontal flip to a tensor image or a batch of tensor images with a given probability.
 
     .. image:: _static/img/RandomHorizontalFlip.png
 
@@ -107,7 +107,7 @@ class RandomHorizontalFlip(GeometricAugmentationBase2D):
 
 
 class RandomVerticalFlip(GeometricAugmentationBase2D):
-    r"""Applies a random vertical flip to a tensor image or a batch of tensor images with a given probability.
+    r"""Apply a random vertical flip to a tensor image or a batch of tensor images with a given probability.
 
     .. image:: _static/img/RandomVerticalFlip.png
 
@@ -163,7 +163,7 @@ class RandomVerticalFlip(GeometricAugmentationBase2D):
 
 
 class ColorJitter(IntensityAugmentationBase2D):
-    r"""Applies a random transformation to the brightness, contrast, saturation and hue of a tensor image.
+    r"""Apply a random transformation to the brightness, contrast, saturation and hue of a tensor image.
 
     .. image:: _static/img/ColorJitter.png
 
@@ -263,7 +263,7 @@ class ColorJitter(IntensityAugmentationBase2D):
 
 
 class RandomGrayscale(IntensityAugmentationBase2D):
-    r"""Applies random transformation to Grayscale according to a probability p value.
+    r"""Apply random transformation to Grayscale according to a probability p value.
 
     .. image:: _static/img/RandomGrayscale.png
 
@@ -319,7 +319,7 @@ class RandomGrayscale(IntensityAugmentationBase2D):
 
 
 class RandomErasing(IntensityAugmentationBase2D):
-    r"""Erases a random rectangle of a tensor image according to a probability p value.
+    r"""Erase a random rectangle of a tensor image according to a probability p value.
 
     .. image:: _static/img/RandomErasing.png
 
@@ -407,7 +407,7 @@ class RandomErasing(IntensityAugmentationBase2D):
 
 
 class RandomPerspective(GeometricAugmentationBase2D):
-    r"""Applies a random perspective transformation to an image tensor with a given probability.
+    r"""Apply a random perspective transformation to an image tensor with a given probability.
 
     .. image:: _static/img/RandomPerspective.png
 
@@ -498,7 +498,7 @@ class RandomPerspective(GeometricAugmentationBase2D):
 
 
 class RandomAffine(GeometricAugmentationBase2D):
-    r"""Applies a random 2D affine transformation to a tensor image.
+    r"""Apply a random 2D affine transformation to a tensor image.
 
     .. image:: _static/img/RandomAffine.png
 
@@ -688,7 +688,7 @@ class RandomAffine(GeometricAugmentationBase2D):
 
 
 class CenterCrop(GeometricAugmentationBase2D):
-    r"""Crops a given image tensor at the center.
+    r"""Crop a given image tensor at the center.
 
     .. image:: _static/img/CenterCrop.png
 
@@ -816,7 +816,7 @@ class CenterCrop(GeometricAugmentationBase2D):
 
 
 class RandomRotation(GeometricAugmentationBase2D):
-    r"""Applies a random rotation to a tensor image or a batch of tensor images given an amount of degrees.
+    r"""Apply a random rotation to a tensor image or a batch of tensor images given an amount of degrees.
 
     .. image:: _static/img/RandomRotation.png
 
@@ -913,7 +913,7 @@ class RandomRotation(GeometricAugmentationBase2D):
 
 
 class RandomCrop(GeometricAugmentationBase2D):
-    r"""Crops random patches of a tensor image on a given size.
+    r"""Crop random patches of a tensor image on a given size.
 
     .. image:: _static/img/RandomCrop.png
 
@@ -1146,7 +1146,7 @@ class RandomCrop(GeometricAugmentationBase2D):
 
 
 class RandomResizedCrop(GeometricAugmentationBase2D):
-    r"""Crops random patches in an image tensor and resizes to a given size.
+    r"""Crop random patches in an image tensor and resizes to a given size.
 
     .. image:: _static/img/RandomResizedCrop.png
 
@@ -1908,7 +1908,7 @@ class RandomInvert(IntensityAugmentationBase2D):
 
 
 class RandomChannelShuffle(IntensityAugmentationBase2D):
-    r"""Shuffles the channels of a batch of multi-dimensional images.
+    r"""Shuffle the channels of a batch of multi-dimensional images.
 
     .. image:: _static/img/RandomChannelShuffle.png
 
@@ -2198,7 +2198,7 @@ class RandomThinPlateSpline(GeometricAugmentationBase2D):
 
 
 class RandomBoxBlur(GeometricAugmentationBase2D):
-    """Adds random blur with a box filter to an image tensor.
+    """Add random blur with a box filter to an image tensor.
 
     .. image:: _static/img/RandomBoxBlur.png
 

--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -8,7 +8,7 @@ from kornia.utils import _extract_device_dtype
 
 
 def _validate_input(f: Callable) -> Callable:
-    r"""Validates the 2D input of the wrapped function.
+    r"""Validate the 2D input of the wrapped function.
 
     Args:
         f: a function that takes the first argument as tensor.
@@ -31,7 +31,7 @@ def _validate_input(f: Callable) -> Callable:
 
 
 def _validate_input3d(f: Callable) -> Callable:
-    r"""Validates the 3D input of the wrapped function.
+    r"""Validate the 3D input of the wrapped function.
 
     Args:
         f: a function that takes the first argument as tensor.

--- a/kornia/augmentation/utils/param_validation.py
+++ b/kornia/augmentation/utils/param_validation.py
@@ -48,7 +48,7 @@ def _range_bound(
 
 
 def _joint_range_check(ranged_factor: torch.Tensor, name: str, bounds: Optional[Tuple[float, float]] = None) -> None:
-    """check if bounds[0] <= ranged_factor[0] <= ranged_factor[1] <= bounds[1]"""
+    """Check if bounds[0] <= ranged_factor[0] <= ranged_factor[1] <= bounds[1]"""
     if bounds is None:
         bounds = (float('-inf'), float('inf'))
     if ranged_factor.dim() == 1 and len(ranged_factor) == 2:
@@ -70,7 +70,7 @@ def _singular_range_check(
     skip_none: bool = False,
     mode: str = '2d',
 ) -> None:
-    """check if bounds[0] <= ranged_factor[0] <= bounds[1] and bounds[0] <= ranged_factor[1] <= bounds[1]"""
+    """Check if bounds[0] <= ranged_factor[0] <= bounds[1] and bounds[0] <= ranged_factor[1] <= bounds[1]"""
     if mode == '2d':
         dim_size = 2
     elif mode == '3d':

--- a/kornia/color/lab.py
+++ b/kornia/color/lab.py
@@ -13,7 +13,7 @@ https://github.com/scikit-image/scikit-image/blob/a48bf6774718c64dade4548153ae16
 
 
 def rgb_to_lab(image: torch.Tensor) -> torch.Tensor:
-    r"""Converts a RGB image to Lab.
+    r"""Convert a RGB image to Lab.
 
     .. image:: _static/img/rgb_to_lab.png
 
@@ -64,7 +64,7 @@ def rgb_to_lab(image: torch.Tensor) -> torch.Tensor:
 
 
 def lab_to_rgb(image: torch.Tensor, clip: bool = True) -> torch.Tensor:
-    r"""Converts a Lab image to RGB.
+    r"""Convert a Lab image to RGB.
 
     Args:
         image: Lab image to be converted to RGB with shape :math:`(*, 3, H, W)`.
@@ -121,7 +121,7 @@ def lab_to_rgb(image: torch.Tensor, clip: bool = True) -> torch.Tensor:
 
 
 class RgbToLab(nn.Module):
-    r"""Converts an image from RGB to Lab.
+    r"""Convert an image from RGB to Lab.
 
     The image data is assumed to be in the range of :math:`[0, 1]`. Lab
     color is computed using the D65 illuminant and Observer 2.
@@ -151,7 +151,7 @@ class RgbToLab(nn.Module):
 
 
 class LabToRgb(nn.Module):
-    r"""Converts an image from Lab to RGB.
+    r"""Convert an image from Lab to RGB.
 
     Returns:
         RGB version of the image. Range may not be in :math:`[0, 1]`.

--- a/kornia/color/luv.py
+++ b/kornia/color/luv.py
@@ -15,7 +15,7 @@ https://github.com/scikit-image/scikit-image/blob/a48bf6774718c64dade4548153ae16
 
 
 def rgb_to_luv(image: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
-    r"""Converts a RGB image to Luv.
+    r"""Convert a RGB image to Luv.
 
     .. image:: _static/img/rgb_to_luv.png
 
@@ -68,7 +68,7 @@ def rgb_to_luv(image: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
 
 
 def luv_to_rgb(image: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
-    r"""Converts a Luv image to RGB.
+    r"""Convert a Luv image to RGB.
 
     Args:
         image: Luv image to be converted to RGB with shape :math:`(*, 3, H, W)`.
@@ -117,7 +117,7 @@ def luv_to_rgb(image: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
 
 
 class RgbToLuv(nn.Module):
-    r"""Converts an image from RGB to Luv.
+    r"""Convert an image from RGB to Luv.
 
     The image data is assumed to be in the range of :math:`[0, 1]`. Luv
     color is computed using the D65 illuminant and Observer 2.
@@ -147,7 +147,7 @@ class RgbToLuv(nn.Module):
 
 
 class LuvToRgb(nn.Module):
-    r"""Converts an image from Luv to RGB.
+    r"""Convert an image from Luv to RGB.
 
     Returns:
         RGB version of the image.

--- a/kornia/color/xyz.py
+++ b/kornia/color/xyz.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 
 def rgb_to_xyz(image: torch.Tensor) -> torch.Tensor:
-    r"""Converts a RGB image to XYZ.
+    r"""Convert a RGB image to XYZ.
 
     .. image:: _static/img/rgb_to_xyz.png
 
@@ -37,7 +37,7 @@ def rgb_to_xyz(image: torch.Tensor) -> torch.Tensor:
 
 
 def xyz_to_rgb(image: torch.Tensor) -> torch.Tensor:
-    r"""Converts a XYZ image to RGB.
+    r"""Convert a XYZ image to RGB.
 
     Args:
         image: XYZ Image to be converted to RGB with shape :math:`(*, 3, H, W)`.
@@ -69,7 +69,7 @@ def xyz_to_rgb(image: torch.Tensor) -> torch.Tensor:
 
 
 class RgbToXyz(nn.Module):
-    r"""Converts an image from RGB to XYZ.
+    r"""Convert an image from RGB to XYZ.
 
     The image data is assumed to be in the range of (0, 1).
 

--- a/kornia/contrib/max_blur_pool.py
+++ b/kornia/contrib/max_blur_pool.py
@@ -22,7 +22,7 @@ class MaxBlurPool2d(MaxBlurPool2D):
 
 
 def max_blur_pool2d(input: torch.Tensor, kernel_size: int, ceil_mode: bool = False) -> torch.Tensor:
-    r"""Creates a module that computes pools and blurs and downsample a given feature map.
+    r"""Create a module that computes pools and blurs and downsample a given feature map.
 
     See :class:`~kornia.contrib.MaxBlurPool2d` for details.
     """

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -733,7 +733,7 @@ def equalize(input: torch.Tensor) -> torch.Tensor:
 
 @perform_keep_shape_video
 def equalize3d(input: torch.Tensor) -> torch.Tensor:
-    r"""Equalizes the values for a 3D volumetric tensor.
+    r"""Equalize the values for a 3D volumetric tensor.
 
     Implements Equalize function for a sequence of images using PyTorch ops based on uint8 format:
     https://github.com/tensorflow/tpu/blob/master/models/official/efficientnet/autoaugment.py#L352
@@ -755,7 +755,7 @@ def equalize3d(input: torch.Tensor) -> torch.Tensor:
 
 
 def invert(input: torch.Tensor, max_val: torch.Tensor = torch.tensor(1.0)) -> torch.Tensor:
-    r"""Inverts the values of an input tensor by its maximum value.
+    r"""Invert the values of an input tensor by its maximum value.
 
     .. image:: _static/img/invert.png
 
@@ -983,7 +983,7 @@ class AdjustBrightness(nn.Module):
 
 
 class Invert(nn.Module):
-    r"""Inverts the values of an input tensor by its maximum value.
+    r"""Invert the values of an input tensor by its maximum value.
 
     Args:
         input: The input tensor to invert with an arbitatry shape.

--- a/kornia/enhance/core.py
+++ b/kornia/enhance/core.py
@@ -5,7 +5,7 @@ __all__ = ["add_weighted", "AddWeighted"]
 
 
 def add_weighted(src1: torch.Tensor, alpha: float, src2: torch.Tensor, beta: float, gamma: float) -> torch.Tensor:
-    r"""Calculates the weighted sum of two Tensors.
+    r"""Calculate the weighted sum of two Tensors.
 
     .. image:: _static/img/add_weighted.png
 
@@ -51,7 +51,7 @@ def add_weighted(src1: torch.Tensor, alpha: float, src2: torch.Tensor, beta: flo
 
 
 class AddWeighted(nn.Module):
-    r"""Calculates the weighted sum of two Tensors.
+    r"""Calculate the weighted sum of two Tensors.
 
     The function calculates the weighted sum of two Tensors as follows:
 

--- a/kornia/enhance/histogram.py
+++ b/kornia/enhance/histogram.py
@@ -9,7 +9,7 @@ __all__ = ["histogram", "histogram2d", "image_histogram2d"]
 def marginal_pdf(
     values: torch.Tensor, bins: torch.Tensor, sigma: torch.Tensor, epsilon: float = 1e-10
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Function that calculates the marginal probability distribution function of the input tensor based on the
+    """Calculate the marginal probability distribution function of the input tensor based on the
     number of histogram bins.
 
     Args:
@@ -53,7 +53,7 @@ def marginal_pdf(
 
 
 def joint_pdf(kernel_values1: torch.Tensor, kernel_values2: torch.Tensor, epsilon: float = 1e-10) -> torch.Tensor:
-    """Function that calculates the joint probability distribution function of the input tensors based on the
+    """Calculate the joint probability distribution function of the input tensors based on the
     number of histogram bins.
 
     Args:
@@ -91,7 +91,7 @@ def joint_pdf(kernel_values1: torch.Tensor, kernel_values2: torch.Tensor, epsilo
 
 
 def histogram(x: torch.Tensor, bins: torch.Tensor, bandwidth: torch.Tensor, epsilon: float = 1e-10) -> torch.Tensor:
-    """Function that estimates the histogram of the input tensor.
+    """Estimate the histogram of the input tensor.
 
     The calculation uses kernel density estimation which requires a bandwidth (smoothing) parameter.
 
@@ -120,7 +120,7 @@ def histogram(x: torch.Tensor, bins: torch.Tensor, bandwidth: torch.Tensor, epsi
 def histogram2d(
     x1: torch.Tensor, x2: torch.Tensor, bins: torch.Tensor, bandwidth: torch.Tensor, epsilon: float = 1e-10
 ) -> torch.Tensor:
-    """Function that estimates the 2d histogram of the input tensor.
+    """Estimate the 2d histogram of the input tensor.
 
     The calculation uses kernel density estimation which requires a bandwidth (smoothing) parameter.
 

--- a/kornia/enhance/histogram.py
+++ b/kornia/enhance/histogram.py
@@ -9,8 +9,8 @@ __all__ = ["histogram", "histogram2d", "image_histogram2d"]
 def marginal_pdf(
     values: torch.Tensor, bins: torch.Tensor, sigma: torch.Tensor, epsilon: float = 1e-10
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Calculate the marginal probability distribution function of the input tensor based on the
-    number of histogram bins.
+    """Calculate the marginal probability distribution function of the input tensor based on the number of
+    histogram bins.
 
     Args:
         values: shape [BxNx1].
@@ -53,8 +53,8 @@ def marginal_pdf(
 
 
 def joint_pdf(kernel_values1: torch.Tensor, kernel_values2: torch.Tensor, epsilon: float = 1e-10) -> torch.Tensor:
-    """Calculate the joint probability distribution function of the input tensors based on the
-    number of histogram bins.
+    """Calculate the joint probability distribution function of the input tensors based on the number of histogram
+    bins.
 
     Args:
         kernel_values1: shape [BxNxNUM_BINS].

--- a/kornia/enhance/zca.py
+++ b/kornia/enhance/zca.py
@@ -9,7 +9,7 @@ __all__ = ["zca_mean", "zca_whiten", "linear_transform", "ZCAWhitening"]
 
 
 class ZCAWhitening(nn.Module):
-    r"""Computes the ZCA whitening matrix transform and the mean vector and applies the transform to the data.
+    r"""Compute the ZCA whitening matrix transform and the mean vector and applies the transform to the data.
 
     The data tensor is flattened, and the mean :math:`\mathbf{\mu}`
     and covariance matrix :math:`\mathbf{\Sigma}` are computed from
@@ -83,7 +83,7 @@ class ZCAWhitening(nn.Module):
         self.fitted = False
 
     def fit(self, x: torch.Tensor):
-        r"""Fits ZCA whitening matrices to the data.
+        r"""Fit ZCA whitening matrices to the data.
 
         Args:
 
@@ -112,7 +112,7 @@ class ZCAWhitening(nn.Module):
         return self
 
     def forward(self, x: torch.Tensor, include_fit: bool = False) -> torch.Tensor:
-        r"""Applies the whitening transform to the data.
+        r"""Apply the whitening transform to the data.
 
         Args:
             x: Input data.
@@ -134,7 +134,7 @@ class ZCAWhitening(nn.Module):
         return x_whiten
 
     def inverse_transform(self, x: torch.Tensor) -> torch.Tensor:
-        r"""Applies the inverse transform to the whitened data.
+        r"""Apply the inverse transform to the whitened data.
 
         Args:
             x: Whitened data.
@@ -159,7 +159,7 @@ class ZCAWhitening(nn.Module):
 def zca_mean(
     inp: torch.Tensor, dim: int = 0, unbiased: bool = True, eps: float = 1e-6, return_inverse: bool = False
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-    r"""Computes the ZCA whitening matrix and mean vector.
+    r"""Compute the ZCA whitening matrix and mean vector.
 
     The output can be used with :py:meth:`~kornia.color.linear_transform`.
     See :class:`~kornia.color.ZCAWhitening` for details.
@@ -258,7 +258,7 @@ def zca_mean(
 
 
 def zca_whiten(inp: torch.Tensor, dim: int = 0, unbiased: bool = True, eps: float = 1e-6) -> torch.Tensor:
-    r"""Applies ZCA whitening transform.
+    r"""Apply ZCA whitening transform.
 
     See :class:`~kornia.color.ZCAWhitening` for details.
 

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -25,7 +25,7 @@ def raise_error_if_laf_is_not_valid(laf: torch.Tensor) -> None:
 
 
 def get_laf_scale(LAF: torch.Tensor) -> torch.Tensor:
-    """Returns a scale of the LAFs.
+    """Return a scale of the LAFs.
 
     Args:
         LAF: tensor [BxNx2x3] or [BxNx2x2].
@@ -48,7 +48,7 @@ def get_laf_scale(LAF: torch.Tensor) -> torch.Tensor:
 
 
 def get_laf_center(LAF: torch.Tensor) -> torch.Tensor:
-    """Returns a center (keypoint) of the LAFs.
+    """Return a center (keypoint) of the LAFs.
 
     Args:
         LAF: tensor [BxNx2x3].
@@ -70,7 +70,7 @@ def get_laf_center(LAF: torch.Tensor) -> torch.Tensor:
 
 
 def get_laf_orientation(LAF: torch.Tensor) -> torch.Tensor:
-    """Returns orientation of the LAFs, in degrees.
+    """Return orientation of the LAFs, in degrees.
 
     Args:
         LAF: (torch.Tensor): tensor [BxNx2x3].
@@ -92,7 +92,7 @@ def get_laf_orientation(LAF: torch.Tensor) -> torch.Tensor:
 
 
 def set_laf_orientation(LAF: torch.Tensor, angles_degrees: torch.Tensor) -> torch.Tensor:
-    """Changes the orientation of the LAFs.
+    """Change the orientation of the LAFs.
 
     Args:
         LAF: tensor [BxNx2x3].
@@ -115,7 +115,7 @@ def set_laf_orientation(LAF: torch.Tensor, angles_degrees: torch.Tensor) -> torc
 
 
 def laf_from_center_scale_ori(xy: torch.Tensor, scale: torch.Tensor, ori: torch.Tensor) -> torch.Tensor:
-    """Returns orientation of the LAFs, in radians. Useful to create kornia LAFs from OpenCV keypoints.
+    """Return orientation of the LAFs, in radians. Useful to create kornia LAFs from OpenCV keypoints.
 
     Args:
         xy: tensor [BxNx2].
@@ -173,7 +173,7 @@ def scale_laf(laf: torch.Tensor, scale_coef: Union[float, torch.Tensor]) -> torc
 
 
 def make_upright(laf: torch.Tensor, eps: float = 1e-9) -> torch.Tensor:
-    """Rectifies the affine matrix, so that it becomes upright.
+    """Rectify the affine matrix, so that it becomes upright.
 
     Args:
         laf: tensor of LAFs.
@@ -209,7 +209,7 @@ def make_upright(laf: torch.Tensor, eps: float = 1e-9) -> torch.Tensor:
 
 
 def ellipse_to_laf(ells: torch.Tensor) -> torch.Tensor:
-    """Converts ellipse regions to LAF format.
+    """Convert ellipse regions to LAF format.
 
     Ellipse (a, b, c) and upright covariance matrix [a11 a12; 0 a22] are connected
     by inverse matrix square root: A = invsqrt([a b; b c]).
@@ -258,7 +258,7 @@ def ellipse_to_laf(ells: torch.Tensor) -> torch.Tensor:
 
 
 def laf_to_boundary_points(LAF: torch.Tensor, n_pts: int = 50) -> torch.Tensor:
-    """Converts LAFs to boundary points of the regions + center.
+    """Convert LAFs to boundary points of the regions + center.
 
     Used for local features visualization, see visualize_laf function.
 
@@ -293,7 +293,7 @@ def laf_to_boundary_points(LAF: torch.Tensor, n_pts: int = 50) -> torch.Tensor:
 
 
 def get_laf_pts_to_draw(LAF: torch.Tensor, img_idx: int = 0):
-    """Returns numpy array for drawing LAFs (local features).
+    """Return numpy array for drawing LAFs (local features).
 
     Args:
         LAF:
@@ -321,7 +321,7 @@ def get_laf_pts_to_draw(LAF: torch.Tensor, img_idx: int = 0):
 
 
 def denormalize_laf(LAF: torch.Tensor, images: torch.Tensor) -> torch.Tensor:
-    """De-normalizes LAFs from scale to image scale.
+    """De-normalize LAFs from scale to image scale.
 
         B,N,H,W = images.size()
         MIN_SIZE = min(H,W)
@@ -354,7 +354,7 @@ def denormalize_laf(LAF: torch.Tensor, images: torch.Tensor) -> torch.Tensor:
 
 
 def normalize_laf(LAF: torch.Tensor, images: torch.Tensor) -> torch.Tensor:
-    """Normalizes LAFs to [0,1] scale from pixel scale. See below:
+    """Normalize LAFs to [0,1] scale from pixel scale. See below:
         B,N,H,W = images.size()
         MIN_SIZE = min(H,W)
         [a11 a21 x]
@@ -499,7 +499,7 @@ def extract_patches_from_pyramid(
 
 
 def laf_is_inside_image(laf: torch.Tensor, images: torch.Tensor, border: int = 0) -> torch.Tensor:
-    """Checks if the LAF is touching or partly outside the image boundary.
+    """Check if the LAF is touching or partly outside the image boundary.
 
     Returns the mask of LAFs, which are fully inside the image, i.e. valid.
 
@@ -537,7 +537,7 @@ def laf_to_three_points(laf: torch.Tensor):
 
 
 def laf_from_three_points(threepts: torch.Tensor):
-    """Converts three points to local affine frame.
+    """Convert three points to local affine frame.
 
     Order is (0,0), (0, 1), (1, 0).
 

--- a/kornia/feature/mkd.py
+++ b/kornia/feature/mkd.py
@@ -23,7 +23,7 @@ urls: Dict[str, str] = {
 
 
 def get_grid_dict(patch_size: int = 32) -> Dict[str, torch.Tensor]:
-    r"""Gets cartesian and polar parametrizations of grid."""
+    r"""Get cartesian and polar parametrizations of grid."""
     kgrid = create_meshgrid(height=patch_size, width=patch_size, normalized_coordinates=True)
     x = kgrid[0, :, :, 0]
     y = kgrid[0, :, :, 1]
@@ -33,7 +33,7 @@ def get_grid_dict(patch_size: int = 32) -> Dict[str, torch.Tensor]:
 
 
 def get_kron_order(d1: int, d2: int) -> torch.Tensor:
-    r"""Gets order for doing kronecker product."""
+    r"""Get order for doing kronecker product."""
     kron_order = torch.zeros([d1 * d2, 2], dtype=torch.int64)
     for i in range(d1):
         for j in range(d2):

--- a/kornia/feature/nms.py
+++ b/kornia/feature/nms.py
@@ -24,7 +24,7 @@ def _get_nms_kernel3d(kd: int, ky: int, kx: int) -> torch.Tensor:
 
 
 class NonMaximaSuppression2d(nn.Module):
-    r"""Applies non maxima suppression to filter."""
+    r"""Apply non maxima suppression to filter."""
 
     def __init__(self, kernel_size: Tuple[int, int]):
         super().__init__()
@@ -67,7 +67,7 @@ class NonMaximaSuppression2d(nn.Module):
 
 
 class NonMaximaSuppression3d(nn.Module):
-    r"""Applies non maxima suppression to filter."""
+    r"""Apply non maxima suppression to filter."""
 
     def __init__(self, kernel_size: Tuple[int, int, int]):
         super().__init__()
@@ -113,7 +113,7 @@ class NonMaximaSuppression3d(nn.Module):
 
 
 def nms2d(input: torch.Tensor, kernel_size: Tuple[int, int], mask_only: bool = False) -> torch.Tensor:
-    r"""Applies non maxima suppression to filter.
+    r"""Apply non maxima suppression to filter.
 
     See :class:`~kornia.feature.NonMaximaSuppression2d` for details.
     """
@@ -121,7 +121,7 @@ def nms2d(input: torch.Tensor, kernel_size: Tuple[int, int], mask_only: bool = F
 
 
 def nms3d(input: torch.Tensor, kernel_size: Tuple[int, int, int], mask_only: bool = False) -> torch.Tensor:
-    r"""Applies non maxima suppression to filter.
+    r"""Apply non maxima suppression to filter.
 
     See :class:`~kornia.feature.NonMaximaSuppression3d` for details.
     """

--- a/kornia/feature/responses.py
+++ b/kornia/feature/responses.py
@@ -12,7 +12,7 @@ def harris_response(
     grads_mode: str = 'sobel',
     sigmas: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    r"""Computes the Harris cornerness function.
+    r"""Compute the Harris cornerness function.
 
     Function does not do any normalization or nms. The response map is computed according the following formulation:
 
@@ -100,7 +100,7 @@ def harris_response(
 def gftt_response(
     input: torch.Tensor, grads_mode: str = 'sobel', sigmas: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
-    r"""Computes the Shi-Tomasi cornerness function.
+    r"""Compute the Shi-Tomasi cornerness function.
 
     Function does not do any normalization or nms. The response map is computed according the following formulation:
 
@@ -178,7 +178,7 @@ def gftt_response(
 def hessian_response(
     input: torch.Tensor, grads_mode: str = 'sobel', sigmas: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
-    r"""Computes the absolute of determinant of the Hessian matrix.
+    r"""Compute the absolute of determinant of the Hessian matrix.
 
     Function does not do any normalization or nms. The response map is computed according the following formulation:
 
@@ -256,7 +256,7 @@ def hessian_response(
 
 
 def dog_response(input: torch.Tensor) -> torch.Tensor:
-    r"""Computes the Difference-of-Gaussian response.
+    r"""Compute the Difference-of-Gaussian response.
 
     Args:
         input: a given the gaussian 5d tensor :math:`(B, C, D, H, W)`.

--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -38,7 +38,7 @@ def _scale_index_to_scale(max_coords: torch.Tensor, sigmas: torch.Tensor, num_le
 
 
 def _create_octave_mask(mask: torch.Tensor, octave_shape: List[int]) -> torch.Tensor:
-    r"""Downsamples a mask based on the given octave shape."""
+    r"""Downsample a mask based on the given octave shape."""
     mask_shape = octave_shape[-2:]
     mask_octave = F.interpolate(mask, mask_shape, mode='bilinear', align_corners=False)  # type: ignore
     return mask_octave.unsqueeze(1)

--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -10,7 +10,7 @@ from kornia.geometry.conversions import pi
 
 
 def get_sift_pooling_kernel(ksize: int = 25) -> torch.Tensor:
-    r"""Returns a weighted pooling kernel for SIFT descriptor.
+    r"""Return a weighted pooling kernel for SIFT descriptor.
 
     Args:
         ksize: kernel_size.
@@ -25,7 +25,7 @@ def get_sift_pooling_kernel(ksize: int = 25) -> torch.Tensor:
 
 
 def get_sift_bin_ksize_stride_pad(patch_size: int, num_spatial_bins: int) -> Tuple:
-    r"""Returns a tuple with SIFT parameters.
+    r"""Return a tuple with SIFT parameters.
 
     Args:
         patch_size: the given patch size.
@@ -184,7 +184,7 @@ def sift_describe(
     rootsift: bool = True,
     clipval: float = 0.2,
 ) -> torch.Tensor:
-    r"""Computes the sift descriptor.
+    r"""Compute the sift descriptor.
 
     See :class:`~kornia.feature.SIFTDescriptor` for details.
     """

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -10,7 +10,7 @@ from kornia.filters.kernels import get_box_kernel2d, normalize_kernel2d
 def box_blur(
     input: torch.Tensor, kernel_size: Tuple[int, int], border_type: str = 'reflect', normalized: bool = True
 ) -> torch.Tensor:
-    r"""Blurs an image using the box filter.
+    r"""Blur an image using the box filter.
 
     .. image:: _static/img/box_blur.png
 
@@ -52,7 +52,7 @@ def box_blur(
 
 
 class BoxBlur(nn.Module):
-    r"""Blurs an image using the box filter.
+    r"""Blur an image using the box filter.
 
     The function smooths an image using the kernel:
 

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -21,7 +21,7 @@ def canny(
     hysteresis: bool = True,
     eps: float = 1e-6,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    r"""Finds edges of the input image and filters them using the Canny algorithm.
+    r"""Find edges of the input image and filters them using the Canny algorithm.
 
     .. image:: _static/img/canny.png
 

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -8,7 +8,7 @@ from kornia.filters.kernels import normalize_kernel2d
 
 
 def _compute_padding(kernel_size: List[int]) -> List[int]:
-    """Computes padding tuple."""
+    """Compute padding tuple."""
     # 4 or 6 ints:  (padding_left, padding_right,padding_top,padding_bottom)
     # https://pytorch.org/docs/stable/nn.html#torch.nn.functional.pad
     if len(kernel_size) < 2:

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -10,7 +10,7 @@ from kornia.filters.kernels import get_gaussian_kernel2d
 def gaussian_blur2d(
     input: torch.Tensor, kernel_size: Tuple[int, int], sigma: Tuple[float, float], border_type: str = 'reflect'
 ) -> torch.Tensor:
-    r"""Creates an operator that blurs a tensor using a Gaussian filter.
+    r"""Create an operator that blurs a tensor using a Gaussian filter.
 
     .. image:: _static/img/gaussian_blur2d.png
 
@@ -44,7 +44,7 @@ def gaussian_blur2d(
 
 
 class GaussianBlur2d(nn.Module):
-    r"""Creates an operator that blurs a tensor using a Gaussian filter.
+    r"""Create an operator that blurs a tensor using a Gaussian filter.
 
     The operator smooths the given tensor with a gaussian kernel by convolving
     it to each channel. It supports batched operation.

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -5,7 +5,7 @@ import torch
 
 
 def normalize_kernel2d(input: torch.Tensor) -> torch.Tensor:
-    r"""Normalizes both derivative and smoothing kernel."""
+    r"""Normalize both derivative and smoothing kernel."""
     if len(input.size()) < 2:
         raise TypeError(f"input should be at least 2D tensor. Got {input.size()}")
     norm: torch.Tensor = input.abs().sum(dim=-1).sum(dim=-1)
@@ -136,7 +136,7 @@ def get_box_kernel2d(kernel_size: Tuple[int, int]) -> torch.Tensor:
 
 
 def get_binary_kernel2d(window_size: Tuple[int, int]) -> torch.Tensor:
-    r"""Creates a binary kernel to extract the patches. If the window size
+    r"""Create a binary kernel to extract the patches. If the window size
     is HxW will create a (H*W)xHxW kernel.
     """
     window_range: int = window_size[0] * window_size[1]

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -8,7 +8,7 @@ from kornia.filters.kernels import get_laplacian_kernel2d, normalize_kernel2d
 def laplacian(
     input: torch.Tensor, kernel_size: int, border_type: str = 'reflect', normalized: bool = True
 ) -> torch.Tensor:
-    r"""Creates an operator that returns a tensor using a Laplacian filter.
+    r"""Create an operator that returns a tensor using a Laplacian filter.
 
     .. image:: _static/img/laplacian.png
 
@@ -45,7 +45,7 @@ def laplacian(
 
 
 class Laplacian(nn.Module):
-    r"""Creates an operator that returns a tensor using a Laplacian filter.
+    r"""Create an operator that returns a tensor using a Laplacian filter.
 
     The operator smooths the given tensor with a laplacian kernel by convolving
     it to each channel. It supports batched operation.

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -14,7 +14,7 @@ def _compute_zero_padding(kernel_size: Tuple[int, int]) -> Tuple[int, int]:
 
 
 def median_blur(input: torch.Tensor, kernel_size: Tuple[int, int]) -> torch.Tensor:
-    r"""Blurs an image using the median filter.
+    r"""Blur an image using the median filter.
 
     .. image:: _static/img/median_blur.png
 
@@ -58,7 +58,7 @@ def median_blur(input: torch.Tensor, kernel_size: Tuple[int, int]) -> torch.Tens
 
 
 class MedianBlur(nn.Module):
-    r"""Blurs an image using the median filter.
+    r"""Blur an image using the median filter.
 
     Args:
         kernel_size: the blurring kernel size.

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -6,7 +6,7 @@ from kornia.filters.kernels import get_spatial_gradient_kernel2d, get_spatial_gr
 
 
 def spatial_gradient(input: torch.Tensor, mode: str = 'sobel', order: int = 1, normalized: bool = True) -> torch.Tensor:
-    r"""Computes the first order image derivative in both x and y using a Sobel
+    r"""Compute the first order image derivative in both x and y using a Sobel
     operator.
 
     .. image:: _static/img/spatial_gradient.png
@@ -57,7 +57,7 @@ def spatial_gradient(input: torch.Tensor, mode: str = 'sobel', order: int = 1, n
 
 
 def spatial_gradient3d(input: torch.Tensor, mode: str = 'diff', order: int = 1) -> torch.Tensor:
-    r"""Computes the first and second order volume derivative in x, y and d using a diff
+    r"""Compute the first and second order volume derivative in x, y and d using a diff
     operator.
 
     Args:
@@ -110,7 +110,7 @@ def spatial_gradient3d(input: torch.Tensor, mode: str = 'diff', order: int = 1) 
 
 
 def sobel(input: torch.Tensor, normalized: bool = True, eps: float = 1e-6) -> torch.Tensor:
-    r"""Computes the Sobel operator and returns the magnitude per channel.
+    r"""Compute the Sobel operator and returns the magnitude per channel.
 
     .. image:: _static/img/sobel.png
 
@@ -152,7 +152,7 @@ def sobel(input: torch.Tensor, normalized: bool = True, eps: float = 1e-6) -> to
 
 
 class SpatialGradient(nn.Module):
-    r"""Computes the first order image derivative in both x and y using a Sobel
+    r"""Compute the first order image derivative in both x and y using a Sobel
     operator.
 
     Args:
@@ -189,7 +189,7 @@ class SpatialGradient(nn.Module):
 
 
 class SpatialGradient3d(nn.Module):
-    r"""Computes the first and second order volume derivative in x, y and d using a diff
+    r"""Compute the first and second order volume derivative in x, y and d using a diff
     operator.
 
     Args:
@@ -225,7 +225,7 @@ class SpatialGradient3d(nn.Module):
 
 
 class Sobel(nn.Module):
-    r"""Computes the Sobel operator and returns the magnitude per channel.
+    r"""Compute the Sobel operator and returns the magnitude per channel.
 
     Args:
         normalized: if True, L1 norm of the kernel is set to 1.

--- a/kornia/filters/unsharp.py
+++ b/kornia/filters/unsharp.py
@@ -9,7 +9,7 @@ from kornia.filters import gaussian_blur2d
 def unsharp_mask(
     input: torch.Tensor, kernel_size: Tuple[int, int], sigma: Tuple[float, float], border_type: str = 'reflect'
 ) -> torch.Tensor:
-    r"""Creates an operator that blurs a tensor using the existing Gaussian filter available with the Kornia library.
+    r"""Create an operator that blurs a tensor using the existing Gaussian filter available with the Kornia library.
 
     .. image:: _static/img/unsharp_mask.png
 
@@ -36,7 +36,7 @@ def unsharp_mask(
 
 
 class UnsharpMask(nn.Module):
-    r"""Creates an operator that sharpens image using the existing Gaussian filter available with the Kornia library..
+    r"""Create an operator that sharpens image using the existing Gaussian filter available with the Kornia library..
 
     Args:
         kernel_size: the size of the kernel.

--- a/kornia/geometry/camera/perspective.py
+++ b/kornia/geometry/camera/perspective.py
@@ -5,7 +5,7 @@ from kornia.geometry.conversions import convert_points_from_homogeneous, convert
 
 
 def project_points(point_3d: torch.Tensor, camera_matrix: torch.Tensor) -> torch.Tensor:
-    r"""Projects a 3d point onto the 2d camera plane.
+    r"""Project a 3d point onto the 2d camera plane.
 
     Args:
         point3d: tensor containing the 3d points to be projected
@@ -56,7 +56,7 @@ def project_points(point_3d: torch.Tensor, camera_matrix: torch.Tensor) -> torch
 def unproject_points(
     point_2d: torch.Tensor, depth: torch.Tensor, camera_matrix: torch.Tensor, normalize: bool = False
 ) -> torch.Tensor:
-    r"""Unprojects a 2d point in 3d.
+    r"""Unproject a 2d point in 3d.
 
     Transform coordinates in the pixel frame to the camera frame.
 

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -83,7 +83,7 @@ class PinholeCamera:
 
     @property
     def batch_size(self) -> int:
-        r"""Returns the batch size of the storage.
+        r"""Return the batch size of the storage.
 
         Returns:
             scalar with the batch size.
@@ -92,7 +92,7 @@ class PinholeCamera:
 
     @property
     def fx(self) -> torch.Tensor:
-        r"""Returns the focal length in the x-direction.
+        r"""Return the focal length in the x-direction.
 
         Returns:
             tensor of shape :math:`(B)`.
@@ -101,7 +101,7 @@ class PinholeCamera:
 
     @property
     def fy(self) -> torch.Tensor:
-        r"""Returns the focal length in the y-direction.
+        r"""Return the focal length in the y-direction.
 
         Returns:
             tensor of shape :math:`(B)`.
@@ -110,7 +110,7 @@ class PinholeCamera:
 
     @property
     def cx(self) -> torch.Tensor:
-        r"""Returns the x-coordinate of the principal point.
+        r"""Return the x-coordinate of the principal point.
 
         Returns:
             tensor of shape :math:`(B)`.
@@ -119,7 +119,7 @@ class PinholeCamera:
 
     @property
     def cy(self) -> torch.Tensor:
-        r"""Returns the y-coordinate of the principal point.
+        r"""Return the y-coordinate of the principal point.
 
         Returns:
             tensor of shape :math:`(B)`.
@@ -128,7 +128,7 @@ class PinholeCamera:
 
     @property
     def tx(self) -> torch.Tensor:
-        r"""Returns the x-coordinate of the translation vector.
+        r"""Return the x-coordinate of the translation vector.
 
         Returns:
             tensor of shape :math:`(B)`.
@@ -143,7 +143,7 @@ class PinholeCamera:
 
     @property
     def ty(self) -> torch.Tensor:
-        r"""Returns the y-coordinate of the translation vector.
+        r"""Return the y-coordinate of the translation vector.
 
         Returns:
             tensor of shape :math:`(B)`.
@@ -173,7 +173,7 @@ class PinholeCamera:
 
     @property
     def rt_matrix(self) -> torch.Tensor:
-        r"""Returns the 3x4 rotation-translation matrix.
+        r"""Return the 3x4 rotation-translation matrix.
 
         Returns:
             tensor of shape :math:`(B, 3, 4)`.
@@ -182,7 +182,7 @@ class PinholeCamera:
 
     @property
     def camera_matrix(self) -> torch.Tensor:
-        r"""Returns the 3x3 camera matrix containing the intrinsics.
+        r"""Return the 3x3 camera matrix containing the intrinsics.
 
         Returns:
             tensor of shape :math:`(B, 3, 3)`.
@@ -191,7 +191,7 @@ class PinholeCamera:
 
     @property
     def rotation_matrix(self) -> torch.Tensor:
-        r"""Returns the 3x3 rotation matrix from the extrinsics.
+        r"""Return the 3x3 rotation matrix from the extrinsics.
 
         Returns:
             tensor of shape :math:`(B, 3, 3)`.
@@ -200,7 +200,7 @@ class PinholeCamera:
 
     @property
     def translation_vector(self) -> torch.Tensor:
-        r"""Returns the translation vector from the extrinsics.
+        r"""Return the translation vector from the extrinsics.
 
         Returns:
             tensor of shape :math:`(B, 3, 1)`.
@@ -208,7 +208,7 @@ class PinholeCamera:
         return self.extrinsics[..., :3, -1:]
 
     def clone(self) -> 'PinholeCamera':
-        r"""Returns a deep copy of the current object instance."""
+        r"""Return a deep copy of the current object instance."""
         height: torch.Tensor = self.height.clone()
         width: torch.Tensor = self.width.clone()
         intrinsics: torch.Tensor = self.intrinsics.clone()
@@ -216,7 +216,7 @@ class PinholeCamera:
         return PinholeCamera(intrinsics, extrinsics, height, width)
 
     def intrinsics_inverse(self) -> torch.Tensor:
-        r"""Returns the inverse of the 4x4 instrisics matrix.
+        r"""Return the inverse of the 4x4 instrisics matrix.
 
         Returns:
             tensor of shape :math:`(B, 4, 4)`.
@@ -224,7 +224,7 @@ class PinholeCamera:
         return self.intrinsics.inverse()
 
     def scale(self, scale_factor) -> 'PinholeCamera':
-        r"""Scales the pinhole model.
+        r"""Scale the pinhole model.
 
         Args:
             scale_factor: a tensor with the scale factor. It has
@@ -246,7 +246,7 @@ class PinholeCamera:
         return PinholeCamera(intrinsics, self.extrinsics, height, width)
 
     def scale_(self, scale_factor) -> 'PinholeCamera':
-        r"""Scales the pinhole model in-place.
+        r"""Scale the pinhole model in-place.
 
         Args:
             scale_factor: a tensor with the scale factor. It has
@@ -324,7 +324,7 @@ class PinholeCamerasList(PinholeCamera):
         self._initialize_parameters(pinholes_list)
 
     def _initialize_parameters(self, pinholes: Iterable[PinholeCamera]) -> 'PinholeCamerasList':
-        r"""Initialises the class attributes given a cameras list."""
+        r"""Initialise the class attributes given a cameras list."""
         if not isinstance(pinholes, (list, tuple)):
             raise TypeError(f"pinhole must of type list or tuple. Got {type(pinholes)}")
         height, width = [], []
@@ -345,14 +345,14 @@ class PinholeCamerasList(PinholeCamera):
 
     @property
     def num_cameras(self) -> int:
-        r"""Returns the number of pinholes cameras per batch."""
+        r"""Return the number of pinholes cameras per batch."""
         num_cameras: int = -1
         if self.intrinsics is not None:
             num_cameras = int(self.intrinsics.shape[1])
         return num_cameras
 
     def get_pinhole(self, idx: int) -> PinholeCamera:
-        r"""Returns a PinholeCamera object with parameters such as Bx4x4."""
+        r"""Return a PinholeCamera object with parameters such as Bx4x4."""
         height: torch.Tensor = self.height[..., idx]
         width: torch.Tensor = self.width[..., idx]
         intrinsics: torch.Tensor = self.intrinsics[:, idx]
@@ -405,7 +405,7 @@ def pinhole_matrix(pinholes: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
 
 
 def inverse_pinhole_matrix(pinhole: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-    r"""Returns the inverted pinhole matrix from a pinhole model
+    r"""Return the inverted pinhole matrix from a pinhole model
 
     .. note::
         This method is going to be deprecated in version 0.2 in favour of
@@ -449,7 +449,7 @@ def inverse_pinhole_matrix(pinhole: torch.Tensor, eps: float = 1e-6) -> torch.Te
 
 
 def scale_pinhole(pinholes: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    r"""Scales the pinhole matrix for each pinhole model.
+    r"""Scale the pinhole matrix for each pinhole model.
 
     .. note::
         This method is going to be deprecated in version 0.2 in favour of
@@ -619,7 +619,7 @@ def cam2pixel(cam_coords_src: torch.Tensor, dst_proj_src: torch.Tensor, eps: flo
 
 # layer api
 '''class PinholeMatrix(nn.Module):
-    r"""Creates an object that returns the pinhole matrix from a pinhole model
+    r"""Create an object that returns the pinhole matrix from a pinhole model
 
     Args:
         pinholes (Tensor): tensor of pinhole models.
@@ -645,7 +645,7 @@ def cam2pixel(cam_coords_src: torch.Tensor, dst_proj_src: torch.Tensor, eps: flo
 
 
 class InversePinholeMatrix(nn.Module):
-    r"""Returns and object that inverts a pinhole matrix from a pinhole model
+    r"""Return and object that inverts a pinhole matrix from a pinhole model
 
     Args:
         pinholes (Tensor): tensor with pinhole models.

--- a/kornia/geometry/camera/stereo.py
+++ b/kornia/geometry/camera/stereo.py
@@ -109,7 +109,7 @@ class StereoCamera:
 
     @property
     def batch_size(self) -> int:
-        r"""Returns the batch size of the storage.
+        r"""Return the batch size of the storage.
 
         Returns:
            scalar with the batch size
@@ -118,7 +118,7 @@ class StereoCamera:
 
     @property
     def fx(self) -> torch.Tensor:
-        r"""Returns the focal length in the x-direction.
+        r"""Return the focal length in the x-direction.
 
         Note that the focal lengths of the rectified left and right
         camera are assumed to be equal.
@@ -142,7 +142,7 @@ class StereoCamera:
 
     @property
     def cx_left(self) -> torch.Tensor:
-        r"""Returns the x-coordinate of the principal point for the left camera.
+        r"""Return the x-coordinate of the principal point for the left camera.
 
         Returns:
             tensor of shape :math:`(B)`
@@ -151,7 +151,7 @@ class StereoCamera:
 
     @property
     def cx_right(self) -> torch.Tensor:
-        r"""Returns the x-coordinate of the principal point for the right camera.
+        r"""Return the x-coordinate of the principal point for the right camera.
 
         Returns:
             tensor of shape :math:`(B)`
@@ -160,7 +160,7 @@ class StereoCamera:
 
     @property
     def cy(self) -> torch.Tensor:
-        r"""Returns the y-coordinate of the principal point.
+        r"""Return the y-coordinate of the principal point.
 
         Note that the y-coordinate of the principal points
         is assumed to be equal for the left and right camera.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -427,7 +427,7 @@ def rotation_matrix_to_quaternion(
 
 
 def normalize_quaternion(quaternion: torch.Tensor, eps: float = 1.0e-12) -> torch.Tensor:
-    r"""Normalizes a quaternion.
+    r"""Normalize a quaternion.
 
     The quaternion should be in (x, y, z, w) format.
 
@@ -460,7 +460,7 @@ def normalize_quaternion(quaternion: torch.Tensor, eps: float = 1.0e-12) -> torc
 def quaternion_to_rotation_matrix(
     quaternion: torch.Tensor, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW
 ) -> torch.Tensor:
-    r"""Converts a quaternion to a rotation matrix.
+    r"""Convert a quaternion to a rotation matrix.
 
     The quaternion should be in (x, y, z, w) or (w, x, y, z) format.
 
@@ -618,7 +618,7 @@ def quaternion_to_angle_axis(
 def quaternion_log_to_exp(
     quaternion: torch.Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW
 ) -> torch.Tensor:
-    r"""Applies exponential map to log quaternion.
+    r"""Apply exponential map to log quaternion.
 
     The quaternion should be in (x, y, z, w) or (w, x, y, z) format.
 
@@ -673,7 +673,7 @@ def quaternion_log_to_exp(
 def quaternion_exp_to_log(
     quaternion: torch.Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW
 ) -> torch.Tensor:
-    r"""Applies the log map to a quaternion.
+    r"""Apply the log map to a quaternion.
 
     The quaternion should be in (x, y, z, w) format.
 

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -172,7 +172,7 @@ def warp_frame_depth(
 
 
 class DepthWarper(nn.Module):
-    r"""Warps a patch by depth.
+    r"""Warp a patch by depth.
 
     .. math::
         P_{src}^{\{dst\}} = K_{dst} * T_{src}^{\{dst\}}
@@ -219,7 +219,7 @@ class DepthWarper(nn.Module):
         return convert_points_to_homogeneous(grid)  # append ones to last dim
 
     def compute_projection_matrix(self, pinhole_src: PinholeCamera) -> 'DepthWarper':
-        r"""Computes the projection matrix from the source to destination frame."""
+        r"""Compute the projection matrix from the source to destination frame."""
         if not isinstance(self._pinhole_dst, PinholeCamera):
             raise TypeError(
                 "Member self._pinhole_dst expected to be of class "
@@ -309,7 +309,7 @@ class DepthWarper(nn.Module):
         return pixel_coords_src_norm
 
     def forward(self, depth_src: torch.Tensor, patch_dst: torch.Tensor) -> torch.Tensor:
-        """Warps a tensor from destination frame to reference given the depth in the reference frame.
+        """Warp a tensor from destination frame to reference given the depth in the reference frame.
 
         Args:
             depth_src: the depth in the reference frame. The tensor must have a shape :math:`(B, 1, H, W)`.

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -251,7 +251,7 @@ def motion_from_essential_choose_solution(
 def relative_camera_motion(
     R1: torch.Tensor, t1: torch.Tensor, R2: torch.Tensor, t2: torch.Tensor
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    r"""Computes the relative camera motion between two cameras.
+    r"""Compute the relative camera motion between two cameras.
 
     Given the motion parameters of two cameras, computes the motion parameters of the second
     one assuming the first one to be at the origin. If :math:`T1` and :math:`T2` are the camera motions,

--- a/kornia/geometry/epipolar/fundamental.py
+++ b/kornia/geometry/epipolar/fundamental.py
@@ -49,7 +49,7 @@ def normalize_points(points: torch.Tensor, eps: float = 1e-8) -> Tuple[torch.Ten
 
 
 def normalize_transformation(M: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
-    r"""Normalizes a given transformation matrix.
+    r"""Normalize a given transformation matrix.
 
     The function trakes the transformation matrix and normalize so that the value in
     the last row and column is one.
@@ -69,7 +69,7 @@ def normalize_transformation(M: torch.Tensor, eps: float = 1e-8) -> torch.Tensor
 
 
 def find_fundamental(points1: torch.Tensor, points2: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
-    r"""Computes the fundamental matrix using the DLT formulation.
+    r"""Compute the fundamental matrix using the DLT formulation.
 
     The linear system is solved by using the Weighted Least Squares Solution for the 8 Points algorithm.
 
@@ -120,7 +120,7 @@ def find_fundamental(points1: torch.Tensor, points2: torch.Tensor, weights: torc
 
 
 def compute_correspond_epilines(points: torch.Tensor, F_mat: torch.Tensor) -> torch.Tensor:
-    r"""Computes the corresponding epipolar line for a given set of points.
+    r"""Compute the corresponding epipolar line for a given set of points.
 
     Args:
         points: tensor containing the set of points to project in the shape of :math:`(B, N, 2)`.

--- a/kornia/geometry/epipolar/metrics.py
+++ b/kornia/geometry/epipolar/metrics.py
@@ -8,7 +8,7 @@ import kornia
 def sampson_epipolar_distance(
     pts1: torch.Tensor, pts2: torch.Tensor, Fm: torch.Tensor, squared: bool = True, eps: float = 1e-8
 ) -> torch.Tensor:
-    r"""Returns Sampson distance for correspondences given the fundamental matrix.
+    r"""Return Sampson distance for correspondences given the fundamental matrix.
 
     Args:
         pts1: correspondences from the left images with shape
@@ -60,7 +60,7 @@ def sampson_epipolar_distance(
 def symmetrical_epipolar_distance(
     pts1: torch.Tensor, pts2: torch.Tensor, Fm: torch.Tensor, squared: bool = True, eps: float = 1e-8
 ) -> torch.Tensor:
-    r"""Returns symmetrical epipolar distance for correspondences given the fundamental matrix.
+    r"""Return symmetrical epipolar distance for correspondences given the fundamental matrix.
 
     Args:
        pts1: correspondences from the left images with shape

--- a/kornia/geometry/epipolar/numeric.py
+++ b/kornia/geometry/epipolar/numeric.py
@@ -6,7 +6,7 @@ import torch
 
 
 def cross_product_matrix(x: torch.Tensor) -> torch.Tensor:
-    r"""Returns the cross_product_matrix symmetric matrix of a vector.
+    r"""Return the cross_product_matrix symmetric matrix of a vector.
 
     Args:
         x: The input vector to construct the matrix in the shape :math:`(B, 3)`.
@@ -29,7 +29,7 @@ def cross_product_matrix(x: torch.Tensor) -> torch.Tensor:
 
 
 def eye_like(n: int, input: torch.Tensor) -> torch.Tensor:
-    r"""Returns a 2-D tensor with ones on the diagonal and zeros elsewhere with same size as the input.
+    r"""Return a 2-D tensor with ones on the diagonal and zeros elsewhere with same size as the input.
 
     Args:
         n: the number of rows :math:`(N)`.
@@ -50,7 +50,7 @@ def eye_like(n: int, input: torch.Tensor) -> torch.Tensor:
 
 
 def vec_like(n, tensor):
-    r"""Returns a 2-D tensor with a vector containing zeros with same size as the input.
+    r"""Return a 2-D tensor with a vector containing zeros with same size as the input.
 
     Args:
         n: the number of rows :math:`(N)`.

--- a/kornia/geometry/epipolar/projection.py
+++ b/kornia/geometry/epipolar/projection.py
@@ -7,7 +7,7 @@ from kornia.geometry.epipolar import numeric
 
 
 def intrinsics_like(focal: float, input: torch.Tensor) -> torch.Tensor:
-    r"""Returns a 3x3 instrinsics matrix, with same size as the input.
+    r"""Return a 3x3 instrinsics matrix, with same size as the input.
 
     The center of projection will be based in the input image size.
 
@@ -36,7 +36,7 @@ def intrinsics_like(focal: float, input: torch.Tensor) -> torch.Tensor:
 
 
 def random_intrinsics(low: Union[float, torch.Tensor], high: Union[float, torch.Tensor]) -> torch.Tensor:
-    r"""Generates a random camera matrix based on a given uniform distribution.
+    r"""Generate a random camera matrix based on a given uniform distribution.
 
     Args:
         low: lower range (inclusive).
@@ -109,7 +109,7 @@ def projection_from_KRt(K: torch.Tensor, R: torch.Tensor, t: torch.Tensor) -> to
 
 
 def KRt_from_projection(P: torch.Tensor, eps: float = 1e-6) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    r"""This function decomposes the Projection matrix into Camera-Matrix, Rotation Matrix and Translation vector.
+    r"""Decompose the Projection matrix into Camera-Matrix, Rotation Matrix and Translation vector.
 
     Args:
         P: the projection matrix with shape :math:`(B, 3, 4)`.
@@ -148,7 +148,7 @@ def KRt_from_projection(P: torch.Tensor, eps: float = 1e-6) -> Tuple[torch.Tenso
 
 
 def depth(R: torch.Tensor, t: torch.Tensor, X: torch.Tensor) -> torch.Tensor:
-    r"""Returns the depth of a point transformed by a rigid transform.
+    r"""Return the depth of a point transformed by a rigid transform.
 
     Args:
        R: The rotation matrix with shape :math:`(*, 3, 3)`.

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -13,7 +13,7 @@ TupleTensor = Tuple[torch.Tensor, torch.Tensor]
 def oneway_transfer_error(
     pts1: torch.Tensor, pts2: torch.Tensor, H: torch.Tensor, squared: bool = True, eps: float = 1e-8
 ) -> torch.Tensor:
-    r"""Returns transfer error in image 2 for correspondences given the homography matrix.
+    r"""Return transfer error in image 2 for correspondences given the homography matrix.
 
     Args:
         pts1: correspondences from the left images with shape
@@ -52,7 +52,7 @@ def oneway_transfer_error(
 def symmetric_transfer_error(
     pts1: torch.Tensor, pts2: torch.Tensor, H: torch.Tensor, squared: bool = True, eps: float = 1e-8
 ) -> torch.Tensor:
-    r"""Returns Symmetric transfer error for correspondences given the homography matrix.
+    r"""Return Symmetric transfer error for correspondences given the homography matrix.
 
     Args:
         pts1: correspondences from the left images with shape
@@ -92,7 +92,7 @@ def symmetric_transfer_error(
 def find_homography_dlt(
     points1: torch.Tensor, points2: torch.Tensor, weights: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
-    r"""Computes the homography matrix using the DLT formulation.
+    r"""Compute the homography matrix using the DLT formulation.
 
     The linear system is solved by using the Weighted Least Squares Solution for the 4 Points algorithm.
 
@@ -151,7 +151,7 @@ def find_homography_dlt(
 def find_homography_dlt_iterated(
     points1: torch.Tensor, points2: torch.Tensor, weights: torch.Tensor, soft_inl_th: float = 3.0, n_iter: int = 5
 ) -> torch.Tensor:
-    r"""Computes the homography matrix using the iteratively-reweighted least squares (IRWLS).
+    r"""Compute the homography matrix using the iteratively-reweighted least squares (IRWLS).
 
     The linear system is solved by using the Reweighted Least Squares Solution for the 4 Points algorithm.
 

--- a/kornia/geometry/linalg.py
+++ b/kornia/geometry/linalg.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def compose_transformations(trans_01: torch.Tensor, trans_12: torch.Tensor) -> torch.Tensor:
-    r"""Functions that composes two homogeneous transformations.
+    r"""Function that composes two homogeneous transformations.
 
     .. math::
         T_0^{2} = \begin{bmatrix} R_0^1 R_1^{2} & R_0^{1} t_1^{2} + t_0^{1} \\
@@ -299,7 +299,7 @@ def perspective_transform_lafs(trans_01: torch.Tensor, lafs_1: torch.Tensor) -> 
 
 # NOTE: is it needed ?
 '''class TransformPoints(nn.Module):
-    r"""Creates an object to transform a set of points.
+    r"""Create an object to transform a set of points.
 
     Args:
         dst_pose_src (torhc.Tensor): tensor for transformations of
@@ -328,7 +328,7 @@ def perspective_transform_lafs(trans_01: torch.Tensor, lafs_1: torch.Tensor) -> 
 
 
 class InversePose(nn.Module):
-    r"""Creates a transformation that inverts a 4x4 pose.
+    r"""Create a transformation that inverts a 4x4 pose.
 
     Args:
         points (Tensor): tensor with poses.

--- a/kornia/geometry/subpix/dsnt.py
+++ b/kornia/geometry/subpix/dsnt.py
@@ -19,7 +19,7 @@ def _validate_batched_image_tensor_input(tensor):
 
 
 def spatial_softmax2d(input: torch.Tensor, temperature: torch.Tensor = torch.tensor(1.0)) -> torch.Tensor:
-    r"""Applies the Softmax function over features in each image channel.
+    r"""Apply the Softmax function over features in each image channel.
 
     Note that this function behaves differently to :py:class:`torch.nn.Softmax2d`, which
     instead applies Softmax over features at each spatial location.
@@ -53,7 +53,7 @@ def spatial_softmax2d(input: torch.Tensor, temperature: torch.Tensor = torch.ten
 
 
 def spatial_expectation2d(input: torch.Tensor, normalized_coordinates: bool = True) -> torch.Tensor:
-    r"""Computes the expectation of coordinate values using spatial probabilities.
+    r"""Compute the expectation of coordinate values using spatial probabilities.
 
     The input heatmap is assumed to represent a valid spatial probability distribution,
     which can be achieved using :func:`~kornia.geometry.subpixel.spatial_softmax2d`.
@@ -103,7 +103,7 @@ def _safe_zero_division(numerator: torch.Tensor, denominator: torch.Tensor, eps:
 def render_gaussian2d(
     mean: torch.Tensor, std: torch.Tensor, size: Tuple[int, int], normalized_coordinates: bool = True
 ):
-    r"""Renders the PDF of a 2D Gaussian distribution.
+    r"""Render the PDF of a 2D Gaussian distribution.
 
     Args:
         mean: the mean location of the Gaussian to render, :math:`(\mu_x, \mu_y)`. Shape: :math:`(*, 2)`.

--- a/kornia/geometry/subpix/spatial_soft_argmax.py
+++ b/kornia/geometry/subpix/spatial_soft_argmax.py
@@ -268,7 +268,7 @@ def conv_soft_argmax2d(
     eps: float = 1e-8,
     output_value: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-    r"""Computes the convolutional spatial Soft-Argmax 2D over the windows of a given heatmap.
+    r"""Compute the convolutional spatial Soft-Argmax 2D over the windows of a given heatmap.
 
     .. math::
         ij(X) = \frac{\sum{(i,j)} * exp(x / T)  \in X} {\sum{exp(x / T)  \in X}}
@@ -382,7 +382,7 @@ def conv_soft_argmax3d(
     output_value: bool = True,
     strict_maxima_bonus: float = 0.0,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-    r"""Computes the convolutional spatial Soft-Argmax 3D over the windows of a given heatmap.
+    r"""Compute the convolutional spatial Soft-Argmax 3D over the windows of a given heatmap.
 
     .. math::
              ijk(X) = \frac{\sum{(i,j,k)} * exp(x / T)  \in X} {\sum{exp(x / T)  \in X}}
@@ -504,7 +504,7 @@ def spatial_soft_argmax2d(
     temperature: torch.Tensor = torch.tensor(1.0),
     normalized_coordinates: bool = True,
 ) -> torch.Tensor:
-    r"""Function that computes the Spatial Soft-Argmax 2D of a given input heatmap.
+    r"""Compute the Spatial Soft-Argmax 2D of a given input heatmap.
 
     Args:
         input: the given heatmap with shape :math:`(B, N, H, W)`.
@@ -530,7 +530,7 @@ def spatial_soft_argmax2d(
 
 
 class SpatialSoftArgmax2d(nn.Module):
-    r"""Module that computes the Spatial Soft-Argmax 2D of a given heatmap.
+    r"""Compute the Spatial Soft-Argmax 2D of a given heatmap.
 
     See :func:`~kornia.geometry.subpix.spatial_soft_argmax2d` for details.
     """
@@ -560,7 +560,7 @@ class SpatialSoftArgmax2d(nn.Module):
 def conv_quad_interp3d(
     input: torch.Tensor, strict_maxima_bonus: float = 10.0, eps: float = 1e-7
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    r"""Function that computes the single iteration of quadratic interpolation of the extremum (max or min).
+    r"""Compute the single iteration of quadratic interpolation of the extremum (max or min).
 
     Args:
         input: the given heatmap with shape :math:`(N, C, D_{in}, H_{in}, W_{in})`.
@@ -640,7 +640,7 @@ def conv_quad_interp3d(
 
 
 class ConvQuadInterp3d(nn.Module):
-    r"""Module that calculates soft argmax 3d per window
+    r"""Calculate soft argmax 3d per window
 
     See :func:`~kornia.geometry.subpix.conv_quad_interp3d` for details.
     """

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -32,7 +32,7 @@ __all__ = [
 
 
 def _compute_tensor_center(tensor: torch.Tensor) -> torch.Tensor:
-    """Computes the center of tensor plane for (H, W), (C, H, W) and (B, C, H, W)."""
+    """Compute the center of tensor plane for (H, W), (C, H, W) and (B, C, H, W)."""
     if not 2 <= len(tensor.shape) <= 4:
         raise AssertionError(f"Must be a 3D tensor as HW, CHW and BCHW. Got {tensor.shape}.")
     height, width = tensor.shape[-2:]
@@ -43,7 +43,7 @@ def _compute_tensor_center(tensor: torch.Tensor) -> torch.Tensor:
 
 
 def _compute_tensor_center3d(tensor: torch.Tensor) -> torch.Tensor:
-    """Computes the center of tensor plane for (D, H, W), (C, D, H, W) and (B, C, D, H, W)."""
+    """Compute the center of tensor plane for (D, H, W), (C, D, H, W) and (B, C, D, H, W)."""
     if not 3 <= len(tensor.shape) <= 5:
         raise AssertionError(f"Must be a 3D tensor as DHW, CDHW and BCDHW. Got {tensor.shape}.")
     depth, height, width = tensor.shape[-3:]
@@ -55,7 +55,7 @@ def _compute_tensor_center3d(tensor: torch.Tensor) -> torch.Tensor:
 
 
 def _compute_rotation_matrix(angle: torch.Tensor, center: torch.Tensor) -> torch.Tensor:
-    """Computes a pure affine rotation matrix."""
+    """Compute a pure affine rotation matrix."""
     scale: torch.Tensor = torch.ones_like(center)
     matrix: torch.Tensor = get_rotation_matrix2d(center, angle, scale)
     return matrix
@@ -64,7 +64,7 @@ def _compute_rotation_matrix(angle: torch.Tensor, center: torch.Tensor) -> torch
 def _compute_rotation_matrix3d(
     yaw: torch.Tensor, pitch: torch.Tensor, roll: torch.Tensor, center: torch.Tensor
 ) -> torch.Tensor:
-    """Computes a pure affine rotation matrix."""
+    """Compute a pure affine rotation matrix."""
     if len(yaw.shape) == len(pitch.shape) == len(roll.shape) == 0:
         yaw = yaw.unsqueeze(dim=0)
         pitch = pitch.unsqueeze(dim=0)
@@ -85,7 +85,7 @@ def _compute_rotation_matrix3d(
 
 
 def _compute_translation_matrix(translation: torch.Tensor) -> torch.Tensor:
-    """Computes affine matrix for translation."""
+    """Compute affine matrix for translation."""
     matrix: torch.Tensor = torch.eye(3, device=translation.device, dtype=translation.dtype)
     matrix = matrix.repeat(translation.shape[0], 1, 1)
 
@@ -96,14 +96,14 @@ def _compute_translation_matrix(translation: torch.Tensor) -> torch.Tensor:
 
 
 def _compute_scaling_matrix(scale: torch.Tensor, center: torch.Tensor) -> torch.Tensor:
-    """Computes affine matrix for scaling."""
+    """Compute affine matrix for scaling."""
     angle: torch.Tensor = torch.zeros(scale.shape[:1], device=scale.device, dtype=scale.dtype)
     matrix: torch.Tensor = get_rotation_matrix2d(center, angle, scale)
     return matrix
 
 
 def _compute_shear_matrix(shear: torch.Tensor) -> torch.Tensor:
-    """Computes affine matrix for shearing."""
+    """Compute affine matrix for shearing."""
     matrix: torch.Tensor = torch.eye(3, device=shear.device, dtype=shear.dtype)
     matrix = matrix.repeat(shear.shape[0], 1, 1)
 

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -18,7 +18,7 @@ def elastic_transform2d(
     align_corners: bool = False,
     mode: str = 'bilinear',
 ) -> torch.Tensor:
-    r"""Applies elastic transform of images as described in :cite:`Simard2003BestPF`.
+    r"""Apply elastic transform of images as described in :cite:`Simard2003BestPF`.
 
     .. image:: _static/img/elastic_transform2d.png
 

--- a/kornia/geometry/transform/image_registrator.py
+++ b/kornia/geometry/transform/image_registrator.py
@@ -86,7 +86,7 @@ class Similarity(nn.Module):
                \n shift={self.shift}, \n scale={self.scale})'
 
     def reset_model(self) -> None:
-        """Initializes the model with identity transform."""
+        """Initialize the model with identity transform."""
         torch.nn.init.zeros_(self.rot)
         torch.nn.init.zeros_(self.shift)
         torch.nn.init.ones_(self.scale)
@@ -182,7 +182,7 @@ class ImageRegistrator(nn.Module):
                               img_src: torch.Tensor,
                               img_dst: torch.Tensor,
                               transform_model: torch.Tensor) -> torch.Tensor:
-        """Warps img_src into img_dst with transform_model and returns loss."""
+        """Warp img_src into img_dst with transform_model and returns loss."""
         # ToDo: Make possible registration of images of different shape
         if img_src.shape != img_dst.shape:
             raise ValueError(f"Cannot register images of different shapes\
@@ -206,7 +206,7 @@ class ImageRegistrator(nn.Module):
                  verbose: bool = False,
                  output_intermediate_models: bool = False) -> \
             Union[torch.Tensor, Tuple[torch.Tensor, List[torch.Tensor]]]:
-        r"""Estimates the tranformation' which warps src_img into dst_img by gradient descent.
+        r"""Estimate the tranformation' which warps src_img into dst_img by gradient descent.
         The shape of the tensors is not checked, because it may depend on the model, e.g. volume registration
 
         Args:
@@ -257,14 +257,14 @@ class ImageRegistrator(nn.Module):
         return self.model()
 
     def warp_src_into_dst(self, src_img: torch.Tensor) -> torch.Tensor:
-        r"""Warps src_img with estimated model."""
+        r"""Warp src_img with estimated model."""
         _height, _width = src_img.shape[-2:]
         warper = self.warper(_height, _width)
         img_src_to_dst = warper(src_img, self.model())
         return img_src_to_dst
 
     def warp_dst_inro_src(self, dst_img: torch.Tensor) -> torch.Tensor:
-        r"""Warps src_img with inverted estimated model."""
+        r"""Warp src_img with inverted estimated model."""
         _height, _width = dst_img.shape[-2:]
         warper = self.warper(_height, _width)
         img_dst_to_src = warper(dst_img, self.model.forward_inverse())

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -39,7 +39,7 @@ def warp_perspective(
     padding_mode: str = 'zeros',
     align_corners: Optional[bool] = None,
 ) -> torch.Tensor:
-    r"""Applies a perspective transformation to an image.
+    r"""Apply a perspective transformation to an image.
 
     .. image:: https://kornia-tutorials.readthedocs.io/en/latest/_images/warp_perspective_10_1.png
 
@@ -125,7 +125,7 @@ def warp_affine(
     padding_mode: str = 'zeros',
     align_corners: Optional[bool] = None,
 ) -> torch.Tensor:
-    r"""Applies an affine transformation to a tensor.
+    r"""Apply an affine transformation to a tensor.
 
     .. image:: _static/img/warp_affine.png
 
@@ -200,7 +200,7 @@ def warp_affine(
 
 
 def get_perspective_transform(src, dst):
-    r"""Calculates a perspective transform from four pairs of the corresponding
+    r"""Calculate a perspective transform from four pairs of the corresponding
     points.
 
     The function calculates the matrix of a perspective transform so that:
@@ -328,7 +328,7 @@ def angle_to_rotation_matrix(angle: torch.Tensor) -> torch.Tensor:
 
 
 def get_rotation_matrix2d(center: torch.Tensor, angle: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    r"""Calculates an affine matrix of 2D rotation.
+    r"""Calculate an affine matrix of 2D rotation.
 
     The function calculates the following matrix:
 
@@ -437,7 +437,7 @@ def remap(
     align_corners: Optional[bool] = None,
     normalized_coordinates: bool = False,
 ) -> torch.Tensor:
-    r"""Applies a generic geometrical transformation to a tensor.
+    r"""Apply a generic geometrical transformation to a tensor.
 
     .. image:: _static/img/remap.png
 
@@ -508,7 +508,7 @@ def remap(
 
 
 def invert_affine_transform(matrix: torch.Tensor) -> torch.Tensor:
-    r"""Inverts an affine transformation.
+    r"""Invert an affine transformation.
 
     The function computes an inverse affine transformation represented by
     2×3 matrix:
@@ -551,7 +551,7 @@ def get_affine_matrix2d(
     sx: Optional[torch.Tensor] = None,
     sy: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    r"""Composes affine matrix from the components.
+    r"""Compose affine matrix from the components.
 
     Args:
         translations: tensor containing the translation vector with shape :math:`(B, 2)`.
@@ -581,7 +581,7 @@ def get_affine_matrix2d(
 
 
 def get_shear_matrix2d(center: torch.Tensor, sx: Optional[torch.Tensor] = None, sy: Optional[torch.Tensor] = None):
-    r"""Composes shear matrix Bx4x4 from the components.
+    r"""Compose shear matrix Bx4x4 from the components.
 
     Note: Ordered shearing, shear x-axis then y-axis.
 
@@ -650,7 +650,7 @@ def get_affine_matrix3d(
     szx: Optional[torch.Tensor] = None,
     szy: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    r"""Composes 3d affine matrix from the components.
+    r"""Compose 3d affine matrix from the components.
 
     Args:
         translations: tensor containing the translation vector (dx,dy,dz) with shape :math:`(B, 3)`.
@@ -693,7 +693,7 @@ def get_shear_matrix3d(
     szx: Optional[torch.Tensor] = None,
     szy: Optional[torch.Tensor] = None,
 ):
-    r"""Composes shear matrix Bx4x4 from the components.
+    r"""Compose shear matrix Bx4x4 from the components.
     Note: Ordered shearing, shear x-axis then y-axis then z-axis.
 
     .. math::

--- a/kornia/geometry/transform/projwarp.py
+++ b/kornia/geometry/transform/projwarp.py
@@ -27,7 +27,7 @@ def warp_affine3d(
     padding_mode: str = 'zeros',
     align_corners: Optional[bool] = None,
 ) -> torch.Tensor:
-    r"""Applies a projective transformation a to 3d tensor.
+    r"""Apply a projective transformation a to 3d tensor.
 
     .. warning::
         This API signature it is experimental and might suffer some changes in the future.
@@ -111,7 +111,7 @@ def projection_from_Rt(rmat: torch.Tensor, tvec: torch.Tensor) -> torch.Tensor:
 
 
 def get_projective_transform(center: torch.Tensor, angles: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
-    r"""Calculates the projection matrix for a 3D rotation.
+    r"""Calculate the projection matrix for a 3D rotation.
 
     .. warning::
         This API signature it is experimental and might suffer some changes in the future.
@@ -384,7 +384,7 @@ def warp_perspective3d(
     border_mode: str = 'zeros',
     align_corners: bool = False,
 ) -> torch.Tensor:
-    r"""Applies a perspective transformation to an image.
+    r"""Apply a perspective transformation to an image.
 
     The function warp_perspective transforms the source image using
     the specified matrix:

--- a/kornia/geometry/transform/pyramid.py
+++ b/kornia/geometry/transform/pyramid.py
@@ -30,7 +30,7 @@ def _get_pyramid_gaussian_kernel() -> torch.Tensor:
 
 
 class PyrDown(nn.Module):
-    r"""Blurs a tensor and downsamples it.
+    r"""Blur a tensor and downsamples it.
 
     Args:
         border_type: the padding mode to be applied before convolving.
@@ -60,7 +60,7 @@ class PyrDown(nn.Module):
 
 
 class PyrUp(nn.Module):
-    r"""Upsamples a tensor and then blurs it.
+    r"""Upsample a tensor and then blurs it.
 
     Args:
         borde_type: the padding mode to be applied before convolving.
@@ -90,7 +90,7 @@ class PyrUp(nn.Module):
 
 
 class ScalePyramid(nn.Module):
-    r"""Creates an scale pyramid of image, usually used for local feature detection.
+    r"""Create an scale pyramid of image, usually used for local feature detection.
 
     Images are consequently smoothed with Gaussian blur and downscaled.
 
@@ -227,7 +227,7 @@ class ScalePyramid(nn.Module):
 
 
 def pyrdown(input: torch.Tensor, border_type: str = 'reflect', align_corners: bool = False) -> torch.Tensor:
-    r"""Blurs a tensor and downsamples it.
+    r"""Blur a tensor and downsamples it.
 
     .. image:: _static/img/pyrdown.png
 
@@ -263,7 +263,7 @@ def pyrdown(input: torch.Tensor, border_type: str = 'reflect', align_corners: bo
 
 
 def pyrup(input: torch.Tensor, border_type: str = 'reflect', align_corners: bool = False) -> torch.Tensor:
-    r"""Upsamples a tensor and then blurs it.
+    r"""Upsample a tensor and then blurs it.
 
     .. image:: _static/img/pyrup.png
 
@@ -302,7 +302,7 @@ def pyrup(input: torch.Tensor, border_type: str = 'reflect', align_corners: bool
 def build_pyramid(
     input: torch.Tensor, max_level: int, border_type: str = 'reflect', align_corners: bool = False
 ) -> List[torch.Tensor]:
-    r"""Constructs the Gaussian pyramid for an image.
+    r"""Construct the Gaussian pyramid for an image.
 
     .. image:: _static/img/build_pyramid.png
 

--- a/kornia/losses/divergence.py
+++ b/kornia/losses/divergence.py
@@ -30,7 +30,7 @@ def _reduce_loss(losses: torch.Tensor, reduction: str) -> torch.Tensor:
 
 
 def js_div_loss_2d(input: torch.Tensor, target: torch.Tensor, reduction: str = 'mean'):
-    r"""Calculates the Jensen-Shannon divergence loss between heatmaps.
+    r"""Calculate the Jensen-Shannon divergence loss between heatmaps.
 
     Args:
         input: the input tensor with shape :math:`(B, N, H, W)`.
@@ -51,7 +51,7 @@ def js_div_loss_2d(input: torch.Tensor, target: torch.Tensor, reduction: str = '
 
 
 def kl_div_loss_2d(input: torch.Tensor, target: torch.Tensor, reduction: str = 'mean'):
-    r"""Calculates the Kullback-Leibler divergence loss between heatmaps.
+    r"""Calculate the Kullback-Leibler divergence loss between heatmaps.
 
     Args:
         input: the input tensor with shape :math:`(B, N, H, W)`.

--- a/kornia/losses/psnr.py
+++ b/kornia/losses/psnr.py
@@ -4,7 +4,7 @@ from torch.nn.functional import mse_loss as mse
 
 
 def psnr(input: torch.Tensor, target: torch.Tensor, max_val: float) -> torch.Tensor:
-    r"""Creates a function that calculates the PSNR between 2 images.
+    r"""Create a function that calculates the PSNR between 2 images.
 
     PSNR is Peek Signal to Noise Ratio, which is similar to mean squared error.
     Given an m x n image, the PSNR is:
@@ -79,7 +79,7 @@ def psnr_loss(input: torch.Tensor, target: torch.Tensor, max_val: float) -> torc
 
 
 class PSNRLoss(nn.Module):
-    r"""Creates a criterion that calculates the PSNR loss.
+    r"""Create a criterion that calculates the PSNR loss.
 
     The loss is computed as follows:
 

--- a/kornia/losses/ssim.py
+++ b/kornia/losses/ssim.py
@@ -137,7 +137,7 @@ def ssim_loss(
 
 
 class SSIM(nn.Module):
-    r"""Creates a module that computes the Structural Similarity (SSIM) index between two images.
+    r"""Create a module that computes the Structural Similarity (SSIM) index between two images.
 
     Measures the (SSIM) index between each element in the input `x` and target `y`.
 
@@ -182,7 +182,7 @@ class SSIM(nn.Module):
 
 
 class SSIMLoss(nn.Module):
-    r"""Creates a criterion that computes a loss based on the SSIM measurement.
+    r"""Create a criterion that computes a loss based on the SSIM measurement.
 
     The loss, or the Structural dissimilarity (DSSIM) is described as:
 

--- a/kornia/losses/total_variation.py
+++ b/kornia/losses/total_variation.py
@@ -39,7 +39,7 @@ def total_variation(img: torch.Tensor) -> torch.Tensor:
 
 
 class TotalVariation(nn.Module):
-    r"""Computes the Total Variation according to [1].
+    r"""Compute the Total Variation according to [1].
 
     Shape:
         - Input: :math:`(N, C, H, W)` or :math:`(C, H, W)`.

--- a/kornia/morphology/morphology.py
+++ b/kornia/morphology/morphology.py
@@ -13,7 +13,7 @@ def dilation(
     border_value: float = 0.0,
     max_val: float = 1e4,
 ) -> torch.Tensor:
-    r"""Returns the dilated image applying the same kernel in each channel.
+    r"""Return the dilated image applying the same kernel in each channel.
 
     .. image:: _static/img/dilation.png
 
@@ -95,7 +95,7 @@ def erosion(
     border_value: float = 0.0,
     max_val: float = 1e4,
 ) -> torch.Tensor:
-    r"""Returns the eroded image applying the same kernel in each channel.
+    r"""Return the eroded image applying the same kernel in each channel.
 
     .. image:: _static/img/erosion.png
 
@@ -177,7 +177,7 @@ def opening(
     border_value: float = 0.0,
     max_val: float = 1e4,
 ) -> torch.Tensor:
-    r"""Returns the opened image, (that means, dilation after an erosion) applying the same kernel in each channel.
+    r"""Return the opened image, (that means, dilation after an erosion) applying the same kernel in each channel.
 
     .. image:: _static/img/opening.png
 
@@ -251,7 +251,7 @@ def closing(
     border_value: float = 0.0,
     max_val: float = 1e4,
 ) -> torch.Tensor:
-    r"""Returns the closed image, (that means, erosion after a dilation) applying the same kernel in each channel.
+    r"""Return the closed image, (that means, erosion after a dilation) applying the same kernel in each channel.
 
     .. image:: _static/img/closing.png
 
@@ -326,7 +326,7 @@ def gradient(
     border_value: float = 0.0,
     max_val: float = 1e4,
 ) -> torch.Tensor:
-    r"""Returns the morphological gradient of an image.
+    r"""Return the morphological gradient of an image.
 
     .. image:: _static/img/gradient.png
 
@@ -389,7 +389,7 @@ def top_hat(
     border_value: float = 0.0,
     max_val: float = 1e4,
 ) -> torch.Tensor:
-    r"""Returns the top hat transformation of an image.
+    r"""Return the top hat transformation of an image.
 
     .. image:: _static/img/top_hat.png
 
@@ -458,7 +458,7 @@ def bottom_hat(
     border_value: float = 0.0,
     max_val: float = 1e4,
 ) -> torch.Tensor:
-    r"""Returns the bottom hat transformation of an image.
+    r"""Return the bottom hat transformation of an image.
 
     .. image:: _static/img/bottom_hat.png
 

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -47,7 +47,7 @@ def compute_patch_error(x, y, h, w):
 
 
 def check_is_tensor(obj):
-    """Checks whether the supplied object is a tensor."""
+    """Check whether the supplied object is a tensor."""
     if not isinstance(obj, torch.Tensor):
         raise TypeError(f"Input type is not a torch.Tensor. Got {type(obj)}")
 

--- a/kornia/utils/draw.py
+++ b/kornia/utils/draw.py
@@ -11,7 +11,7 @@ def draw_rectangle(
     color: Optional[torch.Tensor] = None,
     fill: Optional[bool] = None,
 ) -> torch.Tensor:
-    r"""Draws N rectangles on a batch of image tensors.
+    r"""Draw N rectangles on a batch of image tensors.
 
     Args:
         image: is tensor of BxCxHxW.

--- a/kornia/utils/grid.py
+++ b/kornia/utils/grid.py
@@ -10,7 +10,7 @@ def create_meshgrid(
     device: Optional[torch.device] = torch.device('cpu'),
     dtype: torch.dtype = torch.float32,
 ) -> torch.Tensor:
-    """Generates a coordinate grid for an image.
+    """Generate a coordinate grid for an image.
 
     When the flag ``normalized_coordinates`` is set to True, the grid is
     normalized to be in the range :math:`[-1,1]` to be consistent with the pytorch
@@ -69,7 +69,7 @@ def create_meshgrid3d(
     device: Optional[torch.device] = torch.device('cpu'),
     dtype: torch.dtype = torch.float32,
 ) -> torch.Tensor:
-    """Generates a coordinate grid for an image.
+    """Generate a coordinate grid for an image.
 
     When the flag ``normalized_coordinates`` is set to True, the grid is
     normalized to be in the range :math:`[-1,1]` to be consistent with the pytorch

--- a/kornia/utils/one_hot.py
+++ b/kornia/utils/one_hot.py
@@ -10,7 +10,7 @@ def one_hot(
     dtype: Optional[torch.dtype] = None,
     eps: float = 1e-6,
 ) -> torch.Tensor:
-    r"""Converts an integer label x-D tensor to a one-hot (x+1)-D tensor.
+    r"""Convert an integer label x-D tensor to a one-hot (x+1)-D tensor.
 
     Args:
         labels: tensor with labels of shape :math:`(N, *)`, where N is batch size.

--- a/test/geometry/test_linalg.py
+++ b/test/geometry/test_linalg.py
@@ -8,7 +8,7 @@ from kornia.testing import assert_close
 
 
 def identity_matrix(batch_size, device, dtype):
-    r"""Creates a batched homogeneous identity matrix"""
+    r"""Create a batched homogeneous identity matrix"""
     return torch.eye(4, device=device, dtype=dtype).repeat(batch_size, 1, 1)  # Nx4x4
 
 

--- a/test/geometry/test_pinhole.py
+++ b/test/geometry/test_pinhole.py
@@ -22,7 +22,7 @@ class TestCam2Pixel:
         return intrinsics_inv
 
     def _get_samples(self, shape, low, high, device, dtype):
-        """Returns a tensor having the given shape and whose values are in the range [low, high)"""
+        """Return a tensor having the given shape and whose values are in the range [low, high)"""
         return ((high - low) * torch.rand(shape, device=device, dtype=dtype)) + low
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
@@ -125,7 +125,7 @@ class TestPixel2Cam:
         return intrinsics_inv
 
     def _get_samples(self, shape, low, high, device, dtype):
-        """Returns a tensor having the given shape and whose values are in the range [low, high)"""
+        """Return a tensor having the given shape and whose values are in the range [low, high)"""
         return ((high - low) * torch.rand(shape, device=device, dtype=dtype)) + low
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))

--- a/test/integration/test_soft_argmax2d.py
+++ b/test/integration/test_soft_argmax2d.py
@@ -20,7 +20,7 @@ class TestIntegrationSoftArgmax2d:
     width = 320
 
     def generate_sample(self, base_target, std_val=1.0):
-        """Generates a random sample around the given point.
+        """Generate a random sample around the given point.
 
         The standard deviation is in pixel.
         """


### PR DESCRIPTION
#### Changes
Convert all docstrings to active tense as described in #1244 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
