### PR TITLE
Feat/stereo rectify

### DIFF
--- a/kornia/geometry/camera/stereo.py
+++ b/kornia/geometry/camera/stereo.py
@@ -308,9 +308,7 @@ def reproject_disparity_to_3D(disparity_tensor: torch.Tensor, Q_matrix: torch.Te
 
 
 def rectify_calibrated(left_uncalibrated_projection_matrix, right_uncalibrated_projection_matrix):
-    """
-    TODO
-    """
+    """TODO."""
     # Optical centers
     c1 = -torch.inverse(left_uncalibrated_projection_matrix[:, :, 0:3]) @ \
          left_uncalibrated_projection_matrix[:, :, 3].T

--- a/kornia/geometry/camera/stereo.py
+++ b/kornia/geometry/camera/stereo.py
@@ -307,17 +307,20 @@ def reproject_disparity_to_3D(disparity_tensor: torch.Tensor, Q_matrix: torch.Te
     return points
 
 
-def rectify_calibrated(left_camera_matrix, right_camera_matrix):
+def rectify_calibrated(left_uncalibrated_projection_matrix, right_uncalibrated_projection_matrix):
     """
     TODO
     """
     # Optical centers
-    c1 = -torch.inverse(left_camera_matrix[:, :, 0:3]) @ left_camera_matrix[:, :, 3].T
-    c2 = -torch.inverse(right_camera_matrix[:, :, 0:3]) @ right_camera_matrix[:, :, 3].T
+    c1 = -torch.inverse(left_uncalibrated_projection_matrix[:, :, 0:3]) @ \
+         left_uncalibrated_projection_matrix[:, :, 3].T
+
+    c2 = -torch.inverse(right_uncalibrated_projection_matrix[:, :, 0:3]) @ \
+         right_uncalibrated_projection_matrix[:, :, 3].T
 
     # Factorize
-    A1, R1, t1 = _factorize_art(left_camera_matrix)
-    A2, R2, t2 = _factorize_art(right_camera_matrix)
+    A1, R1, t1 = _factorize_art(left_uncalibrated_projection_matrix)
+    A2, R2, t2 = _factorize_art(right_uncalibrated_projection_matrix)
 
     # New x axis
     v1 = c1 - c2
@@ -348,8 +351,8 @@ def rectify_calibrated(left_camera_matrix, right_camera_matrix):
     Pn2 = A @ torch.cat([R, -R @ c2], dim=-1)
 
     # Rectifying image transformation
-    T1 = Pn1[:, 0:3, 0:3] @ torch.inverse(left_camera_matrix[:, 0:3, 0:3])
-    T2 = Pn2[:, 0:3, 0:3] @ torch.inverse(right_camera_matrix[:, 0:3, 0:3])
+    T1 = Pn1[:, 0:3, 0:3] @ torch.inverse(left_uncalibrated_projection_matrix[:, 0:3, 0:3])
+    T2 = Pn2[:, 0:3, 0:3] @ torch.inverse(right_uncalibrated_projection_matrix[:, 0:3, 0:3])
 
     return T1, T2, Pn1, Pn2
 

--- a/kornia/geometry/camera/stereo.py
+++ b/kornia/geometry/camera/stereo.py
@@ -344,8 +344,6 @@ def rectify_calibrated(left_uncalibrated_projection_matrix, right_uncalibrated_p
     A = (A1 + A2) / 2
     A[:, 0, 1] = 0  # No skew
 
-    A[:, 0, 2] = A[:, 0, 2] + 160
-
     # New projection matrices
     Pn1 = A @ torch.cat([R, -R @ c1], dim=-1)
     Pn2 = A @ torch.cat([R, -R @ c2], dim=-1)


### PR DESCRIPTION
#### Changes

Fixes #1448

This PR rectifies a camera projection matrix from a calibrated stereo camera. I get approximately same results as the paper linked in the ticket. I still need to test on some real data, but it requires me to setup my OAK-D and calibrate it, which will require some additional time.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
