### PR TITLE
Fix correct shape after cropping when forwarding parameters

### DIFF
--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -218,6 +218,9 @@ class ImageSequential(SequentialBase):
             if isinstance(module, RandomCrop):
                 mod_param = module.forward_parameters_precrop(batch_shape)
                 param = ParamItem(name, mod_param)
+                cropped_batch_shape = list(batch_shape)
+                cropped_batch_shape[-2:] = module.flags['size']
+                batch_shape = torch.Size(cropped_batch_shape)
             elif isinstance(module, (_AugmentationBase, MixAugmentationBase)):
                 mod_param = module.forward_parameters(batch_shape)
                 param = ParamItem(name, mod_param)


### PR DESCRIPTION
#### Changes
After cropping, the shape of the tensor changes. This has to be taken into account when computing the parameters for the following augmentations applied in sequence.
Also adds a test covering a random crop followed by a horizontal flip, which would be broken before this fix.

Fixes # (issue)

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
