### PR TITLE
improve bbox_to_mask

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -178,8 +178,8 @@ def bbox_to_mask(boxes: torch.Tensor, width: int, height: int) -> torch.Tensor:
     # in order to zero-out the fully filled rows or columns
     box_i = (boxes + 1).long()
     # set all pixels within box to 1
-    mask[:, box_i[:, 0, 1]:box_i[:, 2, 1] + 1, 
-            box_i[:, 0, 0]:box_i[:, 1, 0] + 1] = 1.0  
+    mask[:, box_i[:, 0, 1]:box_i[:, 2, 1] + 1,
+            box_i[:, 0, 0]:box_i[:, 1, 0] + 1] = 1.0
     return mask[:, 1:-1, 1:-1]
 
 


### PR DESCRIPTION
- improves the performance of bbox_to_mask by more than 2x
- fixes a bug where passed bboxes data are modified (incremented) by this function
- function now supports cuda tensors

Notebook linked here tests correctness and benchmarks performance 
- https://gist.github.com/PWhiddy/689155a8fb292d62ddc66e8cf53bcf56

Notes:
 - validate_bbox can now be a primary performance bottleneck of this function
 - this implementation can be used as a guide to improve the 3d bbox functions


🐞 Bug fix (non-breaking change which fixes an issue)

