### PR TITLE
Update `combine_tensor_patches`

### DIFF
--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -151,7 +151,7 @@ def combine_tensor_patches(
     original_size: Union[int, Tuple[int, int]],
     window_size: Union[int, Tuple[int, int]],
     stride: Union[int, Tuple[int, int]],
-    unpadding: Union[int, Tuple[int, int]] = 0,
+    unpadding: Union[int, Tuple[int, int], Tuple[int, int, int, int]] = 0,
 ) -> torch.Tensor:
     r"""Restore input from patches.
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -180,7 +180,7 @@ def combine_tensor_patches(
     """
 
     if len(patches.shape) != 5:
-        raise ValueError(f"Invalid input shape, we expect BxPxCxHxW. Got: {patches.shape}")
+        raise ValueError(f"Invalid input shape, we expect BxNxCxHxW. Got: {patches.shape}")
 
     original_size = _pair(original_size)
     window_size = _pair(window_size)

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -148,12 +148,14 @@ class CombineTensorPatches(nn.Module):
 
 def combine_tensor_patches(
     patches: torch.Tensor,
-    original_size: Tuple[int, int] = (16, 16),
-    window_size: Tuple[int, int] = (4, 4),
-    stride: Tuple[int, int] = (4, 4),
-    unpadding: Optional[Tuple[int, int, int, int]] = None,
+    original_size: Union[int, Tuple[int, int]],
+    window_size: Union[int, Tuple[int, int]],
+    stride: Union[int, Tuple[int, int]],
+    unpadding: Union[int, Tuple[int, int]] = 0,
 ) -> torch.Tensor:
     r"""Restore input from patches.
+
+    See :class:`~kornia.contrib.CombineTensorPatches` for details.
 
     Args:
         patches: patched tensor with shape :math:`(B, N, C, H_{out}, W_{out})`.
@@ -176,6 +178,18 @@ def combine_tensor_patches(
     .. note::
         This function is supposed to be used in conjunction with :func:`extract_tensor_patches`.
     """
+
+    if len(patches.shape) != 5:
+        raise ValueError(f"Invalid input shape, we expect BxPxCxHxW. Got: {patches.shape}")
+
+    original_size = _pair(original_size)
+    window_size = _pair(window_size)
+    stride = _pair(stride)
+    unpadding = _pair(unpadding)
+
+    if len(unpadding) == 2:
+        unpadding = _pair(unpadding[0]) + _pair(unpadding[1])
+
     if stride[0] != window_size[0] or stride[1] != window_size[1]:
         raise NotImplementedError(
             f"Only stride == window_size is supported. Got {stride} and {window_size}."

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -200,7 +200,7 @@ def combine_tensor_patches(
         unpadding = cast(PadType, _pair(unpadding))
 
         if len(unpadding) not in [2, 4]:
-            raise NotImplementedError("Unpadding must be either an int, tuple of two ints or tuple of four ints")
+            raise AssertionError("Unpadding must be either an int, tuple of two ints or tuple of four ints")
 
         if len(unpadding) == 2:
             pad_vert = _pair(unpadding[0])
@@ -281,7 +281,7 @@ def extract_tensor_patches(
         padding = cast(PadType, _pair(padding))
 
         if len(padding) not in [2, 4]:
-            raise NotImplementedError("Padding must be either an int, tuple of two ints or tuple of four ints")
+            raise AssertionError("Padding must be either an int, tuple of two ints or tuple of four ints")
 
         if len(padding) == 2:
             pad_vert = _pair(padding[0])

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -294,6 +294,24 @@ class TestCombineTensorPatches:
                 patches, original_size=(8, 8), window_size=(4, 4), stride=(4, 4), unpadding=(1, 1, 1, 1)
             )
 
+    def test_pad_triple_error(self, device, dtype):
+        patches = kornia.contrib.extract_tensor_patches(
+            torch.arange(36, device=device, dtype=dtype).view(1, 1, 6, 6), window_size=(4, 4), stride=(4, 4), padding=1
+        )
+        with pytest.raises(NotImplementedError):
+            kornia.contrib.combine_tensor_patches(
+                patches, original_size=(6, 6), window_size=(4, 4), stride=(4, 4), unpadding=(1, 1, 1)
+            )
+
+    def test_pad_quadruple(self, device, dtype):
+        img = torch.arange(36, device=device, dtype=dtype).view(1, 1, 6, 6)
+        patches = kornia.contrib.extract_tensor_patches(img, window_size=(4, 4), stride=(4, 4), padding=1)
+
+        merged = kornia.contrib.combine_tensor_patches(
+            patches, original_size=(6, 6), window_size=(4, 4), stride=(4, 4), unpadding=(1, 1, 1, 1)
+        )
+        assert merged.shape == (1, 1, 6, 6)
+
     def test_rectangle_array(self, device, dtype):
         img = torch.arange(24, device=device, dtype=dtype).view(1, 1, 4, 6)
         patches = kornia.contrib.extract_tensor_patches(img, window_size=(2, 2), stride=(2, 2), padding=1)

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -298,7 +298,7 @@ class TestCombineTensorPatches:
         patches = kornia.contrib.extract_tensor_patches(
             torch.arange(36, device=device, dtype=dtype).view(1, 1, 6, 6), window_size=(4, 4), stride=(4, 4), padding=1
         )
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(AssertionError):
             kornia.contrib.combine_tensor_patches(
                 patches, original_size=(6, 6), window_size=(4, 4), stride=(4, 4), unpadding=(1, 1, 1)
             )


### PR DESCRIPTION
This PR aims to have `combine_tensor_patches` expose a similar API as `extract_tensor_patches`

#### Changes
- Have `combine_tensor_patches` accept `int` or `Tuple[int,int]`
- Have unpadding also accept Tuple[int, int, int, int]
- Remove default value for args
- Bugfix for padding
- Add tests for invalid padding





#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
