### PR TITLE
Add RandomGaussianBlur with instance-level gaussian kernel generation

### DIFF
--- a/kornia/augmentation/_2d/intensity/gaussian_blur.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_blur.py
@@ -1,26 +1,31 @@
+import warnings
 from typing import Any, Dict, Optional, Tuple
 
 from torch import Tensor
 
+from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.constants import BorderType
-from kornia.filters import gaussian_blur2d
+from kornia.filters import gaussian_blur2d_t
 
 
 class RandomGaussianBlur(IntensityAugmentationBase2D):
-    r"""Apply gaussian blur given tensor image or a batch of tensor images randomly.
+    r"""Apply gaussian blur given tensor image or a batch of tensor images randomly. The standard deviation is
+    sampled for each instance.
 
     .. image:: _static/img/RandomGaussianBlur.png
 
     Args:
         kernel_size: the size of the kernel.
-        sigma: the standard deviation of the kernel.
+        sigma: the range for the standard deviation of the kernel.
         border_type: the padding mode to be applied before convolving.
           The expected modes are: ``constant``, ``reflect``, ``replicate`` or ``circular``.
+        separable: run as composition of two 1d-convolutions.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
+        silence_instantiation_warning: if True, silence the warning at instantiation.
 
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
@@ -34,11 +39,11 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         >>> input = torch.rand(1, 1, 5, 5)
         >>> blur = RandomGaussianBlur((3, 3), (0.1, 2.0), p=1.)
         >>> blur(input)
-        tensor([[[[0.6699, 0.4645, 0.3193, 0.1741, 0.1955],
-                  [0.5422, 0.6657, 0.6261, 0.6527, 0.5195],
-                  [0.3826, 0.2638, 0.1902, 0.1620, 0.2141],
-                  [0.6329, 0.6732, 0.5634, 0.4037, 0.2049],
-                  [0.8307, 0.6753, 0.7147, 0.5768, 0.7097]]]])
+        tensor([[[[0.5941, 0.5833, 0.5022, 0.4384, 0.3934],
+                  [0.5310, 0.4964, 0.4113, 0.3637, 0.3472],
+                  [0.4991, 0.4997, 0.4312, 0.3620, 0.3081],
+                  [0.6082, 0.5667, 0.4954, 0.3825, 0.3508],
+                  [0.7042, 0.6849, 0.6275, 0.4753, 0.4105]]]])
 
     To apply the exact augmenation again, you may take the advantage of the previous parameter state:
         >>> input = torch.randn(1, 3, 32, 32)
@@ -52,17 +57,35 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         kernel_size: Tuple[int, int],
         sigma: Tuple[float, float],
         border_type: str = "reflect",
+        separable: bool = True,
         same_on_batch: bool = False,
         p: float = 0.5,
         keepdim: bool = False,
         return_transform: Optional[bool] = None,
+        silence_instantiation_warning: bool = False,
     ) -> None:
         super().__init__(
             p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim
         )
-        self.flags = dict(kernel_size=kernel_size, sigma=sigma, border_type=BorderType.get(border_type))
+
+        if not silence_instantiation_warning:
+            warnings.warn(
+                "`RandomGaussianBlur` has changed its behavior and now randomly sample sigma for both axes. "
+                "To retrieve old behavior please consider using kornia.filters.GaussianBlur2d",
+                category=DeprecationWarning,
+            )
+
+        self.flags = dict(kernel_size=kernel_size, separable=separable, border_type=BorderType.get(border_type))
+        self._param_generator = rg.RandomGaussianBlurGenerator(sigma)
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        return gaussian_blur2d(input, flags["kernel_size"], flags["sigma"], flags["border_type"].name.lower())
+        sigma = params["sigma"].to(device=input.device, dtype=input.dtype).unsqueeze(-1).expand(-1, 2)
+        return gaussian_blur2d_t(
+            input,
+            self.flags["kernel_size"],
+            sigma,
+            self.flags["border_type"].name.lower(),
+            separable=self.flags["separable"],
+        )

--- a/kornia/augmentation/random_generator/_2d/__init__.py
+++ b/kornia/augmentation/random_generator/_2d/__init__.py
@@ -3,6 +3,7 @@ from kornia.augmentation.random_generator._2d.color_jiggle import *
 from kornia.augmentation.random_generator._2d.color_jitter import *
 from kornia.augmentation.random_generator._2d.crop import *
 from kornia.augmentation.random_generator._2d.cutmix import *
+from kornia.augmentation.random_generator._2d.gaussian_blur import *
 from kornia.augmentation.random_generator._2d.jigsaw import *
 from kornia.augmentation.random_generator._2d.mixup import *
 from kornia.augmentation.random_generator._2d.mosaic import *

--- a/kornia/augmentation/random_generator/_2d/gaussian_blur.py
+++ b/kornia/augmentation/random_generator/_2d/gaussian_blur.py
@@ -1,0 +1,54 @@
+from typing import Dict, Tuple
+
+import torch
+from torch import Tensor
+from torch.distributions import Uniform
+
+from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check
+from kornia.utils.helpers import _extract_device_dtype
+
+
+class RandomGaussianBlurGenerator(RandomGeneratorBase):
+    r"""Generate random gaussian blur parameters for a batch of images.
+
+    Args:
+        sigma: The range to uniformly sample the standard deviation for the Gaussian kernel.
+
+    Returns:
+        A dict of parameters to be passed for transformation.
+            - sigma: element-wise standard deviation with a shape of (B,).
+
+    Note:
+        The generated random numbers are not reproducible across different devices and dtypes. By default,
+        the parameters will be generated on CPU in float32. This can be changed by calling
+        ``self.set_rng_device_and_dtype(device="cuda", dtype=torch.float64)``.
+    """
+
+    def __init__(self, sigma: Tuple[float, float] = (0.1, 2.0)) -> None:
+        super().__init__()
+        if sigma[1] < sigma[0]:
+            raise TypeError(f"sigma_max should be higher than sigma_min: {sigma} passed.")
+
+        self.sigma = sigma
+
+    def __repr__(self) -> str:
+        repr = f"sigma={self.sigma}"
+        return repr
+
+    def make_samplers(self, device: torch.device, dtype: torch.dtype) -> None:
+        if not isinstance(self.sigma, (torch.Tensor)):
+            sigma = torch.tensor(self.sigma, device=device, dtype=dtype)
+        else:
+            sigma = sigma.to(device=device, dtype=dtype)
+
+        _joint_range_check(sigma, "sigma", (0, float('inf')))
+
+        self.sigma_sampler = Uniform(sigma[0], sigma[1], validate_args=False)
+
+    def forward(self, batch_shape: torch.Size, same_on_batch: bool = False) -> Dict[str, Tensor]:
+        batch_size = batch_shape[0]
+        _common_param_check(batch_size, same_on_batch)
+        _device, _dtype = _extract_device_dtype([self.sigma])
+        sigma = _adapted_rsampling((batch_size,), self.sigma_sampler, same_on_batch)
+        return dict(sigma=sigma.to(device=_device, dtype=_dtype))

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -3,7 +3,7 @@ from .blur_pool import BlurPool2D, MaxBlurPool2D, blur_pool2d, edge_aware_blur_p
 from .canny import Canny, canny
 from .dexined import DexiNed
 from .filter import filter2d, filter2d_separable, filter3d
-from .gaussian import GaussianBlur2d, gaussian_blur2d
+from .gaussian import GaussianBlur2d, gaussian_blur2d, gaussian_blur2d_t
 from .kernels import (
     gaussian,
     get_binary_kernel2d,
@@ -12,7 +12,9 @@ from .kernels import (
     get_gaussian_discrete_kernel1d,
     get_gaussian_erf_kernel1d,
     get_gaussian_kernel1d,
+    get_gaussian_kernel1d_t,
     get_gaussian_kernel2d,
+    get_gaussian_kernel2d_t,
     get_hanning_kernel1d,
     get_hanning_kernel2d,
     get_laplacian_kernel1d,
@@ -34,9 +36,11 @@ __all__ = [
     "get_binary_kernel2d",
     "get_box_kernel2d",
     "get_gaussian_kernel1d",
+    "get_gaussian_kernel1d_t",
     "get_gaussian_discrete_kernel1d",
     "get_gaussian_erf_kernel1d",
     "get_gaussian_kernel2d",
+    "get_gaussian_kernel2d_t",
     "get_hanning_kernel1d",
     "get_hanning_kernel2d",
     "get_laplacian_kernel1d",
@@ -48,6 +52,7 @@ __all__ = [
     "get_sobel_kernel2d",
     "get_diff_kernel2d",
     "gaussian_blur2d",
+    "gaussian_blur2d_t",
     "laplacian",
     "laplacian_1d",
     "unsharp_mask",

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -181,7 +181,7 @@ def filter2d_separable(
                   [0., 5., 5., 5., 0.],
                   [0., 0., 0., 0., 0.]]]])
     """
-    out_x = filter2d(input, kernel_x.unsqueeze(0), border_type, normalized, padding)
+    out_x = filter2d(input, kernel_x.unsqueeze(-2), border_type, normalized, padding)
     out = filter2d(out_x, kernel_y.unsqueeze(-1), border_type, normalized, padding)
     return out
 

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -4,9 +4,8 @@ from typing import List, Tuple
 
 import torch
 
-from kornia.testing import KORNIA_CHECK_SHAPE
-
 from kornia.core import Tensor, as_tensor, stack, tensor, zeros
+from kornia.testing import KORNIA_CHECK_SHAPE
 
 
 def normalize_kernel2d(input: Tensor) -> Tensor:

--- a/kornia/metrics/ssim.py
+++ b/kornia/metrics/ssim.py
@@ -75,7 +75,7 @@ def ssim(
         raise ValueError(f"img1 and img2 shapes must be the same. Got: {img1.shape} and {img2.shape}")
 
     # prepare kernel
-    kernel: torch.Tensor = get_gaussian_kernel2d((window_size, window_size), (1.5, 1.5)).unsqueeze(0)
+    kernel: torch.Tensor = get_gaussian_kernel2d((window_size, window_size), (1.5, 1.5))
 
     # compute coefficients
     C1: float = (0.01 * max_val) ** 2

--- a/test/filters/test_gaussian.py
+++ b/test/filters/test_gaussian.py
@@ -11,7 +11,7 @@ from kornia.testing import assert_close
 @pytest.mark.parametrize("sigma", [1.5, 5.0])
 def test_get_gaussian_kernel(window_size, sigma):
     kernel = kornia.filters.get_gaussian_kernel1d(window_size, sigma)
-    assert kernel.shape == (window_size,)
+    assert kernel.shape == (1, window_size)
     assert kernel.sum().item() == pytest.approx(1.0)
 
 
@@ -36,7 +36,7 @@ def test_get_gaussian_erf_kernel(window_size, sigma):
 @pytest.mark.parametrize("sigma", [1.5, 2.1])
 def test_get_gaussian_kernel2d(ksize_x, ksize_y, sigma):
     kernel = kornia.filters.get_gaussian_kernel2d((ksize_x, ksize_y), (sigma, sigma))
-    assert kernel.shape == (ksize_x, ksize_y)
+    assert kernel.shape == (1, ksize_x, ksize_y)
     assert kernel.sum().item() == pytest.approx(1.0)
 
 
@@ -47,6 +47,34 @@ def test_separable(ksize_x, ksize_y, sigma, device, dtype):
     input = torch.rand(2, 3, 16, 16, device=device, dtype=dtype)
     out = kornia.filters.gaussian_blur2d(input, (ksize_x, ksize_y), (sigma, sigma), "replicate", separable=False)
     out_sep = kornia.filters.gaussian_blur2d(input, (ksize_x, ksize_y), (sigma, sigma), "replicate", separable=True)
+
+    assert_close(out, out_sep)
+
+
+@pytest.mark.parametrize("window_size", [5, 11])
+@pytest.mark.parametrize("sigma", [torch.tensor([1.5, 5.0]), torch.tensor([1.5, 5.0])])
+def test_get_gaussian_kernel_t(window_size, sigma):
+    kernel = kornia.filters.get_gaussian_kernel1d_t(window_size, sigma)
+    assert kernel.shape == (2, window_size)
+    assert_close(kernel.sum(1), torch.ones(2))
+
+
+@pytest.mark.parametrize("ksize_x", [5, 11])
+@pytest.mark.parametrize("ksize_y", [3, 7])
+@pytest.mark.parametrize("sigma", [torch.tensor([[1.5, 2.1], [1.5, 2.1]]), torch.tensor([[1.5, 2.1], [3.5, 2.1]])])
+def test_get_gaussian_kernel2d_t(ksize_x, ksize_y, sigma):
+    kernel = kornia.filters.get_gaussian_kernel2d_t((ksize_x, ksize_y), sigma)
+    assert kernel.shape == (2, ksize_x, ksize_y)
+    assert_close(kernel.sum([1, 2]), torch.ones(2))
+
+
+@pytest.mark.parametrize("ksize_x", [5, 11])
+@pytest.mark.parametrize("ksize_y", [3, 7])
+@pytest.mark.parametrize("sigma", [torch.tensor([[1.5, 2.1], [1.5, 2.1]]), torch.tensor([[1.5, 2.1], [2.5, 2.1]])])
+def test_separable_t(ksize_x, ksize_y, sigma, device, dtype):
+    input = torch.rand(2, 3, 16, 16, device=device, dtype=dtype)
+    out = kornia.filters.gaussian_blur2d_t(input, (ksize_x, ksize_y), sigma, "replicate", separable=False)
+    out_sep = kornia.filters.gaussian_blur2d_t(input, (ksize_x, ksize_y), sigma, "replicate", separable=True)
 
     assert_close(out, out_sep)
 


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes a comment I put in #691  

The current implementation of `RandomGaussianBlur` is random in the sense of only some instances are augmented given the `p` probability, with a shared fixed gaussian kernel. This differs from other existing approaches such as torchvision [`GaussianBlur`](http://pytorch.org/vision/main/generated/torchvision.transforms.GaussianBlur.html).

In Torchvision philosophy, the randomness of gaussian blur is on the sampling of the `sigma` std factor to generate the gaussian kernels. To allow reproducibility of various works that are based on torchvision such as papers on Self-Supervised Learning for example (SimCLR, MoCo, Byol, ...), just to cite this area of work, it would be a great feature to have in Kornia.

I propose a new version of `RandomGaussianBlur` that takes as an input a sigma tuple to provide bounds for uniform sampling. A filter is then generated independently for each instance following a vectorized process to not provoke a bottleneck.

I renamed the previous `RandomGaussianBlur` back to `GaussianBlur` but I can change the names to whatever you feel is best.

I implemented tests to validate the process and everything works except the gradcheck through the module but I don't know why, so I'm more than happy to receive help to debug this aspect.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
