### PR TITLE
Fix docstring of normalize_quaternion

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -456,7 +456,7 @@ def rotation_matrix_to_quaternion(
 def normalize_quaternion(quaternion: torch.Tensor, eps: float = 1.0e-12) -> torch.Tensor:
     r"""Normalize a quaternion.
 
-    The quaternion should be in (x, y, z, w) format.
+    The quaternion should be in (x, y, z, w) or (w, x, y, z) format.
 
     Args:
         quaternion: a tensor containing a quaternion to be normalized.


### PR DESCRIPTION
#### Changes
The docstring of the function `normalize_quaternion` used to mention that `The quaternion should be in (x, y, z, w) format.`. But the function is being used for both `(x, y, z, w)` and `(w, x, y, z)` formats. Also looks like the function can be used for either format as is. Hence, fixing the docstring.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation