### PR TITLE
Precompute padding parameters when RandomCrop aug in container

### DIFF
--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -1074,13 +1074,13 @@ class RandomCrop(GeometricAugmentationBase2D):
 
     def forward_parameters_precrop(self, batch_shape) -> Dict[str, torch.Tensor]:
         input_pad = self.compute_padding(batch_shape)
-        batch_shape = (
+        batch_shape_new = (
             *batch_shape[:2],
-            batch_shape[2] + input_pad[1] + input_pad[3],  # original height + top + bottom padding
-            batch_shape[3] + input_pad[0] + input_pad[2]  # original width + left + right padding
+            batch_shape[2] + input_pad[2] + input_pad[3],  # original height + top + bottom padding
+            batch_shape[3] + input_pad[0] + input_pad[1]  # original width + left + right padding
         )
         padding_size = torch.tensor(tuple(input_pad), dtype=torch.long).expand(batch_shape[0], -1)
-        _params = super().forward_parameters(batch_shape)
+        _params = super().forward_parameters(batch_shape_new)
         _params.update({"padding_size": padding_size})
         return _params
 

--- a/kornia/augmentation/augmentation.py
+++ b/kornia/augmentation/augmentation.py
@@ -1078,7 +1078,7 @@ class RandomCrop(GeometricAugmentationBase2D):
             *batch_shape[:2],
             batch_shape[2] + input_pad[1] + input_pad[3],  # original height + top + bottom padding
             batch_shape[3] + input_pad[0] + input_pad[2]  # original width + left + right padding
-            )
+        )
         padding_size = torch.tensor(tuple(input_pad), dtype=torch.long).expand(batch_shape[0], -1)
         _params = super().forward_parameters(batch_shape)
         _params.update({"padding_size": padding_size})

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -12,6 +12,7 @@ from kornia.augmentation.base import (
     MixAugmentationBase,
     TensorWithTransformMat,
 )
+from kornia.augmentation import RandomCrop
 
 from .base import ParamItem, SequentialBase
 from .utils import ApplyInverseInterface, InputApplyInverse
@@ -216,7 +217,10 @@ class ImageSequential(SequentialBase):
         params: List[ParamItem] = []
         mod_param: Union[dict, list]
         for name, module in named_modules:
-            if isinstance(module, (_AugmentationBase, MixAugmentationBase)):
+            if isinstance(module, RandomCrop):
+                mod_param = module.forward_parameters_precrop(batch_shape)
+                param = ParamItem(name, mod_param)
+            elif isinstance(module, (_AugmentationBase, MixAugmentationBase)):
                 mod_param = module.forward_parameters(batch_shape)
                 param = ParamItem(name, mod_param)
             elif isinstance(module, ImageSequential):

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 
 import kornia
+from kornia.augmentation import RandomCrop
 from kornia.augmentation.base import (
     _AugmentationBase,
     GeometricAugmentationBase2D,
@@ -12,7 +13,6 @@ from kornia.augmentation.base import (
     MixAugmentationBase,
     TensorWithTransformMat,
 )
-from kornia.augmentation import RandomCrop
 
 from .base import ParamItem, SequentialBase
 from .utils import ApplyInverseInterface, InputApplyInverse

--- a/kornia/augmentation/container/utils.py
+++ b/kornia/augmentation/container/utils.py
@@ -386,7 +386,8 @@ class BBoxXYWHApplyInverse(BBoxXYXYApplyInverse):
 class KeypointsApplyInverse(BBoxXYWHApplyInverse):
     """Apply and inverse transformations for keypoints tensors."""
 
-    apply_func = transform_points
+    # Hot fix for the typing mismatching
+    apply_func = partial(transform_points)
 
 
 class ApplyInverse:

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -184,8 +184,8 @@ class VideoSequential(ImageSequential):
             if isinstance(module, RandomCrop):
                 mod_param = module.forward_parameters_precrop(batch_shape)
                 if self.same_on_frame:
-                    param["src"] = param["src"].repeat(frame_num, 1, 1)
-                    param["dst"] = param["dst"].repeat(frame_num, 1, 1)
+                    mod_param["src"] = mod_param["src"].repeat(frame_num, 1, 1)
+                    mod_param["dst"] = mod_param["dst"].repeat(frame_num, 1, 1)
                 param = ParamItem(name, mod_param)
             elif isinstance(module, (SequentialBase,)):
                 seq_param = module.forward_parameters(batch_shape)

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -182,11 +182,11 @@ class VideoSequential(ImageSequential):
         params = []
         for name, module in named_modules:
             if isinstance(module, RandomCrop):
-                param = module.forward_parameters_precrop(batch_shape)
+                mod_param = module.forward_parameters_precrop(batch_shape)
                 if self.same_on_frame:
                     param["src"] = param["src"].repeat(frame_num, 1, 1)
                     param["dst"] = param["dst"].repeat(frame_num, 1, 1)
-                param = ParamItem(name, param)
+                param = ParamItem(name, mod_param)
             elif isinstance(module, (SequentialBase,)):
                 seq_param = module.forward_parameters(batch_shape)
                 if self.same_on_frame:

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -184,7 +184,6 @@ class VideoSequential(ImageSequential):
             if isinstance(module, RandomCrop):
                 param = module.forward_parameters_precrop(batch_shape)
                 if self.same_on_frame:
-                # param.update({'src': self.__repeat_param_across_channels__(param['src'], frame_num)})
                     param["src"] = param["src"].repeat(frame_num, 1, 1)
                     param["dst"] = param["dst"].repeat(frame_num, 1, 1)
                 param = ParamItem(name, param)

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -135,7 +135,7 @@ class TestVideoSequential:
         if data_format == 'BCTHW':
             input = input.transpose(1, 2)
         output_2 = aug_list_2(input.reshape(-1, 3, 5, 6))
-        if any([isinstance(a, K.RandomCrop) for a in augmentations]):
+        if any(isinstance(a, K.RandomCrop) for a in augmentations):
             output_2 = output_2.view(2, 4, 3, 2, 2)
         else:
             output_2 = output_2.view(2, 4, 3, 5, 6)

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -321,7 +321,7 @@ class TestAugmentationSequential:
             [[[1., 2.], [3., 2.], [3., 4.], [1., 4.]],
              [[1., 1.], [3., 1.], [3., 3.], [1., 3.]],
              [[2., 0.], [4., 0.], [4., 2.], [2., 2.]]],
-        device=_params[0].data['src'].device, dtype=_params[0].data['src'].dtype)
+            device=_params[0].data['src'].device, dtype=_params[0].data['src'].dtype)
 
         expected_out_bbox = torch.tensor(
             [[[1., 0., 2., 1.], [0., -1., 1., 1.], [0., -1., 2., 0.]],

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -317,31 +317,19 @@ class TestAugmentationSequential:
 
         _params = aug.forward_parameters(input.shape)
         # specifying the crops allows us to compute by hand the expected outputs
-        _params[0].data['src'] = torch.Tensor([[[1., 2.],
-                                                [3., 2.],
-                                                [3., 4.],
-                                                [1., 4.]],
-                                               [[1., 1.],
-                                                [3., 1.],
-                                                [3., 3.],
-                                                [1., 3.]],
-                                               [[2., 0.],
-                                                [4., 0.],
-                                                [4., 2.],
-                                                [2., 2.]]])
+        _params[0].data['src'] = torch.tensor(
+            [[[1., 2.], [3., 2.], [3., 4.], [1., 4.]],
+             [[1., 1.], [3., 1.], [3., 3.], [1., 3.]],
+             [[2., 0.], [4., 0.], [4., 2.], [2., 2.]]], device=device, dtype=dtype)
 
-        expected_out_bbox = torch.Tensor([[[1., 0., 2., 1.],
-                                           [0., -1., 1., 1.],
-                                           [0., -1., 2., 0.]],
-                                          [[1., 1., 2., 2.],
-                                           [0., 0., 1., 2.],
-                                           [0., 0., 2., 1.]],
-                                          [[0., 2., 1., 3.],
-                                           [-1., 1., 0., 3.],
-                                           [-1., 1., 1., 2.]]])
-        expected_out_points = torch.Tensor([[[0., -1.], [1., 0.]],
-                                            [[0., 0.], [1., 1.]],
-                                            [[-1., 1.], [0., 2.]]])
+        expected_out_bbox = torch.tensor(
+            [[[1., 0., 2., 1.], [0., -1., 1., 1.], [0., -1., 2., 0.]],
+             [[1., 1., 2., 2.], [0., 0., 1., 2.], [0., 0., 2., 1.]],
+             [[0., 2., 1., 3.], [-1., 1., 0., 3.], [-1., 1., 1., 2.]]], device=device, dtype=dtype)
+        expected_out_points = torch.tensor(
+            [[[0., -1.], [1., 0.]],
+             [[0., 0.], [1., 1.]],
+             [[-1., 1.], [0., 2.]]], device=device, dtype=dtype)
 
         out = aug(input, input, bbox, points, params=_params)
         assert out[0].shape == (3, 3, 3, 3)

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -113,6 +113,7 @@ class TestVideoSequential:
         'augmentations',
         [
             [K.RandomAffine(360, p=1.0)],
+            [K.RandomCrop((2, 2), padding=2)],
             [K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0)],
             [K.RandomAffine(360, p=0.0), K.ImageSequential(K.RandomAffine(360, p=0.0))],
         ],
@@ -134,7 +135,10 @@ class TestVideoSequential:
         if data_format == 'BCTHW':
             input = input.transpose(1, 2)
         output_2 = aug_list_2(input.reshape(-1, 3, 5, 6))
-        output_2 = output_2.view(2, 4, 3, 5, 6)
+        if any([isinstance(a, K.RandomCrop) for a in augmentations]):
+            output_2 = output_2.view(2, 4, 3, 2, 2)
+        else:
+            output_2 = output_2.view(2, 4, 3, 5, 6)
         if data_format == 'BCTHW':
             output_2 = output_2.transpose(1, 2)
         assert (output_1 == output_2).all(), dict(aug_list_1._params)

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -320,7 +320,8 @@ class TestAugmentationSequential:
         _params[0].data['src'] = torch.tensor(
             [[[1., 2.], [3., 2.], [3., 4.], [1., 4.]],
              [[1., 1.], [3., 1.], [3., 3.], [1., 3.]],
-             [[2., 0.], [4., 0.], [4., 2.], [2., 2.]]], device=device, dtype=dtype)
+             [[2., 0.], [4., 0.], [4., 2.], [2., 2.]]],
+        device=_params[0].data['src'].device, dtype=_params[0].data['src'].dtype)
 
         expected_out_bbox = torch.tensor(
             [[[1., 0., 2., 1.], [0., -1., 1., 1.], [0., -1., 2., 0.]],
@@ -333,19 +334,19 @@ class TestAugmentationSequential:
 
         out = aug(input, input, bbox, points, params=_params)
         assert out[0].shape == (3, 3, 3, 3)
-        assert_close(out[0], out[1])
+        assert_close(out[0], out[1], atol=1e-4, rtol=1e-4)
         assert out[2].shape == bbox.shape
-        assert_close(out[2], expected_out_bbox)
+        assert_close(out[2], expected_out_bbox, atol=1e-4, rtol=1e-4)
         assert out[3].shape == points.shape
-        assert_close(out[3], expected_out_points)
+        assert_close(out[3], expected_out_points, atol=1e-4, rtol=1e-4)
 
         out_inv = aug.inverse(*out)
         assert out_inv[0].shape == input.shape
-        assert_close(out_inv[0], out_inv[1])
+        assert_close(out_inv[0], out_inv[1], atol=1e-4, rtol=1e-4)
         assert out_inv[2].shape == bbox.shape
-        assert_close(out_inv[2], bbox)
+        assert_close(out_inv[2], bbox, atol=1e-4, rtol=1e-4)
         assert out_inv[3].shape == points.shape
-        assert_close(out_inv[3], points)
+        assert_close(out_inv[3], points, atol=1e-4, rtol=1e-4)
 
     @pytest.mark.parametrize('random_apply', [1, (2, 2), (1, 2), (2,), 10, True, False])
     @pytest.mark.parametrize('return_transform', [True, False])


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->
When computing parameters for RandomCrops used inside a container, compute padding parameters and use them to compute correct input size. Also, if `padding_size` in parameters, use that instead of recomputing it. Update test cases to cover RandomCrops inside containers.

Fixes #1491, fixes #1492

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
