### PR TITLE
Undistort image function

### DIFF
--- a/docs/source/geometry.calibration.rst
+++ b/docs/source/geometry.calibration.rst
@@ -5,4 +5,120 @@ kornia.geometry.calibration
 
 Module with useful functionalities for camera calibration.
 
+The pinhole model is an ideal projection model that not considers lens distortion for the projection of a 3D point :math:`(X, Y, Z)` onto the image plane. To model the distortion of a projected 2D pixel point :math:`(u,v)` with the linear pinhole model, we need first to estimate the normalized 2D points coordinates :math:`(\bar{u}, \bar{v})`. For that, we can use the calibration matrix :math:`\mathbf{K}` with the following expression
+
+:math:`
+\begin{align}
+\begin{bmatrix}
+\bar{u}\\
+\bar{v}\\
+1
+\end{bmatrix} = \mathbf{K}^{-1} \begin{bmatrix}
+u \\ 
+v \\ 
+1
+\end{bmatrix} \enspace,
+\end{align}
+`
+which is equivalent to directly using the internal parameters: focals :math:`f_u, f_v` and principal point :math:`(u_0, v_0)` to estimated the normalized coordinates
+
+:math:`
+\begin{equation}
+\bar{u} = (u - u_0)/f_u \enspace, \\
+\bar{v} = (v - v_0)/f_v \enspace.
+\end{equation}
+`
+
+
+The normalized distorted point :math:`(\bar{u}_d, \bar{v}_d)` is given by
+
+:math:`
+\begin{align}
+\begin{bmatrix}
+\bar{u}_d\\
+\bar{v}_d
+\end{bmatrix} = \dfrac{1+k_1r^2+k_2r^4+k_3r^6}{1+k_4r^2+k_5r^4+k_6r^6} \begin{bmatrix}
+\bar{u}\\ 
+\bar{v}
+\end{bmatrix} +
+\begin{bmatrix}
+2p_1\bar{u}\bar{v} + p_2(r^2 + 2\bar{u}^2) + s_1r^2 + s_2r^4\\ 
+2p_2\bar{u}\bar{v} + p_1(r^2 + 2\bar{v}^2) + s_3r^2 + s_4r^4
+\end{bmatrix} \enspace,
+\end{align}
+`
+
+where :math:`r = \bar{u}^2 + \bar{v}^2`. With this model we consider radial :math:`(k_1, k_2, k_3, k_4, k_4, k_6)`, tangential :math:`(p_1, p_2)`, and thin prism :math:`(s_1, s_2, s_3, s_4)` distortion. If we want to consider tilt distortion :math:`(\tau_x, \tau_y)`, we need an additional step where we estimate a point :math:`(\bar{u}'_d, \bar{v}'_d)`
+
+:math:`
+\begin{align}
+\begin{bmatrix}
+\bar{u}'_d\\
+\bar{v}'_d\\
+1
+\end{bmatrix} = \begin{bmatrix}
+\mathbf{R}_{33}(\tau_x, \tau_y) & 0 & -\mathbf{R}_{13}(\tau_x, \tau_y)\\
+0 & \mathbf{R}_{33}(\tau_x, \tau_y) & -\mathbf{R}_{23}(\tau_x, \tau_y)\\
+0 & 0 & 1
+\end{bmatrix}
+\mathbf{R}(\tau_x, \tau_y) \begin{bmatrix}
+\bar{u}_d \\ 
+\bar{v}_d \\ 
+1
+\end{bmatrix} \enspace,
+\end{align}
+`
+
+where :math:`\mathbf{R}(\tau_x, \tau_y)` is a 3D rotation matrix defined by an :math:`X` and :math:`Y` rotation given by the angles :math:`\tau_x` and :math:`\tau_y`. Furtheremore, :math:`\mathbf{R}_{ij}(\tau_x, \tau_y)` represent the :math:`i`-th row and :math:`j`-th column from :math:`\mathbf{R}(\tau_x, \tau_y)` matrix.
+
+:math:`
+\begin{align}
+\mathbf{R}(\tau_x, \tau_y) = 
+\begin{bmatrix}
+\cos \tau_y & 0 & -\sin \tau_y \\
+0 & 1 & 0 \\
+\sin \tau_y & 0 & \cos \tau_y
+\end{bmatrix} 
+\begin{bmatrix}
+1 & 0 & 0 \\
+0 & \cos \tau_x & \sin \tau_x \\
+0 & -\sin \tau_x & \cos \tau_x
+\end{bmatrix}  \enspace.
+\end{align}
+`
+
+
+Finally, we just need to come back to the original (unnormalized) pixel space. For that we can use the intrinsic matrix
+
+:math:`
+\begin{align}
+\begin{bmatrix}
+u_d\\
+v_d\\
+1
+\end{bmatrix} = \mathbf{K} \begin{bmatrix}
+\bar{u}'_d\\
+\bar{v}'_d\\ 
+1
+\end{bmatrix} \enspace,
+\end{align}
+`
+
+which is equivalent to
+
+:math:`
+\begin{equation}
+u_d = f_u \bar{u}'_d + u_0 \enspace, \\
+v_d = f_v \bar{v}'_d + v_0 \enspace.
+\end{equation}
+`
+
+To compensate for lens distortion a set of 2D points, i.e., to estimate the undistorted coordinates for a given set of distorted points, we need to inverse the previously explained distortion model. For the case of undistorting an image, instead of estimating the undistorted location for each pixel, we distort each pixel in the destination image (final undistorted image) to match them with the input image. We finally interpolate the intensity values at each pixel.
+
+.. autofunction:: undistort_image
+
 .. autofunction:: undistort_points
+
+.. autofunction:: distort_points
+
+.. autofunction:: tiltProjection

--- a/kornia/geometry/calibration/distort.py
+++ b/kornia/geometry/calibration/distort.py
@@ -57,3 +57,72 @@ def tiltProjection(taux: torch.Tensor, tauy: torch.Tensor, inv: bool = False) ->
             tilt = torch.squeeze(tilt)
 
         return tilt
+
+
+def distort_points(points: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) -> torch.Tensor:
+    r"""Distortion of a set of 2D points based on the lens distortion model.
+
+    Radial :math:`(k_1, k_2, k_3, k_4, k_4, k_6)`,
+    tangential :math:`(p_1, p_2)`, thin prism :math:`(s_1, s_2, s_3, s_4)`, and tilt :math:`(\tau_x, \tau_y)` distortion models are considered in this function.
+
+    Args:
+        points: Input image points with shape :math:`(*, N, 2)`.
+        K: Intrinsic camera matrix with shape :math:`(*, 3, 3)`.
+        dist: Distortion coefficients
+            :math:`(k_1,k_2,p_1,p_2[,k_3[,k_4,k_5,k_6[,s_1,s_2,s_3,s_4[,\tau_x,\tau_y]]]])`. This is
+            a vector with 4, 5, 8, 12 or 14 elements with shape :math:`(*, n)`
+
+    Returns:
+        Undistorted 2D points with shape :math:`(*, N, 2)`.
+    """
+    assert points.dim() >= 2 and points.shape[-1] == 2
+    assert K.shape[-2:] == (3, 3)
+    assert dist.shape[-1] in [4, 5, 8, 12, 14]
+
+    if dist.shape[-1] < 14:
+        dist = torch.nn.functional.pad(dist, [0, 14 - dist.shape[-1]])
+
+    # Convert 2D points from pixels to normalized camera coordinates
+    cx: torch.Tensor = K[..., 0:1, 2]  # princial point in x (Bx1)
+    cy: torch.Tensor = K[..., 1:2, 2]  # princial point in y (Bx1)
+    fx: torch.Tensor = K[..., 0:1, 0]  # focal in x (Bx1)
+    fy: torch.Tensor = K[..., 1:2, 1]  # focal in y (Bx1)
+    # This is equivalent to K^-1 [u,v,1]^T
+    x: torch.Tensor = (points[..., 0] - cx) / fx  # (BxN - Bx1)/Bx1 -> BxN or (N,)
+    y: torch.Tensor = (points[..., 1] - cy) / fy  # (BxN - Bx1)/Bx1 -> BxN or (N,)
+
+    # Distort points
+    r2 = x * x + y * y
+
+    rad_poly = (1 + dist[..., 0:1] * r2 + dist[..., 1:2] * r2 * r2 + dist[..., 4:5] * r2 ** 3) / (
+        1 + dist[..., 5:6] * r2 + dist[..., 6:7] * r2 * r2 + dist[..., 7:8] * r2 ** 3
+    )
+    xd = (
+        x * rad_poly
+        + 2 * dist[..., 2:3] * x * y
+        + dist[..., 3:4] * (r2 + 2 * x * x)
+        + dist[..., 8:9] * r2
+        + dist[..., 9:10] * r2 * r2
+    )
+    yd = (
+        y * rad_poly
+        + dist[..., 2:3] * (r2 + 2 * y * y)
+        + 2 * dist[..., 3:4] * x * y
+        + dist[..., 10:11] * r2
+        + dist[..., 11:12] * r2 * r2
+    )
+
+    # Compensate for tilt distortion
+    if torch.any(dist[..., 12] != 0) or torch.any(dist[..., 13] != 0):
+        tilt = tiltProjection(dist[..., 12], dist[..., 13])
+
+        # Transposed untilt points (instead of [x,y,1]^T, we obtain [x,y,1])
+        pointsUntilt = torch.stack([xd, yd, torch.ones(xd.shape, device=xd.device, dtype=xd.dtype)], -1) @ tilt.transpose(-2, -1)
+        xd = pointsUntilt[..., 0] / pointsUntilt[..., 2]
+        yd = pointsUntilt[..., 1] / pointsUntilt[..., 2]
+
+    # Covert points from normalized camera coordinates to pixel coordinates
+    x = fx * xd + cx
+    y = fy * yd + cy
+
+    return torch.stack([x, y], -1)

--- a/kornia/geometry/calibration/distort.py
+++ b/kornia/geometry/calibration/distort.py
@@ -1,0 +1,59 @@
+import torch
+
+
+# Based on https://github.com/opencv/opencv/blob/master/modules/calib3d/src/distortion_model.hpp#L75
+def tiltProjection(taux: torch.Tensor, tauy: torch.Tensor, inv: bool = False) -> torch.Tensor:
+    r"""Estimate the tilt projection matrix or the inverse tilt projection matrix
+
+    Args:
+        taux (torch.Tensor): Rotation angle in radians around the :math:`x`-axis with shape :math:`(*, 1)`.
+        tauy (torch.Tensor): Rotation angle in radians around the :math:`y`-axis with shape :math:`(*, 1)`.
+        inv (bool): False to obtain the the tilt projection matrix. False for the inverse matrix
+
+    Returns:
+        torch.Tensor: Inverse tilt projection matrix with shape :math:`(*, 3, 3)`.
+    """
+    assert taux.dim() == tauy.dim()
+    assert taux.numel() == tauy.numel()
+
+    ndim = taux.dim()
+    taux = taux.reshape(-1)
+    tauy = tauy.reshape(-1)
+
+    cTx = torch.cos(taux)
+    sTx = torch.sin(taux)
+    cTy = torch.cos(tauy)
+    sTy = torch.sin(tauy)
+    zero = torch.zeros_like(cTx)
+    one = torch.ones_like(cTx)
+
+    Rx = torch.stack([one, zero, zero, zero, cTx, sTx, zero, -sTx, cTx], -1).reshape(-1, 3, 3)
+    Ry = torch.stack([cTy, zero, -sTy, zero, one, zero, sTy, zero, cTy], -1).reshape(-1, 3, 3)
+    R = Ry @ Rx
+
+    if inv:
+        invR22 = 1 / R[..., 2, 2]
+        invPz = torch.stack(
+            [invR22, zero, R[..., 0, 2] * invR22,
+            zero, invR22, R[..., 1, 2] * invR22,
+            zero, zero, one], -1
+        ).reshape(-1, 3, 3)
+
+        invTilt = R.transpose(-1, -2) @ invPz
+        if ndim == 0:
+            invTilt = torch.squeeze(invTilt)
+
+        return invTilt
+
+    else:
+        Pz = torch.stack(
+            [R[..., 2, 2], zero, -R[..., 0, 2],
+            zero, R[..., 2, 2], -R[..., 1, 2],
+            zero, zero, one], -1
+        ).reshape(-1, 3, 3)
+
+        tilt = Pz @ R.transpose(-1, -2)
+        if ndim == 0:
+            tilt = torch.squeeze(tilt)
+
+        return tilt

--- a/test/geometry/calibration/test_distort.py
+++ b/test/geometry/calibration/test_distort.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+from torch.autograd import gradcheck
+
+from kornia.geometry.calibration.distort import distort_points
+
+
+class TestDistortPoints:
+    def test_smoke(self, device, dtype):
+        points = torch.rand(1, 2, device=device, dtype=dtype)
+        K = torch.rand(3, 3, device=device, dtype=dtype)
+        distCoeff = torch.rand(4, device=device, dtype=dtype)
+        pointsu = distort_points(points, K, distCoeff)
+        assert points.shape == pointsu.shape
+
+        points = torch.rand(1, 1, 2, device=device, dtype=dtype)
+        K = torch.rand(1, 3, 3, device=device, dtype=dtype)
+        distCoeff = torch.rand(1, 4, device=device, dtype=dtype)
+        pointsu = distort_points(points, K, distCoeff)
+        assert points.shape == pointsu.shape
+
+    @pytest.mark.parametrize(
+        "batch_size, num_points, num_distcoeff", [(1, 3, 4), (2, 4, 5), (3, 5, 8), (4, 6, 12), (5, 7, 14)]
+    )
+    def test_shape(self, batch_size, num_points, num_distcoeff, device, dtype):
+        B, N, Ndist = batch_size, num_points, num_distcoeff
+
+        points = torch.rand(B, N, 2, device=device, dtype=dtype)
+        K = torch.rand(B, 3, 3, device=device, dtype=dtype)
+        distCoeff = torch.rand(B, Ndist, device=device, dtype=dtype)
+
+        pointsu = distort_points(points, K, distCoeff)
+        assert pointsu.shape == (B, N, 2)
+
+    def test_gradcheck(self, device):
+        points = torch.rand(1, 8, 2, device=device, dtype=torch.float64, requires_grad=True)
+        K = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
+        distCoeff = torch.rand(1, 4, device=device, dtype=torch.float64)
+
+        assert gradcheck(distort_points, (points, K, distCoeff), raise_exception=True)

--- a/test/geometry/calibration/test_undistort.py
+++ b/test/geometry/calibration/test_undistort.py
@@ -2,11 +2,11 @@ import pytest
 import torch
 from torch.autograd import gradcheck
 
-from kornia.geometry.calibration.undistort import undistort_points
+from kornia.geometry.calibration.undistort import undistort_points, undistort_image
 from kornia.testing import assert_close
 
 
-class TestUndistortion:
+class TestUndistortPoints:
     def test_smoke(self, device, dtype):
         points = torch.rand(1, 2, device=device, dtype=dtype)
         K = torch.rand(3, 3, device=device, dtype=dtype)
@@ -191,3 +191,20 @@ class TestUndistortion:
         distCoeff = torch.rand(1, 4, device=device, dtype=torch.float64)
 
         assert gradcheck(undistort_points, (points, K, distCoeff), raise_exception=True)
+
+
+class TestUndistortImage:
+    def test_shape(self, device, dtype):
+        im = torch.rand(1, 3, 5, 5, device=device, dtype=dtype)
+        K = torch.rand(3, 3, device=device, dtype=dtype)
+        distCoeff = torch.rand(4, device=device, dtype=dtype)
+
+        imu = undistort_image(im, K, distCoeff)
+        assert imu.shape == (1, 3, 5, 5)
+
+    def test_gradcheck(self, device, dtype):
+        im = torch.rand(1, 1, 15, 15, device=device, dtype=dtype, requires_grad=True)
+        K = torch.rand(3, 3, device=device, dtype=dtype)
+        distCoeff = torch.rand(4, device=device, dtype=dtype)
+
+        assert gradcheck(undistort_image, (im, K, distCoeff), raise_exception=True)


### PR DESCRIPTION
#### Changes
Adding `undistort_image` function to compensate for lens distortion an image. A new file `distort.py` was included where the function `distort_points` is added which is important for undistortion of an image. The previous `inverseTiltProjection` was moved from `undistort.py` to `distort.py` and now returns the tilt projection matrix or the inverse tilt projection matrix. Finally, mathematical lens distortion model was added to the documentation.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update
