### PR TITLE
Attempting to fix an mypy issue for torch 1.6 for solve_pnp_dlt

### DIFF
--- a/kornia/geometry/calibration/pnp.py
+++ b/kornia/geometry/calibration/pnp.py
@@ -213,7 +213,7 @@ def solve_pnp_dlt(
     # matrices are 1. Do note that the norm of any column of a rotation
     # matrix should be 1. Here we use the 0th column to calculate norm_col.
     # We then multiply solution with mul_factor.
-    norm_col = torch.sqrt(torch.sum(input=solution[:, :3, 0] ** 2, dim=1))
+    norm_col = torch.norm(input=solution[:, :3, 0], p=2, dim=1)
     mul_factor = (1 / norm_col)[:, None, None]
     pred_world_to_cam = solution * mul_factor
 


### PR DESCRIPTION
I have now used `torch.norm` to calculate `norm_col` so that the mypy issue would not possibly happen (since the issue seemed to be with the type inference in the custom code that calculated the norm). @edgarriba I think this should solve the issue you mentioned.

