### PR TITLE
Fix binary focal loss

### DIFF
--- a/kornia/losses/focal.py
+++ b/kornia/losses/focal.py
@@ -155,8 +155,8 @@ def binary_focal_loss_with_logits(
        - :math:`p_t` is the model's estimated probability for each class.
 
     Args:
-        input: input data tensor with shape :math:`(N, 1, *)`.
-        target: the target tensor with shape :math:`(N, 1, *)`.
+        input: input data tensor of arbitrary shape.
+        target: the target tensor with shape matching input.
         alpha: Weighting factor for the rare class :math:`\alpha \in [0, 1]`.
         gamma: Focusing parameter :math:`\gamma >= 0`.
         reduction: Specifies the reduction to apply to the
@@ -170,9 +170,8 @@ def binary_focal_loss_with_logits(
         the computed loss.
 
     Examples:
-        >>> num_classes = 1
         >>> kwargs = {"alpha": 0.25, "gamma": 2.0, "reduction": 'mean'}
-        >>> logits = torch.tensor([[[[6.325]]],[[[5.26]]],[[[87.49]]]])
+        >>> logits = torch.tensor([[[6.325]],[[5.26]],[[87.49]]])
         >>> labels = torch.tensor([[[1.]],[[1.]],[[0.]]])
         >>> binary_focal_loss_with_logits(logits, labels, **kwargs)
         tensor(4.6052)
@@ -188,12 +187,9 @@ def binary_focal_loss_with_logits(
         raise ValueError(f'Expected input batch_size ({input.size(0)}) to match target batch_size ({target.size(0)}).')
 
     probs = torch.sigmoid(input)
-    target = target.unsqueeze(dim=1)
     loss_tmp = -alpha * torch.pow((1.0 - probs + eps), gamma) * target * torch.log(probs + eps) - (
         1 - alpha
     ) * torch.pow(probs + eps, gamma) * (1.0 - target) * torch.log(1.0 - probs + eps)
-
-    loss_tmp = loss_tmp.squeeze(dim=1)
 
     if reduction == 'none':
         loss = loss_tmp

--- a/test/losses/test_losses.py
+++ b/test/losses/test_losses.py
@@ -11,8 +11,7 @@ from kornia.testing import assert_close
 
 class TestBinaryFocalLossWithLogits:
     def test_smoke_none(self, device, dtype):
-        num_classes = 1
-        logits = torch.rand(2, num_classes, 3, 2, dtype=dtype, device=device)
+        logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
 
         assert kornia.losses.binary_focal_loss_with_logits(
@@ -20,8 +19,7 @@ class TestBinaryFocalLossWithLogits:
         ).shape == (2, 3, 2)
 
     def test_smoke_sum(self, device, dtype):
-        num_classes = 1
-        logits = torch.rand(2, num_classes, 3, 2, dtype=dtype, device=device)
+        logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
 
         assert (
@@ -30,8 +28,7 @@ class TestBinaryFocalLossWithLogits:
         )
 
     def test_smoke_mean(self, device, dtype):
-        num_classes = 1
-        logits = torch.rand(2, num_classes, 3, 2, dtype=dtype, device=device)
+        logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
 
         assert (
@@ -40,8 +37,7 @@ class TestBinaryFocalLossWithLogits:
         )
 
     def test_smoke_mean_flat(self, device, dtype):
-        num_classes = 1
-        logits = torch.rand(2, num_classes, 3, 2, dtype=dtype, device=device)
+        logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
 
         assert (
@@ -50,8 +46,7 @@ class TestBinaryFocalLossWithLogits:
         )
 
     def test_jit(self, device, dtype):
-        num_classes = 1
-        logits = torch.rand(2, num_classes, 3, 2, dtype=dtype, device=device)
+        logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
 
         op = kornia.losses.binary_focal_loss_with_logits
@@ -61,10 +56,9 @@ class TestBinaryFocalLossWithLogits:
         assert_close(actual, expected)
 
     def test_gradcheck(self, device):
-        num_classes = 1
         alpha, gamma = 0.5, 2.0  # for focal loss with logits
-        logits = torch.rand(2, num_classes, 3, 2).to(device)
-        labels = torch.rand(2, 1, 3, 2) * num_classes
+        logits = torch.rand(2, 3, 2).to(device)
+        labels = torch.rand(2, 1, 3, 2)
         labels = labels.to(device).long()
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
@@ -73,8 +67,7 @@ class TestBinaryFocalLossWithLogits:
         )
 
     def test_same_output(self, device, dtype):
-        num_classes = 1
-        logits = torch.rand(2, num_classes, 3, 2, dtype=dtype, device=device)
+        logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
 
         kwargs = {"alpha": 0.25, "gamma": 2.0, "reduction": 'mean'}


### PR DESCRIPTION
#### Changes
Fixes the batching semantics of `binary_focal_loss_with_logits`. Previously, the docs stated that both input and labels need to be of shape `(N, 1, ...)` which created a pair-wise output of shape `(N, N, 1, ...)`. The code was actually expecting input of shape `(N, 1, ...)` while labels of shape `(N, ...)`, equivalently to that of class-based focal loss and seemingly due to copy-paste of that code. This change makes it work element-wise on tensors of arbitrary (and equal) shapes. 

Fixes #1308 

#### Type of change
- [x] 📚  Documentation Update
- [x] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
