### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/generate_example_images.py
+++ b/docs/generate_example_images.py
@@ -92,7 +92,7 @@ def main():
         aug = cls(*args, p=1.0)
         # set seed
         torch.manual_seed(seed)
-        # apply the augmentaiton to the image and concat
+        # apply the augmentation to the image and concat
         out = aug(img_in)
 
         if aug_name == "CenterCrop":
@@ -121,7 +121,7 @@ def main():
         aug = cls(*args, p=1.0)
         # set seed
         torch.manual_seed(seed)
-        # apply the augmentaiton to the image and concat
+        # apply the augmentation to the image and concat
         out, _ = aug(img_in, torch.tensor([0, 1]))
         out = torch.cat([img_in[0], img_in[1], *(out[i] for i in range(out.size(0)))], dim=-1)
         # save the output image

--- a/kornia/metrics/mean_iou.py
+++ b/kornia/metrics/mean_iou.py
@@ -61,7 +61,7 @@ def mean_iou(input: torch.Tensor, target: torch.Tensor, num_classes: int, eps: f
 
 
 def mean_iou_bbox(boxes_1: torch.Tensor, boxes_2: torch.Tensor) -> torch.Tensor:
-    """Compute the IoU of the cartisian product of two sets of boxes.
+    """Compute the IoU of the cartesian product of two sets of boxes.
 
     Each box in each set shall be (x1, y1, x2, y2).
 

--- a/kornia/utils/draw.py
+++ b/kornia/utils/draw.py
@@ -79,7 +79,7 @@ def draw_line(image: torch.Tensor, p1: torch.Tensor, p2: torch.Tensor, color: to
     B = x1 - x2
     C = x2 * y1 - x1 * y2
 
-    # make sure A is positive to utilize the functiom properly
+    # make sure A is positive to utilize the function properly
     if A < 0:
         A = -A
         B = -B


### PR DESCRIPTION
There are small typos in:
- docs/generate_example_images.py
- kornia/metrics/mean_iou.py
- kornia/utils/draw.py

Fixes:
- Should read `augmentation` rather than `augmentaiton`.
- Should read `function` rather than `functiom`.
- Should read `cartesian` rather than `cartisian`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md