### PR TITLE
Add rgb_to_y to __all__

### DIFF
--- a/kornia/color/__init__.py
+++ b/kornia/color/__init__.py
@@ -52,6 +52,7 @@ __all__ = [
     "hls_to_rgb",
     "rgb_to_ycbcr",
     "ycbcr_to_rgb",
+    "rgb_to_y",
     "rgb_to_yuv",
     "rgb_to_yuv420",
     "rgb_to_yuv422",


### PR DESCRIPTION
DeepSpeed was reporting an antipattern due to not using `rgb_to_y`. 
