### PR TITLE
Fix warning: `meshgrid` need `indexing argument`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: ^$|.devcontainer
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--diff]

--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -39,7 +39,7 @@ else:
 
 
 if version.parse(torch_version()) > version.parse("1.9.1"):
-    from torch import torch_meshgrid  # type: ignore
+    from torch import meshgrid  # type: ignore
 else:
     from torch import meshgrid as _meshgrid
 

--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -1,4 +1,7 @@
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
 import torch
+from torch import Tensor
 
 from packaging import version
 
@@ -22,7 +25,7 @@ else:
     from torch import solve as _solve
 
     # NOTE: in previous versions `torch.solve` accepted arguments in another order.
-    def solve(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+    def solve(A: Tensor, B: Tensor) -> Tensor:
         return _solve(B, A).solution
 
 
@@ -33,3 +36,19 @@ if version.parse(torch_version()) > version.parse("1.7.1"):
     from torch.linalg import qr as linalg_qr  # type: ignore
 else:
     from torch import qr as linalg_qr  # type: ignore # noqa: F401
+
+
+if version.parse(torch_version()) > version.parse("1.9.1"):
+    from torch import torch_meshgrid  # type: ignore
+else:
+    from torch import meshgrid as _meshgrid
+
+    if TYPE_CHECKING:
+        # The JIT doesn't understand Union, so only add type annotation for mypy
+        def torch_meshgrid(*tensors: Union[Tensor, List[Tensor]]) -> Tuple[Tensor, ...]:
+            return _meshgrid(*tensors)
+
+    else:
+        # NOTE: the typing below has been modified to make happy torchscript
+        def torch_meshgrid(tensors: List[Tensor], indexing: Optional[str] = None) -> List[Tensor]:
+            return _meshgrid(tensors)

--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -38,17 +38,22 @@ else:
     from torch import qr as linalg_qr  # type: ignore # noqa: F401
 
 
+# TODO: remove after deprecating < 1.9.1
 if version.parse(torch_version()) > version.parse("1.9.1"):
-    from torch import meshgrid as torch_meshgrid  # type: ignore
+
+    if not TYPE_CHECKING:
+
+        def torch_meshgrid(tensors: List[Tensor], indexing: str):
+            return torch.meshgrid(tensors, indexing=indexing)
+
 else:
-    from torch import meshgrid as _meshgrid
 
     if TYPE_CHECKING:
-        # The JIT doesn't understand Union, so only add type annotation for mypy
-        def torch_meshgrid(*tensors: Union[Tensor, List[Tensor]]) -> Tuple[Tensor, ...]:
-            return _meshgrid(*tensors)
+
+        def torch_meshgrid(tensors: List[Tensor], indexing: Optional[str] = None) -> Tuple[Tensor, ...]:
+            return torch.meshgrid(tensors)
 
     else:
-        # NOTE: the typing below has been modified to make happy torchscript
-        def torch_meshgrid(tensors: List[Tensor], indexing: Optional[str] = None) -> List[Tensor]:
-            return _meshgrid(tensors)
+
+        def torch_meshgrid(tensors: List[Tensor], indexing: str):
+            return torch.meshgrid(tensors)

--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -39,7 +39,7 @@ else:
 
 
 if version.parse(torch_version()) > version.parse("1.9.1"):
-    from torch import meshgrid  # type: ignore
+    from torch import meshgrid as torch_meshgrid  # type: ignore
 else:
     from torch import meshgrid as _meshgrid
 

--- a/kornia/utils/grid.py
+++ b/kornia/utils/grid.py
@@ -60,7 +60,7 @@ def create_meshgrid(
         xs = (xs / (width - 1) - 0.5) * 2
         ys = (ys / (height - 1) - 0.5) * 2
     # generate grid by stacking coordinates
-    base_grid = stack(torch_meshgrid([xs, ys], indexing="ij"), dim=-1)  # WxHx2
+    base_grid: Tensor = stack(torch_meshgrid([xs, ys], indexing="ij"), dim=-1)  # WxHx2
     return base_grid.permute(1, 0, 2).unsqueeze(0)  # 1xHxWx2
 
 

--- a/kornia/utils/grid.py
+++ b/kornia/utils/grid.py
@@ -57,7 +57,7 @@ def create_meshgrid(
         xs = (xs / (width - 1) - 0.5) * 2
         ys = (ys / (height - 1) - 0.5) * 2
     # generate grid by stacking coordinates
-    base_grid: torch.Tensor = torch.stack(torch.meshgrid([xs, ys]), dim=-1)  # WxHx2
+    base_grid: torch.Tensor = torch.stack(torch.meshgrid([xs, ys], indexing="ij"), dim=-1)  # WxHx2
     return base_grid.permute(1, 0, 2).unsqueeze(0)  # 1xHxWx2
 
 

--- a/kornia/utils/grid.py
+++ b/kornia/utils/grid.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
 import torch
+from torch import Tensor, stack
+
+from kornia.utils._compat import torch_meshgrid
 
 
 def create_meshgrid(
@@ -9,7 +12,7 @@ def create_meshgrid(
     normalized_coordinates: bool = True,
     device: Optional[torch.device] = torch.device('cpu'),
     dtype: torch.dtype = torch.float32,
-) -> torch.Tensor:
+) -> Tensor:
     """Generate a coordinate grid for an image.
 
     When the flag ``normalized_coordinates`` is set to True, the grid is
@@ -43,8 +46,8 @@ def create_meshgrid(
                  [[0., 1.],
                   [1., 1.]]]])
     """
-    xs: torch.Tensor = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
-    ys: torch.Tensor = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
+    xs: Tensor = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
+    ys: Tensor = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
     # Fix TracerWarning
     # Note: normalize_pixel_coordinates still gots TracerWarning since new width and height
     #       tensors will be generated.
@@ -57,7 +60,7 @@ def create_meshgrid(
         xs = (xs / (width - 1) - 0.5) * 2
         ys = (ys / (height - 1) - 0.5) * 2
     # generate grid by stacking coordinates
-    base_grid: torch.Tensor = torch.stack(torch.meshgrid([xs, ys], indexing="ij"), dim=-1)  # WxHx2
+    base_grid = stack(torch_meshgrid([xs, ys], indexing="ij"), dim=-1)  # WxHx2
     return base_grid.permute(1, 0, 2).unsqueeze(0)  # 1xHxWx2
 
 
@@ -68,7 +71,7 @@ def create_meshgrid3d(
     normalized_coordinates: bool = True,
     device: Optional[torch.device] = torch.device('cpu'),
     dtype: torch.dtype = torch.float32,
-) -> torch.Tensor:
+) -> Tensor:
     """Generate a coordinate grid for an image.
 
     When the flag ``normalized_coordinates`` is set to True, the grid is
@@ -88,14 +91,14 @@ def create_meshgrid3d(
     Return:
         grid tensor with shape :math:`(1, D, H, W, 3)`.
     """
-    xs: torch.Tensor = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
-    ys: torch.Tensor = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
-    zs: torch.Tensor = torch.linspace(0, depth - 1, depth, device=device, dtype=dtype)
+    xs: Tensor = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
+    ys: Tensor = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
+    zs: Tensor = torch.linspace(0, depth - 1, depth, device=device, dtype=dtype)
     # Fix TracerWarning
     if normalized_coordinates:
         xs = (xs / (width - 1) - 0.5) * 2
         ys = (ys / (height - 1) - 0.5) * 2
         zs = (zs / (depth - 1) - 0.5) * 2
     # generate grid by stacking coordinates
-    base_grid: torch.Tensor = torch.stack(torch.meshgrid([zs, xs, ys]), dim=-1)  # DxWxHx3
+    base_grid = stack(torch_meshgrid([zs, xs, ys], indexing="ij"), dim=-1)  # DxWxHx3
     return base_grid.permute(0, 2, 1, 3).unsqueeze(0)  # 1xDxHxWx3


### PR DESCRIPTION
UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. 

Look at (this)[https://github.com/pytorch/pytorch/issues/50276]

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
