### PR TITLE
Not to globally set warning filter at import time

### DIFF
--- a/kornia/filters/__tmp__.py
+++ b/kornia/filters/__tmp__.py
@@ -6,7 +6,7 @@ from typing import Callable
 def __deprecation_warning(name: str, replacement: str):
     warnings.warn(
         f"`{name}` will be renamed to `{replacement}` in the future versions. " f"Please use `{replacement}` instead.",
-        category=DeprecationWarning,
+        category=FutureWarning,
     )
 
 

--- a/kornia/filters/__tmp__.py
+++ b/kornia/filters/__tmp__.py
@@ -2,8 +2,6 @@ import warnings
 from functools import wraps
 from typing import Callable
 
-warnings.simplefilter('always', DeprecationWarning)
-
 
 def __deprecation_warning(name: str, replacement: str):
     warnings.warn(


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

In the current `kornia` implementation `warnings.simplefilter` is globally set at import time.
https://github.com/kornia/kornia/blob/v0.6.1/kornia/filters/__tmp__.py#L5
Because of this, simply importing `kornia` could affect to other packages that are imported later.

For example with the latest `tensorflow==2.6.2` (just an example, but yes, there is a situation where we combine tensorflow and pytorch in practice).

```python
# When importing the latest tensorflow only:
>>> import tensorflow as tf
>>> tf.__version__
'2.6.2'
```

```python
# Import tf right after kornia
>>> import kornia
>>> kornia.__version__
'0.6.1'
>>> import tensorflow as tf
/xxxx/xxxx/python3.8/site-packages/tensorflow/python/autograph/impl/api.py:22: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```

In this PR I'd like to propose to prevent globally changing the state of the `warnings` module.
For now I have simply removed the `filterwarnings` line, but if there could be a better place to move it to (but still can avoid running at import time), please guide me there.

I do understand there may be a discussion that the package that yields such deprecation warnings at import time (tf in the above example) has to be addressed rather than simply ignoring them. They can be separately handled, but in this PR I'd like to solve the unexpected ill-effects from `kornia`.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
