### PR TITLE
:stars: deprecate 1.6/1.7 and add 1.9.1

### DIFF
--- a/.github/workflows/tests_cpu.yml
+++ b/.github/workflows/tests_cpu.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
-        pytorch-version: [1.9.0]
+        pytorch-version: [1.9.1]
 
     steps:
     - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7]
-        pytorch-version: [1.6.0, 1.7.0, 1.7.1, 1.8.0, 1.9.0]
+        pytorch-version: [1.8.1, 1.9.0, 1.9.1]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests_cpu_versions.yml
+++ b/.github/workflows/tests_cpu_versions.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
-        pytorch-version: [1.6.0, 1.7.0, 1.7.1, 1.8.0, 1.9.0]
+        pytorch-version: [1.8.1, 1.9.0, 1.9.1]
     steps:
     - uses: actions/checkout@v2
     - name: Setup conda dependencies


### PR DESCRIPTION
#### Changes

- deprecates PyTorch 1.6/1.7 support and includes 1.9.1
- deprecation is based on pytorch downloading versions from : https://pepy.tech/project/torch?versions=1.8.1&versions=1.9.0&versions=1.9.1&versions=1.6.0&versions=1.7.0&versions=1.7.1&versions=1.8.0
- Checks also that cuda tests are :ok: 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
