### PR TITLE
add option for `sampling_method` in 2d perspective transform generation (#1591)

### DIFF
--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -22,9 +22,9 @@ class RandomPerspective(GeometricAugmentationBase2D):
         align_corners: interpolation flag.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
-        sampling_method: ``'basic'`` | ``'warpc'``. Default: ``'basic'``
+        sampling_method: ``'basic'`` | ``'area_preserving'``. Default: ``'basic'``
             If ``'basic'``, samples by translating the image corners randomly inwards.
-            If ``'warpc'``, samples by randomly translating the image corners in any direction.
+            If ``'area_preserving'``, samples by randomly translating the image corners in any direction.
             Preserves area on average. See https://arxiv.org/abs/2104.03308 for further details.
 
     Shape:

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -22,7 +22,10 @@ class RandomPerspective(GeometricAugmentationBase2D):
         align_corners: interpolation flag.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
-        area_preserving: if to apply random offsets which preserve image area on average.
+        sampling_method: ``'basic'`` | ``'warpc'``. Default: ``'basic'``
+            If ``'basic'``, samples by translating the image corners randomly inwards.
+            If ``'warpc'``, samples by randomly translating the image corners in any direction.
+            Preserves area on average. See https://arxiv.org/abs/2104.03308 for further details.
 
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
@@ -62,13 +65,13 @@ class RandomPerspective(GeometricAugmentationBase2D):
         align_corners: bool = False,
         p: float = 0.5,
         keepdim: bool = False,
-        area_preserving: bool = False,
+        sampling_method: str = "basic",
         return_transform: Optional[bool] = None,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         self._param_generator = cast(
             rg.PerspectiveGenerator,
-            rg.PerspectiveGenerator(distortion_scale, area_preserving=area_preserving)
+            rg.PerspectiveGenerator(distortion_scale, sampling_method=sampling_method)
         )
         self.flags: Dict[str, Any] = dict(align_corners=align_corners, resample=Resample.get(resample))
 

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -23,7 +23,7 @@ class RandomPerspective(GeometricAugmentationBase2D):
         align_corners: interpolation flag.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
-
+        area_preserving: if ``True``, applies random offsets which preserve image area on average.
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
         - Output: :math:`(B, C, H, W)`
@@ -63,9 +63,13 @@ class RandomPerspective(GeometricAugmentationBase2D):
         align_corners: bool = False,
         p: float = 0.5,
         keepdim: bool = False,
+        area_preserving: bool = False,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
-        self._param_generator = cast(rg.PerspectiveGenerator, rg.PerspectiveGenerator(distortion_scale))
+        self._param_generator = cast(
+            rg.PerspectiveGenerator,
+            rg.PerspectiveGenerator(distortion_scale, area_preserving=area_preserving)
+        )
         self.flags: Dict[str, Any] = dict(align_corners=align_corners, resample=Resample.get(resample))
 
     def compute_transformation(self, input: torch.Tensor, params: Dict[str, torch.Tensor]) -> torch.Tensor:

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -23,7 +23,8 @@ class RandomPerspective(GeometricAugmentationBase2D):
         align_corners: interpolation flag.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
-        area_preserving: if ``True``, applies random offsets which preserve image area on average.
+        area_preserving: if to apply random offsets which preserve image area on average.
+
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
         - Output: :math:`(B, C, H, W)`

--- a/kornia/augmentation/random_generator/_2d/perspective.py
+++ b/kornia/augmentation/random_generator/_2d/perspective.py
@@ -13,9 +13,9 @@ class PerspectiveGenerator(RandomGeneratorBase):
 
     Args:
         distortion_scale: the degree of distortion, ranged from 0 to 1.
-        sampling_method: ``'basic'`` | ``'warpc'``. Default: ``'basic'``
+        sampling_method: ``'basic'`` | ``'area_preserving'``. Default: ``'basic'``
             If ``'basic'``, samples by translating the image corners randomly inwards.
-            If ``'warpc'``, samples by randomly translating the image corners in any direction.
+            If ``'area_preserving'``, samples by randomly translating the image corners in any direction.
             Preserves area on average. See https://arxiv.org/abs/2104.03308 for further details.
 
     Returns:
@@ -31,7 +31,7 @@ class PerspectiveGenerator(RandomGeneratorBase):
 
     def __init__(self, distortion_scale: Union[torch.Tensor, float] = 0.5, sampling_method: str = "basic") -> None:
         super().__init__()
-        if sampling_method not in ("basic", "warpc"):
+        if sampling_method not in ("basic", "area_preserving"):
             raise NotImplementedError(f"Sampling method {self.sampling_method} not yet implemented.")
         self.distortion_scale = distortion_scale
         self.sampling_method = sampling_method
@@ -77,7 +77,7 @@ class PerspectiveGenerator(RandomGeneratorBase):
         if self.sampling_method == "basic":
             pts_norm = torch.tensor([[[1, 1], [-1, 1], [-1, -1], [1, -1]]], device=_device, dtype=_dtype)
             offset = factor * rand_val * pts_norm
-        elif self.sampling_method == "warpc":
+        elif self.sampling_method == "area_preserving":
             offset = 2 * factor * (rand_val - 0.5)
 
         end_points = start_points + offset

--- a/kornia/augmentation/random_generator/_2d/perspective.py
+++ b/kornia/augmentation/random_generator/_2d/perspective.py
@@ -32,7 +32,7 @@ class PerspectiveGenerator(RandomGeneratorBase):
     def __init__(self, distortion_scale: Union[torch.Tensor, float] = 0.5, sampling_method: str = "basic") -> None:
         super().__init__()
         if sampling_method not in ("basic", "area_preserving"):
-            raise NotImplementedError(f"Sampling method {self.sampling_method} not yet implemented.")
+            raise NotImplementedError(f"Sampling method {sampling_method} not yet implemented.")
         self.distortion_scale = distortion_scale
         self.sampling_method = sampling_method
 

--- a/test/augmentation/test_perspective_rand.py
+++ b/test/augmentation/test_perspective_rand.py
@@ -84,7 +84,7 @@ class TestRandomPerspective:
         assert out_perspective.shape == x_data.shape
         assert aug.transform_matrix.shape == (1, 3, 3)
         assert_close(out_perspective, x_data)
-        assert_close(aug.transform_matrix, torch.eye(3, device=device)[None])
+        assert_close(aug.transform_matrix, torch.eye(3, device=device, dtype=dtype)[None])
         assert aug.inverse(out_perspective).shape == x_data.shape
 
     def test_transform_module_should_return_expected_transform(self, device, dtype):

--- a/test/augmentation/test_perspective_rand.py
+++ b/test/augmentation/test_perspective_rand.py
@@ -89,7 +89,7 @@ class TestRandomPerspective:
 
     def test_transform_module_should_return_expected_transform(self, device, dtype):
         torch.manual_seed(0)
-        x_data = torch.rand(1, 2, 4, 5, dtype=dtype).to(device)
+        x_data = torch.rand(1, 2, 4, 5).to(device).type(dtype)
 
         expected_output = torch.tensor(
             [

--- a/test/augmentation/test_perspective_rand.py
+++ b/test/augmentation/test_perspective_rand.py
@@ -45,7 +45,7 @@ class TestRandomPerspective:
     def test_smoke_transform_sampling_method(self, device):
         x_data = torch.rand(1, 2, 4, 5).to(device)
 
-        aug = kornia.augmentation.RandomPerspective(0.5, p=0.5, sampling_method="warpc")
+        aug = kornia.augmentation.RandomPerspective(0.5, p=0.5, sampling_method="area_preserving")
 
         out_perspective = aug(x_data)
 

--- a/test/augmentation/test_perspective_rand.py
+++ b/test/augmentation/test_perspective_rand.py
@@ -42,10 +42,10 @@ class TestRandomPerspective:
         assert aug.transform_matrix.shape == torch.Size([1, 3, 3])
         assert aug.inverse(out_perspective).shape == x_data.shape
 
-    def test_smoke_transform_area_preserving(self, device):
+    def test_smoke_transform_sampling_method(self, device):
         x_data = torch.rand(1, 2, 4, 5).to(device)
 
-        aug = kornia.augmentation.RandomPerspective(0.5, p=0.5, area_preserving=True)
+        aug = kornia.augmentation.RandomPerspective(0.5, p=0.5, sampling_method="warpc")
 
         out_perspective = aug(x_data)
 

--- a/test/augmentation/test_perspective_rand.py
+++ b/test/augmentation/test_perspective_rand.py
@@ -44,6 +44,19 @@ class TestRandomPerspective:
         assert out_perspective[1].shape == (1, 3, 3)
         assert aug.inverse(out_perspective).shape == x_data.shape
 
+    def test_smoke_transform_area_preserving(self, device):
+        x_data = torch.rand(1, 2, 4, 5).to(device)
+
+        aug = kornia.augmentation.RandomPerspective(0.5, p=0.5, return_transform=True, area_preserving=True)
+
+        out_perspective = aug(x_data)
+
+        assert isinstance(out_perspective, tuple)
+        assert len(out_perspective) == 2
+        assert out_perspective[0].shape == x_data.shape
+        assert out_perspective[1].shape == (1, 3, 3)
+        assert aug.inverse(out_perspective).shape == x_data.shape
+
     def test_no_transform_module(self, device):
         x_data = torch.rand(1, 2, 8, 9).to(device)
         aug = kornia.augmentation.RandomPerspective()

--- a/test/augmentation/test_perspective_rand.py
+++ b/test/augmentation/test_perspective_rand.py
@@ -45,14 +45,12 @@ class TestRandomPerspective:
     def test_smoke_transform_area_preserving(self, device):
         x_data = torch.rand(1, 2, 4, 5).to(device)
 
-        aug = kornia.augmentation.RandomPerspective(0.5, p=0.5, return_transform=True, area_preserving=True)
+        aug = kornia.augmentation.RandomPerspective(0.5, p=0.5, area_preserving=True)
 
         out_perspective = aug(x_data)
 
-        assert isinstance(out_perspective, tuple)
-        assert len(out_perspective) == 2
-        assert out_perspective[0].shape == x_data.shape
-        assert out_perspective[1].shape == (1, 3, 3)
+        assert out_perspective.shape == x_data.shape
+        assert aug.transform_matrix.shape == torch.Size([1, 3, 3])
         assert aug.inverse(out_perspective).shape == x_data.shape
 
     def test_no_transform_module(self, device):

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -269,10 +269,10 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
         assert_close(res['start_points'], expected['start_points'])
         assert_close(res['end_points'], expected['end_points'])
 
-    def test_area_preserving(self, device, dtype):
+    def test_sampling_method(self, device, dtype):
         torch.manual_seed(42)
         batch_size = 2
-        res = PerspectiveGenerator(torch.tensor(0.5, device=device, dtype=dtype), area_preserving=True)(
+        res = PerspectiveGenerator(torch.tensor(0.5, device=device, dtype=dtype), sampling_method="warpc")(
             torch.Size([batch_size, 1, 200, 200])
         )
 

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -269,6 +269,36 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
         assert_close(res['start_points'], expected['start_points'])
         assert_close(res['end_points'], expected['end_points'])
 
+    def test_area_preserving(self, device, dtype):
+        torch.manual_seed(42)
+        batch_size = 2
+        res = PerspectiveGenerator(torch.tensor(0.5, device=device, dtype=dtype), area_preserving=True)(
+            torch.Size([batch_size, 1, 200, 200])
+        )
+
+        expected = dict(
+            start_points=torch.tensor(
+                [
+                    [[0.0, 0.0], [199.0, 0.0], [199.0, 199.0], [0.0, 199.0]],
+                    [[0.0, 0.0], [199.0, 0.0], [199.0, 199.0], [0.0, 199.0]],
+                ],
+                device=device,
+                dtype=dtype,
+            ),
+            end_points=torch.tensor(
+                [
+                    [[38.2269, 41.5004], [187.2864, 45.9306], [188.0448, 209.0895], [-24.3428, 228.3641]],
+                    [[44.0771, -36.6814], [242.4598, 9.3580], [235.9404, 205.7715], [24.1094, 191.9404]],
+                ],
+                device=device,
+                dtype=dtype,
+            ),
+        )
+        print(res['end_points'])
+        assert res.keys() == expected.keys()
+        assert_close(res['start_points'], expected['start_points'])
+        assert_close(res['end_points'], expected['end_points'])
+
 
 class TestRandomAffineGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize('batch_size', [0, 1, 4])

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -272,7 +272,7 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
     def test_sampling_method(self, device, dtype):
         torch.manual_seed(42)
         batch_size = 2
-        res = PerspectiveGenerator(torch.tensor(0.5, device=device, dtype=dtype), sampling_method="warpc")(
+        res = PerspectiveGenerator(torch.tensor(0.5, device=device, dtype=dtype), sampling_method="area_preserving")(
             torch.Size([batch_size, 1, 200, 200])
         )
 

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -298,6 +298,15 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
         assert_close(res['start_points'], expected['start_points'])
         assert_close(res['end_points'], expected['end_points'])
 
+    def test_not_implemented_sampling_method(self, device, dtype):
+        batch_size = 2
+        with pytest.raises(NotImplementedError):
+            PerspectiveGenerator(
+                torch.tensor(0.5, device=device, dtype=dtype),
+                sampling_method="non_existing_method")(
+                torch.Size([batch_size, 1, 200, 200])
+            )
+
 
 class TestRandomAffineGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize('batch_size', [0, 1, 4])

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -294,7 +294,6 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
                 dtype=dtype,
             ),
         )
-        print(res['end_points'])
         assert res.keys() == expected.keys()
         assert_close(res['start_points'], expected['start_points'])
         assert_close(res['end_points'], expected['end_points'])


### PR DESCRIPTION
#### Changes
Adds the requested functionality of #1591 for the 2D case.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
