### PR TITLE
Implement `project` and `unproject` in `PinholeCamera`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ kornia.egg-info/
 *bak
 *ipynb_checkpoints*
 docs/source/_static/*jpg
+*DS_Store

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -289,8 +289,8 @@ class PinholeCamera:
             >>> pinhole.project_points(X)
             tensor([[5.6088, 8.6827]])
         """
-        point_3d_cam = transform_points(self.extrinsics, point_3d)
-        return convert_points_from_homogeneous(transform_points(self.intrinsics, point_3d_cam))
+        P = self.intrinsics @ self.extrinsics
+        return convert_points_from_homogeneous(transform_points(P, point_3d))
 
     def unproject(self, point_2d: torch.Tensor, depth: torch.Tensor):
         r"""Unproject a 2d point in 3d.
@@ -321,10 +321,9 @@ class PinholeCamera:
             >>> pinhole.unproject_points(x, depth)
             tensor([[0.4963, 0.7682, 1.0000]])
         """
-        extrinsics_inv = _torch_inverse_cast(self.extrinsics)
-        intrinsics_inv = _torch_inverse_cast(self.intrinsics)
-        point_3d_cam = transform_points(intrinsics_inv, convert_points_to_homogeneous(point_2d)) * depth
-        return transform_points(extrinsics_inv, point_3d_cam)
+        P = self.intrinsics @ self.extrinsics
+        P_inv = _torch_inverse_cast(P)
+        return transform_points(P_inv, convert_points_to_homogeneous(point_2d) * depth)
 
     # NOTE: just for test. Decide if we keep it.
     @classmethod

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -2,6 +2,7 @@ from typing import Iterable, Optional
 
 import torch
 
+from kornia.geometry.camera.perspective import project_points  # , unproject_points
 from kornia.geometry.linalg import inverse_transformation, transform_points
 
 
@@ -265,6 +266,12 @@ class PinholeCamera:
         self.height *= scale_factor
         self.width *= scale_factor
         return self
+
+    def project_points(self, point_3d: torch.Tensor) -> torch.Tensor:
+        R = self.rotation_matrix
+        t = self.translation_vector
+        point_3d_cam = torch.matmul(R, point_3d.view(3, 1)) + t
+        return project_points(point_3d_cam.view(point_3d_cam.shape[0], 3), self.camera_matrix)
 
     # NOTE: just for test. Decide if we keep it.
     @classmethod

--- a/test/geometry/camera/test_pinhole.py
+++ b/test/geometry/camera/test_pinhole.py
@@ -434,12 +434,12 @@ class TestPinholeCamera:
         assert_close(pinhole_scale.height, pinhole.height * scale_val, atol=1e-4, rtol=1e-4)
         assert_close(pinhole_scale.width, pinhole.width * scale_val, atol=1e-4, rtol=1e-4)
 
-    def test_pinhole_camera_project_unproject(self, device, dtype):
+    def test_pinhole_camera_project_and_unproject(self, device, dtype):
         batch_size = 4
         height, width = 4, 6
         fx, fy, cx, cy = 1, 2, width / 2, height / 2
-        alpha, beta, gamma = 0.2, 0.3, 0.4
-        tx, ty, tz = 1, 2, 3
+        alpha, beta, gamma = 0.0, 0.0, 0.4
+        tx, ty, tz = 0, 0, 3
 
         intrinsics = self._create_intrinsics(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
         extrinsics = self._create_extrinsics_with_rotation(
@@ -452,6 +452,9 @@ class TestPinholeCamera:
         pinhole = kornia.geometry.camera.PinholeCamera(intrinsics, extrinsics, height, width)
 
         point_3d = torch.tensor([[10.0, 2.0, 30.0]], device=device, dtype=dtype)
-        depth = point_3d[..., -1:]
+
+        depth = torch.tensor(33.0).expand(1)
+
         point_2d = pinhole.project_points(point_3d)
-        print(depth, point_2d)
+        point_3d_hat = pinhole.unproject_points(point_2d, depth)
+        assert_close(point_3d, point_3d_hat[0], atol=1e-4, rtol=1e-4)

--- a/test/geometry/camera/test_pinhole.py
+++ b/test/geometry/camera/test_pinhole.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 import torch
 from torch.autograd import gradcheck
@@ -240,6 +242,36 @@ class TestPinholeCamera:
         extrinsics[..., 2, -1] = tz
         return extrinsics.expand(batch_size, -1, -1)
 
+    def _create_extrinsics_with_rotation(self, batch_size, alpha, beta, gamma, tx, ty, tz, device, dtype):
+        Rx = torch.eye(3, device=device, dtype=dtype)
+        Rx[1, 1] = math.cos(alpha)
+        Rx[1, 2] = math.sin(alpha)
+        Rx[2, 1] = -Rx[1, 2]
+        Rx[2, 2] = Rx[1, 1]
+
+        Ry = torch.eye(3, device=device, dtype=dtype)
+        Ry[0, 0] = math.cos(beta)
+        Ry[0, 2] = -math.sin(beta)
+        Ry[2, 0] = -Ry[0, 2]
+        Ry[2, 2] = Ry[0, 0]
+
+        Rz = torch.eye(3, device=device, dtype=dtype)
+        Rz[0, 0] = math.cos(gamma)
+        Rz[0, 1] = math.sin(gamma)
+        Rz[1, 0] = -Rz[0, 1]
+        Rz[1, 1] = Rz[0, 0]
+
+        Ryz = torch.matmul(Ry, Rz)
+        R = torch.matmul(Rx, Ryz)
+
+        extrinsics = torch.eye(4, device=device, dtype=dtype)
+        extrinsics[..., 0, -1] = tx
+        extrinsics[..., 1, -1] = ty
+        extrinsics[..., 2, -1] = tz
+        extrinsics[:3, :3] = R
+
+        return extrinsics.expand(batch_size, -1, -1)
+
     def test_smoke(self, device, dtype):
         intrinsics = torch.eye(4, device=device, dtype=dtype)[None]
         extrinsics = torch.eye(4, device=device, dtype=dtype)[None]
@@ -401,3 +433,25 @@ class TestPinholeCamera:
         )  # cy
         assert_close(pinhole_scale.height, pinhole.height * scale_val, atol=1e-4, rtol=1e-4)
         assert_close(pinhole_scale.width, pinhole.width * scale_val, atol=1e-4, rtol=1e-4)
+
+    def test_pinhole_camera_project_unproject(self, device, dtype):
+        batch_size = 4
+        height, width = 4, 6
+        fx, fy, cx, cy = 1, 2, width / 2, height / 2
+        alpha, beta, gamma = 0.2, 0.3, 0.4
+        tx, ty, tz = 1, 2, 3
+
+        intrinsics = self._create_intrinsics(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
+        extrinsics = self._create_extrinsics_with_rotation(
+            batch_size, alpha, beta, gamma, tx, ty, tz, device=device, dtype=dtype
+        )
+
+        height = torch.ones(batch_size, device=device, dtype=dtype) * height
+        width = torch.ones(batch_size, device=device, dtype=dtype) * width
+
+        pinhole = kornia.geometry.camera.PinholeCamera(intrinsics, extrinsics, height, width)
+
+        point_3d = torch.tensor([[10.0, 2.0, 30.0]], device=device, dtype=dtype)
+        depth = point_3d[..., -1:]
+        point_2d = pinhole.project_points(point_3d)
+        print(depth, point_2d)

--- a/test/geometry/camera/test_pinhole.py
+++ b/test/geometry/camera/test_pinhole.py
@@ -435,7 +435,8 @@ class TestPinholeCamera:
         assert_close(pinhole_scale.width, pinhole.width * scale_val, atol=1e-4, rtol=1e-4)
 
     def test_pinhole_camera_project_and_unproject(self, device, dtype):
-        batch_size = 4
+        batch_size = 5
+        n = 2  # Point per batch
         height, width = 4, 6
         fx, fy, cx, cy = 1, 2, width / 2, height / 2
         alpha, beta, gamma = 0.0, 0.0, 0.4
@@ -451,10 +452,10 @@ class TestPinholeCamera:
 
         pinhole = kornia.geometry.camera.PinholeCamera(intrinsics, extrinsics, height, width)
 
-        point_3d = torch.tensor([[10.0, 2.0, 30.0]], device=device, dtype=dtype)
+        point_3d = torch.rand((batch_size, n, 3), device=device, dtype=dtype)
 
-        depth = torch.tensor(33.0).expand(1)
+        depth = point_3d[..., -1:] + tz
 
-        point_2d = pinhole.project_points(point_3d)
-        point_3d_hat = pinhole.unproject_points(point_2d, depth)
-        assert_close(point_3d, point_3d_hat[0], atol=1e-4, rtol=1e-4)
+        point_2d = pinhole.project(point_3d)
+        point_3d_hat = pinhole.unproject(point_2d, depth)
+        assert_close(point_3d, point_3d_hat, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
#### Changes
Two methods are proposed as addition to the class `PinholeCamera` to project and unproject between points in 3D world coordinates to/from camera plane.

The current implementation of project/unproject under `kornia.geometry.camera.perspective` includes these transforms taking into account only camera intrinsics. The current proposal includes both camera intrinsics and extrinsics in the project/unproject operations.

The main motivation of this addition is to allow an easier implementation of raymarching from a batch of cameras in different positions, which is part of the ongoing Nerf contribution to Kornia (#1384)

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
