### PR TITLE
fix translation sampling in AffineGenerator3D

### DIFF
--- a/kornia/augmentation/random_generator/_3d/affine.py
+++ b/kornia/augmentation/random_generator/_3d/affine.py
@@ -181,9 +181,9 @@ class AffineGenerator3D(RandomGeneratorBase):
             # translations should be in x,y,z
             translations = torch.stack(
                 [
-                    (_adapted_rsampling((batch_size,), self.yaw_sampler, same_on_batch) - 0.5) * max_dx * 2,
-                    (_adapted_rsampling((batch_size,), self.pitch_sampler, same_on_batch) - 0.5) * max_dy * 2,
-                    (_adapted_rsampling((batch_size,), self.roll_sampler, same_on_batch) - 0.5) * max_dz * 2,
+                     _adapted_uniform((batch_size,), -max_dx, max_dx, same_on_batch),
+                     _adapted_uniform((batch_size,), -max_dy, max_dy, same_on_batch),
+                     _adapted_uniform((batch_size,), -max_dz, max_dz, same_on_batch),
                 ],
                 dim=1,
             )


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
The translations were sampled using "yaw_sampler, pitch_sampler and roll_sampler", which should be independent of the translations.
<!-- Please also include relevant motivation and context. -->
Using the existing samplers does not return the desired values.
<!-- List any dependencies that are required for this change. -->
-
Fixes # (issue)
-

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
