### PR TITLE
Fix for nested AugmentationSequential containers

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -286,7 +286,7 @@ class AugmentationSequential(ImageSequential):
                 input = cast(TensorWithTransformMat, out)
             outputs[idx] = input
 
-        self.return_label = label is not None or self.contains_label_operations(params)
+        self.return_label = self.return_label or label is not None or self.contains_label_operations(params)
 
         for idx, (input, dcate, out) in enumerate(zip(args, data_keys, outputs)):
             if out is not None:

--- a/kornia/augmentation/container/utils.py
+++ b/kornia/augmentation/container/utils.py
@@ -166,7 +166,7 @@ class InputApplyInverse(ApplyInverseImpl):
             param: the corresponding parameters to the module.
         """
         if isinstance(module, (MixAugmentationBase,)):
-            input, label = module(input, label, params=param.data)
+            input, label = module(input, label=label, params=param.data)
         elif isinstance(module, (_AugmentationBase,)):
             input = module(input, params=param.data)
         elif isinstance(module, kornia.augmentation.container.ImageSequential):
@@ -174,7 +174,7 @@ class InputApplyInverse(ApplyInverseImpl):
             temp2 = module.return_label
             module.apply_inverse_func = InputApplyInverse
             module.return_label = True
-            input, label = module(input, label, param.data)
+            input, label = module(input, label=label, params=param.data)
             module.apply_inverse_func = temp
             module.return_label = temp2
         else:
@@ -198,11 +198,11 @@ class InputApplyInverse(ApplyInverseImpl):
             param: the corresponding parameters to the module.
         """
         if isinstance(module, GeometricAugmentationBase2D):
-            input = module.inverse(input, None if param is None else cast(Dict, param.data))
+            input = module.inverse(input, params=None if param is None else cast(Dict, param.data))
         elif isinstance(module, kornia.augmentation.container.ImageSequential):
             temp = module.apply_inverse_func
             module.apply_inverse_func = InputApplyInverse
-            input = module.inverse(input, None if param is None else cast(List, param.data))
+            input = module.inverse(input, params=None if param is None else cast(List, param.data))
             module.apply_inverse_func = temp
         return input
 
@@ -244,13 +244,13 @@ class MaskApplyInverse(ApplyInverseImpl):
 
         if isinstance(module, GeometricAugmentationBase2D):
             _param = cast(Dict[str, torch.Tensor], _param)
-            input = module(input, _param, return_transform=False)
+            input = module(input, params=_param, return_transform=False)
         elif isinstance(module, kornia.augmentation.container.ImageSequential) and not module.is_intensity_only():
             _param = cast(List[ParamItem], _param)
             temp = module.apply_inverse_func
             module.apply_inverse_func = MaskApplyInverse
             geo_param: List[ParamItem] = _get_geometric_only_param(module, _param)
-            input = cls.make_input_only_sequential(module)(input, None, geo_param)
+            input = cls.make_input_only_sequential(module)(input, label=None, params=geo_param)
             module.apply_inverse_func = temp
         else:
             pass  # No need to update anything
@@ -269,11 +269,11 @@ class MaskApplyInverse(ApplyInverseImpl):
             param: the corresponding parameters to the module.
         """
         if isinstance(module, GeometricAugmentationBase2D):
-            input = module.inverse(input, None if param is None else cast(Dict, param.data))
+            input = module.inverse(input, params=None if param is None else cast(Dict, param.data))
         elif isinstance(module, kornia.augmentation.container.ImageSequential):
             temp = module.apply_inverse_func
             module.apply_inverse_func = MaskApplyInverse
-            input = module.inverse(input, None if param is None else cast(List, param.data))
+            input = module.inverse(input, params=None if param is None else cast(List, param.data))
             module.apply_inverse_func = temp
         return input
 

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -311,6 +311,9 @@ class TestAugmentationSequential:
             K.ImageSequential(
                 K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
             ),
+            K.AugmentationSequential(
+                K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
+            ),
             K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0),
             K.RandomAffine(360, p=1.0),
             data_keys=["input", "mask", "bbox", "keypoints"],
@@ -345,6 +348,9 @@ class TestAugmentationSequential:
             K.ImageSequential(
                 K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
             ),
+            K.AugmentationSequential(
+                K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
+            ),
             K.RandomAffine(360, p=1.0, return_transform=False),
             data_keys=['input', 'mask', 'bbox', 'keypoints'],
         )
@@ -371,6 +377,9 @@ class TestAugmentationSequential:
         )[:, None].float()
         aug = K.AugmentationSequential(
             K.ImageSequential(
+                K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
+            ),
+            K.AugmentationSequential(
                 K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
             ),
             K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0, return_transform=True),
@@ -402,6 +411,9 @@ class TestAugmentationSequential:
         )[:, None].float()
         aug = K.AugmentationSequential(
             K.ImageSequential(
+                K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
+            ),
+            K.AugmentationSequential(
                 K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
             ),
             K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0, return_transform=True),


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->
Nesting AugmentationSequential containers currently fails in both forward and inverse due to the use of `*args` as the first argument for their forward and inverse methods and not specifying the argument names of other arguments in their calls in multiple places, as well as failing to set the `return_labels` flag already set in the superclass.
This PR names the arguments in calls to forward and inverse, sets the `return_labels` flag correctly and changes the test cases to use AugmentationSequential instead of ImageSequential to cover this in the tests.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
