### PR TITLE
Fix ``undistort_image`` documentation and support additional dimensions.

### DIFF
--- a/kornia/geometry/calibration/undistort.py
+++ b/kornia/geometry/calibration/undistort.py
@@ -117,7 +117,7 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
     Example:
         >>> img = torch.rand(1, 3, 5, 5)
         >>> K = torch.eye(3)[None]
-        >>> dist_coeff = torch.rand(4)
+        >>> dist_coeff = torch.rand(1, 4)
         >>> out = undistort_image(img, K, dist_coeff)
         >>> out.shape
         torch.Size([1, 3, 5, 5])

--- a/kornia/geometry/calibration/undistort.py
+++ b/kornia/geometry/calibration/undistort.py
@@ -1,5 +1,3 @@
-from functools import reduce
-
 import torch
 
 from kornia.geometry.linalg import transform_points

--- a/kornia/geometry/calibration/undistort.py
+++ b/kornia/geometry/calibration/undistort.py
@@ -105,7 +105,7 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
     distortion models are considered in this function.
 
     Args:
-        image: Input image with shape :math:`(*, N, C, H, W)`.
+        image: Input image with shape :math:`(*, C, H, W)`.
         K: Intrinsic camera matrix with shape :math:`(*, 3, 3)`.
         dist: Distortion coefficients
             :math:`(k_1,k_2,p_1,p_2[,k_3[,k_4,k_5,k_6[,s_1,s_2,s_3,s_4[,\tau_x,\tau_y]]]])`. This is
@@ -123,7 +123,7 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
         torch.Size([1, 3, 5, 5])
 
     """
-    if len(image.shape) < 4:
+    if len(image.shape) < 3:
         raise ValueError(f"Image shape is invalid. Got: {image.shape}.")
 
     if K.shape[-2:] != (3, 3):

--- a/kornia/geometry/calibration/undistort.py
+++ b/kornia/geometry/calibration/undistort.py
@@ -135,6 +135,15 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
     if not image.is_floating_point():
         raise ValueError(f'Invalid input image data type. Input should be float. Got {image.dtype}.')
 
+    if image.shape[:-3] != K.shape[:-2] or image.shape[:-3] != dist.shape[:-1]:
+        # Input with image shape (1, C, H, W), K shape (3, 3), dist shape (4) 
+        # allowed to avoid a breaking change.
+        if not all((image.shape[:-3] == (1,), K.shape[:-2] == (), dist.shape[:-1] == ())):
+            raise ValueError(
+                f'Input shape is invalid. Input batch dimensions should match. '
+                f'Got {image.shape[:-3]}, {K.shape[:-2]}, {dist.shape[:-1]}.'
+            )
+
     channels, rows, cols = image.shape[-3:]
     B = image.numel() // (channels * rows * cols)
 

--- a/kornia/geometry/calibration/undistort.py
+++ b/kornia/geometry/calibration/undistort.py
@@ -136,7 +136,7 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
         raise ValueError(f'Invalid input image data type. Input should be float. Got {image.dtype}.')
 
     if image.shape[:-3] != K.shape[:-2] or image.shape[:-3] != dist.shape[:-1]:
-        # Input with image shape (1, C, H, W), K shape (3, 3), dist shape (4) 
+        # Input with image shape (1, C, H, W), K shape (3, 3), dist shape (4)
         # allowed to avoid a breaking change.
         if not all((image.shape[:-3] == (1,), K.shape[:-2] == (), dist.shape[:-1] == ())):
             raise ValueError(

--- a/kornia/geometry/calibration/undistort.py
+++ b/kornia/geometry/calibration/undistort.py
@@ -135,9 +135,8 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
     if not image.is_floating_point():
         raise ValueError(f'Invalid input image data type. Input should be float. Got {image.dtype}.')
 
-    B_dims, image_dims = image.shape[:-3], image.shape[-3:]
-    B = int(torch.prod(torch.tensor(B_dims)))
-    channels, rows, cols = image_dims
+    channels, rows, cols = image.shape[-3:]
+    B = image.numel() // (channels * rows * cols)
 
     # Create point coordinates for each pixel of the image
     xy_grid: torch.Tensor = create_meshgrid(rows, cols, False, image.device, image.dtype)
@@ -149,6 +148,6 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
     mapy: torch.Tensor = ptsd[..., 1].reshape(B, rows, cols)  # B x rows x cols, float
 
     # Remap image to undistort
-    out = remap(image.reshape(-1, channels, rows, cols), mapx, mapy, align_corners=True)
+    out = remap(image.reshape(B, channels, rows, cols), mapx, mapy, align_corners=True)
 
     return out.view_as(image)

--- a/kornia/geometry/calibration/undistort.py
+++ b/kornia/geometry/calibration/undistort.py
@@ -151,4 +151,4 @@ def undistort_image(image: torch.Tensor, K: torch.Tensor, dist: torch.Tensor) ->
     # Remap image to undistort
     out = remap(image.reshape(-1, channels, rows, cols), mapx, mapy, align_corners=True)
 
-    return out.reshape(B_dims + image_dims)
+    return out.view_as(image)

--- a/test/geometry/calibration/test_undistort.py
+++ b/test/geometry/calibration/test_undistort.py
@@ -212,13 +212,21 @@ class TestUndistortImage:
         imu = undistort_image(im, K, distCoeff)
         assert imu.shape == (1, 3, 5, 5)
 
-    def test_shape_extra_dims(self, device, dtype):
-        im = torch.rand(1, 1, 3, 5, 5, device=device, dtype=dtype).tile(3, 1, 1, 1, 1)
-        K = torch.rand(1, 3, 3, device=device, dtype=dtype).tile(3, 1, 1)
-        distCoeff = torch.rand(1, 4, device=device, dtype=dtype).tile(3, 1)
+    def test_shape_minimum_dims(self, device, dtype):
+        im = torch.rand(3, 5, 5, device=device, dtype=dtype)
+        K = torch.rand(3, 3, device=device, dtype=dtype)
+        distCoeff = torch.rand(4, device=device, dtype=dtype)
 
         imu = undistort_image(im, K, distCoeff)
-        assert imu.shape == (3, 1, 3, 5, 5)
+        assert imu.shape == (3, 5, 5)
+
+    def test_shape_extra_dims(self, device, dtype):
+        im = torch.rand(1, 1, 3, 5, 5, device=device, dtype=dtype).tile(3, 2, 1, 1, 1)
+        K = torch.rand(1, 1, 3, 3, device=device, dtype=dtype).tile(3, 2, 1, 1)
+        distCoeff = torch.rand(1, 1, 4, device=device, dtype=dtype).tile(3, 2, 1)
+
+        imu = undistort_image(im, K, distCoeff)
+        assert imu.shape == (3, 2, 3, 5, 5)
         torch.testing.assert_allclose(imu[0], imu[1])
 
     def test_opencv(self, device, dtype):

--- a/test/geometry/calibration/test_undistort.py
+++ b/test/geometry/calibration/test_undistort.py
@@ -212,6 +212,15 @@ class TestUndistortImage:
         imu = undistort_image(im, K, distCoeff)
         assert imu.shape == (1, 3, 5, 5)
 
+    def test_shape_extra_dims(self, device, dtype):
+        im = torch.rand(1, 1, 3, 5, 5, device=device, dtype=dtype).tile(3, 1, 1, 1, 1)
+        K = torch.rand(1, 3, 3, device=device, dtype=dtype).tile(3, 1, 1)
+        distCoeff = torch.rand(1, 4, device=device, dtype=dtype).tile(3, 1)
+
+        imu = undistort_image(im, K, distCoeff)
+        assert imu.shape == (3, 1, 3, 5, 5)
+        torch.testing.assert_allclose(imu[0], imu[1])
+
     def test_opencv(self, device, dtype):
         im = torch.tensor(
             [

--- a/test/geometry/calibration/test_undistort.py
+++ b/test/geometry/calibration/test_undistort.py
@@ -229,6 +229,37 @@ class TestUndistortImage:
         assert imu.shape == (3, 2, 3, 5, 5)
         torch.testing.assert_allclose(imu[0], imu[1])
 
+    def test_exception(self, device, dtype):
+        with pytest.raises(ValueError):
+            im = torch.rand(5, 5, device=device, dtype=dtype)
+            K = torch.rand(3, 3, device=device, dtype=dtype)
+            distCoeff = torch.rand(4, device=device, dtype=dtype)
+            undistort_image(im, K, distCoeff)
+
+        with pytest.raises(ValueError):
+            im = torch.rand(3, 5, 5, device=device, dtype=dtype)
+            K = torch.rand(4, 4, device=device, dtype=dtype)
+            distCoeff = torch.rand(4, device=device, dtype=dtype)
+            undistort_image(im, K, distCoeff)
+
+        with pytest.raises(ValueError):
+            im = torch.rand(3, 5, 5, device=device, dtype=dtype)
+            K = torch.rand(3, 3, device=device, dtype=dtype)
+            distCoeff = torch.rand(6, device=device, dtype=dtype)
+            undistort_image(im, K, distCoeff)
+
+        with pytest.raises(ValueError):
+            im = torch.randint(0, 256, (3, 5, 5), device=device, dtype=torch.uint8)
+            K = torch.rand(3, 3, device=device, dtype=dtype)
+            distCoeff = torch.rand(4, device=device, dtype=dtype)
+            undistort_image(im, K, distCoeff)
+
+        with pytest.raises(ValueError):
+            im = torch.rand(1, 1, 3, 5, 5, device=device, dtype=dtype)
+            K = torch.rand(1, 3, 3, device=device, dtype=dtype)
+            distCoeff = torch.rand(1, 4, device=device, dtype=dtype)
+            undistort_image(im, K, distCoeff)
+
     def test_opencv(self, device, dtype):
         im = torch.tensor(
             [


### PR DESCRIPTION
#### Changes
`undistort_image` is described a taking an "Input image with shape (*, C, H, W)" as input, however, it actually expects the shape to be (B, C, H, W). Meaning:
1. It expects a minimum of 4 dims, not 3.
2. It does not support additional dimensions at the start of the tensor as implied.

This PR fixes the documentation to read "Input image with shape (*, N, C, H, W)" and adds support for the additional dimensions at the start of the tensor.

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
