### PR TITLE
ImageStitcher accepts classical local feature matcher

### DIFF
--- a/kornia/contrib/image_stitching.py
+++ b/kornia/contrib/image_stitching.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Dict, List, Optional, Tuple
 
 import torch


### PR DESCRIPTION
LoFTR and LocalFeatureMatcher now have the same signature and are completely compatible