### PR TITLE
:point_down: Special case implementation for local features speed up

### DIFF
--- a/kornia/feature/nms.py
+++ b/kornia/feature/nms.py
@@ -93,17 +93,50 @@ class NonMaximaSuppression3d(nn.Module):
             raise AssertionError(x.shape)
         # find local maximum values
         B, CH, D, H, W = x.size()
-        max_non_center = (
-            F.conv3d(
-                F.pad(x, list(self.padding)[::-1], mode='replicate'),
-                self.kernel.repeat(CH, 1, 1, 1, 1).to(x.device, x.dtype),
-                stride=1,
-                groups=CH,
+        if self.kernel_size == (3, 3, 3):
+            mask = torch.zeros(B, CH, D, H, W, device=x.device, dtype=torch.bool)
+            center = slice(1, -1)
+            left = slice(0, -2)
+            right = slice(2, None)
+            center_tensor = x[..., center, center, center]
+            mask[..., 1: -1, 1: -1, 1: -1] = ((center_tensor > x[..., center, center, left]) &  # noqa: W504
+                                              (center_tensor > x[..., center, center, right]) &  # noqa: W504
+                                              (center_tensor > x[..., center, left, center]) &  # noqa: W504
+                                              (center_tensor > x[..., center, left, left]) &  # noqa: W504
+                                              (center_tensor > x[..., center, left, right]) &  # noqa: W504
+                                              (center_tensor > x[..., center, right, center]) &  # noqa: W504
+                                              (center_tensor > x[..., center, right, left]) &  # noqa: W504
+                                              (center_tensor > x[..., center, right, right]) &  # noqa: W504
+                                              (center_tensor > x[..., left, center, center]) &  # noqa: W504
+                                              (center_tensor > x[..., left, center, left]) &  # noqa: W504
+                                              (center_tensor > x[..., left, center, right]) &  # noqa: W504
+                                              (center_tensor > x[..., left, left, center]) &  # noqa: W504
+                                              (center_tensor > x[..., left, left, left]) &  # noqa: W504
+                                              (center_tensor > x[..., left, left, right]) &  # noqa: W504
+                                              (center_tensor > x[..., left, right, center]) &  # noqa: W504
+                                              (center_tensor > x[..., left, right, left]) &  # noqa: W504
+                                              (center_tensor > x[..., left, right, right]) &  # noqa: W504
+                                              (center_tensor > x[..., right, center, center]) &  # noqa: W504
+                                              (center_tensor > x[..., right, center, left]) &  # noqa: W504
+                                              (center_tensor > x[..., right, center, right]) &  # noqa: W504
+                                              (center_tensor > x[..., right, left, center]) &  # noqa: W504
+                                              (center_tensor > x[..., right, left, left]) &  # noqa: W504
+                                              (center_tensor > x[..., right, left, right]) &  # noqa: W504
+                                              (center_tensor > x[..., right, right, center]) &  # noqa: W504
+                                              (center_tensor > x[..., right, right, left]) &  # noqa: W504
+                                              (center_tensor > x[..., right, right, right]))
+        else:
+            max_non_center = (
+                F.conv3d(
+                    F.pad(x, list(self.padding)[::-1], mode='replicate'),
+                    self.kernel.repeat(CH, 1, 1, 1, 1).to(x.device, x.dtype),
+                    stride=1,
+                    groups=CH,
+                )
+                .view(B, CH, -1, D, H, W)
+                .max(dim=2, keepdim=False)[0]
             )
-            .view(B, CH, -1, D, H, W)
-            .max(dim=2, keepdim=False)[0]
-        )
-        mask = x > max_non_center
+            mask = x > max_non_center
         if mask_only:
             return mask
         return x * (mask.to(x.dtype))

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -83,30 +83,44 @@ def spatial_gradient3d(input: torch.Tensor, mode: str = 'diff', order: int = 1) 
 
     if not len(input.shape) == 5:
         raise ValueError(f"Invalid input shape, we expect BxCxDxHxW. Got: {input.shape}")
-    # allocate kernel
-    kernel: torch.Tensor = get_spatial_gradient_kernel3d(mode, order)
-
-    # prepare kernel
     b, c, d, h, w = input.shape
-    tmp_kernel: torch.Tensor = kernel.to(input).detach()
-    tmp_kernel = tmp_kernel.repeat(c, 1, 1, 1, 1)
+    dev = input.device
+    dtype = input.dtype
+    if (mode == 'diff') and (order == 1):
+        # we go for the special case implementation due to conv3d bad speed
+        x: torch.Tensor = F.pad(input, 6 * [1], 'replicate')
+        center = slice(1, -1)
+        left = slice(0, -2)
+        right = slice(2, None)
+        out = torch.empty(b, c, 3, d, h, w, device=dev, dtype=dtype)
+        out[..., 0, :, :, :] = (x[..., center, center, right] - x[..., center, center, left])
+        out[..., 1, :, :, :] = (x[..., center, right, center] - x[..., center, left, center])
+        out[..., 2, :, :, :] = (x[..., right, center, center] - x[..., left, center, center])
+        out = 0.5 * out
+    else:
+        # prepare kernel
+        # allocate kernel
+        kernel: torch.Tensor = get_spatial_gradient_kernel3d(mode, order)
 
-    # convolve input tensor with grad kernel
-    kernel_flip: torch.Tensor = tmp_kernel.flip(-3)
+        tmp_kernel: torch.Tensor = kernel.to(input).detach()
+        tmp_kernel = tmp_kernel.repeat(c, 1, 1, 1, 1)
 
-    # Pad with "replicate for spatial dims, but with zeros for channel
-    spatial_pad = [
-        kernel.size(2) // 2,
-        kernel.size(2) // 2,
-        kernel.size(3) // 2,
-        kernel.size(3) // 2,
-        kernel.size(4) // 2,
-        kernel.size(4) // 2,
-    ]
-    out_ch: int = 6 if order == 2 else 3
-    return F.conv3d(F.pad(input, spatial_pad, 'replicate'), kernel_flip, padding=0, groups=c).view(
-        b, c, out_ch, d, h, w
-    )
+        # convolve input tensor with grad kernel
+        kernel_flip: torch.Tensor = tmp_kernel.flip(-3)
+
+        # Pad with "replicate for spatial dims, but with zeros for channel
+        spatial_pad = [kernel.size(2) // 2,
+                       kernel.size(2) // 2,
+                       kernel.size(3) // 2,
+                       kernel.size(3) // 2,
+                       kernel.size(4) // 2,
+                       kernel.size(4) // 2]
+        out_ch: int = 6 if order == 2 else 3
+        out = F.conv3d(F.pad(input, spatial_pad, 'replicate'),
+                       kernel_flip,
+                       padding=0,
+                       groups=c).view(b, c, out_ch, d, h, w)
+    return out
 
 
 def sobel(input: torch.Tensor, normalized: bool = True, eps: float = 1e-6) -> torch.Tensor:


### PR DESCRIPTION
#### Changes
Added hardcoded implementation for spatial_gradient_3d and nms3d for the cases of kernel == (3,3,3),
because the general implementation with conv3d sucks.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Benchmark spatial_gradient3d


Benchmarks:


```python3
import torch
import torch.nn.functional as F
import torch.backends.cudnn as cudnn
from time import time
import numpy as np
from tqdm import tqdm
import matplotlib.pyplot as plt

import torch
import torch.nn as nn
import torch.nn.functional as F

from kornia.filters.kernels import get_spatial_gradient_kernel2d, get_spatial_gradient_kernel3d, normalize_kernel2d

def spatial_gradient3d(input: torch.Tensor, mode: str = 'diff', order: int = 1, special=True) -> torch.Tensor:
    r"""Compute the first and second order volume derivative in x, y and d using a diff
    operator.

    Args:
        input: input features tensor with shape :math:`(B, C, D, H, W)`.
        mode: derivatives modality, can be: `sobel` or `diff`.
        order: the order of the derivatives.

    Return:
        the spatial gradients of the input feature map.

    Shape:
        - Input: :math:`(B, C, D, H, W)`. D, H, W are spatial dimensions, gradient is calculated w.r.t to them.
        - Output: :math:`(B, C, 3, D, H, W)` or :math:`(B, C, 6, D, H, W)`

    Examples:
        >>> input = torch.rand(1, 4, 2, 4, 4)
        >>> output = spatial_gradient3d(input)
        >>> output.shape
        torch.Size([1, 4, 3, 2, 4, 4])
    """
    if not isinstance(input, torch.Tensor):
        raise TypeError(f"Input type is not a torch.Tensor. Got {type(input)}")

    if not len(input.shape) == 5:
        raise ValueError(f"Invalid input shape, we expect BxCxDxHxW. Got: {input.shape}")
    b, c, d, h, w = input.shape
    dev = input.device
    dtype = input.dtype
    if (mode == 'diff') and (order == 1) and special:
        x = F.pad(input, 6 * [1], 'replicate')
        # we go for the special case implementation due to conv3d bad speed
        center = slice(1, -1)
        left = slice(0, -2)
        right = slice(2, None)
        out = torch.empty(b, c, 3, d, h, w, device=dev, dtype=dtype)
        out[..., 0, :, :, :] = (x[..., center, center, right] - x[..., center, center, left])
        out[..., 1, :, :, :] = (x[..., center, right, center] - x[..., center, left, center])
        out[..., 2, :, :, :] = (x[..., right, center, center] - x[..., left, center, center])
        out = 0.5 * out
    else:
      # prepare kernel
      # allocate kernel
      kernel: torch.Tensor = get_spatial_gradient_kernel3d(mode, order)

      tmp_kernel: torch.Tensor = kernel.to(input).detach()
      tmp_kernel = tmp_kernel.repeat(c, 1, 1, 1, 1)

      # convolve input tensor with grad kernel
      kernel_flip: torch.Tensor = tmp_kernel.flip(-3)

      # Pad with "replicate for spatial dims, but with zeros for channel
      spatial_pad = [
          kernel.size(2) // 2,
          kernel.size(2) // 2,
          kernel.size(3) // 2,
          kernel.size(3) // 2,
          kernel.size(4) // 2,
          kernel.size(4) // 2,
      ]
      out_ch: int = 6 if order == 2 else 3
      out = F.conv3d(F.pad(input, spatial_pad, 'replicate'), kernel_flip, padding=0, groups=c).view(
          b, c, out_ch, d, h, w
      )
    return out 



def benchmark_grad3d(input, device, sh):
    torch.cuda.synchronize()
    x = spatial_gradient3d(input, special=False, order=1)
    loss = x.sum()
    loss.backward()
    torch.cuda.synchronize()
    return


def benchmark_grad3d_special(input, device, sh):
    torch.cuda.synchronize()
    x = spatial_gradient3d(input, special=True, order=1)
    loss = x.sum()
    loss.backward()
    torch.cuda.synchronize()
    return

#For square kernels



N = 10
b,c,h,w = 16, 1, 1024, 1024
sh = [b,c,h,w]
for device in  ['cpu', 'cuda']:
    data = torch.rand(b,c,5,h,w, device=device, requires_grad=True).float()
    #torch.cuda.synchronize()

    # print (ks, 'group', str(device))

    l = []
    print (f" {device} special case")
    data = torch.rand(b,c,5,h,w, device=device,  requires_grad=True).float()
    %timeit benchmark_grad3d_special(data,device, sh)
    #torch.cuda.synchronize()
    print (f" {device} conv3d")
    data = torch.rand(b,c,5,h,w, device=device,  requires_grad=True).float()
    %timeit benchmark_grad3d(data, device, sh)

```

Results COLAB:
```
 cpu special case
1 loop, best of 5: 8.78 s per loop
 cpu conv3d
1 loop, best of 5: 17.5 s per loop
 cuda special case
1 loop, best of 5: 402 ms per loop
 cuda conv3d
1 loop, best of 5: 1.1 s per loop
```

Results A100:
```
 cpu special case
1.43 s ± 22.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 cpu conv3d
1.8 s ± 35.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 cuda special case
40.7 ms ± 29.5 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
 cuda conv3d
136 ms ± 119 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

#### Benchmark NMS3d
```python3
from typing import Tuple

import torch
import torch.nn as nn
import torch.nn.functional as F

def _get_nms_kernel3d(kd: int, ky: int, kx: int) -> torch.Tensor:
    """Utility function, which returns neigh2channels conv kernel."""
    numel: int = kd * ky * kx
    center: int = numel // 2
    weight = torch.eye(numel)
    weight[center, center] = 0
    return weight.view(numel, 1, kd, ky, kx)

class NonMaximaSuppression3d(nn.Module):
    r"""Apply non maxima suppression to filter."""

    def __init__(self, kernel_size: Tuple[int, int, int]):
        super().__init__()
        self.kernel_size: Tuple[int, int, int] = kernel_size
        self.padding: Tuple[int, int, int, int, int, int] = self._compute_zero_padding3d(kernel_size)
        self.kernel = _get_nms_kernel3d(*kernel_size)

    @staticmethod
    def _compute_zero_padding3d(kernel_size: Tuple[int, int, int]) -> Tuple[int, int, int, int, int, int]:
        if not isinstance(kernel_size, tuple):
            raise AssertionError(type(kernel_size))
        if len(kernel_size) != 3:
            raise AssertionError(kernel_size)

        def pad(x):
            return (x - 1) // 2  # zero padding function

        kd, ky, kx = kernel_size  # we assume a cubic kernel
        return pad(kd), pad(kd), pad(ky), pad(ky), pad(kx), pad(kx)

    def forward(self, x: torch.Tensor, mask_only: bool = False, special=False) -> torch.Tensor:  # type: ignore
        if len(x.shape) != 5:
            raise AssertionError(x.shape)
        # find local maximum values
        B, CH, D, H, W = x.size()
        if special and self.kernel_size == (3,3,3):
          mask = torch.zeros(B, CH, D, H, W, device=x.device, dtype=torch.bool)
          center = slice(1, -1)
          left = slice(0, -2)
          right = slice(2, None)
          center_tensor = x[..., center, center, center]
          mask[..., 1: -1, 1: -1, 1: -1] = ((center_tensor > x[..., center, center, left]) &
                                            (center_tensor > x[..., center, center, right]) &
                                            (center_tensor > x[..., center, left, center]) &
                                            (center_tensor > x[..., center, left, left]) &
                                            (center_tensor > x[..., center, left, right]) &
                                            (center_tensor > x[..., center, right, center]) &
                                            (center_tensor > x[..., center, right, left]) &
                                            (center_tensor > x[..., center, right, right]) &

                                            (center_tensor > x[..., left, center, center]) &
                                            (center_tensor > x[..., left, center, left]) &
                                            (center_tensor > x[..., left, center, right]) &
                                            (center_tensor > x[..., left, left, center]) &
                                            (center_tensor > x[..., left, left, left]) &
                                            (center_tensor > x[..., left, left, right]) &
                                            (center_tensor > x[..., left, right, center]) &
                                            (center_tensor > x[..., left, right, left]) &
                                            (center_tensor > x[..., left, right, right]) &

                                            (center_tensor > x[..., right, center, center]) &
                                            (center_tensor > x[..., right, center, left]) &
                                            (center_tensor > x[..., right, center, right]) &
                                            (center_tensor > x[..., right, left, center]) &
                                            (center_tensor > x[..., right, left, left]) &
                                            (center_tensor > x[..., right, left, right]) &
                                            (center_tensor > x[..., right, right, center]) &
                                            (center_tensor > x[..., right, right, left]) &
                                            (center_tensor > x[..., right, right, right]))
                                            
        else:
          max_non_center = (
              F.conv3d(
                  F.pad(x, list(self.padding)[::-1], mode='replicate'),
                  self.kernel.repeat(CH, 1, 1, 1, 1).to(x.device, x.dtype),
                  stride=1,
                  groups=CH,
              )
              .view(B, CH, -1, D, H, W)
              .max(dim=2, keepdim=False)[0]
          )
          mask = x > max_non_center
        if mask_only:
            return mask
        return x * (mask.to(x.dtype))

import torch
import torch.nn.functional as F
import torch.backends.cudnn as cudnn
from time import time
import numpy as np
from tqdm import tqdm
import matplotlib.pyplot as plt

def benchmark_nms3d(input, device, sh):
    torch.cuda.synchronize()
    x = nms(input, special=False)
    loss = x.sum()
    loss.backward()
    torch.cuda.synchronize()
    return


def benchmark_nms3d_special(input, device, sh):
    torch.cuda.synchronize()
    x = nms(input, special=True)
    loss = x.sum()
    loss.backward()
    torch.cuda.synchronize()
    return


N = 10
b,c,h,w = 2,3,600, 800
sh = [b,c,h,w]

for device in  ['cpu', 'cuda']:
    data = torch.rand(b,c,5,h,w, device=device, requires_grad=True).float()
    nms = NonMaximaSuppression3d((3, 3, 3)).to(device)
    print (f"{device} conv3d")
    data = torch.rand(b,c,5,h,w, device=device,  requires_grad=True).float()
    %timeit benchmark_nms3d(data, device, sh)
    print (f"{device} special case")
    data = torch.rand(b,c,5,h,w, device=device,  requires_grad=True).float()
    %timeit benchmark_nms3d_special(data,device, sh)
```

Results COLAB:

```
cpu conv3d
1 loop, best of 5: 4.54 s per loop
cpu special case
1 loop, best of 5: 746 ms per loop
cuda conv3d
10 loops, best of 5: 110 ms per loop
cuda special case
10 loops, best of 5: 48.7 ms per loop
```

Results  NVIDIA A100
```
cpu conv3d
702 ms ± 13.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
cpu special case
54.5 ms ± 1.98 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
cuda conv3d
14.5 ms ± 2.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
cuda special case
2.95 ms ± 6.32 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)


```


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
