### PR TITLE
[fix]receive num_features as KeyNetDetector constructor arg

### DIFF
--- a/kornia/feature/integrated.py
+++ b/kornia/feature/integrated.py
@@ -182,6 +182,7 @@ class KeyNetHardNet(LocalFeature):
                  device: torch.device = torch.device('cpu')):
         ori_module = PassLAF() if upright else LAFOrienter(angle_detector=OriNet(True))
         detector = KeyNetDetector(True,
+                                  num_features=num_features,
                                   ori_module=ori_module).to(device)
         descriptor = LAFDescriptor(None,
                                    patch_size=32,
@@ -197,6 +198,7 @@ class KeyNetAffNetHardNet(LocalFeature):
                  device: torch.device = torch.device('cpu')):
         ori_module = PassLAF() if upright else LAFOrienter(angle_detector=OriNet(True))
         detector = KeyNetDetector(True,
+                                  num_features=num_features,
                                   ori_module=ori_module,
                                   aff_module=LAFAffNetShapeEstimator(True).eval()).to(device)
         descriptor = LAFDescriptor(None,


### PR DESCRIPTION
#### Changes
I was tuning the number of features based on KeyNet-type of modules in integrated.py. However, ``` KeyNetDetector``` class being constructed in the module does not receive ``` num_features``` as an argument, which means ``` KeyNetDetector``` just uses its default value for ``` num_features ``` whatever we do with the integrated module. So I just made a little change so that the ``` KeyNetDetector``` receives this argument.  


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
