### PR TITLE
Add background color selection in ``warp_perspective``

### DIFF
--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -89,10 +89,10 @@ def warp_perspective(
 
     if not (len(M.shape) == 3 and M.shape[-2:] == (3, 3)):
         raise ValueError(f"Input M must be a Bx3x3 tensor. Got {M.shape}")
-        
+
     if padding_mode == "fill" and padding_tensor is None:
         raise ValueError("Padding_tensor needs to be supplied when padding_mode is 'fill'.")
-    
+
     # fill padding is only supported for 3 channels because we can't set padding_tensor default
     # to None as this gives jit issues.
     if padding_mode == "fill" and padding_tensor.shape != torch.Size([3]):

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -36,7 +36,7 @@ def warp_perspective(
     dsize: Tuple[int, int],
     mode: str = 'bilinear',
     padding_mode: str = 'zeros',
-    padding_tensor: torch.Tensor = torch.zeros(3), # needed for jit
+    padding_tensor: torch.Tensor = torch.zeros(3),  # needed for jit
     align_corners: bool = True,
 ) -> torch.Tensor:
     r"""Apply a perspective transformation to an image.
@@ -57,7 +57,8 @@ def warp_perspective(
         M: transformation matrix with shape :math:`(B, 3, 3)`.
         dsize: size of the output image (height, width).
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
-        padding_mode (str): padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'`` | ``'fill'``.
+        padding_mode (str): padding mode for outside grid values 
+          ``'zeros'`` | ``'border'`` | ``'reflection'`` | ``'fill'``.
         padding_tensor: tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
         align_corners(bool, optional): interpolation flag.
 

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -36,7 +36,7 @@ def warp_perspective(
     dsize: Tuple[int, int],
     mode: str = 'bilinear',
     padding_mode: str = 'zeros',
-    padding_tensor: torch.Tensor = torch.zeros(3),  # needed for jit
+    fill_value: torch.Tensor = torch.zeros(3),  # needed for jit
     align_corners: bool = True,
 ) -> torch.Tensor:
     r"""Apply a perspective transformation to an image.
@@ -57,10 +57,9 @@ def warp_perspective(
         M: transformation matrix with shape :math:`(B, 3, 3)`.
         dsize: size of the output image (height, width).
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
-        padding_mode (str): padding mode for outside grid values
-          ``'zeros'`` | ``'border'`` | ``'reflection'`` | ``'fill'``.
-        padding_tensor: tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
-        align_corners(bool, optional): interpolation flag.
+        padding_mode: padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'`` | ``'fill'``.
+        fill_value: tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
+        align_corners: interpolation flag.
 
     Returns:
         the warped input image :math:`(B, C, H, W)`.
@@ -91,13 +90,13 @@ def warp_perspective(
     if not (len(M.shape) == 3 and M.shape[-2:] == (3, 3)):
         raise ValueError(f"Input M must be a Bx3x3 tensor. Got {M.shape}")
 
-    if padding_mode == "fill" and padding_tensor is None:
+    if padding_mode == "fill" and fill_value is None:
         raise ValueError("Padding_tensor needs to be supplied when padding_mode is 'fill'.")
 
-    # fill padding is only supported for 3 channels because we can't set padding_tensor default
+    # fill padding is only supported for 3 channels because we can't set fill_value default
     # to None as this gives jit issues.
-    if padding_mode == "fill" and padding_tensor.shape != torch.Size([3]):
-        raise ValueError(f"Padding_tensor only supported for 3 channels. Got {padding_tensor.shape}")
+    if padding_mode == "fill" and fill_value.shape != torch.Size([3]):
+        raise ValueError(f"Padding_tensor only supported for 3 channels. Got {fill_value.shape}")
 
     B, _, H, W = src.size()
     h_out, w_out = dsize
@@ -114,14 +113,8 @@ def warp_perspective(
     grid = transform_points(src_norm_trans_dst_norm[:, None, None], grid)
 
     if padding_mode == "fill":
-        # warp a mask of ones, then multiple with padding_tensor and add to src warp
-        ones_mask = torch.ones_like(src)
-        padding_tensor = padding_tensor.to(ones_mask.device)
-        inv_ones_mask = 1 - F.grid_sample(ones_mask, grid, align_corners=align_corners, mode=mode, padding_mode="zeros")
-        inv_color_mask = inv_ones_mask * padding_tensor.unsqueeze(-1).unsqueeze(-1)
-        return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode="zeros") + inv_color_mask
-    else:
-        return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode=padding_mode)
+        return _warp_and_fill(src, grid, align_corners=align_corners, mode=mode, fill_value=fill_value)
+    return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode=padding_mode)
 
 
 def warp_affine(
@@ -130,6 +123,7 @@ def warp_affine(
     dsize: Tuple[int, int],
     mode: str = 'bilinear',
     padding_mode: str = 'zeros',
+    fill_value: torch.Tensor = torch.zeros(3),  # needed for jit
     align_corners: bool = True,
 ) -> torch.Tensor:
     r"""Apply an affine transformation to a tensor.
@@ -148,7 +142,8 @@ def warp_affine(
         M: affine transformation of shape :math:`(B, 2, 3)`.
         dsize: size of the output image (height, width).
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
-        padding_mode (str): padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'``.
+        padding_mode: padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'`` | ``'fill'``.
+        fill_value: tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
         align_corners : mode for grid_generation.
 
     Returns:
@@ -181,6 +176,14 @@ def warp_affine(
     if not (len(M.shape) == 3 or M.shape[-2:] == (2, 3)):
         raise ValueError(f"Input M must be a Bx2x3 tensor. Got {M.shape}")
 
+    if padding_mode == "fill" and fill_value is None:
+        raise ValueError("Padding_tensor needs to be supplied when padding_mode is 'fill'.")
+
+    # fill padding is only supported for 3 channels because we can't set fill_value default
+    # to None as this gives jit issues.
+    if padding_mode == "fill" and fill_value.shape != torch.Size([3]):
+        raise ValueError(f"Padding_tensor only supported for 3 channels. Got {fill_value.shape}")
+
     B, C, H, W = src.size()
 
     # we generate a 3x3 transformation matrix from 2x3 affine
@@ -192,7 +195,35 @@ def warp_affine(
 
     grid = F.affine_grid(src_norm_trans_dst_norm[:, :2, :], [B, C, dsize[0], dsize[1]], align_corners=align_corners)
 
+    if padding_mode == "fill":
+        return _warp_and_fill(src, grid, align_corners=align_corners, mode=mode, fill_value=fill_value)
     return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode=padding_mode)
+
+
+def _warp_and_fill(
+    src: torch.Tensor,
+    grid: torch.Tensor,
+    mode: str,
+    align_corners: bool,
+    fill_value: torch.Tensor,
+) -> torch.Tensor:
+    r"""Warp a mask of ones, then multiple with fill_value and add to default warp.
+
+    Args:
+        src: input tensor of shape :math:`(B, 3, H, W)`.
+        grid: grid tensor from `transform_points`.
+        mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
+        align_corners: interpolation flag.
+        fill_value: tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
+
+    Returns:
+        the warped and filled tensor with shape :math:`(B, 3, H, W)`.
+    """
+    ones_mask = torch.ones_like(src)
+    fill_value = fill_value.to(ones_mask)[None, None, :]  # cast and add dimensions for broadcasting
+    inv_ones_mask = 1 - F.grid_sample(ones_mask, grid, align_corners=align_corners, mode=mode, padding_mode="zeros")
+    inv_color_mask = inv_ones_mask * fill_value
+    return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode="zeros") + inv_color_mask
 
 
 def get_perspective_transform(src, dst):

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -216,7 +216,6 @@ def _warp_and_fill(
     ones_mask = torch.ones_like(src)
     fill_value = fill_value.to(ones_mask)[None, :, None, None]  # cast and add dimensions for broadcasting
     inv_ones_mask = 1 - F.grid_sample(ones_mask, grid, align_corners=align_corners, mode=mode, padding_mode="zeros")
-    print(inv_ones_mask.shape, fill_value.shape)
     inv_color_mask = inv_ones_mask * fill_value
     return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode="zeros") + inv_color_mask
 

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -194,7 +194,7 @@ def warp_affine(
     return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode=padding_mode)
 
 
-def _warp_and_fill(
+def _fill_and_warp(
     src: torch.Tensor,
     grid: torch.Tensor,
     mode: str,

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -36,7 +36,7 @@ def warp_perspective(
     dsize: Tuple[int, int],
     mode: str = 'bilinear',
     padding_mode: str = 'zeros',
-    padding_tensor: torch.Tensor = torch.zeros(3),
+    padding_tensor: torch.Tensor = torch.zeros(3), # needed for jit
     align_corners: bool = True,
 ) -> torch.Tensor:
     r"""Apply a perspective transformation to an image.
@@ -93,7 +93,7 @@ def warp_perspective(
     if padding_mode == "fill" and padding_tensor is None:
         raise ValueError("Padding_tensor needs to be supplied when padding_mode is 'fill'.")
     
-    # fill padding is only supported for 1 or 3 channels because we can't set padding_tensor default
+    # fill padding is only supported for 3 channels because we can't set padding_tensor default
     # to None as this gives jit issues.
     if padding_mode == "fill" and padding_tensor.shape != torch.Size([3]):
         raise ValueError(f"Padding_tensor only supported for 3 channels. Got {padding_tensor.shape}")

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -57,7 +57,7 @@ def warp_perspective(
         M: transformation matrix with shape :math:`(B, 3, 3)`.
         dsize: size of the output image (height, width).
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
-        padding_mode (str): padding mode for outside grid values 
+        padding_mode (str): padding mode for outside grid values
           ``'zeros'`` | ``'border'`` | ``'reflection'`` | ``'fill'``.
         padding_tensor: tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
         align_corners(bool, optional): interpolation flag.

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -110,7 +110,7 @@ def warp_perspective(
     grid = transform_points(src_norm_trans_dst_norm[:, None, None], grid)
 
     if padding_mode == "fill":
-        return _warp_and_fill(src, grid, align_corners=align_corners, mode=mode, fill_value=fill_value)
+        return _fill_and_warp(src, grid, align_corners=align_corners, mode=mode, fill_value=fill_value)
     return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode=padding_mode)
 
 
@@ -190,7 +190,7 @@ def warp_affine(
     grid = F.affine_grid(src_norm_trans_dst_norm[:, :2, :], [B, C, dsize[0], dsize[1]], align_corners=align_corners)
 
     if padding_mode == "fill":
-        return _warp_and_fill(src, grid, align_corners=align_corners, mode=mode, fill_value=fill_value)
+        return _fill_and_warp(src, grid, align_corners=align_corners, mode=mode, fill_value=fill_value)
     return F.grid_sample(src, grid, align_corners=align_corners, mode=mode, padding_mode=padding_mode)
 
 

--- a/test/geometry/transform/test_imgwarp.py
+++ b/test/geometry/transform/test_imgwarp.py
@@ -179,7 +179,8 @@ class TestWarpAffine:
 
         img_b = torch.arange(float(3 * h * w), device=device, dtype=dtype).view(1, 3, h, w)
 
-        fill_value = torch.tensor([0.5, 0.2, 0.1])
+        # normally fill_value will also be converted to the right device and type in warp_affine
+        fill_value = torch.tensor([0.5, 0.2, 0.1], device=device, dtype=dtype)
 
         img_a = kornia.geometry.warp_affine(img_b, aff_ab, (h, w), padding_mode="fill", fill_value=fill_value)
         top_row_mean = img_a[..., :1, :].mean(dim=[0, 2, 3])
@@ -383,7 +384,8 @@ class TestWarpPerspective:
         homo_ab = kornia.eye_like(3, img_b)
         homo_ab[..., :2, -1] += offset
 
-        fill_value = torch.tensor([0.5, 0.2, 0.1])
+        # normally fill_value will also be converted to the right device and type in warp_perspective
+        fill_value = torch.tensor([0.5, 0.2, 0.1], device=device, dtype=dtype)
 
         img_a = kornia.geometry.warp_perspective(img_b, homo_ab, (h, w), padding_mode="fill", fill_value=fill_value)
         top_row_mean = img_a[..., :1, :].mean(dim=[0, 2, 3])


### PR DESCRIPTION
#### Changes
Added `"fill"` padding to warp_perspective().
This requires a tensor of shape 3 to be given as well, cf. arg `"padding_tensor"`
Shape of 3 is fixed for jit to work and if I'm not mistaken its prototypical use case is for filling
the background with an RGB color. (It could be extended to single channel and RGBA, but also
ran in some trouble with jit there)

Fixes #901 

#### Type of change
- [x] 📚  Documentation Update
- [x] 🔬 New feature (non-breaking change which adds functionality)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code # also tested in notebook environment
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings # 4 tests failing for `test/enhance/test_histogram.py `, not related?
- [x] Did you update CHANGELOG in case of a major change? # n/a
