### PR TITLE
Add fn to automatically compute padding

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -24,6 +24,7 @@ Image Segmentation
 Image Patches
 -------------
 
+.. autofunction:: compute_padding
 .. autofunction:: extract_tensor_patches
 .. autofunction:: combine_tensor_patches
 

--- a/kornia/contrib/__init__.py
+++ b/kornia/contrib/__init__.py
@@ -1,7 +1,13 @@
 from .classification import ClassificationHead
 from .connected_components import connected_components
 from .distance_transform import DistanceTransform, distance_transform
-from .extract_patches import CombineTensorPatches, ExtractTensorPatches, combine_tensor_patches, extract_tensor_patches
+from .extract_patches import (
+    CombineTensorPatches,
+    ExtractTensorPatches,
+    combine_tensor_patches,
+    compute_padding,
+    extract_tensor_patches,
+)
 from .face_detection import *
 from .histogram_matching import histogram_matching, interp
 from .image_stitching import ImageStitcher
@@ -15,6 +21,7 @@ __all__ = [
     "ExtractTensorPatches",
     "combine_tensor_patches",
     "CombineTensorPatches",
+    "compute_padding",
     "histogram_matching",
     "interp",
     "VisionTransformer",

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -11,8 +11,8 @@ PadType = Union[Tuple[int, int], Tuple[int, int, int, int]]
 def compute_padding(
     original_size: Union[int, Tuple[int, int]], window_size: Union[int, Tuple[int, int]]
 ) -> Tuple[int, int, int, int]:
-    r"""Compute required padding to ensure chaining of :class:`~kornia.contrib.ExtractTensorPatches` and
-    :class:`~kornia.contrib.CombineTensorPatches` produces expected result.
+    r"""Compute required padding to ensure chaining of :func:`extract_tensor_patches` and
+    :func:`combine_tensor_patches` produces expected result.
 
     Args:
         original_size: the size of the original tensor.

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -8,6 +8,55 @@ from torch.nn.modules.utils import _pair
 PadType = Union[Tuple[int, int], Tuple[int, int, int, int]]
 
 
+def compute_padding(
+    original_size: Union[int, Tuple[int, int]], window_size: Union[int, Tuple[int, int]]
+) -> Tuple[int, int, int, int]:
+    r"""Compute required padding to ensure chaining of :class:`~kornia.contrib.ExtractTensorPatches` and
+    :class:`~kornia.contrib.CombineTensorPatches` produces expected result.
+
+    Args:
+        original_size: the size of the original tensor.
+        window_size: the size of the sliding window used while extracting patches.
+
+    Return:
+        The required padding for `(top, bottom, left, right)` as a tuple of 4 ints.
+
+    Example:
+        >>> image = torch.arange(12).view(1, 1, 4, 3)
+        >>> padding = compute_padding((4,3), (3,3))
+        >>> out = extract_tensor_patches(image, window_size=(3, 3), stride=(3, 3), padding=padding)
+        >>> combine_tensor_patches(out, original_size=(4, 3), window_size=(3, 3), stride=(3, 3), unpadding=padding)
+        tensor([[[[ 0,  1,  2],
+                  [ 3,  4,  5],
+                  [ 6,  7,  8],
+                  [ 9, 10, 11]]]])
+
+    .. note::
+        This function is supposed to be used in conjunction with :func:`extract_tensor_patches`
+        and :func:`combine_tensor_patches`.
+    """
+    original_size = cast(Tuple[int, int], _pair(original_size))
+    window_size = cast(Tuple[int, int], _pair(window_size))
+
+    def paddim(dim1: int, dim2: int) -> Tuple[int, int]:
+        if dim1 % dim2 == 0:
+            p1 = 0
+            p2 = 0
+        else:
+            tmp = dim2 - (dim1 % dim2)
+            if tmp % 2 == 0:
+                p1 = p2 = tmp // 2
+            else:
+                p1 = tmp
+                p2 = 0
+        return p1, p2
+
+    padt, padb = paddim(original_size[0], window_size[0])
+    padl, padr = paddim(original_size[1], window_size[1])
+
+    return (padt, padb, padl, padr)
+
+
 class ExtractTensorPatches(nn.Module):
     r"""Module that extract patches from tensors and stack them.
 


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Previously, users were required to compute the padding themselves to ensure chaining of `ExtractTensorPatches` and `CombineTensorPatches` produced the expected result. This PR adds a function to automatically compute the required padding.

Before:

```
import torch
from kornia.contrib import CombineTensorPatches, ExtractTensorPatches

# Original size
orig = (12, 23)
# Window size
win = (7, 7)
padding = (1, 1, 5, 0) # or (1, 1, 0, 5) / (1, 1, 2, 3) / (1, 1, 3, 2) / (1, 1, 4, 1) / (1, 1, 1, 4)
image = torch.randn(1, 1, orig[0], orig[1])
tiler = ExtractTensorPatches(window_size=win, stride=win, padding=padding)
merger = CombineTensorPatches(original_size=orig, window_size=win, unpadding=padding)
image_tiles = tiler(image)
new_image = merger(image_tiles)
print(new_image.shape)
assert (image == new_image).all()
```


With `compute_padding`:

```
import torch
from kornia.contrib import CombineTensorPatches, ExtractTensorPatches, compute_padding

# Original size
orig = (12, 23)
# Window size
win = (7, 7)
padding = compute_padding(orig_size, win)
image = torch.randn(1, 1, orig[0], orig[1])
tiler = ExtractTensorPatches(window_size=win, stride=win, padding=padding)
merger = CombineTensorPatches(original_size=orig, window_size=win, unpadding=padding)
image_tiles = tiler(image)
new_image = merger(image_tiles)
print(new_image.shape)
assert (image == new_image).all()
```



#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
