### PR TITLE
improve the `histogram_matching` function

### DIFF
--- a/kornia/contrib/histogram_matching.py
+++ b/kornia/contrib/histogram_matching.py
@@ -45,25 +45,24 @@ def histogram_matching(source: torch.Tensor, template: torch.Tensor) -> torch.Te
 
 
 def interp(x: torch.Tensor, xp: torch.Tensor, fp: torch.Tensor) -> torch.Tensor:
-    """Interpolate ``x`` tensor according to ``xp`` and ``fp`` as in ``np.interp``.
+    """One-dimensional linear interpolation for monotonically increasing sample
+    points.
 
-    This implementation cannot reproduce numpy results identically, but reasonable.
-    Code referred to `here <https://github.com/pytorch/pytorch/issues/1552#issuecomment-926972915>`_.
+    Returns the one-dimensional piecewise linear interpolant to a function with
+    given discrete data points :math:`(xp, fp)`, evaluated at :math:`x`.
+    
+    This is confirmed to be a correct implementation. 
+    See https://github.com/pytorch/pytorch/issues/1552#issuecomment-979998307
 
     Args:
-        x: the input tensor that needs to be interpolated.
-        xp: the x-coordinates of the referred data points.
-        fp: the y-coordinates of the referred data points, same length as ``xp``.
+        x: the :math:`x`-coordinates at which to evaluate the interpolated
+            values.
+        xp: the :math:`x`-coordinates of the data points, must be increasing.
+        fp: the :math:`y`-coordinates of the data points, same length as `xp`.
 
     Returns:
-        The interpolated values, same shape as ``x``.
+        the interpolated values, same size as `x`.
     """
-    if x.dim() != xp.dim() != fp.dim() != 1:
-        raise ValueError(
-            f"Required 1D vector across ``x``, ``xp``, ``fp``. Got {x.dim()}, {xp.dim()}, {fp.dim()}."
-        )
+    i = torch.clip(torch.searchsorted(xp, x, right=True), 1, len(xp) - 1)
 
-    slopes = (fp[1:] - fp[:-1]) / (xp[1:] - xp[:-1])
-    locs = torch.searchsorted(xp, x)
-    locs = locs.clip(1, len(xp) - 1) - 1
-    return slopes[locs] * (x - xp[locs]) + xp[locs]
+    return (fp[i - 1] *  (xp[i] - x) + fp[i] * (x - xp[i - 1])) / (xp[i] - xp[i - 1])

--- a/kornia/contrib/histogram_matching.py
+++ b/kornia/contrib/histogram_matching.py
@@ -64,4 +64,4 @@ def interp(x: torch.Tensor, xp: torch.Tensor, fp: torch.Tensor) -> torch.Tensor:
     """
     i = torch.clip(torch.searchsorted(xp, x, right=True), 1, len(xp) - 1)
 
-    return (fp[i - 1] *  (xp[i] - x) + fp[i] * (x - xp[i - 1])) / (xp[i] - xp[i - 1])
+    return (fp[i - 1] * (xp[i] - x) + fp[i] * (x - xp[i - 1])) / (xp[i] - xp[i - 1])

--- a/kornia/contrib/histogram_matching.py
+++ b/kornia/contrib/histogram_matching.py
@@ -45,13 +45,12 @@ def histogram_matching(source: torch.Tensor, template: torch.Tensor) -> torch.Te
 
 
 def interp(x: torch.Tensor, xp: torch.Tensor, fp: torch.Tensor) -> torch.Tensor:
-    """One-dimensional linear interpolation for monotonically increasing sample
-    points.
+    """One-dimensional linear interpolation for monotonically increasing sample points.
 
     Returns the one-dimensional piecewise linear interpolant to a function with
     given discrete data points :math:`(xp, fp)`, evaluated at :math:`x`.
-    
-    This is confirmed to be a correct implementation. 
+
+    This is confirmed to be a correct implementation.
     See https://github.com/pytorch/pytorch/issues/1552#issuecomment-979998307
 
     Args:

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -372,12 +372,11 @@ class TestImageStitcher:
 
 
 class TestHistMatch:
-
     def test_interp(self, device, dtype):
         xp = torch.tensor([1, 2, 3], device=device, dtype=dtype)
         fp = torch.tensor([4, 2, 0], device=device, dtype=dtype)
         x = torch.tensor([4, 5, 6], device=device, dtype=dtype)
-        x_hat_expected = torch.tensor([-2., -4., -6.], device=device, dtype=dtype)
+        x_hat_expected = torch.tensor([-2.0, -4.0, -6.0], device=device, dtype=dtype)
         x_hat = kornia.contrib.interp(x, xp, fp)
         assert (x_hat_expected == x_hat).all()
 
@@ -387,12 +386,18 @@ class TestHistMatch:
         src = torch.randn(1, 4, 4).to(device=device, dtype=dtype)
         dst = torch.randn(1, 16, 16).to(device=device, dtype=dtype)
         out = kornia.contrib.histogram_matching(src, dst)
-        exp = torch.tensor([[
-            [0.9356, 0.8270, 1.3687, 0.5640],
-            [0.6273, 0.9119, 0.4965, 0.4020],
-            [0.4353, 0.1475, 0.3384, 0.2580],
-            [0.0606, 0.7531, 0.2139, 0.6932]
-        ]], device=device, dtype=dtype)
+        exp = torch.tensor(
+            [
+                [
+                    [1.5902, 0.9295, 2.9409, 0.1211],
+                    [0.2472, 1.2137, -0.1098, -0.4272],
+                    [-0.2644, -1.1983, -0.6065, -0.8091],
+                    [-1.4999, 0.6370, -0.9800, 0.4474],
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
         assert exp.shape == out.shape
         assert_close(out, exp, rtol=1e-4, atol=1e-4)
 
@@ -401,7 +406,7 @@ class TestHistMatch:
         B, C, H, W = 1, 3, 32, 32
         src = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         dst = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.contrib.histogram_matching, (src, dst,), raise_exception=True)
+        assert gradcheck(kornia.contrib.histogram_matching, (src, dst), raise_exception=True)
 
 
 class TestFaceDetection:
@@ -421,26 +426,28 @@ class TestFaceDetection:
         assert op_jit is not None
 
     def test_results(self, device, dtype):
-        data = torch.tensor([
-            0., 0., 100., 200., 10., 10., 20., 10., 10., 50., 100., 50., 150., 10., 0.99,
-        ], device=device, dtype=dtype)
+        data = torch.tensor(
+            [0.0, 0.0, 100.0, 200.0, 10.0, 10.0, 20.0, 10.0, 10.0, 50.0, 100.0, 50.0, 150.0, 10.0, 0.99],
+            device=device,
+            dtype=dtype,
+        )
         res = kornia.contrib.FaceDetectorResult(data)
-        assert res.xmin == 0.
-        assert res.ymin == 0.
-        assert res.xmax == 100.
-        assert res.ymax == 200.
+        assert res.xmin == 0.0
+        assert res.ymin == 0.0
+        assert res.xmax == 100.0
+        assert res.ymax == 200.0
         assert res.score == 0.99
-        assert res.width == 100.
-        assert res.height == 200.
-        assert res.top_left.tolist() == [0., 0.]
-        assert res.top_right.tolist() == [100., 0.]
-        assert res.bottom_right.tolist() == [100., 200.]
-        assert res.bottom_left.tolist() == [0., 200.]
-        assert res.get_keypoint(FaceKeypoint.EYE_LEFT).tolist() == [10., 10.]
-        assert res.get_keypoint(FaceKeypoint.EYE_RIGHT).tolist() == [20., 10.]
-        assert res.get_keypoint(FaceKeypoint.NOSE).tolist() == [10., 50.]
-        assert res.get_keypoint(FaceKeypoint.MOUTH_LEFT).tolist() == [100., 50.]
-        assert res.get_keypoint(FaceKeypoint.MOUTH_RIGHT).tolist() == [150., 10.]
+        assert res.width == 100.0
+        assert res.height == 200.0
+        assert res.top_left.tolist() == [0.0, 0.0]
+        assert res.top_right.tolist() == [100.0, 0.0]
+        assert res.bottom_right.tolist() == [100.0, 200.0]
+        assert res.bottom_left.tolist() == [0.0, 200.0]
+        assert res.get_keypoint(FaceKeypoint.EYE_LEFT).tolist() == [10.0, 10.0]
+        assert res.get_keypoint(FaceKeypoint.EYE_RIGHT).tolist() == [20.0, 10.0]
+        assert res.get_keypoint(FaceKeypoint.NOSE).tolist() == [10.0, 50.0]
+        assert res.get_keypoint(FaceKeypoint.MOUTH_LEFT).tolist() == [100.0, 50.0]
+        assert res.get_keypoint(FaceKeypoint.MOUTH_RIGHT).tolist() == [150.0, 10.0]
 
     def test_results_raise(self, device, dtype):
         data = torch.zeros(14, device=device, dtype=dtype)


### PR DESCRIPTION
#### Changes
Update to the new `interp` function so that the `histogram_matching` works properly.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

#### See the visual result here
Comparison based on skimage's histogram matching
https://scikit-image.org/docs/0.16.x/auto_examples/color_exposure/plot_histogram_matching.html
![image](https://user-images.githubusercontent.com/9111958/150464035-10202441-579a-4459-9322-1ee184884563.png)


