### PR TITLE
Change embedded Gradio demo to use web component instead of iframe

### DIFF
--- a/docs/source/gradio/enhance_gradio.html
+++ b/docs/source/gradio/enhance_gradio.html
@@ -1,1 +1,4 @@
-<iframe src="https://hf.space/embed/kornia/kornia-image-enhancement/+" frameBorder="0" height="1060px" width="100%" title="Gradio app" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+<script type="module"
+src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js">
+</script>
+<gradio-app space="kornia/kornia-image-enhancement" src="https://hf.space/embed/kornia/kornia-image-enhancement/+"></gradio-app>


### PR DESCRIPTION
#### Changes
This is a follow-up to #1793.

Gradio now supports embedding with [web components](https://gradio.app/sharing_your_app/#embedding-with-web-components). This makes the embedding code easier to read and write (useful for future contributions), and also ensures that the app renders properly (iframe apps somethings have broken layouts).

The current embedded demo has a scroll bar and is laid out vertically:
<img width="778" alt="image" src="https://user-images.githubusercontent.com/6765188/186798217-aaf0b719-f49b-48d5-bc5b-5b07fa11c395.png">

With the changes in this PR, the demo renders properly:
<img width="638" alt="image" src="https://user-images.githubusercontent.com/6765188/186798286-2fd1676a-18c4-4f50-984c-a1df60937a74.png">

#### Type of change
- [x] 📚  Documentation Update
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
