### PR TITLE
DOCS - added ranges in docs for output of rgb_to_lab function

### DIFF
--- a/kornia/color/lab.py
+++ b/kornia/color/lab.py
@@ -24,7 +24,7 @@ def rgb_to_lab(image: torch.Tensor) -> torch.Tensor:
         image: RGB Image to be converted to Lab with shape :math:`(*, 3, H, W)`.
 
     Returns:
-        Lab version of the image with shape :math:`(*, 3, H, W)`.
+        Lab version of the image with shape :math:`(*, 3, H, W)`. The L channel values are in the range 0..100. a and b are in the range -127..127.
 
     Example:
         >>> input = torch.rand(2, 3, 4, 5)

--- a/kornia/color/lab.py
+++ b/kornia/color/lab.py
@@ -24,7 +24,8 @@ def rgb_to_lab(image: torch.Tensor) -> torch.Tensor:
         image: RGB Image to be converted to Lab with shape :math:`(*, 3, H, W)`.
 
     Returns:
-        Lab version of the image with shape :math:`(*, 3, H, W)`. The L channel values are in the range 0..100. a and b are in the range -127..127.
+        Lab version of the image with shape :math:`(*, 3, H, W)`.
+        The L channel values are in the range 0..100. a and b are in the range -127..127.
 
     Example:
         >>> input = torch.rand(2, 3, 4, 5)


### PR DESCRIPTION
#### Changes
Added missing Lab ranges in the rgb_to_lab function documentation
ref: [https://docs.opencv.org/4.0.1/de/d25/imgproc_color_conversions.html]()

Fixes # (issue)
#1167 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update
