### PR TITLE
Add solve_pnp_dlt

### DIFF
--- a/docs/source/geometry.calibration.rst
+++ b/docs/source/geometry.calibration.rst
@@ -5,4 +5,12 @@ kornia.geometry.calibration
 
 Module with useful functionalities for camera calibration.
 
+Undistortion
+------------
+
 .. autofunction:: undistort_points
+
+Perspective-n-Point (PnP)
+-------------------------
+
+.. autofunction:: solve_pnp_dlt

--- a/kornia/geometry/calibration/__init__.py
+++ b/kornia/geometry/calibration/__init__.py
@@ -1,1 +1,2 @@
 from kornia.geometry.calibration.undistort import *
+from kornia.geometry.calibration.pnp import *

--- a/kornia/geometry/calibration/pnp.py
+++ b/kornia/geometry/calibration/pnp.py
@@ -1,0 +1,130 @@
+import torch
+from kornia.geometry.conversions import convert_points_to_homogeneous
+
+
+def solve_pnp_dlt(
+    world_points: torch.Tensor, img_points: torch.Tensor,
+    intrinsic: torch.Tensor, eps: float = 1e-8,
+) -> torch.Tensor:
+    r"""This function attempts to solve the Perspective-n-Point (PnP)
+    problem using Direct Linear Transform (DLT).
+
+    Given :math:`N` 3D points (where :math:`N \geq 6`) in the world
+    space, :math:`N` corresponding 2D points in the image space and
+    an intrinsic matrix, this function tries to estimate the world
+    to camera transformation matrix.
+
+    This function needs atleast 6 points (i.e. :math:`N \geq 6`) to
+    provide a solution. This function cannot be used if all the 3D world
+    points lie on a line or if all the 3D world points lie on a plane.
+
+    Args:
+        world_points        :   A tensor with shape :math:`(N, 3)` representing
+                                the points in the world space.
+        img_points          :   A tensor with shape :math:`(N, 2)` representing
+                                the points in the image space.
+        intrinsic           :   A tensor with shape :math:`(3, 3)` representing
+                                the intrinsic matrix.
+
+    Returns:
+        A tensor with shape :math:`(3, 4)` representing the estimated world to
+        camera transformation matrix.
+    """
+    # This function was implemented based on ideas inspired from multiple references.
+    # ============
+    # References:
+    # ============
+    # 1. https://team.inria.fr/lagadic/camera_localization/tutorial-pose-dlt-opencv.html
+    # 2. https://github.com/opencv/opencv/blob/68d15fc62edad980f1ffa15ee478438335f39cc3/modules/calib3d/src/calibration.cpp # noqa: E501
+    # 3. http://rpg.ifi.uzh.ch/docs/teaching/2020/03_camera_calibration.pdf
+    # 4. http://www.cs.cmu.edu/~16385/s17/Slides/11.3_Pose_Estimation.pdf
+
+    if type(world_points) is not torch.Tensor:
+        raise TypeError(f"Type of world_points is not torch.Tensor. Got {type(world_points)}")
+
+    if type(img_points) is not torch.Tensor:
+        raise TypeError(f"Type of img_points is not torch.Tensor. Got {type(img_points)}")
+
+    if type(intrinsic) is not torch.Tensor:
+        raise TypeError(f"Type of intrinsic is not torch.Tensor. Got {type(intrinsic)}")
+
+    if type(eps) is not float:
+        raise TypeError(f"Type of eps is not float. Got {type(world_points)}")
+
+    if (len(world_points.shape) == 2) and (world_points.shape[1] != 3):
+        raise AssertionError(
+            f"world_points must be of shape (N, 3). Got shape {world_points.shape}."
+        )
+
+    if (len(img_points.shape) == 2) and (img_points.shape[1] != 2):
+        raise AssertionError(
+            f"img_points must be of shape (N, 2). Got shape {img_points.shape}."
+        )
+
+    if intrinsic.shape != (3, 3):
+        raise AssertionError(
+            f"intrinsic must be of shape (3, 3). Got shape {intrinsic.shape}."
+        )
+
+    if world_points.shape[0] != img_points.shape[0]:
+        raise AssertionError("world_points and img_points must have equal number of points.")
+
+    if world_points.shape[0] < 6:
+        raise AssertionError(
+            f"Atleast 6 points are required to use this function. "
+            f"Got {world_points.shape[0]} points."
+        )
+
+    # Checking if world_points has rank = 3. This function cannot be used
+    # if all world_points lie on a line or if all world points lie on a plane.
+    s = torch.linalg.svdvals(world_points)
+    if s[-1] < eps:
+        raise AssertionError(
+            f"The last singular value is smaller than {eps}. This function "
+            f"cannot be used if all world_points lie on a line "
+            f"or if all world_points lie on a plane."
+        )
+
+    N = world_points.shape[0]
+    intrinsic_inv = torch.linalg.inv(intrinsic)
+
+    img_points_h = convert_points_to_homogeneous(img_points)
+    world_points_h = convert_points_to_homogeneous(world_points)
+
+    # Getting normalized image points.
+    norm_points = torch.matmul(intrinsic_inv, img_points_h.T).T
+
+    # Setting up the system (the matrix A in Ax=0)
+    system = torch.zeros((2 * N, 12), dtype=world_points.dtype, device=world_points.device)
+    system[0::2, 0:4] = world_points_h
+    system[1::2, 4:8] = world_points_h
+    system[0::2, 8:12] = world_points_h * (-1) * norm_points[:, 0:1]
+    system[1::2, 8:12] = world_points_h * (-1) * norm_points[:, 1:2]
+
+    # Getting the solution vector.
+    u, s, v = torch.svd(system)
+    solution = v[:, -1]
+
+    # Reshaping the solution vector to the correct shape.
+    pred_world_to_cam = solution.reshape(3, 4)
+
+    # We may need to multiply pred_world_to_cam with a scalar. This is
+    # because if x is a solution to Ax=0, then cx is also a solution.
+    # We can find this scalar by using the properties of the
+    # rotation matrix. We do this in two parts:
+
+    # First, we fix the sign by making sure that the determinant of
+    # the rotation matrix is non negative (since determinant of a rotation
+    # matrix should be 1).
+    det = torch.linalg.det(pred_world_to_cam[:3, :3])
+    if det < 0:
+        pred_world_to_cam = pred_world_to_cam * -1
+
+    # Then, we make sure that norm of a column of the rotation matrix
+    # is 1. Do note that the norm of any column of a rotation matrix
+    # should be 1. Here we use the 0th column to calculate norm_col.
+    # We then multiply all elements of pred_world_to_cam with (1/norm_col)
+    norm_col = torch.linalg.norm(pred_world_to_cam[:3, 0])
+    pred_world_to_cam = pred_world_to_cam * (1 / norm_col)
+
+    return pred_world_to_cam

--- a/test/geometry/calibration/test_pnp.py
+++ b/test/geometry/calibration/test_pnp.py
@@ -1,0 +1,106 @@
+import torch
+import pytest
+from torch.autograd import gradcheck
+
+import kornia
+from kornia.testing import assert_close, tensor_to_gradcheck_var
+from kornia.geometry.conversions import convert_points_to_homogeneous
+
+
+class TestSolvePnpDlt:
+
+    def _get_samples(self, shape, low, high, device, dtype):
+        """Return a tensor having the given shape and whose values are in the range [low, high)"""
+        return ((high - low) * torch.rand(shape, device=device, dtype=dtype)) + low
+
+    def _project_to_image(self, world_points, world_to_cam_4x4, intrinsic):
+        world_points_h = convert_points_to_homogeneous(world_points)
+        cam_points = (torch.matmul(world_to_cam_4x4, world_points_h.T).T)[:, :3]
+
+        temp = torch.matmul(intrinsic, cam_points.T).T
+        img_points = temp[:, :2] / temp[:, 2:3]
+
+        return img_points
+
+    def _get_test_data(self, num_points, device, dtype):
+        intrinsic = torch.tensor([
+            [500.0, 0.0, 250.0],
+            [0.0, 500.0, 250.0],
+            [0.0, 0.0, 1.0],
+        ], dtype=dtype, device=device)
+
+        tau = 2 * 3.141592653589793
+        torch.manual_seed(84)
+
+        angle_axis = self._get_samples(
+            shape=(1, 3), low=-tau, high=tau, dtype=dtype, device=device,
+        )
+        translation = self._get_samples(
+            shape=(3,), low=-100, high=100, dtype=dtype, device=device,
+        )
+        world_points = self._get_samples(
+            shape=(num_points, 3), low=-100, high=100, dtype=dtype, device=device,
+        )
+
+        rotation = kornia.angle_axis_to_rotation_matrix(angle_axis)
+
+        world_to_cam_4x4 = torch.eye(4, dtype=dtype, device=device)
+        world_to_cam_4x4[:3, :3] = rotation
+        world_to_cam_4x4[:3, 3] = translation
+
+        img_points = self._project_to_image(world_points, world_to_cam_4x4, intrinsic)
+        world_to_cam_3x4 = world_to_cam_4x4[:3, :]
+
+        return intrinsic, world_to_cam_3x4, world_points, img_points
+
+    @pytest.mark.parametrize("num_points", (6, 20, 200))
+    def test_smoke(self, num_points, device, dtype):
+        intrinsic, gt_world_to_cam, world_points, img_points = \
+            self._get_test_data(num_points, device, dtype)
+
+        pred_world_to_cam = kornia.solve_pnp_dlt(world_points, img_points, intrinsic)
+        assert pred_world_to_cam.shape == (3, 4)
+
+    @pytest.mark.parametrize("num_points", (6, 20, 200))
+    def test_gradcheck(self, num_points, device, dtype):
+        intrinsic, gt_world_to_cam, world_points, img_points = \
+            self._get_test_data(num_points, device, dtype)
+
+        world_points = tensor_to_gradcheck_var(world_points)
+        img_points = tensor_to_gradcheck_var(img_points)
+        intrinsic = tensor_to_gradcheck_var(intrinsic)
+
+        assert gradcheck(
+            kornia.solve_pnp_dlt, (world_points, img_points, intrinsic),
+            raise_exception=True, atol=1e-4
+        )
+
+    @pytest.mark.parametrize("num_points", (6, 20, 200))
+    def test_pred_world_to_cam(self, num_points, device, dtype):
+        intrinsic, gt_world_to_cam, world_points, img_points = \
+            self._get_test_data(num_points, device, dtype)
+
+        pred_world_to_cam = kornia.solve_pnp_dlt(world_points, img_points, intrinsic)
+        assert_close(pred_world_to_cam, gt_world_to_cam, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize("num_points", (6, 20, 200))
+    def test_project(self, num_points, device, dtype):
+        intrinsic, gt_world_to_cam, world_points, img_points = \
+            self._get_test_data(num_points, device, dtype)
+
+        pred_world_to_cam = kornia.solve_pnp_dlt(world_points, img_points, intrinsic)
+
+        pred_world_to_cam_4x4 = torch.eye(4, dtype=dtype, device=device)
+        pred_world_to_cam_4x4[:3, :] = pred_world_to_cam
+
+        pred_img_points = self._project_to_image(
+            world_points, pred_world_to_cam_4x4, intrinsic
+        )
+
+        # Different tolerances for dtype torch.float32
+        if dtype == torch.float32:
+            atol, rtol = 1e-1, 1e-1
+        else:
+            atol, rtol = 1e-4, 1e-4
+
+        assert_close(pred_img_points, img_points, atol=atol, rtol=rtol)


### PR DESCRIPTION
#### Changes
This PR introduces the function `solve_pnp_dlt`. This function attempts to solve the Perspective-n-Point (PnP) problem using Direct Linear Transform (DLT).

##### Questions and Notes:
1. For the test function `test_project`, for dtype `float32` I have given easier tolerances (`atol` and `rtol` as `1e-1`). I think the error between ground truth image points and estimated image points is large when the estimated world to camera transformation matrix has some error and the camera coordinates are close to 0. For `float64` however stricter tolerances (`atol` and `rtol` as `1e-4`) seem to work. Do let me know if the easier tolerances are ok for `float32`. 
2. For `test_gradcheck` I had given `atol` as `1e-4` so that a test could pass. Do let me know if this fine as well.
3. I ran the following tests:
    - `pytest test/geometry/calibration/test_pnp.py --device all --dtype "float32,float64"`
    - `make lint`
    - `make mypy`
    - `make build-docs`
     
Do let me know if I have to make any changes, thanks!

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (**note:** I need to verify this, however I did run the tests I mentioned in point 3 of the Questions and Notes section above.)
- [ ] Did you update CHANGELOG in case of a major change?
