### PR TITLE
fix: added eps in geometry/rotmat_to_quaternion

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -413,7 +413,7 @@ def rotation_matrix_to_quaternion(
     trace: torch.Tensor = m00 + m11 + m22
 
     def trace_positive_cond():
-        sq = torch.sqrt(trace + 1.0) * 2.0  # sq = 4 * qw.
+        sq = torch.sqrt(trace + 1.0 + eps) * 2.0  # sq = 4 * qw.
         qw = 0.25 * sq
         qx = safe_zero_division(m21 - m12, sq)
         qy = safe_zero_division(m02 - m20, sq)


### PR DESCRIPTION
#### Changes
For numerical stability and to avoid nan gradients added an eps in case the trace is -1 so that the sqrt would be negative.

Fixes # 1653

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
