### PR TITLE
Explicitly cast output to input type to avoid type mismatch errors

### DIFF
--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -255,9 +255,9 @@ class _AugmentationBase(_BasicAugmentationBase):
         else:
             output = in_tensor.clone()
             trans_matrix = self.identity_matrix(in_tensor)
-            trans_matrix[to_apply] = self.compute_transformation(
-                in_tensor[to_apply], params=params, flags=flags
-            ).type(in_tensor.dtype)
+            trans_matrix[to_apply] = self.compute_transformation(in_tensor[to_apply], params=params, flags=flags).type(
+                in_tensor.dtype
+            )
             output[to_apply] = self.apply_transform(
                 in_tensor[to_apply], params=params, flags=flags, transform=trans_matrix[to_apply]
             ).type(in_tensor.dtype)

--- a/test/augmentation/test_base.py
+++ b/test/augmentation/test_base.py
@@ -5,9 +5,9 @@ import torch
 from torch.autograd import gradcheck
 
 import kornia.testing as utils  # test utils
+from kornia.augmentation import RandomGaussianBlur
 from kornia.augmentation._2d.base import AugmentationBase2D
 from kornia.augmentation.base import _BasicAugmentationBase
-from kornia.augmentation import RandomGaussianBlur
 from kornia.testing import assert_close
 
 
@@ -82,7 +82,7 @@ class TestBasicAugmentationBase:
         # seed=1: triggers part of the dta to be augmented
         torch.manual_seed(seed)
 
-        aug = RandomGaussianBlur((3,3), (0.1, 3), p=0.5)
+        aug = RandomGaussianBlur((3, 3), (0.1, 3), p=0.5)
         x = torch.rand(2, 3, 100, 100, dtype=torch.float32).to(device)
         with torch.autocast(device.type):
             res = aug(x)

--- a/test/augmentation/test_base.py
+++ b/test/augmentation/test_base.py
@@ -7,6 +7,7 @@ from torch.autograd import gradcheck
 import kornia.testing as utils  # test utils
 from kornia.augmentation._2d.base import AugmentationBase2D
 from kornia.augmentation.base import _BasicAugmentationBase
+from kornia.augmentation import RandomGaussianBlur
 from kornia.testing import assert_close
 
 
@@ -74,6 +75,19 @@ class TestBasicAugmentationBase:
             output = augmentation(input)
             assert output.shape == expected_output.shape
             assert_close(output, expected_output)
+
+    @pytest.mark.parametrize("seed", [0, 1])
+    def test_autocast(self, seed, device, dtype):
+        # seed=0: triggers all data to be augmented
+        # seed=1: triggers part of the dta to be augmented
+        torch.manual_seed(seed)
+
+        aug = RandomGaussianBlur((3,3), (0.1, 3), p=0.5)
+        x = torch.rand(2, 3, 100, 100, dtype=torch.float32).to(device)
+        with torch.autocast(device.type):
+            res = aug(x)
+
+        assert res.dtype == dtype, "The output dtype should match the input dtype"
 
 
 class TestAugmentationBase2D:


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #1737

I also ran into the type mismatch error in my code. The problem is, that if the input is float32 but the code is run in autocast-enabled region than the output may be float16 depending on the operations used (see [https://pytorch.org/docs/stable/amp.html](https://pytorch.org/docs/stable/amp.html) for all the details. For example, matrix multiplication (which is used to generate some of the transformation matrices) always produces float16 output leading to the error as described in the issue.

I fixed this by explicitly casting the output to the input's dtype which is a no-op if they already match. I think this is in-line with the current philosophy since tensors are also created using the input's dtype.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
