### PR TITLE
Fixed #1534 nested augmentation sequential bug

### DIFF
--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -1,4 +1,3 @@
-from kornia.augmentation import container
 from kornia.augmentation._2d import (
     CenterCrop,
     ColorJitter,

--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -46,6 +46,7 @@ from kornia.augmentation._3d import (
     RandomVerticalFlip3D,
 )
 from kornia.augmentation._3d.base import AugmentationBase3D
+from kornia.augmentation import container
 from kornia.augmentation.container import AugmentationSequential, ImageSequential, PatchSequential, VideoSequential
 
 __all__ = [

--- a/kornia/augmentation/container/utils.py
+++ b/kornia/augmentation/container/utils.py
@@ -17,7 +17,7 @@ from kornia.utils.helpers import _torch_inverse_cast
 
 
 def _get_geometric_only_param(
-    module: "kornia.augmentation.container.ImageSequential", param: List[ParamItem]
+    module: "kornia.augmentation.ImageSequential", param: List[ParamItem]
 ) -> List[ParamItem]:
     named_modules: Iterator[Tuple[str, nn.Module]] = module.get_forward_sequence(param)
 
@@ -84,7 +84,7 @@ class ApplyInverseImpl(ApplyInverseInterface):
         to_apply = None
         if isinstance(module, _AugmentationBase):
             to_apply = param.data['batch_prob']  # type: ignore
-        if isinstance(module, kornia.augmentation.container.ImageSequential):
+        if isinstance(module, kornia.augmentation.ImageSequential):
             to_apply = torch.ones(input.shape[0], device=input.device, dtype=input.dtype).bool()
 
         # If any inputs need to be transformed.
@@ -116,7 +116,7 @@ class ApplyInverseImpl(ApplyInverseInterface):
     ) -> Optional[torch.Tensor]:
 
         if (
-            isinstance(module, (GeometricAugmentationBase2D, kornia.augmentation.container.ImageSequential))
+            isinstance(module, (GeometricAugmentationBase2D, kornia.augmentation.ImageSequential))
             and param is None
         ):
             raise ValueError(f"Parameters of transformation matrix for {module} has not been computed.")
@@ -124,7 +124,7 @@ class ApplyInverseImpl(ApplyInverseInterface):
         if isinstance(module, GeometricAugmentationBase2D):
             _param = cast(Dict[str, torch.Tensor], param.data)  # type: ignore
             mat = module.get_transformation_matrix(input, _param)
-        elif isinstance(module, kornia.augmentation.container.ImageSequential) and not module.is_intensity_only():
+        elif isinstance(module, kornia.augmentation.ImageSequential) and not module.is_intensity_only():
             _param = cast(List[ParamItem], param.data)  # type: ignore
             mat = module.get_transformation_matrix(input, _param)  # type: ignore
         else:
@@ -157,12 +157,12 @@ class InputApplyInverse(ApplyInverseImpl):
             input, label = module(input, label=label, params=param.data)
         elif isinstance(module, (_AugmentationBase,)):
             input = module(input, params=param.data)
-        elif isinstance(module, kornia.augmentation.container.ImageSequential):
+        elif isinstance(module, kornia.augmentation.ImageSequential):
             temp = module.apply_inverse_func
             temp2 = module.return_label
             module.apply_inverse_func = InputApplyInverse
             module.return_label = True
-            if isinstance(module, kornia.augmentation.container.AugmentationSequential):
+            if isinstance(module, kornia.augmentation.AugmentationSequential):
                 input, label = module(input, label=label, params=param.data, data_keys=[cls.data_key])
             else:
                 input, label = module(input, label=label, params=param.data)
@@ -190,7 +190,7 @@ class InputApplyInverse(ApplyInverseImpl):
         """
         if isinstance(module, GeometricAugmentationBase2D):
             input = module.inverse(input, params=None if param is None else cast(Dict, param.data))
-        elif isinstance(module, kornia.augmentation.container.ImageSequential):
+        elif isinstance(module, kornia.augmentation.ImageSequential):
             temp = module.apply_inverse_func
             module.apply_inverse_func = InputApplyInverse
             input = module.inverse(input, params=None if param is None else cast(List, param.data))
@@ -203,7 +203,7 @@ class MaskApplyInverse(ApplyInverseImpl):
     data_key = DataKey.MASK
 
     @classmethod
-    def make_input_only_sequential(cls, module: "kornia.augmentation.container.ImageSequential") -> Callable:
+    def make_input_only_sequential(cls, module: "kornia.augmentation.ImageSequential") -> Callable:
         """Disable all other additional inputs (e.g. ) for ImageSequential."""
 
         def f(*args, **kwargs):
@@ -239,7 +239,7 @@ class MaskApplyInverse(ApplyInverseImpl):
         if isinstance(module, GeometricAugmentationBase2D):
             _param = cast(Dict[str, torch.Tensor], _param)
             input = module(input, params=_param, return_transform=False)
-        elif isinstance(module, kornia.augmentation.container.ImageSequential) and not module.is_intensity_only():
+        elif isinstance(module, kornia.augmentation.ImageSequential) and not module.is_intensity_only():
             _param = cast(List[ParamItem], _param)
             temp = module.apply_inverse_func
             module.apply_inverse_func = MaskApplyInverse
@@ -262,7 +262,7 @@ class MaskApplyInverse(ApplyInverseImpl):
         """
         if isinstance(module, GeometricAugmentationBase2D):
             input = module.inverse(input, params=None if param is None else cast(Dict, param.data))
-        elif isinstance(module, kornia.augmentation.container.ImageSequential):
+        elif isinstance(module, kornia.augmentation.ImageSequential):
             temp = module.apply_inverse_func
             module.apply_inverse_func = MaskApplyInverse
             input = module.inverse(input, params=None if param is None else cast(List, param.data))

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -418,7 +418,9 @@ class TestAugmentationSequential:
                 K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
             ),
             K.AugmentationSequential(
-                K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True)
+                K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0), K.RandomAffine(360, p=1.0, return_transform=True),
+                K.RandomAffine(360, p=1.0),
+                data_keys=["input", "mask", "bbox", "keypoints"]
             ),
             K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0),
             K.RandomAffine(360, p=1.0),


### PR DESCRIPTION
Things like this could work now.

```
aug = K.AugmentationSequential(
    K.ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0),
    K.RandomCrop((224, 224), pad_if_needed=True, cropping_mode="resample"),
    K.RandomAffine(360, [0.1, 0.1], [0.7, 1.2], [30., 50.], p=1.0),
    K.RandomPerspective(0.5, p=1.0),
    K.AugmentationSequential(
        K.RandomAffine(360, [0.1, 0.1], [0.7, 1.2], [30., 50.], p=1.0),
        data_keys=["input", "bbox_xyxy", "mask", "keypoints"]
    ),
    data_keys=["input", "bbox_xyxy", "mask", "keypoints"],  # Just to define the future input here.
    return_transform=False,
    same_on_batch=False,
)
```