### PR TITLE
Enable all bandit tests, add separate hook for tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,11 +51,16 @@ repos:
     rev: 1.7.0
     hooks:
       - id: bandit
+        name: bandit non-test
         language_version: python3
         exclude: ^test/
+      - id: bandit
+        name: bandit test
+        language_version: python3
+        files: ^test/
         args:
           - -s
-          - "B404,B602,B603,B607"
+          - "B101,B311"
 
   - repo: https://github.com/myint/docformatter
     rev: v1.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         language_version: python3
         exclude: ^test/
       - id: bandit
-        name: bandit test
+        name: bandit only the test directory
         language_version: python3
         files: ^test/
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         language_version: python3
         files: ^test/
         args:
-          - -s
+          - --skip
           - "B101,B311"
 
   - repo: https://github.com/myint/docformatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     rev: 1.7.0
     hooks:
       - id: bandit
-        name: bandit non-test
+        name: bandit excluding the test directory
         language_version: python3
         exclude: ^test/
       - id: bandit


### PR DESCRIPTION
#### Changes

This PR enables the remaining Bandit tests in the pre-commit hook. The excluded tests already passed, so all that needed to be done was enabling them.

Additionally, based on the discussion in #1245 a separate hook as been added for `tests/`, which is currently excluded. Specifically, B101 and B311 are not run for `tests/`, but all other tests are.

Closes #1245


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
