### PR TITLE
Adding cropping option for SSIM

### DIFF
--- a/kornia/losses/ssim.py
+++ b/kornia/losses/ssim.py
@@ -92,12 +92,7 @@ class SSIMLoss(nn.Module):
     """
 
     def __init__(
-        self,
-        window_size: int,
-        max_val: float = 1.0,
-        eps: float = 1e-12,
-        reduction: str = 'mean',
-        padding: str = 'same',
+        self, window_size: int, max_val: float = 1.0, eps: float = 1e-12, reduction: str = 'mean', padding: str = 'same'
     ) -> None:
         super().__init__()
         self.window_size: int = window_size
@@ -107,4 +102,4 @@ class SSIMLoss(nn.Module):
         self.padding: str = padding
 
     def forward(self, img1: torch.Tensor, img2: torch.Tensor) -> torch.Tensor:
-        return ssim_loss(img1, img2, self.window_size, self.max_val, self.eps, self.reduction, self.same)
+        return ssim_loss(img1, img2, self.window_size, self.max_val, self.eps, self.reduction, self.padding)

--- a/kornia/losses/ssim.py
+++ b/kornia/losses/ssim.py
@@ -11,6 +11,7 @@ def ssim_loss(
     max_val: float = 1.0,
     eps: float = 1e-12,
     reduction: str = 'mean',
+    cropping: bool = False,
 ) -> torch.Tensor:
     r"""Function that computes a loss based on the SSIM measurement.
 
@@ -32,6 +33,8 @@ def ssim_loss(
          output: ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
          ``'mean'``: the sum of the output will be divided by the number of elements
          in the output, ``'sum'``: the output will be summed.
+        cropping: Whether to crop out the "valid" convolution area to match
+         the MATLAB implementation of original SSIM paper.
 
     Returns:
         The loss based on the ssim index.
@@ -42,7 +45,7 @@ def ssim_loss(
         >>> loss = ssim_loss(input1, input2, 5)
     """
     # compute the ssim map
-    ssim_map: torch.Tensor = metrics.ssim(img1, img2, window_size, max_val, eps)
+    ssim_map: torch.Tensor = metrics.ssim(img1, img2, window_size, max_val, eps, cropping)
 
     # compute and reduce the loss
     loss = torch.clamp((1.0 - ssim_map) / 2, min=0, max=1)
@@ -75,6 +78,8 @@ class SSIMLoss(nn.Module):
          output: ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
          ``'mean'``: the sum of the output will be divided by the number of elements
          in the output, ``'sum'``: the output will be summed.
+        cropping: Whether to crop out the "valid" convolution area to match
+         the MATLAB implementation of original SSIM paper.
 
     Returns:
         The loss based on the ssim index.
@@ -86,12 +91,20 @@ class SSIMLoss(nn.Module):
         >>> loss = criterion(input1, input2)
     """
 
-    def __init__(self, window_size: int, max_val: float = 1.0, eps: float = 1e-12, reduction: str = 'mean') -> None:
+    def __init__(
+        self,
+        window_size: int,
+        max_val: float = 1.0,
+        eps: float = 1e-12,
+        reduction: str = 'mean',
+        cropping: bool = False,
+    ) -> None:
         super().__init__()
         self.window_size: int = window_size
         self.max_val: float = max_val
         self.eps: float = eps
         self.reduction: str = reduction
+        self.cropping: bool = cropping
 
     def forward(self, img1: torch.Tensor, img2: torch.Tensor) -> torch.Tensor:
-        return ssim_loss(img1, img2, self.window_size, self.max_val, self.eps, self.reduction)
+        return ssim_loss(img1, img2, self.window_size, self.max_val, self.eps, self.reduction, self.cropping)

--- a/kornia/losses/ssim.py
+++ b/kornia/losses/ssim.py
@@ -11,7 +11,7 @@ def ssim_loss(
     max_val: float = 1.0,
     eps: float = 1e-12,
     reduction: str = 'mean',
-    cropping: bool = False,
+    padding: str = 'same',
 ) -> torch.Tensor:
     r"""Function that computes a loss based on the SSIM measurement.
 
@@ -33,8 +33,8 @@ def ssim_loss(
          output: ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
          ``'mean'``: the sum of the output will be divided by the number of elements
          in the output, ``'sum'``: the output will be summed.
-        cropping: Whether to crop out the "valid" convolution area to match
-         the MATLAB implementation of original SSIM paper.
+        padding: ``'same'`` | ``'valid'``. Whether to only use the "valid" convolution
+         area to compute SSIM to match the MATLAB implementation of original SSIM paper.
 
     Returns:
         The loss based on the ssim index.
@@ -45,7 +45,7 @@ def ssim_loss(
         >>> loss = ssim_loss(input1, input2, 5)
     """
     # compute the ssim map
-    ssim_map: torch.Tensor = metrics.ssim(img1, img2, window_size, max_val, eps, cropping)
+    ssim_map: torch.Tensor = metrics.ssim(img1, img2, window_size, max_val, eps, padding)
 
     # compute and reduce the loss
     loss = torch.clamp((1.0 - ssim_map) / 2, min=0, max=1)
@@ -78,8 +78,8 @@ class SSIMLoss(nn.Module):
          output: ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
          ``'mean'``: the sum of the output will be divided by the number of elements
          in the output, ``'sum'``: the output will be summed.
-        cropping: Whether to crop out the "valid" convolution area to match
-         the MATLAB implementation of original SSIM paper.
+        padding: ``'same'`` | ``'valid'``. Whether to only use the "valid" convolution
+         area to compute SSIM to match the MATLAB implementation of original SSIM paper.
 
     Returns:
         The loss based on the ssim index.
@@ -97,14 +97,14 @@ class SSIMLoss(nn.Module):
         max_val: float = 1.0,
         eps: float = 1e-12,
         reduction: str = 'mean',
-        cropping: bool = False,
+        padding: str = 'same',
     ) -> None:
         super().__init__()
         self.window_size: int = window_size
         self.max_val: float = max_val
         self.eps: float = eps
         self.reduction: str = reduction
-        self.cropping: bool = cropping
+        self.padding: str = padding
 
     def forward(self, img1: torch.Tensor, img2: torch.Tensor) -> torch.Tensor:
-        return ssim_loss(img1, img2, self.window_size, self.max_val, self.eps, self.reduction, self.cropping)
+        return ssim_loss(img1, img2, self.window_size, self.max_val, self.eps, self.reduction, self.same)

--- a/kornia/metrics/ssim.py
+++ b/kornia/metrics/ssim.py
@@ -9,7 +9,9 @@ from kornia.filters.filter import _compute_padding
 
 def _crop(img: torch.Tensor, cropping_shape: List[int]) -> torch.Tensor:
     """Crop out the part of "valid" convolution area."""
-    return img[:, :, cropping_shape[0] : -cropping_shape[1], cropping_shape[2] : -cropping_shape[3]]
+    return torch.nn.functional.pad(
+        img, (-cropping_shape[2], -cropping_shape[3], -cropping_shape[0], -cropping_shape[1])
+    )
 
 
 def ssim(
@@ -83,9 +85,10 @@ def ssim(
     mu1: torch.Tensor = filter2d(img1, kernel)
     mu2: torch.Tensor = filter2d(img2, kernel)
 
+    cropping_shape: List[int] = []
     if padding == 'valid':
         height, width = kernel.shape[-2:]
-        cropping_shape: List[int] = _compute_padding([height, width])
+        cropping_shape = _compute_padding([height, width])
         mu1 = _crop(mu1, cropping_shape)
         mu2 = _crop(mu2, cropping_shape)
     elif padding == 'same':

--- a/kornia/metrics/ssim.py
+++ b/kornia/metrics/ssim.py
@@ -1,11 +1,24 @@
+from typing import List
+
 import torch
 import torch.nn as nn
 
 from kornia.filters import filter2d, get_gaussian_kernel2d
+from kornia.filters.filter import _compute_padding
+
+
+def _crop(img: torch.Tensor, cropping_shape: List[int]) -> torch.Tensor:
+    """Crop out the part of "valid" convolution area."""
+    return img[:, :, cropping_shape[0] : -cropping_shape[1], cropping_shape[2] : -cropping_shape[3]]
 
 
 def ssim(
-    img1: torch.Tensor, img2: torch.Tensor, window_size: int, max_val: float = 1.0, eps: float = 1e-12
+    img1: torch.Tensor,
+    img2: torch.Tensor,
+    window_size: int,
+    max_val: float = 1.0,
+    eps: float = 1e-12,
+    cropping: bool = False,
 ) -> torch.Tensor:
     r"""Function that computes the Structural Similarity (SSIM) index map between two images.
 
@@ -30,6 +43,8 @@ def ssim(
         window_size: the size of the gaussian kernel to smooth the images.
         max_val: the dynamic range of the images.
         eps: Small value for numerically stability when dividing.
+        cropping: Whether to crop out the "valid" convolution area to match
+         the MATLAB implementation of original SSIM paper.
 
     Returns:
        The ssim index map with shape :math:`(B, C, H, W)`.
@@ -68,14 +83,29 @@ def ssim(
     mu1: torch.Tensor = filter2d(img1, kernel)
     mu2: torch.Tensor = filter2d(img2, kernel)
 
+    if cropping:
+        height, width = kernel.shape[-2:]
+        cropping_shape: List[int] = _compute_padding([height, width])
+        mu1 = _crop(mu1, cropping_shape)
+        mu2 = _crop(mu2, cropping_shape)
+
     mu1_sq = mu1 ** 2
     mu2_sq = mu2 ** 2
     mu1_mu2 = mu1 * mu2
 
+    mu_img1_sq = filter2d(img1 ** 2, kernel)
+    mu_img2_sq = filter2d(img2 ** 2, kernel)
+    mu_img1_img2 = filter2d(img1 * img2, kernel)
+
+    if cropping:
+        mu_img1_sq = _crop(mu_img1_sq, cropping_shape)
+        mu_img2_sq = _crop(mu_img2_sq, cropping_shape)
+        mu_img1_img2 = _crop(mu_img1_img2, cropping_shape)
+
     # compute local sigma per channel
-    sigma1_sq = filter2d(img1 ** 2, kernel) - mu1_sq
-    sigma2_sq = filter2d(img2 ** 2, kernel) - mu2_sq
-    sigma12 = filter2d(img1 * img2, kernel) - mu1_mu2
+    sigma1_sq = mu_img1_sq - mu1_sq
+    sigma2_sq = mu_img2_sq - mu2_sq
+    sigma12 = mu_img1_img2 - mu1_mu2
 
     # compute the similarity index map
     num: torch.Tensor = (2.0 * mu1_mu2 + C1) * (2.0 * sigma12 + C2)
@@ -106,6 +136,8 @@ class SSIM(nn.Module):
         window_size: the size of the gaussian kernel to smooth the images.
         max_val: the dynamic range of the images.
         eps: Small value for numerically stability when dividing.
+        cropping: Whether to crop out the "valid" convolution area to match
+         the MATLAB implementation of original SSIM paper.
 
     Shape:
         - Input: :math:`(B, C, H, W)`.
@@ -119,11 +151,12 @@ class SSIM(nn.Module):
         >>> ssim_map = ssim(input1, input2)  # 1x4x5x5
     """
 
-    def __init__(self, window_size: int, max_val: float = 1.0, eps: float = 1e-12) -> None:
+    def __init__(self, window_size: int, max_val: float = 1.0, eps: float = 1e-12, cropping: bool = False) -> None:
         super().__init__()
         self.window_size: int = window_size
         self.max_val: float = max_val
         self.eps = eps
+        self.cropping = cropping
 
     def forward(self, img1: torch.Tensor, img2: torch.Tensor) -> torch.Tensor:
-        return ssim(img1, img2, self.window_size, self.max_val, self.eps)
+        return ssim(img1, img2, self.window_size, self.max_val, self.eps, self.cropping)


### PR DESCRIPTION
#### Changes
Add cropping option for SSIM to crop out the "valid" convolution part to match the original MATLAB implementation.

Fixes #1204 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [X] 📚  Documentation Update
- [X] 🔬 New feature (non-breaking change which adds functionality)

#### Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
