### PR TITLE
Add mising keepdim with fixed typo

### DIFF
--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -691,7 +691,11 @@ class CenterCrop(GeometricAugmentationBase2D):
     ) -> None:
         # same_on_batch is always True for CenterCrop
         # Since PyTorch does not support ragged tensor. So cropping function happens batch-wisely.
-        super().__init__(p=1.0, return_transform=return_transform, same_on_batch=True, p_batch=p, keepdim=keepdim)
+        super().__init__(p=1.0,
+                         return_transform=return_transform,
+                         same_on_batch=True,
+                         p_batch=p,
+                         keepdim=keepdim)
         if isinstance(size, tuple):
             self.size = (size[0], size[1])
         elif isinstance(size, int):
@@ -824,7 +828,10 @@ class RandomRotation(GeometricAugmentationBase2D):
         p: float = 0.5,
         keepdim: bool = False,
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         keepdim=keepdim)
         self._param_generator = cast(
             rg.PlainUniformGenerator, rg.PlainUniformGenerator((degrees, "degrees", 0., (-360., 360.)))
         )
@@ -1243,6 +1250,12 @@ class Normalize(IntensityAugmentationBase2D):
     Args:
         mean: Mean for each channel.
         std: Standard deviations for each channel.
+        return_transform: if ``True`` return the matrix describing the transformation applied to each
+                          input tensor. If ``False`` and the input is a tuple the applied transformation
+                          won't be concatenated.
+        p: probability of applying the transformation.
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+                 to the batch form (False).
 
     Return:
         Normalised tensor with same size as input :math:`(*, C, H, W)`.
@@ -1389,7 +1402,10 @@ class RandomMotionBlur(IntensityAugmentationBase2D):
         p: float = 0.5,
         keepdim: bool = False,
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         keepdim=keepdim)
         self._param_generator = rg.MotionBlurGenerator(kernel_size, angle, direction)
         self.flags = dict(
             border_type=BorderType.get(border_type),
@@ -1666,6 +1682,8 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+                 to the batch form (False).
 
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
@@ -1700,8 +1718,13 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         p_batch=1.0,
+                         keepdim=keepdim)
         self.flags = dict(
             kernel_size=kernel_size,
             sigma=sigma,
@@ -1727,7 +1750,8 @@ class RandomInvert(IntensityAugmentationBase2D):
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
-
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+                 to the batch form (False).
     .. note::
         This function internally uses :func:`kornia.enhance.invert`.
 
@@ -1755,8 +1779,13 @@ class RandomInvert(IntensityAugmentationBase2D):
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         p_batch=1.0,
+                         keepdim=keepdim)
         self.flags = dict(
             max_val=max_val,
         )
@@ -1795,8 +1824,16 @@ class RandomChannelShuffle(IntensityAugmentationBase2D):
         tensor(True)
     """
 
-    def __init__(self, return_transform: bool = False, same_on_batch: bool = False, p: float = 0.5) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+    def __init__(self,
+                 return_transform: bool = False,
+                 same_on_batch: bool = False,
+                 p: float = 0.5,
+                 keepdim: bool = False) -> None:
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         p_batch=1.0,
+                         keepdim=keepdim)
 
     def generate_parameters(self, shape: torch.Size) -> Dict[str, torch.Tensor]:
         B, C, _, _ = shape
@@ -1824,7 +1861,8 @@ class RandomGaussianNoise(IntensityAugmentationBase2D):
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
-
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+                 to the batch form (False).
     Examples:
         >>> rng = torch.manual_seed(0)
         >>> img = torch.ones(1, 1, 2, 2)
@@ -1846,8 +1884,13 @@ class RandomGaussianNoise(IntensityAugmentationBase2D):
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         p_batch=1.0,
+                         keepdim=keepdim)
         self.flags = dict(mean=mean, std=std)
 
     def generate_parameters(self, shape: torch.Size) -> Dict[str, torch.Tensor]:
@@ -1873,7 +1916,8 @@ class RandomFisheye(GeometricAugmentationBase2D):
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
-
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+                 to the batch form (False).
     Examples:
         >>> img = torch.ones(1, 1, 2, 2)
         >>> center_x = torch.tensor([-.3, .3])
@@ -1898,8 +1942,13 @@ class RandomFisheye(GeometricAugmentationBase2D):
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         p_batch=1.0,
+                         keepdim=keepdim)
         self._check_tensor(center_x)
         self._check_tensor(center_y)
         self._check_tensor(gamma)
@@ -1988,8 +2037,9 @@ class RandomElasticTransform(GeometricAugmentationBase2D):
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0, keepdim=False)
         self.flags = dict(
             kernel_size=kernel_size,
             sigma=sigma,
@@ -2033,7 +2083,8 @@ class RandomThinPlateSpline(GeometricAugmentationBase2D):
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
-
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+                 to the batch form (False).
     .. note::
         This function internally uses :func:`kornia.geometry.transform.warp_image_tps`.
 
@@ -2057,8 +2108,13 @@ class RandomThinPlateSpline(GeometricAugmentationBase2D):
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch,
+                         p_batch=1.0,
+                         keepdim=keepdim)
         self.flags = dict(align_corners=align_corners)
         self.dist = torch.distributions.Uniform(-scale, scale)
 
@@ -2096,7 +2152,8 @@ class RandomBoxBlur(IntensityAugmentationBase2D):
             input tensor. If ``False`` and the input is a tuple the applied transformation won't be concatenated.
         same_on_batch (bool): apply the same transformation across the batch.
         p: probability of applying the transformation.
-
+        keepdim: whether to keep the output shape the same as input (True) or broadcast it
+                 to the batch form (False).
     .. note::
         This function internally uses :func:`kornia.filters.box_blur`.
 
@@ -2121,8 +2178,12 @@ class RandomBoxBlur(IntensityAugmentationBase2D):
         return_transform: bool = False,
         same_on_batch: bool = False,
         p: float = 0.5,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0)
+        super().__init__(p=p,
+                         return_transform=return_transform,
+                         same_on_batch=same_on_batch, p_batch=1.0,
+                         keepdim=keepdim)
         self.flags = dict(
             kernel_size=kernel_size,
             border_type=border_type,
@@ -2184,8 +2245,13 @@ class PadTo(GeometricAugmentationBase2D):
         pad_mode: str = "constant",
         pad_value: Union[int, float] = 0,
         return_transform: bool = False,
+        keepdim: bool = False
     ) -> None:
-        super().__init__(p=1., return_transform=return_transform, same_on_batch=True, p_batch=1.)
+        super().__init__(p=1.,
+                         return_transform=return_transform,
+                         same_on_batch=True,
+                         p_batch=1.,
+                         keepdim=keepdim)
         self.flags = dict(
             size=size,
             pad_mode=pad_mode,


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Add missing `keepdim` argument in some augmentation constructors to enable keepdim.

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)


#### Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
