### PR TITLE
No crash matching

### DIFF
--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -3,18 +3,19 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 
-from kornia.testing import KORNIA_CHECK_SHAPE, KORNIA_CHECK_DM_DESC, Tensor
+from kornia.testing import KORNIA_CHECK_DM_DESC, KORNIA_CHECK_SHAPE, Tensor
 
 
 def _get_lazy_distance_matrix(desc1: Tensor, desc2: Tensor, dm_: Optional[Tensor] = None):
-    """Helper function, which checks validity of provided distance matrix,
-    or calculates L2-distance matrix dm is not provided
+    """Helper function, which checks validity of provided distance matrix, or calculates L2-distance matrix dm is
+    not provided.
 
     Args:
         desc1: Batch of descriptors of a shape :math:`(B1, D)`.
         desc2: Batch of descriptors of a shape :math:`(B2, D)`.
         dm: Tensor containing the distances from each descriptor in desc1
-          to each descriptor in desc2, shape of :math:`(B1, B2)`."""
+          to each descriptor in desc2, shape of :math:`(B1, B2)`.
+    """
     if dm_ is None:
         dm = torch.cdist(desc1, desc2)
     else:
@@ -24,19 +25,18 @@ def _get_lazy_distance_matrix(desc1: Tensor, desc2: Tensor, dm_: Optional[Tensor
 
 
 def _no_match(dm: Tensor):
-    """Helper function, which output empty tensors
+    """Helper function, which output empty tensors.
 
     Returns:
             - Descriptor distance of matching descriptors, shape of :math:`(0, 1)`.
-            - Long tensor indexes of matching descriptors in desc1 and desc2, shape of :math:`(0, 2)`."""
+            - Long tensor indexes of matching descriptors in desc1 and desc2, shape of :math:`(0, 2)`.
+    """
     dists = torch.empty(0, 1, device=dm.device, dtype=dm.dtype)
     idxs = torch.empty(0, 2, device=dm.device, dtype=torch.long)
     return dists, idxs
 
 
-def match_nn(
-    desc1: Tensor, desc2: Tensor, dm: Optional[Tensor] = None
-) -> Tuple[Tensor, Tensor]:
+def match_nn(desc1: Tensor, desc2: Tensor, dm: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
     r"""Function, which finds nearest neighbors in desc2 for each vector in desc1.
 
     If the distance matrix dm is not provided, :py:func:`torch.cdist` is used.
@@ -61,9 +61,7 @@ def match_nn(
     return match_dists.view(-1, 1), matches_idxs.view(-1, 2)
 
 
-def match_mnn(
-    desc1: Tensor, desc2: Tensor, dm: Optional[Tensor] = None
-) -> Tuple[Tensor, Tensor]:
+def match_mnn(desc1: Tensor, desc2: Tensor, dm: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
     """Function, which finds mutual nearest neighbors in desc2 for each vector in desc1.
 
     If the distance matrix dm is not provided, :py:func:`torch.cdist` is used.
@@ -100,9 +98,7 @@ def match_mnn(
     return match_dists.view(-1, 1), matches_idxs.view(-1, 2)
 
 
-def match_snn(
-    desc1: Tensor, desc2: Tensor, th: float = 0.8, dm: Optional[Tensor] = None
-) -> Tuple[Tensor, Tensor]:
+def match_snn(desc1: Tensor, desc2: Tensor, th: float = 0.8, dm: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
     """Function, which finds nearest neighbors in desc2 for each vector in desc1.
 
     The method satisfies first to second nearest neighbor distance <= th.
@@ -141,9 +137,7 @@ def match_snn(
     return match_dists.view(-1, 1), matches_idxs.view(-1, 2)
 
 
-def match_smnn(
-    desc1: Tensor, desc2: Tensor, th: float = 0.95, dm: Optional[Tensor] = None
-) -> Tuple[Tensor, Tensor]:
+def match_smnn(desc1: Tensor, desc2: Tensor, th: float = 0.95, dm: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
     """Function, which finds mutual nearest neighbors in desc2 for each vector in desc1.
 
     the method satisfies first to second nearest neighbor distance <= th.

--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -23,7 +23,7 @@ def _get_lazy_distance_matrix(desc1: Tensor, desc2: Tensor, dm_: Optional[Tensor
     return dm
 
 
-def no_match(dm: Tensor):
+def _no_match(dm: Tensor):
     """Helper function, which output empty tensors
 
     Returns:
@@ -32,6 +32,7 @@ def no_match(dm: Tensor):
     dists = torch.empty(0, 1, device=dm.device, dtype=dm.dtype)
     idxs = torch.empty(0, 2, device=dm.device, dtype=torch.long)
     return dists, idxs
+
 
 def match_nn(
     desc1: Tensor, desc2: Tensor, dm: Optional[Tensor] = None
@@ -126,14 +127,14 @@ def match_snn(
     distance_matrix = _get_lazy_distance_matrix(desc1, desc2, dm)
 
     if desc2.shape[0] < 2:  # We cannot perform snn check, so output empty matches
-        return no_match(distance_matrix)
+        return _no_match(distance_matrix)
 
     vals, idxs_in_2 = torch.topk(distance_matrix, 2, dim=1, largest=False)
     ratio = vals[:, 0] / vals[:, 1]
     mask = ratio <= th
     match_dists = ratio[mask]
-    if len (match_dists) == 0:
-        return no_match(distance_matrix)
+    if len(match_dists) == 0:
+        return _no_match(distance_matrix)
     idxs_in1 = torch.arange(0, idxs_in_2.size(0), device=distance_matrix.device)[mask]
     idxs_in_2 = idxs_in_2[:, 0][mask]
     matches_idxs = torch.cat([idxs_in1.view(-1, 1), idxs_in_2.view(-1, 1)], dim=1)
@@ -165,7 +166,7 @@ def match_smnn(
     KORNIA_CHECK_SHAPE(desc2, ["B", "DIM"])
 
     if (desc1.shape[0] < 2) or (desc2.shape[0] < 2):
-        return no_match(desc1)
+        return _no_match(desc1)
 
     distance_matrix = _get_lazy_distance_matrix(desc1, desc2, dm)
 
@@ -188,7 +189,7 @@ def match_smnn(
         matches_idxs = good_idxs1
         match_dists, matches_idxs = match_dists.view(-1, 1), matches_idxs.view(-1, 2)
     else:
-        match_dists, matches_idxs = no_match(distance_matrix)
+        match_dists, matches_idxs = _no_match(distance_matrix)
     return match_dists, matches_idxs
 
 

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -238,3 +238,10 @@ def KORNIA_CHECK_IS_GRAY(x: Tensor, msg: Optional[str] = None):
 def KORNIA_CHECK_IS_COLOR_OR_GRAY(x: Tensor, msg: Optional[str] = None):
     if len(x.shape) < 3 or x.shape[-3] not in [1, 3]:
         raise TypeError(f"Not an color or gray tensor. Got: {type(x)}.\n{msg}")
+
+def KORNIA_CHECK_DM_DESC(desc1: Tensor, desc2: Tensor, dm: Tensor):
+    if not ((dm.size(0) == desc1.size(0)) and (dm.size(1) == desc2.size(0))):
+        message = f"""distance matrix shape {dm.shape} is not
+                      consistent with descriptors shape: desc1 {desc1.shape}
+                      desc2 {desc2.shape}"""
+        raise TypeError(message)

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -239,6 +239,7 @@ def KORNIA_CHECK_IS_COLOR_OR_GRAY(x: Tensor, msg: Optional[str] = None):
     if len(x.shape) < 3 or x.shape[-3] not in [1, 3]:
         raise TypeError(f"Not an color or gray tensor. Got: {type(x)}.\n{msg}")
 
+
 def KORNIA_CHECK_DM_DESC(desc1: Tensor, desc2: Tensor, dm: Tensor):
     if not ((dm.size(0) == desc1.size(0)) and (dm.size(1) == desc2.size(0))):
         message = f"""distance matrix shape {dm.shape} is not

--- a/test/feature/test_matching.py
+++ b/test/feature/test_matching.py
@@ -85,6 +85,14 @@ class TestMatchSNN:
         assert idxs.shape[0] == dists.shape[0]
         assert dists.shape[0] <= num_desc1
 
+    def test_nomatch(self, device):
+        desc1 = torch.tensor([[0, 0.0], [1, 1], [2, 2], [3, 3.0], [5, 5.0]], device=device)
+        desc2 = torch.tensor([[5, 5.0]], device=device)
+
+        dists, idxs = match_snn(desc1, desc2, 0.8)
+        assert len(dists) == 0
+        assert len(idxs) == 0
+
     def test_matching1(self, device):
         desc1 = torch.tensor([[0, 0.0], [1, 1], [2, 2], [3, 3.0], [5, 5.0]], device=device)
         desc2 = torch.tensor([[5, 5.0], [3, 3.0], [2.3, 2.4], [1, 1], [0, 0.0]], device=device)
@@ -147,6 +155,14 @@ class TestMatchSMNN:
         dists1, idxs1 = matcher(desc1, desc2)
         assert_close(dists1, expected_dists)
         assert_close(idxs1, expected_idx)
+
+    def test_nomatch(self, device):
+        desc1 = torch.tensor([[0, 0.0]], device=device)
+        desc2 = torch.tensor([[5, 5.0]], device=device)
+
+        dists, idxs = match_smnn(desc1, desc2, 0.8)
+        assert len(dists) == 0
+        assert len(idxs) == 0
 
     def test_matching2(self, device):
         desc1 = torch.tensor([[0, 0.0], [1, 1], [2, 2], [3, 3.0], [5, 5.0]], device=device)


### PR DESCRIPTION
#### Changes
Before `match_snn` and `match_smnn` would crash if one of the descriptors has only one entry. Now empty tensors are returned instead. 
Also I have de-duplicated shape-check code.



- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)



#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
