### PR TITLE
Added QR step, example and data type checks for solve_pnp_dlt

### DIFF
--- a/kornia/geometry/calibration/pnp.py
+++ b/kornia/geometry/calibration/pnp.py
@@ -156,6 +156,26 @@ def solve_pnp_dlt(
     if type(svd_eps) is not float:
         raise AssertionError(f"Type of svd_eps is not float. Got {type(svd_eps)}")
 
+    accepted_dtypes = (torch.float32, torch.float64)
+
+    if world_points.dtype not in accepted_dtypes:
+        raise AssertionError(
+            f"world_points must have one of the following dtypes {accepted_dtypes}. "
+            f"Currently it has {world_points.dtype}."
+        )
+
+    if img_points.dtype not in accepted_dtypes:
+        raise AssertionError(
+            f"img_points must have one of the following dtypes {accepted_dtypes}. "
+            f"Currently it has {img_points.dtype}."
+        )
+
+    if intrinsics.dtype not in accepted_dtypes:
+        raise AssertionError(
+            f"intrinsics must have one of the following dtypes {accepted_dtypes}. "
+            f"Currently it has {intrinsics.dtype}."
+        )
+
     if (len(world_points.shape) != 3) or (world_points.shape[2] != 3):
         raise AssertionError(
             f"world_points must be of shape (B, N, 3). Got shape {world_points.shape}."


### PR DESCRIPTION
#### Changes

- The rotation matrix part of the estimated world to camera transformation matrix is orthogonalized using QR decomposition.
  -  In #1349, the QR step was once added and then was removed since we were debating if it was necessary. Also, previously QR decomposition was applied on the entire world to camera transformation matrix, and that had an issue for torch 1.6 (the upper triangular matrix given by QR was rectangular and that gave an issue for torch 1.6; you can refer to #1349).
  - Now QR is applied only to the rotation matrix part of the estimated world to camera transformation matrix. In this case the upper triangular matrix given by QR will be square and hence there should not be an issue for torch 1.6.
  - I also thought it would be better to add some orthogonalization step to refine the estimated rotation matrix (even if the original estimate could be orthogonal by itself in ideal cases) and hence I added the QR step to `solve_pnp_dlt`. 
- Added example for `solve_pnp_dlt`.

(**EDIT**: Added Question and Note below)
##### Question
Is this change considered a "breaking change" ? Since the current merged version does not have a QR step and this PR introduces a QR step. The output obtained now maybe more different from the previously obtained output when the inputs are non-ideal (i.e. when correspondences are really bad). But the output obtained now maybe closer to the output obtain previously when the inputs are good (i.e. clean and good correspondences). 

##### Note
(EDIT) 
All tests seemed to pass for the 1st commit. 

For the 2nd commit (which just added dtype checks) the new refactored cpu tests are being run and there are many test fails. I checked a handful of the fails and they were unrelated to this PR. Will check all the fails once they are done running and see if anything is related to this PR. 