### PR TITLE
Fixed a simple typo in __init__.py

### DIFF
--- a/docs/source/get-started/training.rst
+++ b/docs/source/get-started/training.rst
@@ -9,7 +9,7 @@ supported deep learning algorithms within the library.
     .. image:: https://github.com/kornia/data/raw/main/pixie_alchemist.png
        :width: 100%
        :align: center
-       
+
   A seemingly magical process of transformation, creation, or combination of data to usable deep learning models.
 
 

--- a/kornia/__init__.py
+++ b/kornia/__init__.py
@@ -68,6 +68,7 @@ from kornia.filters import (
     get_motion_kernel3d,
     laplacian,
     median_blur,
+    motion_blur,
     motion_blur3d,
     sobel,
     spatial_gradient,

--- a/kornia/__init__.py
+++ b/kornia/__init__.py
@@ -68,7 +68,7 @@ from kornia.filters import (
     get_motion_kernel3d,
     laplacian,
     median_blur,
-    motion_blur,
+    motion_blur3d,
     sobel,
     spatial_gradient,
     unsharp_mask,


### PR DESCRIPTION
#### Changes
In `__init__.py`, `motion_blur3d` is not imported.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
