### PR TITLE
Adds oriented contraint check to Homography RANSAC

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -127,3 +127,20 @@
   year={2019},
   publisher={IEEE}
 }
+
+@article{Marquez-Neila2015,
+  author = {M\'{a}rquez-Neila, Pablo and L\'{o}pez-Alberca, Javier and Buenaposada, Jos\'{e} M. and Baumela, Luis},
+  title = {Speeding-up Homography Estimation in Mobile Devices},
+  year = {2016},
+  publisher = {Springer-Verlag},
+  address = {Berlin, Heidelberg},
+  volume = {11},
+  number = {1},
+  issn = {1861-8200},
+  url = {https://doi.org/10.1007/s11554-012-0314-1},
+  doi = {10.1007/s11554-012-0314-1},
+  journal = {J. Real-Time Image Process.},
+  month = jan,
+  pages = {141–154},
+  numpages = {14}
+}

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -183,15 +183,17 @@ def find_homography_dlt_iterated(
 
 
 def sample_is_valid_for_homography(points1: torch.Tensor, points2: torch.Tensor) -> torch.Tensor:
-    '''Function, which implements oriented contraint check from :cite:`Marquez-Neila2015`
+    """Function, which implements oriented constraint check from :cite:`Marquez-Neila2015`.
+
     Analogous to https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/degeneracy.cpp#L88
+
     Args:
         points1: A set of points in the first image with a tensor shape :math:`(B, 4, 2)`.
         points2: A set of points in the second image with a tensor shape :math:`(B, 4, 2)`.
 
     Returns:
-        mask: if the minimal sample is good for homography estimation:math:`(B, 3, 3)`.
-        '''
+        Mask with the minimal sample is good for homography estimation:math:`(B, 3, 3)`.
+    """
     if points1.shape != points2.shape:
         raise AssertionError(points1.shape)
     if not (len(points1.shape) >= 1 and points1.shape[-1] == 2):

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -5,10 +5,7 @@ import torch
 
 from kornia.utils import _extract_device_dtype, safe_inverse_with_mask
 
-from .conversions import (
-    convert_points_from_homogeneous,
-    convert_points_to_homogeneous
-)
+from .conversions import convert_points_from_homogeneous, convert_points_to_homogeneous
 from .epipolar import normalize_points
 from .linalg import transform_points
 

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -186,7 +186,7 @@ def find_homography_dlt_iterated(
 
 
 def sample_is_valid_for_homography(points1: torch.Tensor, points2: torch.Tensor) -> torch.Tensor:
-    '''Function, which implements oriented contraint check from [Marquez-Neila2015]
+    '''Function, which implements oriented contraint check from :cite:`Marquez-Neila2015`
     Analogous to https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/degeneracy.cpp#L88
     Args:
         points1: A set of points in the first image with a tensor shape :math:`(B, 4, 2)`.

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -5,7 +5,10 @@ import torch
 
 from kornia.utils import _extract_device_dtype, safe_inverse_with_mask
 
-from .conversions import convert_points_from_homogeneous
+from .conversions import (
+    convert_points_from_homogeneous,
+    convert_points_to_homogeneous
+)
 from .epipolar import normalize_points
 from .linalg import transform_points
 
@@ -180,3 +183,37 @@ def find_homography_dlt_iterated(
         weights_new: torch.Tensor = torch.exp(-errors / (2.0 * (soft_inl_th ** 2)))
         H = find_homography_dlt(points1, points2, weights_new)
     return H
+
+
+def sample_is_valid_for_homography(points1: torch.Tensor, points2: torch.Tensor) -> torch.Tensor:
+    '''Function, which implements oriented contraint check from [Marquez-Neila2015]
+    Analogous to https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/degeneracy.cpp#L88
+    Args:
+        points1: A set of points in the first image with a tensor shape :math:`(B, 4, 2)`.
+        points2: A set of points in the second image with a tensor shape :math:`(B, 4, 2)`.
+
+    Returns:
+        mask: if the minimal sample is good for homography estimation:math:`(B, 3, 3)`.
+        '''
+    if points1.shape != points2.shape:
+        raise AssertionError(points1.shape)
+    if not (len(points1.shape) >= 1 and points1.shape[-1] == 2):
+        raise AssertionError(points1.shape)
+    if points1.shape[1] != 4:
+        raise AssertionError(points1.shape)
+    device = points1.device
+    idx_perm = torch.tensor([[0, 1, 2],
+                             [0, 1, 3],
+                             [0, 2, 3],
+                             [1, 2, 3]], dtype=torch.long, device=device)
+    points_src_h = convert_points_to_homogeneous(points1)
+    points_dst_h = convert_points_to_homogeneous(points2)
+
+    src_perm = points_src_h[:, idx_perm]
+    dst_perm = points_dst_h[:, idx_perm]
+    left_sign = (torch.cross(src_perm[..., 1:2, :],
+                             src_perm[..., 2:3, :]) @ src_perm[..., 0:1, :].permute(0, 1, 3, 2)).sign()
+    right_sign = (torch.cross(dst_perm[..., 1:2, :],
+                              dst_perm[..., 2:3, :]) @ dst_perm[..., 0:1, :].permute(0, 1, 3, 2)).sign()
+    sample_is_valid = (left_sign == right_sign).view(-1, 4).max(dim=1)[0]
+    return sample_is_valid

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -212,5 +212,5 @@ def sample_is_valid_for_homography(points1: torch.Tensor, points2: torch.Tensor)
                              src_perm[..., 2:3, :]) @ src_perm[..., 0:1, :].permute(0, 1, 3, 2)).sign()
     right_sign = (torch.cross(dst_perm[..., 1:2, :],
                               dst_perm[..., 2:3, :]) @ dst_perm[..., 0:1, :].permute(0, 1, 3, 2)).sign()
-    sample_is_valid = (left_sign == right_sign).view(-1, 4).max(dim=1)[0]
+    sample_is_valid = (left_sign == right_sign).view(-1, 4).min(dim=1)[0]
     return sample_is_valid

--- a/kornia/geometry/ransac.py
+++ b/kornia/geometry/ransac.py
@@ -11,8 +11,7 @@ from kornia.geometry import (
     find_homography_dlt_iterated,
     symmetrical_epipolar_distance,
 )
-
-from kornia.geometry.homography import sample_is_valid_for_homography, oneway_transfer_error
+from kornia.geometry.homography import oneway_transfer_error, sample_is_valid_for_homography
 
 __all__ = ["RANSAC"]
 

--- a/kornia/geometry/ransac.py
+++ b/kornia/geometry/ransac.py
@@ -188,6 +188,8 @@ class RANSAC(nn.Module):
             kp2_sampled = kp2[idxs]
 
             kp1_sampled, kp2_sampled = self.remove_bad_samples(kp1_sampled, kp2_sampled)
+            if len(kp1_sampled) == 0:
+                continue
             # Estimate models
             models = self.estimate_model_from_minsample(kp1_sampled, kp2_sampled)
             models = self.remove_bad_models(models)

--- a/kornia/geometry/ransac.py
+++ b/kornia/geometry/ransac.py
@@ -11,10 +11,7 @@ from kornia.geometry import (
     find_homography_dlt_iterated,
     symmetrical_epipolar_distance,
 )
-from kornia.geometry.homography import (
-    symmetric_transfer_error,
-    sample_is_valid_for_homography
-)
+from kornia.geometry.homography import sample_is_valid_for_homography, symmetric_transfer_error
 
 __all__ = ["RANSAC"]
 

--- a/kornia/geometry/ransac.py
+++ b/kornia/geometry/ransac.py
@@ -11,7 +11,10 @@ from kornia.geometry import (
     find_homography_dlt_iterated,
     symmetrical_epipolar_distance,
 )
-from kornia.geometry.homography import symmetric_transfer_error
+from kornia.geometry.homography import (
+    symmetric_transfer_error,
+    sample_is_valid_for_homography
+)
 
 __all__ = ["RANSAC"]
 
@@ -119,6 +122,9 @@ class RANSAC(nn.Module):
         """"""
         # ToDo: add (model-specific) verification of the samples,
         # E.g. constraints on not to be a degenerate sample
+        if self.model_type == 'homography':
+            mask = sample_is_valid_for_homography(kp1, kp2)
+            return kp1[mask], kp2[mask]
         return kp1, kp2
 
     def remove_bad_models(self, models: torch.Tensor) -> torch.Tensor:

--- a/test/geometry/test_homography.py
+++ b/test/geometry/test_homography.py
@@ -11,8 +11,41 @@ from kornia.geometry.homography import (
     find_homography_dlt_iterated,
     oneway_transfer_error,
     symmetric_transfer_error,
+    sample_is_valid_for_homography,
 )
 from kornia.testing import assert_close
+
+
+class TestSampleValidation:
+    def test_good(self, device, dtype):
+        pts1 = torch.tensor([[0.0, 0.0],
+                             [0.0, 1.0],
+                             [1.0, 1.0],
+                             [1.0, 0.0]], device=device, dtype=dtype)[None]
+        mask = sample_is_valid_for_homography(pts1, pts1)
+        expected = torch.tensor([True], device=device, dtype=torch.bool)
+        assert torch.equal(mask, expected)
+
+    def test_bad(self, device, dtype):
+        pts1 = torch.tensor([[0.0, 0.0],
+                             [1.0, 0.0],
+                             [0.0, 1.0],
+                             [1.0, 1.0]], device=device, dtype=dtype)[None]
+
+        pts2 = torch.tensor([[0.0, 0.0],
+                             [0.0, 1.0],
+                             [1.0, 0.0],
+                             [1.0, 1.0]], device=device, dtype=dtype)[None]
+        mask = sample_is_valid_for_homography(pts1, pts2)
+        expected = torch.tensor([False], device=device, dtype=torch.bool)
+        assert torch.equal(mask, expected)
+
+    def test_batch(self, device, dtype):
+        batch_size = 5
+        pts1 = torch.rand(batch_size, 4, 2, device=device, dtype=dtype)
+        pts2 = torch.rand(batch_size, 4, 2, device=device, dtype=dtype)
+        mask = sample_is_valid_for_homography(pts1, pts2)
+        assert (mask.shape == torch.Size([batch_size]))
 
 
 class TestOneWayError:

--- a/test/geometry/test_homography.py
+++ b/test/geometry/test_homography.py
@@ -10,8 +10,8 @@ from kornia.geometry.homography import (
     find_homography_dlt,
     find_homography_dlt_iterated,
     oneway_transfer_error,
-    symmetric_transfer_error,
     sample_is_valid_for_homography,
+    symmetric_transfer_error,
 )
 from kornia.testing import assert_close
 

--- a/test/geometry/test_ransac.py
+++ b/test/geometry/test_ransac.py
@@ -10,6 +10,7 @@ from kornia.testing import assert_close
 
 class TestRANSACHomography:
     def test_smoke(self, device, dtype):
+        torch.random.manual_seed(0)
         points1 = torch.rand(4, 2, device=device, dtype=dtype)
         points2 = torch.rand(4, 2, device=device, dtype=dtype)
         ransac = RANSAC('homography').to(device=device, dtype=dtype)


### PR DESCRIPTION
#### Changes
Removes bad samples prior to model estimation to speed-up RANSAC.
References: 
http://www.dia.fi.upm.es/~pcr/publications/jrtip2015.pdf - paper, formula (5)
OpenCV implementation: https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/usac/degeneracy.cpp#L88

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
