### PR TITLE
Fixed classificationhead typo 

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,10 +17,11 @@ Ready to use with state-of-the art Deep Learning models:
 
 .. code:: python
 
+   >>> import torch.nn as nn
    >>> import kornia.contrib as K
    >>> classifier = nn.Sequential(
    ...   K.VisionTransformer(image_size=224, patch_size=16),
-   ...   K.ClassficationHead(num_classes=1000),
+   ...   K.ClassificationHead(num_classes=1000),
    ... )
    >>> logits = classifier(img)    # BxN
    >>> scores = logits.argmax(-1)  # B

--- a/docs/source/models/vit.rst
+++ b/docs/source/models/vit.rst
@@ -69,8 +69,8 @@ class with two different classification heads:
             super().__init__()
             self.transformer = K.VisionTransformer(
                 image_size=224, patch_size=16)
-            self.head1 = K.ClassficationHead(num_classes=10)
-            self.head2 = K.ClassficationHead(num_classes=50)
+            self.head1 = K.ClassificationHead(num_classes=10)
+            self.head2 = K.ClassificationHead(num_classes=50)
 
         def forward(self, x: torch.Tensor):
             out = self.transformer(x)


### PR DESCRIPTION
… the first example

#### Changes
After looking at the documentation for looking at ways to contribute I noticed some typos in the initial sample (which also occured on the vision transformer. As a warmup I thought I could fix them before digging in to more serious issues.

Fixes # (issue)
Not reported

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- N/A I have commented my code, particularly in hard-to-understand areas
- N/A I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- N/A Did you update CHANGELOG in case of a major change?
