### PR TITLE
Fixes `filter2d`'s output shape shrink when `padding='same'`

### DIFF
--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -13,20 +13,20 @@ def _compute_padding(kernel_size: List[int]) -> List[int]:
     # https://pytorch.org/docs/stable/nn.html#torch.nn.functional.pad
     if len(kernel_size) < 2:
         raise AssertionError(kernel_size)
-    computed = [k // 2 for k in kernel_size]
+    computed = [k - 1 for k in kernel_size]
 
     # for even kernels we need to do asymmetric padding :(
-
     out_padding = 2 * len(kernel_size) * [0]
 
     for i in range(len(kernel_size)):
         computed_tmp = computed[-(i + 1)]
-        if kernel_size[i] % 2 == 0:
-            padding = computed_tmp - 1
-        else:
-            padding = computed_tmp
-        out_padding[2 * i + 0] = padding
-        out_padding[2 * i + 1] = computed_tmp
+        
+        pad_front = computed_tmp // 2
+        pad_rear = computed_tmp - pad_front
+
+        out_padding[2 * i + 0] = pad_front
+        out_padding[2 * i + 1] = pad_rear
+        
     return out_padding
 
 

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -221,6 +221,44 @@ class TestFilter2D:
             assert_close(actual, expected_valid)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
+    def test_mix_sized_filter_padding_same(self, padding, device, dtype):
+        kernel = torch.ones(1, 5, 6, device=device, dtype=dtype)
+        input = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        expected_same = torch.tensor(
+            [
+                [
+                    [
+                        [2.0, 2.0, 2.0, 2.0, 2.0, 0.0],
+                        [3.0, 3.0, 3.0, 3.0, 3.0, 0.0],
+                        [3.0, 3.0, 3.0, 3.0, 3.0, 0.0],
+                        [3.0, 3.0, 3.0, 3.0, 3.0, 0.0],
+                        [2.0, 2.0, 2.0, 2.0, 2.0, 0.0]
+                    ]
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        actual = kornia.filters.filter2d(input, kernel, padding='same', border_type='constant')
+        assert_close(actual, expected_same)
+
+    @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_noncontiguous(self, padding, device, dtype):
         batch_size = 3
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -223,7 +223,7 @@ class TestFilter2D:
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_mix_sized_filter_padding_same(self, padding, device, dtype):
         kernel = torch.ones(1, 5, 6, device=device, dtype=dtype)
-        input = torch.tensor(
+        input_ = torch.tensor(
             [
                 [
                     [
@@ -255,7 +255,7 @@ class TestFilter2D:
             dtype=dtype,
         )
 
-        actual = kornia.filters.filter2d(input, kernel, padding='same', border_type='constant')
+        actual = kornia.filters.filter2d(input_, kernel, padding='same', border_type='constant')
         assert_close(actual, expected_same)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #1660

The old code will shrink even-sized edge of image when using `filter2d` with `padding='same'`, which is expected to return a same-shaped image. (Refer to the issue for detail.)

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
