### PR TITLE
NeRF

### DIFF
--- a/kornia/geometry/nerf/from_nerfmm.py
+++ b/kornia/geometry/nerf/from_nerfmm.py
@@ -171,7 +171,7 @@ def train_one_epoch(imgs, H, W, ray_params, n_selected_rays, opt_nerf, opt_focal
     np.random.shuffle(ids)
 
     for i in ids:
-        fxfy = focal_net()
+        fxfy = focal_net(i)
 
         # KEY 1: compute ray directions using estimated intrinsics online.
         ray_dir_cam = comp_ray_dir_cam_fxfy(H, W, fxfy[0], fxfy[1])

--- a/kornia/geometry/nerf/from_nerfmm.py
+++ b/kornia/geometry/nerf/from_nerfmm.py
@@ -58,7 +58,7 @@ class TinyNerf(nn.Module):
         return rgb_den
 
 
-class RayParameters():
+class RayParameters:
     def __init__(self):
         self.NEAR, self.FAR = 0.0, 1.0  # ndc near far
         self.N_SAMPLE = 128  # samples per ray
@@ -121,7 +121,7 @@ def train_one_epoch(imgs, H, W, ray_params, opt_nerf, opt_focal,
     # shuffle the training imgs
     N_IMGS = imgs.shape[0]
 
-    print("N_IMGS = ", N_IMGS, " H = ", H, " W = ", W)
+    # print("N_IMGS = ", N_IMGS, " H = ", H, " W = ", W)
 
     ids = np.arange(N_IMGS)
     np.random.shuffle(ids)
@@ -145,7 +145,7 @@ def train_one_epoch(imgs, H, W, ray_params, opt_nerf, opt_focal,
                                            H, W, fxfy, nerf_model, perturb_t=True, sigma_noise_std=0.0)
         rgb_rendered = render_result['rgb']  # (N_select_rows, N_select_cols, 3)
 
-        print("SHAPES: ", rgb_rendered.shape, img_selected.shape)
+        # print("SHAPES: ", rgb_rendered.shape, img_selected.shape)
 
         L2_loss = F.mse_loss(rgb_rendered, img_selected)  # loss for one image
 
@@ -193,10 +193,9 @@ def render_novel_view(c2w, H, W, fxfy, ray_params, nerf_model, device):
 
 
 def train_model(imgs: torch.Tensor, n_epoch = 1, device: str = 'cpu')->Tuple[nn.Module, nn.Module, nn.Module]:
-    # n_epoch = 1 # 200  # set to 1000 to get slightly better results. we use 10K epoch in our paper.
     EVAL_INTERVAL = 50  # render an image to visualise for every this interval.
 
-    # Initialise all trainabled parameters
+    # Initialise all trainable parameters
     N_IMGS = imgs.shape[0]
     H = imgs.shape[1]
     W = imgs.shape[2]
@@ -227,7 +226,7 @@ def train_model(imgs: torch.Tensor, n_epoch = 1, device: str = 'cpu')->Tuple[nn.
     # writer = SummaryWriter(log_dir=os.path.join('logs', scene_name, str(datetime.datetime.now().strftime('%y%m%d_%H%M%S'))))
 
     # Store poses to visualise them later
-    pose_history = []
+    # pose_history = []
 
     # Training
     print('Training... Check results in the tensorboard above.')
@@ -246,18 +245,18 @@ def train_model(imgs: torch.Tensor, n_epoch = 1, device: str = 'cpu')->Tuple[nn.
         scheduler_focal.step()
         scheduler_pose.step()
 
-        learned_c2ws = torch.stack([pose_param_net(i) for i in range(N_IMGS)])  # (N, 4, 4)
-        pose_history.append(learned_c2ws[:, :3, 3])  # (N, 3) only store positions as we vis in 2D.
+        # learned_c2ws = torch.stack([pose_param_net(i) for i in range(N_IMGS)])  # (N, 4, 4)
+        # pose_history.append(learned_c2ws[:, :3, 3])  # (N, 3) only store positions as we vis in 2D.
 
-        with torch.no_grad():
-            if (epoch_i + 1) % EVAL_INTERVAL == 0:
-                eval_c2w = torch.eye(4, dtype=torch.float32)  # (4, 4)
-                fxfy = focal_net()
-                rendered_img, rendered_depth = render_novel_view(eval_c2w, H, W, fxfy, ray_params, nerf_model, device)
-                # writer.add_image('eval/img', rendered_img.permute(2, 0, 1), global_step=epoch_i)
-                # writer.add_image('eval/depth', rendered_depth.unsqueeze(0), global_step=epoch_i)
+        # with torch.no_grad():
+        #     if (epoch_i + 1) % EVAL_INTERVAL == 0:
+        #         eval_c2w = torch.eye(4, dtype=torch.float32)  # (4, 4)
+        #         fxfy = focal_net()
+        #         rendered_img, rendered_depth = render_novel_view(eval_c2w, H, W, fxfy, ray_params, nerf_model, device)
+        #         # writer.add_image('eval/img', rendered_img.permute(2, 0, 1), global_step=epoch_i)
+        #         # writer.add_image('eval/depth', rendered_depth.unsqueeze(0), global_step=epoch_i)
 
-    pose_history = torch.stack(pose_history).detach().cpu().numpy()  # (n_epoch, N_img, 3)
+    # pose_history = torch.stack(pose_history).detach().cpu().numpy()  # (n_epoch, N_img, 3)
     print('Training finished.')
 
     return nerf_model, focal_net, pose_param_net

--- a/kornia/geometry/nerf/from_nerfmm.py
+++ b/kornia/geometry/nerf/from_nerfmm.py
@@ -1,0 +1,300 @@
+from kornia.geometry.nerf.nerfmm.utils.pos_enc import encode_position
+from kornia.geometry.nerf.nerfmm.utils.volume_op import volume_rendering, volume_sampling_ndc
+from kornia.geometry.nerf.nerfmm.utils.comp_ray_dir import comp_ray_dir_cam_fxfy
+from kornia.geometry.nerf.nerfmm.utils.training_utils import mse2psnr
+
+from kornia.geometry.nerf.nerfmm.models.intrinsics import LearnFocal
+from kornia.geometry.nerf.nerfmm.models.poses import LearnPose
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import numpy as np
+
+from typing import Tuple
+
+
+class TinyNerf(nn.Module):
+    def __init__(self, pos_in_dims, dir_in_dims, D):
+        """
+        :param pos_in_dims: scalar, number of channels of encoded positions
+        :param dir_in_dims: scalar, number of channels of encoded directions
+        :param D:           scalar, number of hidden dimensions
+        """
+        super(TinyNerf, self).__init__()
+
+        self.pos_in_dims = pos_in_dims
+        self.dir_in_dims = dir_in_dims
+
+        self.layers0 = nn.Sequential(
+            nn.Linear(pos_in_dims, D), nn.ReLU(),
+            nn.Linear(D, D), nn.ReLU(),
+            nn.Linear(D, D), nn.ReLU(),
+            nn.Linear(D, D), nn.ReLU(),
+        )
+
+        self.fc_density = nn.Linear(D, 1)
+        self.fc_feature = nn.Linear(D, D)
+        self.rgb_layers = nn.Sequential(nn.Linear(D + dir_in_dims, D // 2), nn.ReLU())
+        self.fc_rgb = nn.Linear(D // 2, 3)
+
+        self.fc_density.bias.data = torch.tensor([0.1]).float()
+        self.fc_rgb.bias.data = torch.tensor([0.02, 0.02, 0.02]).float()
+
+    def forward(self, pos_enc, dir_enc):
+        """
+        :param pos_enc: (H, W, N_sample, pos_in_dims) encoded positions
+        :param dir_enc: (H, W, N_sample, dir_in_dims) encoded directions
+        :return: rgb_density (H, W, N_sample, 4)
+        """
+        x = self.layers0(pos_enc)  # (H, W, N_sample, D)
+        density = self.fc_density(x)  # (H, W, N_sample, 1)
+
+        feat = self.fc_feature(x)  # (H, W, N_sample, D)
+        x = torch.cat([feat, dir_enc], dim=3)  # (H, W, N_sample, D+dir_in_dims)
+        x = self.rgb_layers(x)  # (H, W, N_sample, D/2)
+        rgb = self.fc_rgb(x)  # (H, W, N_sample, 3)
+
+        rgb_den = torch.cat([rgb, density], dim=3)  # (H, W, N_sample, 4)
+        return rgb_den
+
+
+class RayParameters():
+    def __init__(self):
+        self.NEAR, self.FAR = 0.0, 1.0  # ndc near far
+        self.N_SAMPLE = 128  # samples per ray
+        self.POS_ENC_FREQ = 10  # positional encoding freq for location
+        self.DIR_ENC_FREQ = 4  # positional encoding freq for direction
+
+
+ray_params = RayParameters()
+
+
+def model_render_image(c2w, rays_cam, t_vals, ray_params, H, W, fxfy, nerf_model,
+                       perturb_t, sigma_noise_std):
+    """
+    :param c2w:         (4, 4)                  pose to transform ray direction from cam to world.
+    :param rays_cam:    (someH, someW, 3)       ray directions in camera coordinate, can be random selected
+                                                rows and cols, or some full rows, or an entire image.
+    :param t_vals:      (N_samples)             sample depth along a ray.
+    :param perturb_t:   True/False              perturb t values.
+    :param sigma_noise_std: float               add noise to raw density predictions (sigma).
+    :return:            (someH, someW, 3)       volume rendered images for the input rays.
+    """
+    # KEY 2: sample the 3D volume using estimated poses and intrinsics online.
+    # (H, W, N_sample, 3), (H, W, 3), (H, W, N_sam)
+    sample_pos, _, ray_dir_world, t_vals_noisy = volume_sampling_ndc(c2w, rays_cam, t_vals, ray_params.NEAR,
+                                                                     ray_params.FAR, H, W, fxfy, perturb_t)
+
+    # encode position: (H, W, N_sample, (2L+1)*C = 63)
+    pos_enc = encode_position(sample_pos, levels=ray_params.POS_ENC_FREQ, inc_input=True)
+
+    # encode direction: (H, W, N_sample, (2L+1)*C = 27)
+    ray_dir_world = F.normalize(ray_dir_world, p=2, dim=2)  # (H, W, 3)
+    dir_enc = encode_position(ray_dir_world, levels=ray_params.DIR_ENC_FREQ, inc_input=True)  # (H, W, 27)
+    dir_enc = dir_enc.unsqueeze(2).expand(-1, -1, ray_params.N_SAMPLE, -1)  # (H, W, N_sample, 27)
+
+    # inference rgb and density using position and direction encoding.
+    rgb_density = nerf_model(pos_enc, dir_enc)  # (H, W, N_sample, 4)
+
+    render_result = volume_rendering(rgb_density, t_vals_noisy, sigma_noise_std, rgb_act_fn=torch.sigmoid)
+    rgb_rendered = render_result['rgb']  # (H, W, 3)
+    depth_map = render_result['depth_map']  # (H, W)
+
+    result = {
+        'rgb': rgb_rendered,  # (H, W, 3)
+        'depth_map': depth_map,  # (H, W)
+    }
+
+    return result
+
+
+def train_one_epoch(imgs, H, W, ray_params, opt_nerf, opt_focal,
+                    opt_pose, nerf_model, focal_net, pose_param_net):
+    nerf_model.train()
+    focal_net.train()
+    pose_param_net.train()
+
+    t_vals = torch.linspace(ray_params.NEAR, ray_params.FAR, ray_params.N_SAMPLE,
+                            device='cpu')  # (N_sample,) sample position
+    L2_loss_epoch = []
+
+    # shuffle the training imgs
+    N_IMGS = imgs.shape[0]
+
+    print("N_IMGS = ", N_IMGS, " H = ", H, " W = ", W)
+
+    ids = np.arange(N_IMGS)
+    np.random.shuffle(ids)
+
+    for i in ids:
+        fxfy = focal_net()
+
+        # KEY 1: compute ray directions using estimated intrinsics online.
+        ray_dir_cam = comp_ray_dir_cam_fxfy(H, W, fxfy[0], fxfy[1])
+        img = imgs[i].to('cpu')  # (H, W, 4)
+        c2w = pose_param_net(i)  # (4, 4)
+
+        # sample 32x32 pixel on an image and their rays for training.
+        r_id = torch.randperm(H, device='cpu')[:32]  # (N_select_rows)
+        c_id = torch.randperm(W, device='cpu')[:32]  # (N_select_cols)
+        ray_selected_cam = ray_dir_cam[r_id][:, c_id]  # (N_select_rows, N_select_cols, 3)
+        img_selected = img[r_id][:, c_id]  # (N_select_rows, N_select_cols, 3)
+
+        # render an image using selected rays, pose, sample intervals, and the network
+        render_result = model_render_image(c2w, ray_selected_cam, t_vals, ray_params,
+                                           H, W, fxfy, nerf_model, perturb_t=True, sigma_noise_std=0.0)
+        rgb_rendered = render_result['rgb']  # (N_select_rows, N_select_cols, 3)
+
+        print("SHAPES: ", rgb_rendered.shape, img_selected.shape)
+
+        L2_loss = F.mse_loss(rgb_rendered, img_selected)  # loss for one image
+
+        L2_loss.backward()
+        opt_nerf.step()
+        opt_focal.step()
+        opt_pose.step()
+        opt_nerf.zero_grad()
+        opt_focal.zero_grad()
+        opt_pose.zero_grad()
+
+        L2_loss_epoch.append(L2_loss)
+
+    L2_loss_epoch_mean = torch.stack(L2_loss_epoch).mean().item()
+    return L2_loss_epoch_mean
+
+
+def render_novel_view(c2w, H, W, fxfy, ray_params, nerf_model):
+    nerf_model.eval()
+
+    ray_dir_cam = comp_ray_dir_cam_fxfy(H, W, fxfy[0], fxfy[1])
+    t_vals = torch.linspace(ray_params.NEAR, ray_params.FAR, ray_params.N_SAMPLE,
+                            device='cpu')  # (N_sample,) sample position
+
+    c2w = c2w.to('cpu')  # (4, 4)
+
+    # split an image to rows when the input image resolution is high
+    rays_dir_cam_split_rows = ray_dir_cam.split(10, dim=0)  # input 10 rows each time
+    rendered_img = []
+    rendered_depth = []
+    for rays_dir_rows in rays_dir_cam_split_rows:
+        render_result = model_render_image(c2w, rays_dir_rows, t_vals, ray_params,
+                                           H, W, fxfy, nerf_model,
+                                           perturb_t=False, sigma_noise_std=0.0)
+        rgb_rendered_rows = render_result['rgb']  # (num_rows_eval_img, W, 3)
+        depth_map = render_result['depth_map']  # (num_rows_eval_img, W)
+
+        rendered_img.append(rgb_rendered_rows)
+        rendered_depth.append(depth_map)
+
+    # combine rows to an image
+    rendered_img = torch.cat(rendered_img, dim=0)  # (H, W, 3)
+    rendered_depth = torch.cat(rendered_depth, dim=0)  # (H, W)
+    return rendered_img, rendered_depth
+
+
+def train_model(imgs: torch.Tensor, n_epoch = 1)->Tuple[nn.Module, nn.Module, nn.Module]:
+    # n_epoch = 1 # 200  # set to 1000 to get slightly better results. we use 10K epoch in our paper.
+    EVAL_INTERVAL = 50  # render an image to visualise for every this interval.
+
+    # Initialise all trainabled parameters
+    N_IMGS = imgs.shape[0]
+    H = imgs.shape[1]
+    W = imgs.shape[2]
+    focal_net = LearnFocal(H, W, req_grad=True)
+    pose_param_net = LearnPose(num_cams=N_IMGS, learn_R=True, learn_t=True)
+
+    # Get a tiny NeRF model. Hidden dimension set to 128
+    nerf_model = TinyNerf(pos_in_dims=63, dir_in_dims=27, D=128)
+
+    # Set lr and scheduler: these are just stair-case exponantial decay lr schedulers.
+    opt_nerf = torch.optim.Adam(nerf_model.parameters(), lr=0.001)
+    opt_focal = torch.optim.Adam(focal_net.parameters(), lr=0.001)
+    opt_pose = torch.optim.Adam(pose_param_net.parameters(), lr=0.001)
+
+    from torch.optim.lr_scheduler import MultiStepLR
+    scheduler_nerf = MultiStepLR(opt_nerf, milestones=list(range(0, 10000, 10)), gamma=0.9954)
+    scheduler_focal = MultiStepLR(opt_focal, milestones=list(range(0, 10000, 100)), gamma=0.9)
+    scheduler_pose = MultiStepLR(opt_pose, milestones=list(range(0, 10000, 100)), gamma=0.9)
+
+    # Set tensorboard writer
+    # writer = SummaryWriter(log_dir=os.path.join('logs', scene_name, str(datetime.datetime.now().strftime('%y%m%d_%H%M%S'))))
+
+    # Store poses to visualise them later
+    pose_history = []
+
+    # Training
+    print('Training... Check results in the tensorboard above.')
+    for epoch_i in range(n_epoch):
+        L2_loss = train_one_epoch(imgs, H, W, ray_params, opt_nerf, opt_focal,
+                                  opt_pose, nerf_model, focal_net, pose_param_net)
+        train_psnr = mse2psnr(L2_loss)
+
+        # writer.add_scalar('train/psnr', train_psnr, epoch_i)
+
+        fxfy = focal_net()
+        print('epoch {0:4d} Training PSNR {1:.3f}, estimated fx {2:.1f} fy {3:.1f}'.format(epoch_i, train_psnr, fxfy[0],
+                                                                                           fxfy[1]))
+
+        scheduler_nerf.step()
+        scheduler_focal.step()
+        scheduler_pose.step()
+
+        learned_c2ws = torch.stack([pose_param_net(i) for i in range(N_IMGS)])  # (N, 4, 4)
+        pose_history.append(learned_c2ws[:, :3, 3])  # (N, 3) only store positions as we vis in 2D.
+
+        with torch.no_grad():
+            if (epoch_i + 1) % EVAL_INTERVAL == 0:
+                eval_c2w = torch.eye(4, dtype=torch.float32)  # (4, 4)
+                fxfy = focal_net()
+                rendered_img, rendered_depth = render_novel_view(eval_c2w, H, W, fxfy, ray_params, nerf_model)
+                # writer.add_image('eval/img', rendered_img.permute(2, 0, 1), global_step=epoch_i)
+                # writer.add_image('eval/depth', rendered_depth.unsqueeze(0), global_step=epoch_i)
+
+    pose_history = torch.stack(pose_history).detach().cpu().numpy()  # (n_epoch, N_img, 3)
+    print('Training finished.')
+
+    return nerf_model, focal_net, pose_param_net
+
+
+def normalize(v):
+    """Normalize a vector."""
+    return v / np.linalg.norm(v)
+
+
+def create_spiral_poses(radii, focus_depth, n_poses=120, n_circle=2):
+    """
+    Computes poses that follow a spiral path for rendering purpose.
+    See https://github.com/Fyusion/LLFF/issues/19
+    In particular, the path looks like:
+    https://tinyurl.com/ybgtfns3
+
+    Inputs:
+        radii: (3) radii of the spiral for each axis
+        focus_depth: float, the depth that the spiral poses look at
+        n_poses: int, number of poses to create along the path
+
+    Outputs:
+        poses_spiral: (n_poses, 3, 4) the poses in the spiral path
+    """
+
+    poses_spiral = []
+    for t in np.linspace(0, 2 * np.pi * n_circle, n_poses + 1)[:-1]:  # rotate 4pi (2 rounds)
+        # the parametric function of the spiral (see the interactive web)
+        center = np.array([np.cos(t), -np.sin(t), -np.sin(0.5 * t)]) * radii
+        # center = np.array([np.cos(t), -np.sin(t), -np.sin(t)]) * radii  # for pure zoom in
+
+        # the viewing z axis is the vector pointing from the @focus_depth plane
+        # to @center
+        z = normalize(center - np.array([0, 0, -focus_depth]))
+
+        # compute other axes as in @average_poses
+        y_ = np.array([0, 1, 0])  # (3)
+        x = normalize(np.cross(y_, z))  # (3)
+        y = np.cross(z, x)  # (3)
+
+        poses_spiral += [np.stack([x, y, z, center], 1)]  # (3, 4)
+
+    return np.stack(poses_spiral, 0)  # (n_poses, 3, 4)
+

--- a/kornia/geometry/nerf/from_nerfmm.py
+++ b/kornia/geometry/nerf/from_nerfmm.py
@@ -257,10 +257,7 @@ def train_model(imgs: torch.Tensor, n_epoch = 1, device: str = 'cpu')->Tuple[nn.
                 # writer.add_image('eval/img', rendered_img.permute(2, 0, 1), global_step=epoch_i)
                 # writer.add_image('eval/depth', rendered_depth.unsqueeze(0), global_step=epoch_i)
 
-    if device == 'cpu':
-        pose_history = torch.stack(pose_history).detach().cpu().numpy()  # (n_epoch, N_img, 3)
-    else:
-        pose_history = torch.stack(pose_history).detach().gpu().numpy()  # (n_epoch, N_img, 3)
+    pose_history = torch.stack(pose_history).detach().cpu().numpy()  # (n_epoch, N_img, 3)
     print('Training finished.')
 
     return nerf_model, focal_net, pose_param_net

--- a/kornia/geometry/nerf/nerf.py
+++ b/kornia/geometry/nerf/nerf.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 from torch.optim.lr_scheduler import MultiStepLR
 
-from kornia.geometry.nerf.from_nerfmm import train_model, TinyNerf, train_one_epoch, render_novel_view
+from kornia.geometry.nerf.from_nerfmm import TinyNerf, train_one_epoch, render_novel_view
 from kornia.geometry.nerf.nerfmm.models.intrinsics import LearnFocal
 from kornia.geometry.nerf.nerfmm.models.poses import LearnPose
 from kornia.geometry.nerf.nerfmm.utils.training_utils import mse2psnr
@@ -15,6 +15,7 @@ import os
 import cv2
 import numpy as np
 
+
 class RayParameters:
     def __init__(self):
         self.NEAR, self.FAR = 0.0, 1.0  # ndc near far
@@ -23,10 +24,20 @@ class RayParameters:
         self.DIR_ENC_FREQ = 4  # positional encoding freq for direction
 
 
+class LearnFocals(nn.Module):
+    def __init__(self, h: int, w: int, req_grad: bool):
+        super().__init__()
+        self.fxfy = nn.Parameter(torch.ones(size=(num_cams, 2), dtype=torch.float32), requires_grad=req_grad)
+
+    def forward(self, cam_id):
+        pass
+
+
 class CameraCalibration:
     def __init__(self,
                  nerf_model: nn.Module = TinyNerf(pos_in_dims=63, dir_in_dims=27, D=128),
-                 device: str = 'cpu'):
+                 device: str = 'cpu', checkpoint_path: str = None, checkpoint_save_frequency: int = 1,
+                 n_selected_rays: int = 32):
         self._nerf_model: nn.Module = nerf_model
         self._focal_net: nn.Module = None
         self._pose_param_net: nn.Module = None
@@ -43,8 +54,15 @@ class CameraCalibration:
 
         self._device = device
 
+        self._checkpoint_path = checkpoint_path
+        self._checkpoint_save_frequency = checkpoint_save_frequency
+
+        self._n_selected_rays = n_selected_rays
+
         self._images: torch.Tensor = None
         self._image_filenames: List[str] = None
+
+        self._epoch0 = 0
 
     def load_images(self, path, num_of_images_to_use: int = None):
         images: List[np.array] = []
@@ -53,7 +71,6 @@ class CameraCalibration:
             if num_of_images_to_use is not None and i >= num_of_images_to_use:
                 break
             img_bgr: np.array = cv2.imread(os.path.join(path, filename))
-            img_bgr = img_bgr.astype(np.float32) / 255
             images.append(img_bgr)
 
             self._image_filenames.append(filename)
@@ -71,45 +88,90 @@ class CameraCalibration:
     def get_image_sizes(self) -> Tuple[int, int, int, int]:
         return self._images.shape[0], self._images.shape[1], self._images.shape[2], self._images.shape[3]
 
-    def init_training(self):
-        n_imgs = self._images.shape[0]
-        h = self._images.shape[1]
-        w = self._images.shape[2]
-        self._focal_net = LearnFocal(h, w, req_grad=True)
-        self._pose_param_net = LearnPose(num_cams=n_imgs, learn_R=True, learn_t=True)
-        self._ray_params = RayParameters()
-
-        if self._device == 'cuda':
-            self._focal_net.cuda()
-            self._pose_param_net.cuda()
-            self._nerf_model.cuda()
-
+    def __init_optimizers(self):
         self._opt_nerf: torch.optim.Optimizer = torch.optim.Adam(self._nerf_model.parameters(), lr=0.001)
         self._opt_focal: torch.optim.Optimizer = torch.optim.Adam(self._focal_net.parameters(), lr=0.001)
         self._opt_pose: torch.optim.Optimizer = torch.optim.Adam(self._pose_param_net.parameters(), lr=0.001)
 
+    def init_training(self, load_checkpoint_path=None):
+        n_imgs = self._images.shape[0]
+        h = self._images.shape[1]
+        w = self._images.shape[2]
+
+        self._epoch0 = 0
+        self._focal_net = LearnFocal(h, w, req_grad=True)
+        self._pose_param_net = LearnPose(num_cams=n_imgs, learn_R=True, learn_t=True)
+        if load_checkpoint_path is not None:
+            self.__load_model_checkpoint(load_checkpoint_path)
+
+        else:
+            self.__to_device()
+            self.__init_optimizers()
+
+        # FIXME: Verify how these schedulers work when models and optimizers are loaded from a checkpoint
         self._scheduler_nerf = MultiStepLR(self._opt_nerf, milestones=list(range(0, 10000, 10)), gamma=0.9954)
         self._scheduler_focal = MultiStepLR(self._opt_focal, milestones=list(range(0, 10000, 100)), gamma=0.9)
         self._scheduler_pose = MultiStepLR(self._opt_pose, milestones=list(range(0, 10000, 100)), gamma=0.9)
+
+        self._ray_params = RayParameters()
 
     def run(self, n_epoch: int = 1):
         h = self._images.shape[1]
         w = self._images.shape[2]
 
         # Training
-        for epoch_i in range(n_epoch):
-            l2_loss = train_one_epoch(self._images, h, w, self._ray_params, self._opt_nerf, self._opt_focal,
-                                      self._opt_pose, self._nerf_model, self._focal_net, self._pose_param_net,
+        for epoch_i in range(self._epoch0, self._epoch0 + n_epoch):
+
+            # fxfy = self._focal_net()
+            # print('focals before epoch: {:0.1f}, {:0.1f}'.format(fxfy[0], fxfy[1]))
+
+            l2_loss = train_one_epoch(self._images, h, w, self._ray_params, self._n_selected_rays,
+                                      self._opt_nerf, self._opt_focal, self._opt_pose,
+                                      self._nerf_model, self._focal_net, self._pose_param_net,
                                       self._device)
             train_psnr = mse2psnr(l2_loss)
 
             fxfy = self._focal_net()
-            print('epoch {:4d} Training PSNR {:.3f}, estimated fx {:.1f} fy {:.1f}'.format(epoch_i, train_psnr, fxfy[0],
+            print('epoch {:4d} Training PSNR {:.3f}, estimated fx {:.1f} fy {:.1f}'.format(epoch_i + 1, train_psnr, fxfy[0],
                                                                                            fxfy[1]))
 
             self._scheduler_nerf.step()
             self._scheduler_focal.step()
             self._scheduler_pose.step()
+
+            if self._checkpoint_path is not None and (epoch_i + 1) % self._checkpoint_save_frequency == 0:
+                self.__save_model_checkpoint(epoch_i + 1, train_psnr)
+
+    def __save_model_checkpoint(self, epoch: int, train_psnr: float):
+        print('Saving model checkpoint')
+        torch.save({
+            'epoch': epoch,
+            'nerf_model_state_dict': self._nerf_model.state_dict(),
+            'focal_net_state_dict': self._focal_net.state_dict(),
+            'pose_param_net_state_dict': self._pose_param_net.state_dict(),
+            'nerf_optimizer_state_dict': self._opt_nerf.state_dict(),
+            'focal_optimizer_state_dict': self._opt_focal.state_dict(),
+            'pose_optimizer_state_dict': self._opt_pose.state_dict(),
+            'train_psnr': train_psnr}, self._checkpoint_path)
+
+    def __to_device(self):
+        device = torch.device(self._device)
+        self._nerf_model.to(device)
+        self._focal_net.to(device)
+        self._pose_param_net.to(device)
+
+    def __load_model_checkpoint(self, load_checkpoint_path: str):
+        device = torch.device(self._device)
+        checkpoint = torch.load(load_checkpoint_path)
+        self._nerf_model.load_state_dict(checkpoint['nerf_model_state_dict'])
+        self._focal_net.load_state_dict(checkpoint['focal_net_state_dict'])
+        self._pose_param_net.load_state_dict(checkpoint['pose_param_net_state_dict'])
+        self.__to_device()
+        self.__init_optimizers()
+        self._opt_nerf.load_state_dict(checkpoint['nerf_optimizer_state_dict'])
+        self._opt_focal.load_state_dict(checkpoint['focal_optimizer_state_dict'])
+        self._opt_pose.load_state_dict(checkpoint['pose_optimizer_state_dict'])
+        self._epoch0 = checkpoint['epoch']
 
     def model(self) -> nn.Module:
         return self._nerf_model
@@ -120,6 +182,18 @@ class CameraCalibration:
 
     def pose(self, camera_id: int):
         return self._pose_param_net(camera_id)
+
+    def camera_matrix(self, camera_id: int) -> torch.Tensor:
+        device = torch.device('cpu')
+        rt = self.pose(camera_id).to(device)
+        rt = rt[0:3]
+        fxfy = self._focal_net().to(device)
+        h = self._images.shape[1]
+        w = self._images.shape[2]
+        k = torch.tensor([[fxfy[0], 0,       h / 2],
+                          [0,       fxfy[1], w / 2],
+                          [0,       0,       1]])
+        return torch.matmul(k, rt)
 
     def n_epoch(self) -> int:
         return self._n_epoch
@@ -140,7 +214,7 @@ class MyTestCase(unittest.TestCase):
     def test_nerf(self):
         x = CameraCalibration()
         images = torch.rand(2, 40, 50, 3)
-        x.add_images(images)
+        x.set_images(images)
         x.init_training()
         x.run(n_epoch=2)
 

--- a/kornia/geometry/nerf/nerf.py
+++ b/kornia/geometry/nerf/nerf.py
@@ -25,19 +25,38 @@ class RayParameters:
 
 
 class LearnFocals(nn.Module):
-    def __init__(self, h: int, w: int, req_grad: bool):
+    def __init__(self, h: int, w: int, num_cams: int, req_grad: bool, multi_focal: bool):
         super().__init__()
-        self.fxfy = nn.Parameter(torch.ones(size=(num_cams, 2), dtype=torch.float32), requires_grad=req_grad)
+        self.__h = h
+        self.__w = w
+        self.__multi_focal = multi_focal
+        if multi_focal:
+            self.__fxfy = \
+                nn.Parameter(torch.tensor(torch.ones(size=(num_cams, 2)), dtype=torch.float32), requires_grad=req_grad)
+        else:
+            self.__fxfy = \
+                nn.Parameter(torch.tensor(torch.ones(size=(1, 2)), dtype=torch.float32), requires_grad=req_grad)
 
     def forward(self, cam_id):
-        pass
+        if self.__multi_focal:
+            fx = self.__fxfy[cam_id][0]
+            fy = self.__fxfy[cam_id][1]
+        else:
+            fx = self.__fxfy[0][0]
+            fy = self.__fxfy[0][1]
+        fxfy = torch.stack([fx**2 * self.__w, fy**2 * self.__h])
+        return fxfy
+
+    def is_multi_focal(self):
+        return self.__multi_focal
 
 
 class CameraCalibration:
     def __init__(self,
                  nerf_model: nn.Module = TinyNerf(pos_in_dims=63, dir_in_dims=27, D=128),
                  device: str = 'cpu', checkpoint_path: str = None, checkpoint_save_frequency: int = 1,
-                 n_selected_rays: int = 32):
+                 n_selected_rays: int = 32,
+                 lr: float = 0.001):
         self._nerf_model: nn.Module = nerf_model
         self._focal_net: nn.Module = None
         self._pose_param_net: nn.Module = None
@@ -58,6 +77,10 @@ class CameraCalibration:
         self._checkpoint_save_frequency = checkpoint_save_frequency
 
         self._n_selected_rays = n_selected_rays
+
+        self._lr = lr
+
+        self._multi_focal: bool = None
 
         self._images: torch.Tensor = None
         self._image_filenames: List[str] = None
@@ -88,25 +111,41 @@ class CameraCalibration:
     def get_image_sizes(self) -> Tuple[int, int, int, int]:
         return self._images.shape[0], self._images.shape[1], self._images.shape[2], self._images.shape[3]
 
-    def __init_optimizers(self):
-        self._opt_nerf: torch.optim.Optimizer = torch.optim.Adam(self._nerf_model.parameters(), lr=0.001)
-        self._opt_focal: torch.optim.Optimizer = torch.optim.Adam(self._focal_net.parameters(), lr=0.001)
-        self._opt_pose: torch.optim.Optimizer = torch.optim.Adam(self._pose_param_net.parameters(), lr=0.001)
-
-    def init_training(self, load_checkpoint_path=None):
+    def __init_camera_models(self, multi_focal: bool):
         n_imgs = self._images.shape[0]
         h = self._images.shape[1]
         w = self._images.shape[2]
-
-        self._epoch0 = 0
-        self._focal_net = LearnFocal(h, w, req_grad=True)
+        self._focal_net = LearnFocals(h, w, n_imgs, req_grad=True, multi_focal=multi_focal)
         self._pose_param_net = LearnPose(num_cams=n_imgs, learn_R=True, learn_t=True)
+
+    def __init_optimizers(self):     # FIXME: handle learning rate parameterization properly
+        self._opt_nerf: torch.optim.Optimizer = torch.optim.Adam(self._nerf_model.parameters(), lr=self._lr)
+        self._opt_focal: torch.optim.Optimizer = torch.optim.Adam(self._focal_net.parameters(), lr=self._lr)
+        self._opt_pose: torch.optim.Optimizer = torch.optim.Adam(self._pose_param_net.parameters(), lr=self._lr)
+
+    def __reset_nerf(self):
+        for layer in self._nerf_model.children():
+            if hasattr(layer, 'reset_parameters'):
+                layer.reset_parameters()
+
+    def init_training(self, load_checkpoint_path=None, reset_only_nerf=False, multi_focal=True):
+        if reset_only_nerf and (not self._focal_net or not self._pose_param_net):
+            raise RuntimeError('Cannot reset only Nerf model parameters if camera models were not instantiated')
+        self._epoch0 = 0
+
         if load_checkpoint_path is not None:
             self.__load_model_checkpoint(load_checkpoint_path)
 
         else:
+            if not reset_only_nerf:
+                self.__init_camera_models(multi_focal)
+                self._multi_focal = multi_focal
+            self.__reset_nerf()
             self.__to_device()
             self.__init_optimizers()
+
+        if reset_only_nerf:
+            self.__reset_nerf()
 
         # FIXME: Verify how these schedulers work when models and optimizers are loaded from a checkpoint
         self._scheduler_nerf = MultiStepLR(self._opt_nerf, milestones=list(range(0, 10000, 10)), gamma=0.9954)
@@ -131,9 +170,14 @@ class CameraCalibration:
                                       self._device)
             train_psnr = mse2psnr(l2_loss)
 
-            fxfy = self._focal_net()
-            print('epoch {:4d} Training PSNR {:.3f}, estimated fx {:.1f} fy {:.1f}'.format(epoch_i + 1, train_psnr, fxfy[0],
-                                                                                           fxfy[1]))
+            fxfy = self._focal_net(0)
+            if not self._focal_net.is_multi_focal():
+                print('epoch {:4d} Training PSNR {:.3f}, estimated fx {:.1f} fy {:.1f}'
+                      .format(epoch_i + 1, train_psnr, fxfy[0], fxfy[1]))
+            else:
+                fxfy2 = self._focal_net(1)
+                print('epoch {:4d} Training PSNR {:.3f}, estimated fx {:.1f} fy {:.1f}; fx {:.1f} fy {:.1f}'
+                      .format(epoch_i + 1, train_psnr, fxfy[0], fxfy[1], fxfy2[0], fxfy2[1]))
 
             self._scheduler_nerf.step()
             self._scheduler_focal.step()
@@ -147,6 +191,7 @@ class CameraCalibration:
         torch.save({
             'epoch': epoch,
             'nerf_model_state_dict': self._nerf_model.state_dict(),
+            'multi_focal': self._multi_focal,
             'focal_net_state_dict': self._focal_net.state_dict(),
             'pose_param_net_state_dict': self._pose_param_net.state_dict(),
             'nerf_optimizer_state_dict': self._opt_nerf.state_dict(),
@@ -161,9 +206,10 @@ class CameraCalibration:
         self._pose_param_net.to(device)
 
     def __load_model_checkpoint(self, load_checkpoint_path: str):
-        device = torch.device(self._device)
         checkpoint = torch.load(load_checkpoint_path)
         self._nerf_model.load_state_dict(checkpoint['nerf_model_state_dict'])
+        self._multi_focal = checkpoint['multi_focal']
+        self.__init_camera_models(self._multi_focal)
         self._focal_net.load_state_dict(checkpoint['focal_net_state_dict'])
         self._pose_param_net.load_state_dict(checkpoint['pose_param_net_state_dict'])
         self.__to_device()
@@ -176,8 +222,8 @@ class CameraCalibration:
     def model(self) -> nn.Module:
         return self._nerf_model
 
-    def focals(self) -> Tuple[float, float]:
-        fxfy = self._focal_net()
+    def focals(self, camera_id: int) -> Tuple[float, float]:
+        fxfy = self._focal_net(camera_id)
         return fxfy[0], fxfy[1]
 
     def pose(self, camera_id: int):
@@ -187,7 +233,7 @@ class CameraCalibration:
         device = torch.device('cpu')
         rt = self.pose(camera_id).to(device)
         rt = rt[0:3]
-        fxfy = self._focal_net().to(device)
+        fxfy = self._focal_net(camera_id).to(device)
         h = self._images.shape[1]
         w = self._images.shape[2]
         k = torch.tensor([[fxfy[0], 0,       h / 2],
@@ -199,7 +245,7 @@ class CameraCalibration:
         return self._n_epoch
 
     def render_image_from_training_set(self, camera_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
-        fxfy = self._focal_net()
+        fxfy = self._focal_net(camera_id)
         h = self._images.shape[1]
         w = self._images.shape[2]
         c2w = self._pose_param_net(camera_id)
@@ -210,17 +256,86 @@ class CameraCalibration:
         return rendered_img, rendered_depth
 
 
+def initialize_nerf_object_for_testing(checkpoint_path: str = None) -> CameraCalibration:
+    x = CameraCalibration(checkpoint_path = checkpoint_path)
+    images = torch.rand(3, 40, 50, 3)
+    x.set_images(images)
+    return x
+
+def equal_models(model1: nn.Module, model2: nn.Module) -> bool:
+    models_equal = True
+    for p1, p2 in zip(model1.parameters(), model2.parameters()):
+        if p1.data.ne(p2.data).sum() > 0:
+            models_equal = False
+            break
+    return models_equal
+
+import copy
+
+
 class MyTestCase(unittest.TestCase):
     def test_nerf(self):
         x = CameraCalibration()
-        images = torch.rand(2, 40, 50, 3)
+        images = torch.rand(3, 40, 50, 3)
         x.set_images(images)
         x.init_training()
-        x.run(n_epoch=2)
+        x.run(n_epoch=5)
 
         img, depth = x.render_image_from_training_set(1)
         print(img.shape, depth.shape)
 
+    def test_initialize_and_run(self):
+        x = initialize_nerf_object_for_testing()
+        x.init_training()
+        x.run(n_epoch=2)
+
+    def test_initialize_from_checkpoint(self):
+        checkpoint_path = os.path.join(os.getcwd(), 'checkpoint')
+        x = initialize_nerf_object_for_testing(checkpoint_path=checkpoint_path)
+        x.init_training()
+        x.run(n_epoch=2)
+        fxfy = x.focals(0)
+        pose = x.pose(0)
+
+        x = initialize_nerf_object_for_testing()
+        x.init_training(load_checkpoint_path=checkpoint_path)
+        fxfy_after_load = x.focals(0)
+        self.assertEqual(fxfy, fxfy_after_load)
+        pose_after_load = x.pose(0)
+        self.assertTrue(torch.Tensor.equal(pose, pose_after_load))
+
+    def test_initialize_only_nerf_and_run(self):
+        x = initialize_nerf_object_for_testing()
+        with self.assertRaises(RuntimeError):
+            x.init_training(reset_only_nerf=True)
+        x.init_training()
+        x.run(n_epoch=2)
+        fxfy = x.focals(0)
+        pose = x.pose(0)
+        model = copy.deepcopy(x.model())
+
+        x.init_training(reset_only_nerf=True)
+
+        fxfy_after_reset = x.focals(0)
+        self.assertEqual(fxfy, fxfy_after_reset)
+        pose_after_reset = x.pose(0)
+        self.assertTrue(torch.Tensor.equal(pose, pose_after_reset))
+        model_after_reset = x.model()
+
+        self.assertFalse(equal_models(model, model_after_reset))
+
+    def test_initialize_run_and_initialize(self):
+        x = initialize_nerf_object_for_testing()
+        x.init_training()
+        x.run(n_epoch=2)
+        model = copy.deepcopy(x.model())
+
+        x.init_training()
+        model_after_init = x.model()
+
+        self.assertFalse(equal_models(model, model_after_init))
+
 
 if __name__ == '__main__':
     unittest.main()
+    # MyTestCase().test_initialize_run_and_initialize()

--- a/kornia/geometry/nerf/nerf.py
+++ b/kornia/geometry/nerf/nerf.py
@@ -4,10 +4,11 @@ from typing import Tuple
 
 from kornia.geometry.nerf.from_nerfmm import train_model
 import torch.nn as nn
+from enum import Enum
 
 
 class CameraCalibration:
-    def __init__(self, nerf_model: torch.nn.Module, n_epoch: int = 1):
+    def __init__(self, nerf_model: torch.nn.Module, n_epoch: int = 1, device: str = 'cpu'):
         self._nerf_model = nerf_model
         self._images: torch.Tensor = None
         self._nerf_model: nn.Module = None
@@ -15,13 +16,14 @@ class CameraCalibration:
         self._pose_param_net: nn.Module = None
 
         self._n_epoch = n_epoch
+        self._device = device
 
     def add_images(self, images: torch.Tensor):
         self._images = images
 
     def run(self):
         self._nerf_model, self._focal_net, self._pose_param_net = \
-            train_model(self._images, n_epoch = self._n_epoch)
+            train_model(self._images, n_epoch = self._n_epoch, device = self._device)
 
     def model(self) -> nn.Module:
         return self._nerf_model

--- a/kornia/geometry/nerf/nerf.py
+++ b/kornia/geometry/nerf/nerf.py
@@ -1,30 +1,115 @@
 import unittest
-from enum import Enum
 from typing import Tuple
 
 import torch
 import torch.nn as nn
+from torch.optim.lr_scheduler import MultiStepLR
 
-from kornia.geometry.nerf.from_nerfmm import train_model
+from kornia.geometry.nerf.from_nerfmm import train_model, TinyNerf, train_one_epoch, render_novel_view
+from kornia.geometry.nerf.nerfmm.models.intrinsics import LearnFocal
+from kornia.geometry.nerf.nerfmm.models.poses import LearnPose
+from kornia.geometry.nerf.nerfmm.utils.training_utils import mse2psnr
+from kornia.utils import image_list_to_tensor
+
+import os
+import cv2
+import numpy as np
+
+class RayParameters:
+    def __init__(self):
+        self.NEAR, self.FAR = 0.0, 1.0  # ndc near far
+        self.N_SAMPLE = 128  # samples per ray
+        self.POS_ENC_FREQ = 10  # positional encoding freq for location
+        self.DIR_ENC_FREQ = 4  # positional encoding freq for direction
 
 
 class CameraCalibration:
-    def __init__(self, nerf_model: torch.nn.Module, n_epoch: int = 1, device: str = 'cpu'):
-        self._nerf_model = nerf_model
-        self._images: torch.Tensor = None
-        self._nerf_model: nn.Module = None
+    def __init__(self,
+                 nerf_model: nn.Module = TinyNerf(pos_in_dims=63, dir_in_dims=27, D=128),
+                 device: str = 'cpu'):
+        self._nerf_model: nn.Module = nerf_model
         self._focal_net: nn.Module = None
         self._pose_param_net: nn.Module = None
 
-        self._n_epoch = n_epoch
+        self._ray_params: RayParameters = None
+
+        self._opt_nerf: torch.optim.Optimizer = None
+        self._opt_focal: torch.optim.Optimizer = None
+        self._opt_pose: torch.optim.Optimizer = None
+
+        self._scheduler_nerf: MultiStepLR = None
+        self._scheduler_focal: MultiStepLR = None
+        self._scheduler_pose: MultiStepLR = None
+
         self._device = device
 
-    def add_images(self, images: torch.Tensor):
+        self._images: torch.Tensor = None
+        self._image_filenames: List[str] = None
+
+    def load_images(self, path, num_of_images_to_use: int = None):
+        images: List[np.array] = []
+        self._image_filenames: List[str] = []
+        for i, filename in enumerate(os.listdir(path)):
+            if num_of_images_to_use is not None and i >= num_of_images_to_use:
+                break
+            img_bgr: np.array = cv2.imread(os.path.join(path, filename))
+            img_bgr = img_bgr.astype(np.float32) / 255
+            images.append(img_bgr)
+
+            self._image_filenames.append(filename)
+        self._images = image_list_to_tensor(images)
+
+        # FIXME: This part needs to be removed. It is here because the convension in NERFMM is (B, H, W, C), and in Kornia it is (B, C, H, W)
+        self._images = self._images.permute(0, 2, 3, 1)
+
+    def get_image_filenames(self, camera_id: int) -> str:
+        return self._image_filenames[camera_id]
+
+    def set_images(self, images: torch.Tensor):
         self._images = images
 
-    def run(self):
-        self._nerf_model, self._focal_net, self._pose_param_net = \
-            train_model(self._images, n_epoch = self._n_epoch, device = self._device)
+    def get_image_sizes(self) -> Tuple[int, int, int, int]:
+        return self._images.shape[0], self._images.shape[1], self._images.shape[2], self._images.shape[3]
+
+    def init_training(self):
+        n_imgs = self._images.shape[0]
+        h = self._images.shape[1]
+        w = self._images.shape[2]
+        self._focal_net = LearnFocal(h, w, req_grad=True)
+        self._pose_param_net = LearnPose(num_cams=n_imgs, learn_R=True, learn_t=True)
+        self._ray_params = RayParameters()
+
+        if self._device == 'cuda':
+            self._focal_net.cuda()
+            self._pose_param_net.cuda()
+            self._nerf_model.cuda()
+
+        self._opt_nerf: torch.optim.Optimizer = torch.optim.Adam(self._nerf_model.parameters(), lr=0.001)
+        self._opt_focal: torch.optim.Optimizer = torch.optim.Adam(self._focal_net.parameters(), lr=0.001)
+        self._opt_pose: torch.optim.Optimizer = torch.optim.Adam(self._pose_param_net.parameters(), lr=0.001)
+
+        self._scheduler_nerf = MultiStepLR(self._opt_nerf, milestones=list(range(0, 10000, 10)), gamma=0.9954)
+        self._scheduler_focal = MultiStepLR(self._opt_focal, milestones=list(range(0, 10000, 100)), gamma=0.9)
+        self._scheduler_pose = MultiStepLR(self._opt_pose, milestones=list(range(0, 10000, 100)), gamma=0.9)
+
+    def run(self, n_epoch: int = 1):
+        h = self._images.shape[1]
+        w = self._images.shape[2]
+
+        # Training
+        for epoch_i in range(n_epoch):
+            l2_loss = train_one_epoch(self._images, h, w, self._ray_params, self._opt_nerf, self._opt_focal,
+                                      self._opt_pose, self._nerf_model, self._focal_net, self._pose_param_net,
+                                      self._device)
+            train_psnr = mse2psnr(l2_loss)
+
+            fxfy = self._focal_net()
+            print('epoch {:4d} Training PSNR {:.3f}, estimated fx {:.1f} fy {:.1f}'.format(epoch_i, train_psnr, fxfy[0],
+                                                                                           fxfy[1]))
+
+            self._scheduler_nerf.step()
+            self._scheduler_focal.step()
+            self._scheduler_pose.step()
 
     def model(self) -> nn.Module:
         return self._nerf_model
@@ -39,9 +124,28 @@ class CameraCalibration:
     def n_epoch(self) -> int:
         return self._n_epoch
 
+    def render_image_from_training_set(self, camera_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        fxfy = self._focal_net()
+        h = self._images.shape[1]
+        w = self._images.shape[2]
+        c2w = self._pose_param_net(camera_id)
+        with torch.no_grad():
+            rendered_img, rendered_depth = render_novel_view(c2w, h, w, fxfy, self._ray_params, self._nerf_model,
+                                                             self._device)
+        rendered_img = rendered_img[:, :, [2, 1, 0]]
+        return rendered_img, rendered_depth
+
+
 class MyTestCase(unittest.TestCase):
-    def test_something(self):
-        self.assertEqual(True, True)
+    def test_nerf(self):
+        x = CameraCalibration()
+        images = torch.rand(2, 40, 50, 3)
+        x.add_images(images)
+        x.init_training()
+        x.run(n_epoch=2)
+
+        img, depth = x.render_image_from_training_set(1)
+        print(img.shape, depth.shape)
 
 
 if __name__ == '__main__':

--- a/kornia/geometry/nerf/nerf.py
+++ b/kornia/geometry/nerf/nerf.py
@@ -1,0 +1,45 @@
+import unittest
+import torch
+from typing import Tuple
+
+from kornia.geometry.nerf.from_nerfmm import train_model
+import torch.nn as nn
+
+
+class CameraCalibration:
+    def __init__(self, nerf_model: torch.nn.Module, n_epoch: int = 1):
+        self._nerf_model = nerf_model
+        self._images: torch.Tensor = None
+        self._nerf_model: nn.Module = None
+        self._focal_net: nn.Module = None
+        self._pose_param_net: nn.Module = None
+
+        self._n_epoch = n_epoch
+
+    def add_images(self, images: torch.Tensor):
+        self._images = images
+
+    def run(self):
+        self._nerf_model, self._focal_net, self._pose_param_net = \
+            train_model(self._images, n_epoch = self._n_epoch)
+
+    def model(self) -> nn.Module:
+        return self._nerf_model
+
+    def focals(self) -> Tuple[float, float]:
+        fxfy = self._focal_net()
+        return fxfy[0], fxfy[1]
+
+    def pose(self, camera_id: int):
+        return self._pose_param_net(camera_id)
+
+    def n_epoch(self) -> int:
+        return self._n_epoch
+
+class MyTestCase(unittest.TestCase):
+    def test_something(self):
+        self.assertEqual(True, True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/kornia/geometry/nerf/nerfmm/models/intrinsics.py
+++ b/kornia/geometry/nerf/nerfmm/models/intrinsics.py
@@ -1,0 +1,58 @@
+import torch
+import torch.nn as nn
+import numpy as np
+
+
+class LearnFocal(nn.Module):
+    def __init__(self, H, W, req_grad, fx_only = False, order=2, init_focal=None):
+        super(LearnFocal, self).__init__()
+        self.H = H
+        self.W = W
+        self.fx_only = fx_only  # If True, output [fx, fx]. If False, output [fx, fy]
+        self.order = order  # check our supplementary section.
+
+        if self.fx_only:
+            if init_focal is None:
+                self.fx = nn.Parameter(torch.tensor(1.0, dtype=torch.float32), requires_grad=req_grad)  # (1, )
+            else:
+                if self.order == 2:
+                    # a**2 * W = fx  --->  a**2 = fx / W
+                    coe_x = torch.tensor(np.sqrt(init_focal / float(W)), requires_grad=False).float()
+                elif self.order == 1:
+                    # a * W = fx  --->  a = fx / W
+                    coe_x = torch.tensor(init_focal / float(W), requires_grad=False).float()
+                else:
+                    print('Focal init order need to be 1 or 2. Exit')
+                    exit()
+                self.fx = nn.Parameter(coe_x, requires_grad=req_grad)  # (1, )
+        else:
+            if init_focal is None:
+                self.fx = nn.Parameter(torch.tensor(1.0, dtype=torch.float32), requires_grad=req_grad)  # (1, )
+                self.fy = nn.Parameter(torch.tensor(1.0, dtype=torch.float32), requires_grad=req_grad)  # (1, )
+            else:
+                if self.order == 2:
+                    # a**2 * W = fx  --->  a**2 = fx / W
+                    coe_x = torch.tensor(np.sqrt(init_focal / float(W)), requires_grad=False).float()
+                    coe_y = torch.tensor(np.sqrt(init_focal / float(H)), requires_grad=False).float()
+                elif self.order == 1:
+                    # a * W = fx  --->  a = fx / W
+                    coe_x = torch.tensor(init_focal / float(W), requires_grad=False).float()
+                    coe_y = torch.tensor(init_focal / float(H), requires_grad=False).float()
+                else:
+                    print('Focal init order need to be 1 or 2. Exit')
+                    exit()
+                self.fx = nn.Parameter(coe_x, requires_grad=req_grad)  # (1, )
+                self.fy = nn.Parameter(coe_y, requires_grad=req_grad)  # (1, )
+
+    def forward(self, i=None):  # the i=None is just to enable multi-gpu training
+        if self.fx_only:
+            if self.order == 2:
+                fxfy = torch.stack([self.fx ** 2 * self.W, self.fx ** 2 * self.W])
+            else:
+                fxfy = torch.stack([self.fx * self.W, self.fx * self.W])
+        else:
+            if self.order == 2:
+                fxfy = torch.stack([self.fx**2 * self.W, self.fy**2 * self.H])
+            else:
+                fxfy = torch.stack([self.fx * self.W, self.fy * self.H])
+        return fxfy

--- a/kornia/geometry/nerf/nerfmm/models/poses.py
+++ b/kornia/geometry/nerf/nerfmm/models/poses.py
@@ -1,0 +1,32 @@
+import torch
+import torch.nn as nn
+from kornia.geometry.nerf.nerfmm.utils.lie_group_helper import make_c2w
+
+
+class LearnPose(nn.Module):
+    def __init__(self, num_cams, learn_R, learn_t, init_c2w=None):
+        """
+        :param num_cams:
+        :param learn_R:  True/False
+        :param learn_t:  True/False
+        :param init_c2w: (N, 4, 4) torch tensor
+        """
+        super(LearnPose, self).__init__()
+        self.num_cams = num_cams
+        self.init_c2w = None
+        if init_c2w is not None:
+            self.init_c2w = nn.Parameter(init_c2w, requires_grad=False)
+
+        self.r = nn.Parameter(torch.zeros(size=(num_cams, 3), dtype=torch.float32), requires_grad=learn_R)  # (N, 3)
+        self.t = nn.Parameter(torch.zeros(size=(num_cams, 3), dtype=torch.float32), requires_grad=learn_t)  # (N, 3)
+
+    def forward(self, cam_id):
+        r = self.r[cam_id]  # (3, ) axis-angle
+        t = self.t[cam_id]  # (3, )
+        c2w = make_c2w(r, t)  # (4, 4)
+
+        # learn a delta pose between init pose and target pose, if a init pose is provided
+        if self.init_c2w is not None:
+            c2w = c2w @ self.init_c2w[cam_id]
+
+        return c2w

--- a/kornia/geometry/nerf/nerfmm/utils/comp_ray_dir.py
+++ b/kornia/geometry/nerf/nerfmm/utils/comp_ray_dir.py
@@ -1,0 +1,43 @@
+import torch
+
+
+def comp_ray_dir_cam(H, W, focal):
+    """Compute ray directions in the camera coordinate, which only depends on intrinsics.
+    This could be further transformed to world coordinate later, using camera poses.
+    :return: (H, W, 3) torch.float32
+    """
+    y, x = torch.meshgrid(torch.arange(H, dtype=torch.float32),
+                          torch.arange(W, dtype=torch.float32))  # (H, W)
+
+    # Use OpenGL coordinate in 3D:
+    #   x points to right
+    #   y points to up
+    #   z points to backward
+    #
+    # The coordinate of the top left corner of an image should be (-0.5W, 0.5H, -1.0).
+    dirs_x = (x - 0.5*W) / focal  # (H, W)
+    dirs_y = -(y - 0.5*H) / focal  # (H, W)
+    dirs_z = -torch.ones(H, W, dtype=torch.float32)  # (H, W)
+    rays_dir = torch.stack([dirs_x, dirs_y, dirs_z], dim=-1)  # (H, W, 3)
+    return rays_dir
+
+
+def comp_ray_dir_cam_fxfy(H, W, fx, fy):
+    """Compute ray directions in the camera coordinate, which only depends on intrinsics.
+    This could be further transformed to world coordinate later, using camera poses.
+    :return: (H, W, 3) torch.float32
+    """
+    y, x = torch.meshgrid(torch.arange(H, dtype=torch.float32, device=fx.device),
+                          torch.arange(W, dtype=torch.float32, device=fx.device))  # (H, W)
+
+    # Use OpenGL coordinate in 3D:
+    #   x points to right
+    #   y points to up
+    #   z points to backward
+    #
+    # The coordinate of the top left corner of an image should be (-0.5W, 0.5H, -1.0).
+    dirs_x = (x - 0.5*W) / fx  # (H, W)
+    dirs_y = -(y - 0.5*H) / fy  # (H, W)
+    dirs_z = -torch.ones(H, W, dtype=torch.float32, device=fx.device)  # (H, W)
+    rays_dir = torch.stack([dirs_x, dirs_y, dirs_z], dim=-1)  # (H, W, 3)
+    return rays_dir

--- a/kornia/geometry/nerf/nerfmm/utils/lie_group_helper.py
+++ b/kornia/geometry/nerf/nerfmm/utils/lie_group_helper.py
@@ -1,0 +1,81 @@
+import numpy as np
+import torch
+from scipy.spatial.transform import Rotation as RotLib
+
+
+def SO3_to_quat(R):
+    """
+    :param R:  (N, 3, 3) or (3, 3) np
+    :return:   (N, 4, ) or (4, ) np
+    """
+    x = RotLib.from_matrix(R)
+    quat = x.as_quat()
+    return quat
+
+
+def quat_to_SO3(quat):
+    """
+    :param quat:    (N, 4, ) or (4, ) np
+    :return:        (N, 3, 3) or (3, 3) np
+    """
+    x = RotLib.from_quat(quat)
+    R = x.as_matrix()
+    return R
+
+
+def convert3x4_4x4(input):
+    """
+    :param input:  (N, 3, 4) or (3, 4) torch or np
+    :return:       (N, 4, 4) or (4, 4) torch or np
+    """
+    if torch.is_tensor(input):
+        if len(input.shape) == 3:
+            output = torch.cat([input, torch.zeros_like(input[:, 0:1])], dim=1)  # (N, 4, 4)
+            output[:, 3, 3] = 1.0
+        else:
+            output = torch.cat([input, torch.tensor([[0,0,0,1]], dtype=input.dtype, device=input.device)], dim=0)  # (4, 4)
+    else:
+        if len(input.shape) == 3:
+            output = np.concatenate([input, np.zeros_like(input[:, 0:1])], axis=1)  # (N, 4, 4)
+            output[:, 3, 3] = 1.0
+        else:
+            output = np.concatenate([input, np.array([[0,0,0,1]], dtype=input.dtype)], axis=0)  # (4, 4)
+            output[3, 3] = 1.0
+    return output
+
+
+def vec2skew(v):
+    """
+    :param v:  (3, ) torch tensor
+    :return:   (3, 3)
+    """
+    zero = torch.zeros(1, dtype=torch.float32, device=v.device)
+    skew_v0 = torch.cat([ zero,    -v[2:3],   v[1:2]])  # (3, 1)
+    skew_v1 = torch.cat([ v[2:3],   zero,    -v[0:1]])
+    skew_v2 = torch.cat([-v[1:2],   v[0:1],   zero])
+    skew_v = torch.stack([skew_v0, skew_v1, skew_v2], dim=0)  # (3, 3)
+    return skew_v  # (3, 3)
+
+
+def Exp(r):
+    """so(3) vector to SO(3) matrix
+    :param r: (3, ) axis-angle, torch tensor
+    :return:  (3, 3)
+    """
+    skew_r = vec2skew(r)  # (3, 3)
+    norm_r = r.norm() + 1e-15
+    eye = torch.eye(3, dtype=torch.float32, device=r.device)
+    R = eye + (torch.sin(norm_r) / norm_r) * skew_r + ((1 - torch.cos(norm_r)) / norm_r**2) * (skew_r @ skew_r)
+    return R
+
+
+def make_c2w(r, t):
+    """
+    :param r:  (3, ) axis-angle             torch tensor
+    :param t:  (3, ) translation vector     torch tensor
+    :return:   (4, 4)
+    """
+    R = Exp(r)  # (3, 3)
+    c2w = torch.cat([R, t.unsqueeze(1)], dim=1)  # (3, 4)
+    c2w = convert3x4_4x4(c2w)  # (4, 4)
+    return c2w

--- a/kornia/geometry/nerf/nerfmm/utils/pos_enc.py
+++ b/kornia/geometry/nerf/nerfmm/utils/pos_enc.py
@@ -1,0 +1,24 @@
+import torch
+
+
+def encode_position(input, levels, inc_input):
+    """
+    For each scalar, we encode it using a series of sin() and cos() functions with different frequency.
+        - With L pairs of sin/cos function, each scalar is encoded to a vector that has 2L elements. Concatenating with
+          itself results in 2L+1 elements.
+        - With C channels, we get C(2L+1) channels output.
+
+    :param input:   (..., C)            torch.float32
+    :param levels:  scalar L            int
+    :return:        (..., C*(2L+1))     torch.float32
+    """
+
+    # this is already doing 'log_sampling' in the official code.
+    result_list = [input] if inc_input else []
+    for i in range(levels):
+        temp = 2.0**i * input  # (..., C)
+        result_list.append(torch.sin(temp))  # (..., C)
+        result_list.append(torch.cos(temp))  # (..., C)
+
+    result_list = torch.cat(result_list, dim=-1)  # (..., C*(2L+1)) The list has (2L+1) elements, with (..., C) shape each.
+    return result_list  # (..., C*(2L+1))

--- a/kornia/geometry/nerf/nerfmm/utils/training_utils.py
+++ b/kornia/geometry/nerf/nerfmm/utils/training_utils.py
@@ -1,0 +1,65 @@
+import os
+
+import numpy as np
+import random
+import torch
+
+
+def is_DataParallelModel(model):
+    """
+    :param model:   nn.Module or torch.nn.DataParallel(model)
+    :return:        True/False
+    """
+    return hasattr(model, 'module')
+
+
+
+def set_randomness(args):
+    if args.true_rand is False:
+        random.seed(args.rand_seed)
+        np.random.seed(args.rand_seed)
+        torch.manual_seed(args.rand_seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
+def mse2psnr(mse):
+    """
+    :param mse: scalar
+    :return:    scalar np.float32
+    """
+    mse = np.maximum(mse, 1e-10)  # avoid -inf or nan when mse is very small.
+    psnr = -10.0 * np.log10(mse)
+    return psnr.astype(np.float32)
+
+
+def save_checkpoint(epoch, model, optimizer, path, ckpt_name='checkpoint'):
+    savepath = os.path.join(path, ckpt_name+'.pth')
+
+    if is_DataParallelModel(model):
+        model_state = model.module.state_dict()
+    else:
+        model_state = model.state_dict()
+
+    state = {
+        'epoch': epoch,
+        'model_state_dict': model_state,
+        'optimizer_state_dict': optimizer.state_dict(),
+    }
+    torch.save(state, savepath)
+
+
+def load_ckpt_to_net(ckpt_path, net, map_location=None, strict=True):
+    if map_location is None:
+        ckpt = torch.load(ckpt_path)
+    else:
+        ckpt = torch.load(ckpt_path, map_location=map_location)
+
+    weights = ckpt['model_state_dict']
+
+    if is_DataParallelModel(net):
+        net.module.load_state_dict(weights, strict=strict)
+    else:
+        net.load_state_dict(weights, strict=strict)
+
+    return net

--- a/kornia/geometry/nerf/nerfmm/utils/volume_op.py
+++ b/kornia/geometry/nerf/nerfmm/utils/volume_op.py
@@ -1,0 +1,217 @@
+import torch
+
+
+def get_ndc_rays(H, W, focal, near, rays_o, rays_d):
+    """
+    This function is modified from https://github.com/kwea123/nerf_pl.
+
+    Transform rays from world coordinate to NDC.
+    NDC: Space such that the canvas is a cube with sides [-1, 1] in each axis.
+    For detailed derivation, please see:
+    http://www.songho.ca/opengl/gl_projectionmatrix.html
+    https://github.com/bmild/nerf/files/4451808/ndc_derivation.pdf
+
+    In practice, use NDC "if and only if" the scene is unbounded (has a large depth).
+    See https://github.com/bmild/nerf/issues/18
+
+    Inputs:
+        H, W, focal: image height, width and focal length
+        near: (N_rays) or float, the depths of the near plane
+        rays_o: (N_rays, 3), the origin of the rays in world coordinate
+        rays_d: (N_rays, 3), the direction of the rays in world coordinate
+
+    Outputs:
+        rays_o: (N_rays, 3), the origin of the rays in NDC
+        rays_d: (N_rays, 3), the direction of the rays in NDC
+    """
+    t = -(near + rays_o[..., 2]) / rays_d[..., 2]
+    rays_o = rays_o + t[..., None] * rays_d
+
+    # Store some intermediate homogeneous results
+    ox_oz = rays_o[..., 0] / rays_o[..., 2]
+    oy_oz = rays_o[..., 1] / rays_o[..., 2]
+
+    # Projection
+    o0 = -1. / (W / (2. * focal)) * ox_oz
+    o1 = -1. / (H / (2. * focal)) * oy_oz
+    o2 = 1. + 2. * near / rays_o[..., 2]
+
+    d0 = -1. / (W / (2. * focal)) * (rays_d[..., 0] / rays_d[..., 2] - ox_oz)
+    d1 = -1. / (H / (2. * focal)) * (rays_d[..., 1] / rays_d[..., 2] - oy_oz)
+    d2 = 1 - o2
+
+    rays_o = torch.stack([o0, o1, o2], -1)  # (B, 3)
+    rays_d = torch.stack([d0, d1, d2], -1)  # (B, 3)
+
+    return rays_o, rays_d
+
+
+def get_ndc_rays_fxfy(H, W, fxfy, near, rays_o, rays_d):
+    """
+    This function is modified from https://github.com/kwea123/nerf_pl.
+
+    Transform rays from world coordinate to NDC.
+    NDC: Space such that the canvas is a cube with sides [-1, 1] in each axis.
+    For detailed derivation, please see:
+    http://www.songho.ca/opengl/gl_projectionmatrix.html
+    https://github.com/bmild/nerf/files/4451808/ndc_derivation.pdf
+
+    In practice, use NDC "if and only if" the scene is unbounded (has a large depth).
+    See https://github.com/bmild/nerf/issues/18
+
+    Inputs:
+        H, W, focal: image height, width and focal length
+        near: (N_rays) or float, the depths of the near plane
+        rays_o: (N_rays, 3), the origin of the rays in world coordinate
+        rays_d: (N_rays, 3), the direction of the rays in world coordinate
+
+    Outputs:
+        rays_o: (N_rays, 3), the origin of the rays in NDC
+        rays_d: (N_rays, 3), the direction of the rays in NDC
+    """
+    # Shift ray origins to near plane
+    t = -(near + rays_o[..., 2]) / rays_d[..., 2]
+    rays_o = rays_o + t[..., None] * rays_d
+
+    # Store some intermediate homogeneous results
+    ox_oz = rays_o[..., 0] / rays_o[..., 2]
+    oy_oz = rays_o[..., 1] / rays_o[..., 2]
+
+    # Projection
+    o0 = -1. / (W / (2. * fxfy[0])) * ox_oz
+    o1 = -1. / (H / (2. * fxfy[1])) * oy_oz
+    o2 = 1. + 2. * near / rays_o[..., 2]
+
+    d0 = -1. / (W / (2. * fxfy[0])) * (rays_d[..., 0] / rays_d[..., 2] - ox_oz)
+    d1 = -1. / (H / (2. * fxfy[1])) * (rays_d[..., 1] / rays_d[..., 2] - oy_oz)
+    d2 = 1 - o2
+
+    rays_o = torch.stack([o0, o1, o2], -1)  # (B, 3)
+    rays_d = torch.stack([d0, d1, d2], -1)  # (B, 3)
+
+    return rays_o, rays_d
+
+
+def volume_sampling(c2w, ray_dir_cam, t_vals, near, far, perturb_t):
+    """
+    :param c2w:             (4, 4)                  camera pose
+    :param ray_dir_cam:     (H, W, 3)               ray directions in the camera coordinate
+    :param t_vals:          (N_sample, )            sample depth in a ray
+    :param perturb_t:       True/False              whether add noise to t
+    """
+    ray_H, ray_W = ray_dir_cam.shape[0], ray_dir_cam.shape[1]
+    N_sam = t_vals.shape[0]
+
+    # transform rays from camera coordinate to world coordinate
+    ray_dir_world = torch.matmul(c2w[:3, :3].view(1, 1, 3, 3),
+                                 ray_dir_cam.unsqueeze(3)).squeeze(3)  # (1, 1, 3, 3) * (H, W, 3, 1) -> (H, W, 3)
+    ray_ori_world = c2w[:3, 3]  # the translation vector (3, )
+
+    # this perturb only works if we sample depth linearly, not the disparity.
+    if perturb_t:
+        # add some noise to each each z_val
+        t_noise = torch.rand((ray_H, ray_W, N_sam), device=c2w.device, dtype=torch.float32)  # (H, W, N_sam)
+        t_noise = t_noise * (far - near) / N_sam
+        t_vals_noisy = t_vals.view(1, 1, N_sam) + t_noise  # (H, W, N_sam)
+    else:
+        t_vals_noisy = t_vals.view(1, 1, N_sam).expand(ray_H, ray_W, N_sam)
+
+    # Get sample position in the world (1, 1, 1, 3) + (H, W, 1, 3) * (H, W, N_sam, 1) -> (H, W, N_sample, 3)
+    sample_pos = ray_ori_world.view(1, 1, 1, 3) + ray_dir_world.unsqueeze(2) * t_vals_noisy.unsqueeze(3)
+
+    return sample_pos, ray_ori_world, ray_dir_world, t_vals_noisy  # (H, W, N_sample, 3), (3, ), (H, W, 3), (H, W, N_sam)
+
+
+def volume_sampling_ndc(c2w, ray_dir_cam, t_vals, near, far, H, W, focal, perturb_t):
+    """
+    :param c2w:             (3/4, 4)                camera pose
+    :param ray_dir_cam:     (H, W, 3)               ray directions in the camera coordinate
+    :param focal:           a float or a (2,) torch tensor for focal.
+    :param t_vals:          (N_sample, )            sample depth in a ray
+    :param perturb_t:       True/False              whether add noise to t
+    """
+    ray_H, ray_W = ray_dir_cam.shape[0], ray_dir_cam.shape[1]
+    N_sam = t_vals.shape[0]
+
+    # transform rays from camera coordinate to world coordinate
+    ray_dir_world = torch.matmul(c2w[:3, :3].view(1, 1, 3, 3),
+                                 ray_dir_cam.unsqueeze(3)).squeeze(3)  # (1, 1, 3, 3) * (H, W, 3, 1) -> (H, W, 3)
+    ray_ori_world = c2w[:3, 3]  # the translation vector (3, )
+
+    ray_dir_world = ray_dir_world.reshape(-1, 3)  # (H, W, 3) -> (H*W, 3)
+    ray_ori_world = ray_ori_world.view(1, 3).expand_as(ray_dir_world)  # (3, ) -> (1, 3) -> (H*W, 3)
+    if isinstance(focal, float):
+        ray_ori_world, ray_dir_world = get_ndc_rays(H, W, focal, 1.0, rays_o=ray_ori_world, rays_d=ray_dir_world)  # (H*W, 3)
+    else:  # if focal is a tensor contains fxfy
+        ray_ori_world, ray_dir_world = get_ndc_rays_fxfy(H, W, focal, 1.0, rays_o=ray_ori_world,
+                                                         rays_d=ray_dir_world)  # (H*W, 3)
+    ray_dir_world = ray_dir_world.reshape(ray_H, ray_W, 3)  # (H, W, 3)
+    ray_ori_world = ray_ori_world.reshape(ray_H, ray_W, 3)  # (H, W, 3)
+
+    # this perturb only works if we sample depth linearly, not the disparity.
+    if perturb_t:
+        # add some noise to each each z_val
+        t_noise = torch.rand((ray_H, ray_W, N_sam), device=c2w.device, dtype=torch.float32)  # (H, W, N_sam)
+        t_noise = t_noise * (far - near) / N_sam
+        t_vals_noisy = t_vals.view(1, 1, N_sam) + t_noise  # (H, W, N_sam)
+    else:
+        t_vals_noisy = t_vals.view(1, 1, N_sam).expand(ray_H, ray_W, N_sam)
+
+    # Get sample position in the world (H, W, 1, 3) + (H, W, 1, 3) * (H, W, N_sam, 1) -> (H, W, N_sample, 3)
+    sample_pos = ray_ori_world.unsqueeze(2) + ray_dir_world.unsqueeze(2) * t_vals_noisy.unsqueeze(3)
+
+    return sample_pos, ray_ori_world, ray_dir_world, t_vals_noisy  # (H, W, N_sample, 3), (3, ), (H, W, 3), (H, W, N_sam)
+
+
+def volume_rendering(rgb_density, t_vals, sigma_noise_std, rgb_act_fn):
+    """
+    :param rgb_density:     (H, W, N_sample, 4)     network output
+    :param t_vals:          (H, W, N_sample)        compute the distance between each sample points
+    :param sigma_noise_std: A scalar                add some noise to the density output, this is helpful to reduce
+                                                    floating artifacts according to official repo, but they set it to
+                                                    zero in their implementation.
+    :param rgb_act_fn:      relu()                  apply an active fn to the raw rgb output to get actual rgb
+    :return:                (H, W, 3)               rendered rgb image
+                            (H, W, N_sample)        weights at each sample position
+    """
+    ray_H, ray_W, num_sample = t_vals.shape[0], t_vals.shape[1], t_vals.shape[2]
+
+    rgb = rgb_act_fn(rgb_density[:, :, :, :3])  # (H, W, N_sample, 3)
+    sigma_a = rgb_density[:, :, :, 3]  # (H, W, N_sample)
+
+    if sigma_noise_std > 0.0:
+        sigma_noise = torch.randn_like(sigma_a) * sigma_noise_std
+        sigma_a = sigma_a + sigma_noise  # (H, W, N_sample)
+
+    sigma_a = sigma_a.relu()  # (H, W, N_sample)
+
+    # Compute distances between samples.
+    # 1. compute the distances among first (N-1) samples
+    # 2. the distance between the LAST sample and infinite far is 1e10
+    dists = t_vals[:, :, 1:] - t_vals[:, :, :-1]  # (H, W, N_sample-1)
+    dist_far = torch.empty(size=(ray_H, ray_W, 1), dtype=torch.float32, device=dists.device).fill_(1e10)  # (H, W, 1)
+    dists = torch.cat([dists, dist_far], dim=2)  # (H, W, N_sample)
+
+    alpha = 1 - torch.exp(-1.0 * sigma_a * dists)  # (H, W, N_sample)
+
+    # 1. We expand the exp(a+b) to exp(a) * exp(b) for the accumulated transmittance computing.
+    # 2. For the space at the boundary far to camera, the alpha is constant 1.0 and the transmittance at the far boundary
+    # is useless. For the space at the boundary near to camera, we manually set the transmittance to 1.0, which means
+    # 100% transparent. The torch.roll() operation simply discards the transmittance at the far boundary.
+    acc_transmittance = torch.cumprod(1.0 - alpha + 1e-10, dim=2)  # (H, W, N_sample)
+    acc_transmittance = torch.roll(acc_transmittance, shifts=1, dims=2)  # (H, W, N_sample)
+    acc_transmittance[:, :, 0] = 1.0  # (H, W, N_sample)
+
+    weight = acc_transmittance * alpha  # (H, W, N_sample)
+
+    # (H, W, N_sample, 1) * (H, W, N_sample, 3) = (H, W, N_sample, 3) -> (H, W, 3)
+    rgb_rendered = torch.sum(weight.unsqueeze(3) * rgb, dim=2)
+
+    depth_map = torch.sum(weight * t_vals, dim=2)  # (H, W)
+
+    result = {
+        'rgb': rgb_rendered,  # (H, W, 3)
+        'weight': weight,  # (H, W, N_sample)
+        'depth_map': depth_map,  # (H, W)
+    }
+    return result


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

This pull request concerns a draft version of the NeRF algorithm for view synthesis and 3D rendering. 

In this PR I included an API class - CameraCalibration, which drives NeRF, and is designed based on the discussion in #1384. 

I took a brute force approach and **copied** the relevant core algorithms from the paper: Wang et al. (2021) - https://arxiv.org/abs/2102.07064. Most algorithm parameters are hard-coded, whereas some of those can be defined in CameraCalibration API.

I tested the full functionality of CameraCalibration in Colab - https://colab.research.google.com/drive/1xiX1Jf572HAN_TN4p-8IPU3CZRRkfhox#scrollTo=yVT7jsvk4ViS. Please let me know if you can run this notebook, or at least able to copy it and modify the relevant paths to make it work with the NeRF version in this PR.

The next steps in this PR, and I foresee, and please comment on each point:

1. Parameterize the algorithm and export more control to CameraCalibration API (including, e.g., CPU/GPU control, rendering parameters, etc.)

2. Refactor the code I took from https://arxiv.org/abs/2102.07064 to follow Kornia's standards

3. Replace core engine component with of-the-shelve algorithms. Here I mainly refer to the rendering part, which is also the most compute intensive. I'm thinking PyTorch3D may have some good alternatives we may want to explore

Yaniv

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
