### PR TITLE
Update batch shape when augmentations change size of image

### DIFF
--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -48,7 +48,7 @@ class Resize(GeometricAugmentationBase2D):
         self, input: Tensor, params: Dict[str, Tensor], transform: Optional[Tensor] = None
     ) -> Tensor:
         B, C, _, _ = input.shape
-        out_size = tuple(params["output_size"].tolist())
+        out_size = tuple(params["output_size"][0].tolist())
         out = torch.empty(B, C, *out_size, device=input.device, dtype=input.dtype)
         for i in range(B):
             x1 = int(params["src"][i, 0, 0])

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -37,7 +37,7 @@ class Resize(GeometricAugmentationBase2D):
         self.flags = dict(size=size, side=side, resample=Resample.get(resample), align_corners=align_corners)
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor]) -> Tensor:
-        if params["resize_to"] == input.shape[-2:]:
+        if params["output_size"] == input.shape[-2:]:
             return eye_like(3, input)
 
         transform: Tensor = get_perspective_transform(params["src"], params["dst"])
@@ -48,7 +48,7 @@ class Resize(GeometricAugmentationBase2D):
         self, input: Tensor, params: Dict[str, Tensor], transform: Optional[Tensor] = None
     ) -> Tensor:
         B, C, _, _ = input.shape
-        out_size = tuple(params["resize_to"].tolist())
+        out_size = tuple(params["output_size"].tolist())
         out = torch.empty(B, C, *out_size, device=input.device, dtype=input.dtype)
         for i in range(B):
             x1 = int(params["src"][i, 0, 0])

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -225,7 +225,7 @@ class ImageSequential(SequentialBase):
                 param = ParamItem(name, mod_param)
             else:
                 param = ParamItem(name, None)
-            batch_shape: torch.Size = _get_new_batch_shape(param, batch_shape)
+            batch_shape = _get_new_batch_shape(param, batch_shape)
             params.append(param)
         return params
 

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -220,7 +220,7 @@ class ImageSequential(SequentialBase):
             if isinstance(module, RandomCrop):
                 mod_param = module.forward_parameters_precrop(batch_shape)
                 param = ParamItem(name, mod_param)
-            elif isinstance(module, (_AugmentationBase, MixAugmentationBase)):
+            elif isinstance(module, (_AugmentationBase, MixAugmentationBase, ImageSequential,)):
                 mod_param = module.forward_parameters(batch_shape)
                 param = ParamItem(name, mod_param)
             elif isinstance(module, ImageSequential):
@@ -373,7 +373,7 @@ class ImageSequential(SequentialBase):
         return self.__packup_output__(input, label)
 
 
-def _get_new_batch_shape(param, batch_shape):
+def _get_new_batch_shape(param, batch_shape: Size) -> Size:
     if param.data is None:
         return batch_shape
     if isinstance(param.data, list):

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -220,9 +220,6 @@ class ImageSequential(SequentialBase):
             if isinstance(module, RandomCrop):
                 mod_param = module.forward_parameters_precrop(batch_shape)
                 param = ParamItem(name, mod_param)
-                cropped_batch_shape = list(batch_shape)
-                cropped_batch_shape[-2:] = module.flags['size']
-                batch_shape = torch.Size(cropped_batch_shape)
             elif isinstance(module, (_AugmentationBase, MixAugmentationBase)):
                 mod_param = module.forward_parameters(batch_shape)
                 param = ParamItem(name, mod_param)
@@ -231,6 +228,7 @@ class ImageSequential(SequentialBase):
                 param = ParamItem(name, mod_param)
             else:
                 param = ParamItem(name, None)
+            batch_shape = _get_new_batch_shape(param, batch_shape)
             params.append(param)
         return params
 
@@ -373,3 +371,16 @@ class ImageSequential(SequentialBase):
                 param = ParamItem(param.name, None)
             self.update_params(param)
         return self.__packup_output__(input, label)
+
+
+def _get_new_batch_shape(param, batch_shape):
+    if param.data is None:
+        return batch_shape
+    if isinstance(param.data, list):
+        for p in param.data:
+            batch_shape = _get_new_batch_shape(p, batch_shape)
+    elif 'output_size' in param.data:
+        new_batch_shape = list(batch_shape)
+        new_batch_shape[-2:] = param.data['output_size']
+        batch_shape = torch.Size(new_batch_shape)
+    return batch_shape

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -200,13 +200,12 @@ class VideoSequential(ImageSequential):
                 if self.same_on_frame:
                     for k, v in mod_param.items():
                         # TODO: revise colorjitter order param in the future to align the standard.
-                        if not (k == "order" and isinstance(module, kornia.augmentation.ColorJitter)) \
-                                and not (k == 'output_size'):
+                        if not (k == "order" and isinstance(module, kornia.augmentation.ColorJitter)):
                             mod_param.update({k: self.__repeat_param_across_channels__(v, frame_num)})
                 param = ParamItem(name, mod_param)
             else:
                 param = ParamItem(name, None)
-            batch_shape: Size = _get_new_batch_shape(param, batch_shape)
+            batch_shape: torch.Size = _get_new_batch_shape(param, batch_shape)
             params.append(param)
         return params
 

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -205,7 +205,7 @@ class VideoSequential(ImageSequential):
                 param = ParamItem(name, mod_param)
             else:
                 param = ParamItem(name, None)
-            batch_shape: torch.Size = _get_new_batch_shape(param, batch_shape)
+            batch_shape = _get_new_batch_shape(param, batch_shape)
             params.append(param)
         return params
 

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -206,7 +206,7 @@ class VideoSequential(ImageSequential):
                 param = ParamItem(name, mod_param)
             else:
                 param = ParamItem(name, None)
-            batch_shape = _get_new_batch_shape(param, batch_shape)
+            batch_shape: Size = _get_new_batch_shape(param, batch_shape)
             params.append(param)
         return params
 

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -8,7 +8,7 @@ from kornia.augmentation import RandomCrop
 from kornia.augmentation._2d.mix.base import MixAugmentationBase
 from kornia.augmentation.base import _AugmentationBase
 from kornia.augmentation.container.base import SequentialBase
-from kornia.augmentation.container.image import ImageSequential, ParamItem
+from kornia.augmentation.container.image import ImageSequential, ParamItem, _get_new_batch_shape
 from kornia.augmentation.container.utils import InputApplyInverse, MaskApplyInverse
 
 __all__ = ["VideoSequential"]
@@ -200,11 +200,13 @@ class VideoSequential(ImageSequential):
                 if self.same_on_frame:
                     for k, v in mod_param.items():
                         # TODO: revise colorjitter order param in the future to align the standard.
-                        if not (k == "order" and isinstance(module, kornia.augmentation.ColorJitter)):
+                        if not (k == "order" and isinstance(module, kornia.augmentation.ColorJitter)) \
+                                and not (k == 'output_size'):
                             mod_param.update({k: self.__repeat_param_across_channels__(v, frame_num)})
                 param = ParamItem(name, mod_param)
             else:
                 param = ParamItem(name, None)
+            batch_shape = _get_new_batch_shape(param, batch_shape)
             params.append(param)
         return params
 

--- a/kornia/augmentation/random_generator/_2d/crop.py
+++ b/kornia/augmentation/random_generator/_2d/crop.py
@@ -101,7 +101,7 @@ class CropGenerator(RandomGeneratorBase):
                 size[:, 1],
                 size[:, 0],
             )
-            output_size = (int(size[0, 0].item()), int(size[0, 1].item()))
+            _output_size = size.to(dtype=torch.long)
         else:
             if not (
                 len(self.resize_to) == 2
@@ -123,11 +123,11 @@ class CropGenerator(RandomGeneratorBase):
                 device=_device,
                 dtype=_dtype,
             ).repeat(batch_size, 1, 1)
-            output_size = self.resize_to
+            _output_size = torch.tensor(self.resize_to, device=_device, dtype=torch.long).expand(batch_size, -1)
 
         _input_size = torch.tensor(input_size, device=_device, dtype=torch.long).expand(batch_size, -1)
 
-        return dict(src=crop_src, dst=crop_dst, input_size=_input_size, output_size=output_size)
+        return dict(src=crop_src, dst=crop_dst, input_size=_input_size, output_size=_output_size)
 
 
 class ResizedCropGenerator(CropGenerator):
@@ -517,5 +517,6 @@ def center_crop_generator(
     ).expand(batch_size, -1, -1)
 
     _input_size = torch.tensor((height, width), device=device, dtype=torch.long).expand(batch_size, -1)
+    _output_size = torch.tensor(size, device=device, dtype=torch.long).expand(batch_size, -1)
 
-    return dict(src=points_src, dst=points_dst, input_size=_input_size, output_size=size)
+    return dict(src=points_src, dst=points_dst, input_size=_input_size, output_size=_output_size)

--- a/kornia/augmentation/random_generator/_2d/crop.py
+++ b/kornia/augmentation/random_generator/_2d/crop.py
@@ -101,6 +101,7 @@ class CropGenerator(RandomGeneratorBase):
                 size[:, 1],
                 size[:, 0],
             )
+            output_size = (int(size[0, 0].item()), int(size[0, 1].item()))
         else:
             if not (
                 len(self.resize_to) == 2
@@ -122,10 +123,11 @@ class CropGenerator(RandomGeneratorBase):
                 device=_device,
                 dtype=_dtype,
             ).repeat(batch_size, 1, 1)
+            output_size = self.resize_to
 
         _input_size = torch.tensor(input_size, device=_device, dtype=torch.long).expand(batch_size, -1)
 
-        return dict(src=crop_src, dst=crop_dst, input_size=_input_size)
+        return dict(src=crop_src, dst=crop_dst, input_size=_input_size, output_size=output_size)
 
 
 class ResizedCropGenerator(CropGenerator):
@@ -516,4 +518,4 @@ def center_crop_generator(
 
     _input_size = torch.tensor((height, width), device=device, dtype=torch.long).expand(batch_size, -1)
 
-    return dict(src=points_src, dst=points_dst, input_size=_input_size)
+    return dict(src=points_src, dst=points_dst, input_size=_input_size, output_size=size)

--- a/kornia/augmentation/random_generator/_2d/resize.py
+++ b/kornia/augmentation/random_generator/_2d/resize.py
@@ -87,4 +87,4 @@ class ResizeGenerator(RandomGeneratorBase):
 
         _input_size = torch.tensor(input_size, device=_device, dtype=torch.long).expand(batch_size, -1)
 
-        return dict(src=src, dst=dst, input_size=_input_size, resize_to=torch.as_tensor(self.resize_to))
+        return dict(src=src, dst=dst, input_size=_input_size, output_size=torch.as_tensor(self.resize_to))

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -410,7 +410,7 @@ class TestRandomCropGen(RandomGeneratorBaseTests):
                 dtype=dtype,
             ),
             input_size=torch.tensor([[100, 100], [100, 100]], device=device, dtype=torch.long),
-            output_size=(200, 200)
+            output_size=torch.tensor([[200, 200], [200, 200]], device=device, dtype=torch.long)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -433,7 +433,7 @@ class TestRandomCropGen(RandomGeneratorBaseTests):
                 dtype=dtype,
             ),
             input_size=torch.tensor([[100, 100], [100, 100]], device=device, dtype=torch.long),
-            output_size=(200, 200)
+            output_size=torch.tensor([[200, 200], [200, 200]], device=device, dtype=torch.long)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -502,7 +502,7 @@ class TestRandomCropSizeGen(RandomGeneratorBaseTests):
                 device=device,
                 dtype=torch.int64,
             ),
-            output_size=(100, 100)
+            output_size=torch.tensor([[100, 100], [100, 100]], device=device, dtype=torch.long)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -538,7 +538,7 @@ class TestRandomCropSizeGen(RandomGeneratorBaseTests):
                 device=device,
                 dtype=torch.int64,
             ),
-            output_size=(100, 100)
+            output_size=torch.tensor([[100, 100], [100, 100]], device=device, dtype=torch.long)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -675,7 +675,7 @@ class TestCenterCropGen(RandomGeneratorBaseTests):
                 dtype=torch.long,
             ),
             input_size=torch.tensor([[200, 200], [200, 200]], device=device, dtype=torch.long),
-            output_size=(120, 150)
+            output_size=torch.tensor([[120, 150], [120, 150]], device=device, dtype=torch.long)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'].to(device=device), expected['src'])

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -410,6 +410,7 @@ class TestRandomCropGen(RandomGeneratorBaseTests):
                 dtype=dtype,
             ),
             input_size=torch.tensor([[100, 100], [100, 100]], device=device, dtype=torch.long),
+            output_size=(200, 200)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -432,6 +433,7 @@ class TestRandomCropGen(RandomGeneratorBaseTests):
                 dtype=dtype,
             ),
             input_size=torch.tensor([[100, 100], [100, 100]], device=device, dtype=torch.long),
+            output_size=(200, 200)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -500,6 +502,7 @@ class TestRandomCropSizeGen(RandomGeneratorBaseTests):
                 device=device,
                 dtype=torch.int64,
             ),
+            output_size=(100, 100)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -535,6 +538,7 @@ class TestRandomCropSizeGen(RandomGeneratorBaseTests):
                 device=device,
                 dtype=torch.int64,
             ),
+            output_size=(100, 100)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'], expected['src'])
@@ -671,6 +675,7 @@ class TestCenterCropGen(RandomGeneratorBaseTests):
                 dtype=torch.long,
             ),
             input_size=torch.tensor([[200, 200], [200, 200]], device=device, dtype=torch.long),
+            output_size=(120, 150)
         )
         assert res.keys() == expected.keys()
         assert_close(res['src'].to(device=device), expected['src'])


### PR DESCRIPTION
#### Changes
Previously we were only updating the batch shape when computing parameters for the RandomCrop augmentation but there are other augmentations that change the image size, e.g. CenterCrop or Resize, which were not doing so and thus the parameters of next augmentations can be wrongly computed. I'll give an example below.

In this PR I propose to hold in the parameters of such augmentations the output image size so that the batch shape that is used to compute the parameters of subsequent augmentations can be updated correctly.

I might have missed augmentations that change the size and for which we should also add an output size in the parameters, if so let me know and I'll add them.

-----

Fixes an unreported issue I believe but explained below.

Chaining Resize and RandomCrop operations results in wrong parameters for the latter, also chaining any image size changing augmentation inside a container with other augmentations that require the correct batch shape. This code snippet illustrates the issue:

```python
from kornia import augmentation as K
import torch
import matplotlib.pyplot as plt

torch.manual_seed(0)

data_keys = [0]
_ORIGINAL_IMAGE_SIZE = (100, 100)

img = torch.randn((1,3,_ORIGINAL_IMAGE_SIZE[0],_ORIGINAL_IMAGE_SIZE[1]))

transforms = [
            K.AugmentationSequential(
                K.Resize((round(_ORIGINAL_IMAGE_SIZE[0]/2), round(_ORIGINAL_IMAGE_SIZE[1]/2))),
                K.Resize((round(_ORIGINAL_IMAGE_SIZE[0]*2), round(_ORIGINAL_IMAGE_SIZE[1]*2))),
               data_keys=data_keys, random_apply=1
            ),  # simulated random resize with 2 scales
            K.RandomCrop((80,80), pad_if_needed=True, cropping_mode='resample'),
        ]
trans = K.AugmentationSequential(*transforms, data_keys=data_keys)

img = img.to(dtype=torch.float32) / 255

a = trans(img)

print(f"Params: {trans._params}")

b = trans[0](img, params=trans[0]._params)
print(b.shape)
c = trans[1](b, params=trans[1]._params)
print(c.shape)
```

Result in master:
```
Params: [ParamItem(name='AugmentationSequential_0', data=[ParamItem(name='Resize_1', data={'src': tensor([[[ 0.,  0.],
         [99.,  0.],
         [99., 99.],
         [ 0., 99.]]]), 'dst': tensor([[[  0.,   0.],
         [199.,   0.],
         [199., 199.],
         [  0., 199.]]]), 'input_size': tensor([[100, 100]]), 'resize_to': tensor([200, 200]), 'batch_prob': tensor([True]), 'forward_input_shape': tensor([  1,   3, 100, 100])})]), ParamItem(name='RandomCrop_1', data={'src': tensor([[[19., 11.],
         [98., 11.],
         [98., 90.],
         [19., 90.]]]), 'dst': tensor([[[ 0.,  0.],
         [79.,  0.],
         [79., 79.],
         [ 0., 79.]]]), 'input_size': tensor([[100, 100]]), 'batch_prob': tensor([True]), 'forward_input_shape': tensor([  1,   3, 100, 100]), 'padding_size': tensor([[0, 0, 0, 0]])})]
torch.Size([1, 3, 200, 200])
torch.Size([1, 3, 80, 80])
```

Result after this PR:
```
Params: [ParamItem(name='AugmentationSequential_0', data=[ParamItem(name='Resize_1', data={'src': tensor([[[ 0.,  0.],
         [99.,  0.],
         [99., 99.],
         [ 0., 99.]]]), 'dst': tensor([[[  0.,   0.],
         [199.,   0.],
         [199., 199.],
         [  0., 199.]]]), 'input_size': tensor([[100, 100]]), 'output_size': tensor([200, 200]), 'batch_prob': tensor([True]), 'forward_input_shape': tensor([  1,   3, 100, 100])})]), ParamItem(name='RandomCrop_1', data={'src': tensor([[[110.,  68.],
         [189.,  68.],
         [189., 147.],
         [110., 147.]]]), 'dst': tensor([[[ 0.,  0.],
         [79.,  0.],
         [79., 79.],
         [ 0., 79.]]]), 'input_size': tensor([[200, 200]]), 'output_size': (80, 80), 'batch_prob': tensor([True]), 'forward_input_shape': tensor([  1,   3, 200, 200]), 'padding_size': tensor([[0, 0, 0, 0]])})]
torch.Size([1, 3, 200, 200])
torch.Size([1, 3, 80, 80])
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
