### PR TITLE
Add `padding_mode` for RandomElasticTransform augmentation

### DIFF
--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -2170,7 +2170,7 @@ class RandomElasticTransform(GeometricAugmentationBase2D):
         alpha: Tuple[float, float] = (1.0, 1.0),
         align_corners: bool = False,
         mode: str = 'bilinear',
-        padding_mode: Union[str, int, SamplePadding] = SamplePadding.ZEROS.name,
+        padding_mode: str = 'zeros',
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -2146,6 +2146,8 @@ class RandomElasticTransform(GeometricAugmentationBase2D):
           in the y and x directions, respectively.
         align_corners: Interpolation flag used by `grid_sample`.
         mode: Interpolation mode used by `grid_sample`. Either 'bilinear' or 'nearest'.
+        padding_mode: The padding used by ```grid_sample```. Either "zeros" (0), "border" (1) or "refection" (2).
+
         return_transform: if ``True`` return the matrix describing the transformation applied to each
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.
         same_on_batch: apply the same transformation across the batch.
@@ -2168,6 +2170,7 @@ class RandomElasticTransform(GeometricAugmentationBase2D):
         alpha: Tuple[float, float] = (1.0, 1.0),
         align_corners: bool = False,
         mode: str = 'bilinear',
+        padding_mode: Union[str, int, SamplePadding] = SamplePadding.ZEROS.name,
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
@@ -2178,6 +2181,7 @@ class RandomElasticTransform(GeometricAugmentationBase2D):
         self.alpha = alpha
         self.align_corners = align_corners
         self.mode = mode
+        self.padding_mode = padding_mode
 
     def __repr__(self) -> str:
         return self.__class__.__name__ + f"({super().__repr__()})"
@@ -2198,7 +2202,8 @@ class RandomElasticTransform(GeometricAugmentationBase2D):
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], transform: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         return elastic_transform2d(
-            input, params['noise'].to(input), self.kernel_size, self.sigma, self.alpha, self.align_corners, self.mode
+            input, params['noise'].to(input), self.kernel_size, self.sigma, self.alpha, self.align_corners, self.mode,
+            self.padding_mode
         )
 
 

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -2146,7 +2146,7 @@ class RandomElasticTransform(GeometricAugmentationBase2D):
           in the y and x directions, respectively.
         align_corners: Interpolation flag used by `grid_sample`.
         mode: Interpolation mode used by `grid_sample`. Either 'bilinear' or 'nearest'.
-        padding_mode: The padding used by ```grid_sample```. Either "zeros" (0), "border" (1) or "refection" (2).
+        padding_mode: The padding used by ```grid_sample```. Either 'zeros', 'border' or 'refection'.
 
         return_transform: if ``True`` return the matrix describing the transformation applied to each
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -3,7 +3,6 @@ from typing import Tuple
 import torch
 import torch.nn.functional as F
 
-from kornia.constants import SamplePadding
 from kornia.filters import filter2d, get_gaussian_kernel2d
 from kornia.utils import create_meshgrid
 

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -18,7 +18,7 @@ def elastic_transform2d(
     alpha: Tuple[float, float] = (1.0, 1.0),
     align_corners: bool = False,
     mode: str = 'bilinear',
-    padding_mode: str = SamplePadding.ZEROS.name
+    padding_mode: str = 'zeros'
 ) -> torch.Tensor:
     r"""Apply elastic transform of images as described in :cite:`Simard2003BestPF`.
 

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -36,7 +36,7 @@ def elastic_transform2d(
           in the y and x directions, respectively.
         align_corners: Interpolation flag used by ```grid_sample```.
         mode: Interpolation mode used by ```grid_sample```. Either ``'bilinear'`` or ``'nearest'``.
-        padding_mode: The padding used by ```grid_sample```. Either "zeros" (0), "border" (1) or "refection" (2).
+        padding_mode: The padding used by ```grid_sample```. Either ``'zeros'``, ``'border'`` or ``'refection'``.
 
     .. note:
         ```sigma``` and ```alpha``` can also be a ``torch.Tensor``. However, you could not torchscript
@@ -93,6 +93,6 @@ def elastic_transform2d(
     _, _, h, w = image.shape
     grid = create_meshgrid(h, w, device=image.device).to(image.dtype)
     warped = F.grid_sample(image, (grid + disp).clamp(-1, 1), align_corners=align_corners, mode=mode,
-                           padding_mode=SamplePadding.get(padding_mode).name.lower())
+                           padding_mode=padding_mode)
 
     return warped

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -1,10 +1,11 @@
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 import torch.nn.functional as F
 
 from kornia.filters import filter2d, get_gaussian_kernel2d
 from kornia.utils import create_meshgrid
+from kornia.constants import SamplePadding
 
 __all__ = ["elastic_transform2d"]
 
@@ -17,6 +18,7 @@ def elastic_transform2d(
     alpha: Tuple[float, float] = (1.0, 1.0),
     align_corners: bool = False,
     mode: str = 'bilinear',
+    padding_mode: Union[str, int, SamplePadding] = SamplePadding.ZEROS.name
 ) -> torch.Tensor:
     r"""Apply elastic transform of images as described in :cite:`Simard2003BestPF`.
 
@@ -34,6 +36,7 @@ def elastic_transform2d(
           in the y and x directions, respectively.
         align_corners: Interpolation flag used by ```grid_sample```.
         mode: Interpolation mode used by ```grid_sample```. Either ``'bilinear'`` or ``'nearest'``.
+        padding_mode: The padding used by ```grid_sample```. Either "zeros" (0), "border" (1) or "refection" (2).
 
     .. note:
         ```sigma``` and ```alpha``` can also be a ``torch.Tensor``. However, you could not torchscript
@@ -89,6 +92,7 @@ def elastic_transform2d(
     # Warp image based on displacement matrix
     _, _, h, w = image.shape
     grid = create_meshgrid(h, w, device=image.device).to(image.dtype)
-    warped = F.grid_sample(image, (grid + disp).clamp(-1, 1), align_corners=align_corners, mode=mode)
+    warped = F.grid_sample(image, (grid + disp).clamp(-1, 1), align_corners=align_corners, mode=mode,
+                           padding_mode=SamplePadding.get(padding_mode).name.lower())
 
     return warped

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Tuple
 
 import torch
 import torch.nn.functional as F

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -18,7 +18,7 @@ def elastic_transform2d(
     alpha: Tuple[float, float] = (1.0, 1.0),
     align_corners: bool = False,
     mode: str = 'bilinear',
-    padding_mode: Union[str, int, SamplePadding] = SamplePadding.ZEROS.name
+    padding_mode: str = SamplePadding.ZEROS.name
 ) -> torch.Tensor:
     r"""Apply elastic transform of images as described in :cite:`Simard2003BestPF`.
 


### PR DESCRIPTION
#### Changes
Adds padding_mode  for RandomElasticTransform augmentation

Fixes #1192 


#### Type of change
- [x] 📚  Documentation Update
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
