### PR TITLE
Adds conversions between graphics and vision coordinate frames

### DIFF
--- a/docs/source/geometry.conversions.rst
+++ b/docs/source/geometry.conversions.rst
@@ -54,11 +54,10 @@ Angle Axis
 Pose (extrinsics)
 ----------
 
-.. autofunction:: extrinsics_from_Rt
-.. autofunction:: Rt_from_extrinsics
-.. autofunction:: camtoworldRt_to_poseRt
-.. autofunction:: poseRt_to_camtoworldRt
-.. autofunction:: camtoworld_graphics_to_vision
-.. autofunction:: camtoworld_vision_to_graphics
+.. autofunction:: Rt_to_matrix4x4
+.. autofunction:: matrix4x4_to_Rt
+.. autofunction:: worldtocam_to_camtoworld_Rt
+.. autofunction:: camtoworld_to_worldtocam_Rt
+.. autofunction:: camtoworld_graphics_to_vision_4x4
+.. autofunction:: camtoworld_vision_to_graphics_4x4
 .. autofunction:: ARKitQTVecs_to_ColmapQTVecs
-.. autofunction:: screenpose_to_camerapose

--- a/docs/source/geometry.conversions.rst
+++ b/docs/source/geometry.conversions.rst
@@ -60,3 +60,5 @@ Pose (extrinsics)
 .. autofunction:: poseRt_to_camtoworldRt
 .. autofunction:: camtoworld_graphics_to_vision
 .. autofunction:: camtoworld_vision_to_graphics
+.. autofunction:: ARKitQTVecs_to_ColmapQTVecs
+.. autofunction:: screenpose_to_camerapose

--- a/docs/source/geometry.conversions.rst
+++ b/docs/source/geometry.conversions.rst
@@ -50,3 +50,13 @@ Angle Axis
 
 .. autofunction:: angle_axis_to_quaternion
 .. autofunction:: angle_axis_to_rotation_matrix
+
+Pose (extrinsics)
+----------
+
+.. autofunction:: extrinsics_from_Rt
+.. autofunction:: Rt_from_extrinsics
+.. autofunction:: camtoworldRt_to_poseRt
+.. autofunction:: poseRt_to_camtoworldRt
+.. autofunction:: camtoworld_graphics_to_vision
+.. autofunction:: camtoworld_vision_to_graphics

--- a/docs/source/geometry.conversions.rst
+++ b/docs/source/geometry.conversions.rst
@@ -60,4 +60,6 @@ Pose (extrinsics)
 .. autofunction:: camtoworld_to_worldtocam_Rt
 .. autofunction:: camtoworld_graphics_to_vision_4x4
 .. autofunction:: camtoworld_vision_to_graphics_4x4
+.. autofunction:: camtoworld_graphics_to_vision_Rt
+.. autofunction:: camtoworld_vision_to_graphics_Rt
 .. autofunction:: ARKitQTVecs_to_ColmapQTVecs

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -211,7 +211,7 @@
 }
 
 @article{MODS2015,
-  aitle                    = {MODS: Fast and robust method for two-view matching },
+  title                    = {MODS: Fast and robust method for two-view matching },
   author                   = {Dmytro Mishkin and Jiri Matas and Michal Perdoch},
   journal                  = {Computer Vision and Image Understanding },
   year                     = {2015},

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1243,7 +1243,7 @@ def camtoworld_graphics_to_vision_4x4(extrinsics_graphics: Tensor) -> Tensor:
     return extrinsics_graphics @ invert_yz
 
 
-def camtoworld_graphics_to_vision_Rt(extrinsics_graphics: Tensor) -> Tensor:
+def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
     r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate
     frame (e.g. OpenCV.), , i.e. flips y and z axis.
     Graphics convention: [+x, +y, +z] == [right, up, backwards].
@@ -1286,7 +1286,7 @@ def camtoworld_vision_to_graphics_4x4(extrinsics_vision: Tensor) -> Tensor:
     return extrinsics_vision @ invert_yz
 
 
-def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
+def camtoworld_vision_to_graphics_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
     r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate
     frame (e.g. OpenCV.), , i.e. flips y and z axis.
     Graphics convention: [+x, +y, +z] == [right, up, backwards].

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1226,11 +1226,10 @@ def matrix4x4_to_Rt(extrinsics: Tensor) -> Tuple[Tensor, Tensor]:
         >>> ext = torch.eye(4)[None]
         >>> matrix4x4_to_Rt(ext)
         (tensor([[[1., 0., 0.],
-                  [0., 1., 0.],
-                  [0., 0., 1.]]]),
-         tensor([[[0.],
-                  [0.],
-                  [0.]]]))
+                 [0., 1., 0.],
+                 [0., 0., 1.]]]), tensor([[[0.],
+                 [0.],
+                 [0.]]]))
     """
     KORNIA_CHECK_SHAPE(extrinsics, ["B", "4", "4"])
     R, t = extrinsics[:, :3, :3], extrinsics[:, :3, 3:]
@@ -1286,8 +1285,8 @@ def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
         (tensor([[[ 1.,  0.,  0.],
                  [ 0., -1.,  0.],
                  [ 0.,  0., -1.]]]), tensor([[[1.],
-                  [1.],
-                  [1.]]]))
+                 [1.],
+                 [1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1199,7 +1199,7 @@ def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
         the extrinsics :math:`(B, 4, 4)`.
 
     Example:
-        >>> R, t = torch.eye(3)[None], torch.rand(3).reshape(1, 3, 1)
+        >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
         >>> Rt_to_matrix4x4(R, t)
         tensor([[[1., 0., 0., 1.],
                  [0., 1., 0., 1.],
@@ -1284,9 +1284,8 @@ def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
         >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
         >>> camtoworld_graphics_to_vision_Rt(R, t)
         (tensor([[[ 1.,  0.,  0.],
-                  [ 0., -1.,  0.],
-                  [ 0.,  0., -1.]]]),
-         tensor([[[1.],
+                 [ 0., -1.,  0.],
+                 [ 0.,  0., -1.]]]), tensor([[[1.],
                   [1.],
                   [1.]]]))
     """
@@ -1342,11 +1341,10 @@ def camtoworld_vision_to_graphics_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
         >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
         >>> camtoworld_vision_to_graphics_Rt(R, t)
         (tensor([[[ 1.,  0.,  0.],
-                  [ 0., -1.,  0.],
-                  [ 0.,  0., -1.]]]),
-         tensor([[[1.],
-                  [1.],
-                  [1.]]]))
+                 [ 0., -1.,  0.],
+                 [ 0.,  0., -1.]]]), tensor([[[1.],
+                 [1.],
+                 [1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1372,11 +1370,10 @@ def camtoworld_to_worldtocam_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
         >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
         >>> camtoworld_to_worldtocam_Rt(R, t)
         (tensor([[[1., 0., 0.],
-                  [0., 1., 0.],
-                  [0., 0., 1.]]]),
-         tensor([[[-1.],
-                  [-1.],
-                  [-1.]]]))
+                 [0., 1., 0.],
+                 [0., 0., 1.]]]), tensor([[[-1.],
+                 [-1.],
+                 [-1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1403,11 +1400,10 @@ def worldtocam_to_camtoworld_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
         >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
         >>> worldtocam_to_camtoworld_Rt(R, t)
         (tensor([[[1., 0., 0.],
-                  [0., 1., 0.],
-                  [0., 0., 1.]]]),
-         tensor([[[-1.],
-                  [-1.],
-                  [-1.]]]))
+                 [0., 1., 0.],
+                 [0., 0., 1.]]]), tensor([[[-1.],
+                 [-1.],
+                 [-1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1433,10 +1429,9 @@ def ARKitQTVecs_to_ColmapQTVecs(qvec: Tensor, tvec: Tensor) -> Tuple[Tensor, Ten
     Example:
         >>> q, t = torch.tensor([0, 1, 0, 1.])[None], torch.ones(3).reshape(1, 3, 1)
         >>> ARKitQTVecs_to_ColmapQTVecs(q, t)
-        (tensor([[0.7071, 0.0000, 0.7071, 0.0000]]),
-         tensor([[[-1.0000],
-                  [-1.0000],
-                  [ 1.0000]]]))
+        (tensor([[0.7071, 0.0000, 0.7071, 0.0000]]), tensor([[[-1.0000],
+                 [-1.0000],
+                 [ 1.0000]]]))
     """
     # ToDo:  integrate QuaterniaonAPI
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1241,6 +1241,7 @@ def matrix4x4_to_Rt(extrinsics: Tensor) -> Tuple[Tensor, Tensor]:
 def camtoworld_graphics_to_vision_4x4(extrinsics_graphics: Tensor) -> Tensor:
     r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate frame (e.g. OpenCV.), , i.e. flips y
     and z axis. Graphics convention: [+x, +y, +z] == [right, up, backwards]. Vision convention: [+x, +y, +z] ==
+
     [right, down, forwards]
 
     Args:
@@ -1269,6 +1270,7 @@ def camtoworld_graphics_to_vision_4x4(extrinsics_graphics: Tensor) -> Tensor:
 def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
     r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate frame (e.g. OpenCV.), , i.e. flips y
     and z axis. Graphics convention: [+x, +y, +z] == [right, up, backwards]. Vision convention: [+x, +y, +z] ==
+
     [right, down, forwards]
 
     Args:
@@ -1326,6 +1328,7 @@ def camtoworld_vision_to_graphics_4x4(extrinsics_vision: Tensor) -> Tensor:
 def camtoworld_vision_to_graphics_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
     r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate frame (e.g. OpenCV.), , i.e. flips y
     and z axis. Graphics convention: [+x, +y, +z] == [right, up, backwards]. Vision convention: [+x, +y, +z] ==
+
     [right, down, forwards]
 
     Args:

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1189,8 +1189,8 @@ def normalize_homography3d(
 
 
 def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
-    r"""Combines 3x3 R and 1x3 t into 4x4 extrinsics. Extrinsics matrix is usually named `K`, but we avoid this, to
-    not interfere with `import kornia as K`
+    r"""Combines 3x3 rotation matrix R and 1x3 translation vector t
+     into 4x4 extrinsics.
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`
@@ -1214,7 +1214,8 @@ def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
 
 
 def matrix4x4_to_Rt(extrinsics: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Combines 4x4 extrinsics into 3x3 R and 1x3 t .
+    r"""Converts 4x4 extrinsics into 3x3 rotation matrix R
+    and 1x3 translation vector ts.
 
     Args:
         extrinsics: pose matrix :math:`(B, 4, 4)`.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -7,9 +7,8 @@ import torch.nn.functional as F
 from torch import Tensor, tensor
 
 from kornia.constants import pi
-from kornia.utils.helpers import _torch_inverse_cast
 from kornia.testing import KORNIA_CHECK_SHAPE
-
+from kornia.utils.helpers import _torch_inverse_cast
 
 __all__ = [
     "rad2deg",
@@ -1235,12 +1234,11 @@ def camtoworld_graphics_to_vision(extrinsics_graphics: Tensor) -> Tensor:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
     """
     KORNIA_CHECK_SHAPE(extrinsics_graphics, ["B", "4", "4"])
-    invert_yz = tensor([[[1, 0, 0, 0],
-                       [0, -1, 0, 0],
-                       [0, 0, -1, 0],
-                       [0, 0, 0, 1.]]],
-                       dtype=extrinsics_graphics.dtype,
-                       device=extrinsics_graphics.device)
+    invert_yz = tensor(
+        [[[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1.0]]],
+        dtype=extrinsics_graphics.dtype,
+        device=extrinsics_graphics.device,
+    )
     return extrinsics_graphics @ invert_yz
 
 
@@ -1257,12 +1255,11 @@ def camtoworld_vision_to_graphics(extrinsics_vision: Tensor) -> Tensor:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
     """
     KORNIA_CHECK_SHAPE(extrinsics_vision, ["B", "4", "4"])
-    invert_yz = torch.tensor([[[1, 0, 0, 0],
-                             [0, -1, 0, 0],
-                             [0, 0, -1, 0],
-                             [0, 0, 0, 1.]]],
-                             dtype=extrinsics_vision.dtype,
-                             device=extrinsics_vision.device)
+    invert_yz = torch.tensor(
+        [[[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1.0]]],
+        dtype=extrinsics_vision.dtype,
+        device=extrinsics_vision.device,
+    )
     return extrinsics_vision @ invert_yz
 
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -7,9 +7,8 @@ import torch.nn.functional as F
 from torch import Tensor, tensor
 
 from kornia.constants import pi
-from kornia.utils.helpers import _torch_inverse_cast
 from kornia.testing import KORNIA_CHECK_SHAPE
-
+from kornia.utils.helpers import _torch_inverse_cast
 
 __all__ = [
     "rad2deg",
@@ -1188,9 +1187,8 @@ def normalize_homography3d(
 
 
 def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
-    r"""Combines 3x3 R and 1x3 t into 4x4 extrinsics.
-    Extrinsics matrix is usually named `K`, but we avoid this,
-    to not interfere with `import kornia as K`
+    r"""Combines 3x3 R and 1x3 t into 4x4 extrinsics. Extrinsics matrix is usually named `K`, but we avoid this, to
+    not interfere with `import kornia as K`
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`
@@ -1198,7 +1196,6 @@ def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
 
     Returns:
         the extrinsics :math:`(B, 4, 4)`.
-
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1222,10 +1219,9 @@ def matrix4x4_to_Rt(extrinsics: Tensor) -> Tuple[Tensor, Tensor]:
 
 
 def camtoworld_graphics_to_vision_4x4(extrinsics_graphics: Tensor) -> Tensor:
-    r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate
-    frame (e.g. OpenCV.), , i.e. flips y and z axis.
-    Graphics convention: [+x, +y, +z] == [right, up, backwards].
-    Vision convention: [+x, +y, +z] == [right, down, forwards]
+    r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate frame (e.g. OpenCV.), , i.e. flips y
+    and z axis. Graphics convention: [+x, +y, +z] == [right, up, backwards]. Vision convention: [+x, +y, +z] ==
+    [right, down, forwards]
 
     Args:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
@@ -1234,20 +1230,18 @@ def camtoworld_graphics_to_vision_4x4(extrinsics_graphics: Tensor) -> Tensor:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
     """
     KORNIA_CHECK_SHAPE(extrinsics_graphics, ["B", "4", "4"])
-    invert_yz = tensor([[[1, 0, 0, 0],
-                       [0, -1, 0, 0],
-                       [0, 0, -1, 0],
-                       [0, 0, 0, 1.]]],
-                       dtype=extrinsics_graphics.dtype,
-                       device=extrinsics_graphics.device)
+    invert_yz = tensor(
+        [[[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1.0]]],
+        dtype=extrinsics_graphics.dtype,
+        device=extrinsics_graphics.device,
+    )
     return extrinsics_graphics @ invert_yz
 
 
 def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate
-    frame (e.g. OpenCV.), , i.e. flips y and z axis.
-    Graphics convention: [+x, +y, +z] == [right, up, backwards].
-    Vision convention: [+x, +y, +z] == [right, down, forwards]
+    r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate frame (e.g. OpenCV.), , i.e. flips y
+    and z axis. Graphics convention: [+x, +y, +z] == [right, up, backwards]. Vision convention: [+x, +y, +z] ==
+    [right, down, forwards]
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`
@@ -1264,11 +1258,9 @@ def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
 
 
 def camtoworld_vision_to_graphics_4x4(extrinsics_vision: Tensor) -> Tensor:
-    r"""Converts vision coordinate frame (e.g. OpenCV) to graphics coordinate
-    frame (e.g. OpenGK.), i.e. flips y and z axis
-    Graphics convention: [+x, +y, +z] == [right, up, backwards].
-    Vision convention: [+x, +y, +z] == [right, down, forwards]
-
+    r"""Converts vision coordinate frame (e.g. OpenCV) to graphics coordinate frame (e.g. OpenGK.), i.e. flips y and
+    z axis Graphics convention: [+x, +y, +z] == [right, up, backwards]. Vision convention: [+x, +y, +z] == [right,
+    down, forwards]
 
     Args:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
@@ -1277,20 +1269,18 @@ def camtoworld_vision_to_graphics_4x4(extrinsics_vision: Tensor) -> Tensor:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
     """
     KORNIA_CHECK_SHAPE(extrinsics_vision, ["B", "4", "4"])
-    invert_yz = torch.tensor([[[1, 0, 0, 0],
-                             [0, -1, 0, 0],
-                             [0, 0, -1, 0],
-                             [0, 0, 0, 1.]]],
-                             dtype=extrinsics_vision.dtype,
-                             device=extrinsics_vision.device)
+    invert_yz = torch.tensor(
+        [[[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1.0]]],
+        dtype=extrinsics_vision.dtype,
+        device=extrinsics_vision.device,
+    )
     return extrinsics_vision @ invert_yz
 
 
 def camtoworld_vision_to_graphics_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate
-    frame (e.g. OpenCV.), , i.e. flips y and z axis.
-    Graphics convention: [+x, +y, +z] == [right, up, backwards].
-    Vision convention: [+x, +y, +z] == [right, down, forwards]
+    r"""Converts graphics coordinate frame (e.g. OpenGL) to vision coordinate frame (e.g. OpenCV.), , i.e. flips y
+    and z axis. Graphics convention: [+x, +y, +z] == [right, up, backwards]. Vision convention: [+x, +y, +z] ==
+    [right, down, forwards]
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`
@@ -1307,9 +1297,8 @@ def camtoworld_vision_to_graphics_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
 
 
 def camtoworld_to_worldtocam_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Converts camtoworld, i.e. projection from camera coordinate system
-    to world coordinate system, to worldtocam frame i.e. projection from world to the camera
-    coordinate system (used in Colmap).
+    r"""Converts camtoworld, i.e. projection from camera coordinate system to world coordinate system, to worldtocam
+    frame i.e. projection from world to the camera coordinate system (used in Colmap).
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`
@@ -1329,9 +1318,8 @@ def camtoworld_to_worldtocam_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
 
 
 def worldtocam_to_camtoworld_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Converts worldtocam frame i.e. projection from world to the camera
-    coordinate system (used in Colmap) to camtoworld,
-    i.e. projection from camera coordinate system to world coordinate system.
+    r"""Converts worldtocam frame i.e. projection from world to the camera coordinate system (used in Colmap) to
+    camtoworld, i.e. projection from camera coordinate system to world coordinate system.
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`
@@ -1351,9 +1339,8 @@ def worldtocam_to_camtoworld_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
 
 
 def ARKitQTVecs_to_ColmapQTVecs(qvec: Tensor, tvec: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Converts output of Apple ARKit screen pose (in quaternion representation)
-    to the camera-to-world transformation, expected by Colmap, also in quaternion
-    representation
+    r"""Converts output of Apple ARKit screen pose (in quaternion representation) to the camera-to-world
+    transformation, expected by Colmap, also in quaternion representation.
 
     Args:
         qvec: ARKit rotation quaternion :math:`(B, 4)`, [x, y, z, w] format.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1189,8 +1189,7 @@ def normalize_homography3d(
 
 
 def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
-    r"""Combines 3x3 rotation matrix R and 1x3 translation vector t
-     into 4x4 extrinsics.
+    r"""Combines 3x3 rotation matrix R and 1x3 translation vector t into 4x4 extrinsics.
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`
@@ -1214,8 +1213,7 @@ def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
 
 
 def matrix4x4_to_Rt(extrinsics: Tensor) -> Tuple[Tensor, Tensor]:
-    r"""Converts 4x4 extrinsics into 3x3 rotation matrix R
-    and 1x3 translation vector ts.
+    r"""Converts 4x4 extrinsics into 3x3 rotation matrix R and 1x3 translation vector ts.
 
     Args:
         extrinsics: pose matrix :math:`(B, 4, 4)`.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1357,6 +1357,8 @@ def camtoworld_vision_to_graphics_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
 def camtoworld_to_worldtocam_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
     r"""Converts camtoworld, i.e. projection from camera coordinate system to world coordinate system, to worldtocam
     frame i.e. projection from world to the camera coordinate system (used in Colmap).
+    See
+    long-url: https://colmap.github.io/format.html#output-format
 
     Args:
         R: Rotation matrix, :math:`(B, 3, 3).`

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -44,6 +44,8 @@ __all__ = [
     "matrix4x4_to_Rt",
     "camtoworld_graphics_to_vision_4x4",
     "camtoworld_vision_to_graphics_4x4",
+    "camtoworld_graphics_to_vision_Rt",
+    "camtoworld_vision_to_graphics_Rt",
     "ARKitQTVecs_to_ColmapQTVecs",
 ]
 
@@ -1196,6 +1198,14 @@ def Rt_to_matrix4x4(R: Tensor, t: Tensor) -> Tensor:
 
     Returns:
         the extrinsics :math:`(B, 4, 4)`.
+
+    Example:
+        >>> R, t = torch.eye(3)[None], torch.rand(3).reshape(1, 3, 1)
+        >>> Rt_to_matrix4x4(R, t)
+        tensor([[[1., 0., 0., 1.],
+                 [0., 1., 0., 1.],
+                 [0., 0., 1., 1.],
+                 [0., 0., 0., 1.]]])
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1212,6 +1222,16 @@ def matrix4x4_to_Rt(extrinsics: Tensor) -> Tuple[Tensor, Tensor]:
     Returns:
         R: Rotation matrix, :math:`(B, 3, 3).`
         t: Translation matrix :math:`(B, 3, 1)`.
+
+    Example:
+        >>> ext = torch.eye(4)[None]
+        >>> matrix4x4_to_Rt(ext)
+        (tensor([[[1., 0., 0.],
+                  [0., 1., 0.],
+                  [0., 0., 1.]]]),
+         tensor([[[0.],
+                  [0.],
+                  [0.]]]))
     """
     KORNIA_CHECK_SHAPE(extrinsics, ["B", "4", "4"])
     R, t = extrinsics[:, :3, :3], extrinsics[:, :3, 3:]
@@ -1228,6 +1248,14 @@ def camtoworld_graphics_to_vision_4x4(extrinsics_graphics: Tensor) -> Tensor:
 
     Returns:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
+
+    Example:
+        >>> ext = torch.eye(4)[None]
+        >>> camtoworld_graphics_to_vision_4x4(ext)
+        tensor([[[ 1.,  0.,  0.,  0.],
+                 [ 0., -1.,  0.,  0.],
+                 [ 0.,  0., -1.,  0.],
+                 [ 0.,  0.,  0.,  1.]]])
     """
     KORNIA_CHECK_SHAPE(extrinsics_graphics, ["B", "4", "4"])
     invert_yz = tensor(
@@ -1250,6 +1278,16 @@ def camtoworld_graphics_to_vision_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
     Returns:
         R: Rotation matrix, :math:`(B, 3, 3).`
         t: Translation matrix :math:`(B, 3, 1)`.
+
+    Example:
+        >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
+        >>> camtoworld_graphics_to_vision_Rt(R, t)
+        (tensor([[[ 1.,  0.,  0.],
+                  [ 0., -1.,  0.],
+                  [ 0.,  0., -1.]]]),
+         tensor([[[1.],
+                  [1.],
+                  [1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1267,6 +1305,14 @@ def camtoworld_vision_to_graphics_4x4(extrinsics_vision: Tensor) -> Tensor:
 
     Returns:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
+
+    Example:
+        >>> ext = torch.eye(4)[None]
+        >>> camtoworld_vision_to_graphics_4x4(ext)
+        tensor([[[ 1.,  0.,  0.,  0.],
+                 [ 0., -1.,  0.,  0.],
+                 [ 0.,  0., -1.,  0.],
+                 [ 0.,  0.,  0.,  1.]]])
     """
     KORNIA_CHECK_SHAPE(extrinsics_vision, ["B", "4", "4"])
     invert_yz = torch.tensor(
@@ -1289,6 +1335,16 @@ def camtoworld_vision_to_graphics_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tens
     Returns:
         R: Rotation matrix, :math:`(B, 3, 3).`
         t: Translation matrix :math:`(B, 3, 1)`.
+
+    Example:
+        >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
+        >>> camtoworld_vision_to_graphics_Rt(R, t)
+        (tensor([[[ 1.,  0.,  0.],
+                  [ 0., -1.,  0.],
+                  [ 0.,  0., -1.]]]),
+         tensor([[[1.],
+                  [1.],
+                  [1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1307,6 +1363,16 @@ def camtoworld_to_worldtocam_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
     Returns:
         Rinv: Rotation matrix, :math:`(B, 3, 3).`
         tinv: Translation matrix :math:`(B, 3, 1)`.
+
+    Example:
+        >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
+        >>> camtoworld_to_worldtocam_Rt(R, t)
+        (tensor([[[1., 0., 0.],
+                  [0., 1., 0.],
+                  [0., 0., 1.]]]),
+         tensor([[[-1.],
+                  [-1.],
+                  [-1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1328,6 +1394,16 @@ def worldtocam_to_camtoworld_Rt(R: Tensor, t: Tensor) -> Tuple[Tensor, Tensor]:
     Returns:
         Rinv: Rotation matrix, :math:`(B, 3, 3).`
         tinv: Translation matrix :math:`(B, 3, 1)`.
+
+    Example:
+        >>> R, t = torch.eye(3)[None], torch.ones(3).reshape(1, 3, 1)
+        >>> worldtocam_to_camtoworld_Rt(R, t)
+        (tensor([[[1., 0., 0.],
+                  [0., 1., 0.],
+                  [0., 0., 1.]]]),
+         tensor([[[-1.],
+                  [-1.],
+                  [-1.]]]))
     """
     KORNIA_CHECK_SHAPE(R, ["B", "3", "3"])
     KORNIA_CHECK_SHAPE(t, ["B", "3", "1"])
@@ -1349,7 +1425,17 @@ def ARKitQTVecs_to_ColmapQTVecs(qvec: Tensor, tvec: Tensor) -> Tuple[Tensor, Ten
     Returns:
         qvec: Colmap rotation quaternion :math:`(B, 4)`, [w, x, y, z] format.
         tvec: translation vector :math:`(B, 3, 1)`, [x, y, z]
+
+    Example:
+        >>> q, t = torch.tensor([0, 1, 0, 1.])[None], torch.ones(3).reshape(1, 3, 1)
+        >>> ARKitQTVecs_to_ColmapQTVecs(q, t)
+        (tensor([[0.7071, 0.0000, 0.7071, 0.0000]]),
+         tensor([[[-1.0000],
+                  [-1.0000],
+                  [ 1.0000]]]))
     """
+    # ToDo:  integrate QuaterniaonAPI
+
     Rcg = quaternion_to_rotation_matrix(qvec, order=QuaternionCoeffOrder.WXYZ)
     Rcv, Tcv = camtoworld_graphics_to_vision_Rt(Rcg, tvec)
     R_colmap, t_colmap = camtoworld_to_worldtocam_Rt(Rcv, Tcv)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -7,6 +7,7 @@ from torch.autograd import gradcheck
 
 import kornia
 from kornia.geometry.conversions import (
+    ARKitQTVecs_to_ColmapQTVecs,
     QuaternionCoeffOrder,
     Rt_from_extrinsics,
     camtoworld_graphics_to_vision,
@@ -14,8 +15,7 @@ from kornia.geometry.conversions import (
     camtoworldRt_to_poseRt,
     extrinsics_from_Rt,
     poseRt_to_camtoworldRt,
-    ARKitQTVecs_to_ColmapQTVecs,
-    screenpose_to_camerapose
+    screenpose_to_camerapose,
 )
 from kornia.testing import assert_close, create_eye_batch, tensor_to_gradcheck_var
 
@@ -1460,7 +1460,7 @@ class TestCARKitToColmap:
     def test_everything(self, device, dtype):
         # generate input data
         t = torch.tensor([1, 0, 0], device=device, dtype=dtype).view(1, 3, 1)
-        ang_deg = torch.tensor([45, 60., 0.], device=device, dtype=dtype)[None]
+        ang_deg = torch.tensor([45, 60.0, 0.0], device=device, dtype=dtype)[None]
         ang_rad = kornia.geometry.conversions.deg2rad(ang_deg)
         qvec = kornia.geometry.angle_axis_to_quaternion(ang_rad, order=QuaternionCoeffOrder.WXYZ)
 
@@ -1468,7 +1468,7 @@ class TestCARKitToColmap:
 
         angles_colmap = kornia.geometry.conversions.quaternion_to_angle_axis(q_colmap, order=QuaternionCoeffOrder.WXYZ)
         angles_colmap = kornia.geometry.conversions.rad2deg(angles_colmap)
-        expected_angles = torch.tensor([[-45., 60, 0.]], device=device, dtype=dtype)
+        expected_angles = torch.tensor([[-45.0, 60, 0.0]], device=device, dtype=dtype)
         expected_t = torch.tensor([[[-0.5256], [0.3558], [0.7727]]], device=device, dtype=dtype)
 
         assert_close(angles_colmap, expected_angles)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -14,6 +14,8 @@ from kornia.geometry.conversions import (
     camtoworldRt_to_poseRt,
     extrinsics_from_Rt,
     poseRt_to_camtoworldRt,
+    ARKitQTVecs_to_ColmapQTVecs,
+    screenpose_to_camerapose
 )
 from kornia.testing import assert_close, create_eye_batch, tensor_to_gradcheck_var
 
@@ -1410,12 +1412,14 @@ class TestCamtoworldGraphicsToVision:
         R = kornia.geometry.angle_axis_to_rotation_matrix(angles).repeat(batch_size, 1, 1)
         K_vis = extrinsics_from_Rt(R, t)
         K_graf = camtoworld_vision_to_graphics(K_vis)
+        K_graf2 = screenpose_to_camerapose(K_vis)
 
         expected = torch.tensor(
             [[0, 0, -1, 2], [0, -1, 0, 3], [-1, 0, 0, 4], [0, 0, 0, 1]], device=device, dtype=dtype
         )[None].repeat(batch_size, 1, 1)
 
         assert_close(K_graf, expected)
+        assert_close(K_graf2, expected)
 
         Kvis_back = camtoworld_graphics_to_vision(K_graf)
         assert_close(Kvis_back, K_vis)
@@ -1450,3 +1454,22 @@ class TestCamtoworldRtToPoseRt:
         assert gradcheck(
             poseRt_to_camtoworldRt, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
         )
+
+
+class TestCARKitToColmap:
+    def test_everything(self, device, dtype):
+        # generate input data
+        t = torch.tensor([1, 0, 0], device=device, dtype=dtype).view(1, 3, 1)
+        ang_deg = torch.tensor([45, 60., 0.], device=device, dtype=dtype)[None]
+        ang_rad = kornia.geometry.conversions.deg2rad(ang_deg)
+        qvec = kornia.geometry.angle_axis_to_quaternion(ang_rad, order=QuaternionCoeffOrder.WXYZ)
+
+        q_colmap, t_colmap = ARKitQTVecs_to_ColmapQTVecs(qvec, t)
+
+        angles_colmap = kornia.geometry.conversions.quaternion_to_angle_axis(q_colmap, order=QuaternionCoeffOrder.WXYZ)
+        angles_colmap = kornia.geometry.conversions.rad2deg(angles_colmap)
+        expected_angles = torch.tensor([[-45., 60, 0.]], device=device, dtype=dtype)
+        expected_t = torch.tensor([[[-0.5256], [0.3558], [0.7727]]], device=device, dtype=dtype)
+
+        assert_close(angles_colmap, expected_angles)
+        assert_close(t_colmap, expected_t)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -1394,8 +1394,8 @@ class TestRt2Extrinsics:
         assert R2.shape == (batch_size, 3, 3)
         assert t2.shape == (batch_size, 3, 1)
 
-        assert_close(R, R2)
-        assert_close(t, t2)
+        assert_close(R, R2, rtol=1e-4, atol=1e-5)
+        assert_close(t, t2, rtol=1e-4, atol=1e-5)
         assert gradcheck(
             kornia.geometry.conversions.extrinsics_from_Rt,
             (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)),
@@ -1418,11 +1418,11 @@ class TestCamtoworldGraphicsToVision:
             [[0, 0, -1, 2], [0, -1, 0, 3], [-1, 0, 0, 4], [0, 0, 0, 1]], device=device, dtype=dtype
         )[None].repeat(batch_size, 1, 1)
 
-        assert_close(K_graf, expected)
-        assert_close(K_graf2, expected)
+        assert_close(K_graf, expected, rtol=1e-4, atol=1e-5)
+        assert_close(K_graf2, expected, rtol=1e-4, atol=1e-5)
 
         Kvis_back = camtoworld_graphics_to_vision(K_graf)
-        assert_close(Kvis_back, K_vis)
+        assert_close(Kvis_back, K_vis, rtol=1e-4, atol=1e-5)
         assert gradcheck(camtoworld_graphics_to_vision, (tensor_to_gradcheck_var(K_vis)), raise_exception=True)
         assert gradcheck(camtoworld_vision_to_graphics, (tensor_to_gradcheck_var(K_vis)), raise_exception=True)
 
@@ -1441,12 +1441,12 @@ class TestCamtoworldRtToPoseRt:
             batch_size, 1, 1
         )
         expected_tp = torch.tensor([4, -3, -2], device=device, dtype=dtype).view(1, 3, 1).repeat(batch_size, 1, 1)
-        assert_close(Rp, expected_Rp)
-        assert_close(tp, expected_tp)
+        assert_close(Rp, expected_Rp, rtol=1e-4, atol=1e-5)
+        assert_close(tp, expected_tp, rtol=1e-4, atol=1e-5)
 
         Rback, tback = poseRt_to_camtoworldRt(Rp, tp)
-        assert_close(Rback, R)
-        assert_close(tback, t)
+        assert_close(Rback, R, rtol=1e-4, atol=1e-5)
+        assert_close(tback, t, rtol=1e-4, atol=1e-5)
 
         assert gradcheck(
             camtoworldRt_to_poseRt, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
@@ -1471,5 +1471,5 @@ class TestCARKitToColmap:
         expected_angles = torch.tensor([[-45.0, 60, 0.0]], device=device, dtype=dtype)
         expected_t = torch.tensor([[[-0.5256], [0.3558], [0.7727]]], device=device, dtype=dtype)
 
-        assert_close(angles_colmap, expected_angles)
-        assert_close(t_colmap, expected_t)
+        assert_close(angles_colmap, expected_angles, rtol=1e-4, atol=1e-5)
+        assert_close(t_colmap, expected_t, rtol=1e-4, atol=1e-5)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -12,7 +12,7 @@ from kornia.geometry.conversions import (
     Rt_from_extrinsics,
     camtoworld_graphics_to_vision,
     camtoworld_vision_to_graphics,
-    camtoworldRt_to_poseRt,
+    camtoworld_to_worldtocam,
     extrinsics_from_Rt,
     poseRt_to_camtoworldRt,
     screenpose_to_camerapose,
@@ -1435,7 +1435,7 @@ class TestCamtoworldRtToPoseRt:
         angles = torch.tensor([0, kornia.pi / 2.0, 0.0], device=device, dtype=dtype)[None]
         R = kornia.geometry.angle_axis_to_rotation_matrix(angles).repeat(batch_size, 1, 1)
 
-        Rp, tp = camtoworldRt_to_poseRt(R, t)
+        Rp, tp = camtoworld_to_worldtocam(R, t)
 
         expected_Rp = torch.tensor([[0, 0, -1], [0, 1, 0], [1, 0, 0]], device=device, dtype=dtype)[None].repeat(
             batch_size, 1, 1
@@ -1444,15 +1444,16 @@ class TestCamtoworldRtToPoseRt:
         assert_close(Rp, expected_Rp, rtol=1e-4, atol=1e-5)
         assert_close(tp, expected_tp, rtol=1e-4, atol=1e-5)
 
+
         Rback, tback = poseRt_to_camtoworldRt(Rp, tp)
         assert_close(Rback, R, rtol=1e-4, atol=1e-5)
         assert_close(tback, t, rtol=1e-4, atol=1e-5)
 
         assert gradcheck(
-            camtoworldRt_to_poseRt, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
+            camtoworld_to_worldtocam, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
         )
         assert gradcheck(
-            poseRt_to_camtoworldRt, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
+            worldtocam_to_camtoworld, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
         )
 
 

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -9,13 +9,13 @@ import kornia
 from kornia.geometry.conversions import (
     ARKitQTVecs_to_ColmapQTVecs,
     QuaternionCoeffOrder,
-    matrix4x4_to_Rt,
     Rt_to_matrix4x4,
     camtoworld_graphics_to_vision_4x4,
     camtoworld_graphics_to_vision_Rt,
+    camtoworld_to_worldtocam_Rt,
     camtoworld_vision_to_graphics_4x4,
     camtoworld_vision_to_graphics_Rt,
-    camtoworld_to_worldtocam_Rt,
+    matrix4x4_to_Rt,
     worldtocam_to_camtoworld_Rt,
 )
 from kornia.testing import assert_close, create_eye_batch, tensor_to_gradcheck_var
@@ -1420,9 +1420,9 @@ class TestCamtoworldGraphicsToVision:
 
         assert_close(K_graf, expected, rtol=1e-4, atol=1e-5)
         R_graf, t_graf = camtoworld_vision_to_graphics_Rt(R_vis, t_vis)
-        expected_R = torch.tensor(
-            [[0, 0, -1], [0, -1, 0], [-1, 0, 0]], device=device, dtype=dtype
-        )[None].repeat(batch_size, 1, 1)
+        expected_R = torch.tensor([[0, 0, -1], [0, -1, 0], [-1, 0, 0]], device=device, dtype=dtype)[None].repeat(
+            batch_size, 1, 1
+        )
         expected_t = torch.tensor([2, 3, 4], device=device, dtype=dtype).reshape(1, 3, 1).repeat(batch_size, 1, 1)
 
         assert_close(t_graf, expected_t, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
#### Changes

Adds conversions between graphics and vision coordinate frames. Useful when working with Colmap and others. 
See https://github.com/colmap/colmap/issues/1184#issuecomment-803003873 and other similar issues. Now people should be able to just use kornia.

#### Type of change
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
