### PR TITLE
Binary focal loss: Use pre-computed probs and increase readability

### DIFF
--- a/kornia/losses/focal.py
+++ b/kornia/losses/focal.py
@@ -209,12 +209,12 @@ def binary_focal_loss_with_logits(
     KORNIA_CHECK_IS_TENSOR(pos_weight)
     KORNIA_CHECK(input.shape[-1] == pos_weight.shape[0], "Expected pos_weight equals number of classes.")
 
-    probs_pos = input.sigmoid()
+    probs_pos = torch.sigmoid(input)
     probs_neg = torch.sigmoid(-input)
 
     loss_tmp = (
-        -alpha * pos_weight * probs_neg.pow(gamma) * target * input.sigmoid().log()
-        - (1 - alpha) * torch.pow(probs_pos, gamma) * (1.0 - target) * (-input).sigmoid().log()
+        -alpha * pos_weight * probs_neg.pow(gamma) * target * probs_pos.log()
+        - (1 - alpha) * probs_pos.pow(gamma) * (1.0 - target) * probs_neg.log()
     )
 
     if reduction == 'none':

--- a/kornia/losses/focal.py
+++ b/kornia/losses/focal.py
@@ -209,8 +209,8 @@ def binary_focal_loss_with_logits(
     KORNIA_CHECK_IS_TENSOR(pos_weight)
     KORNIA_CHECK(input.shape[-1] == pos_weight.shape[0], "Expected pos_weight equals number of classes.")
 
-    probs_pos = torch.sigmoid(input)
-    probs_neg = torch.sigmoid(-input)
+    probs_pos = input.sigmoid()
+    probs_neg = (-input).sigmoid()
 
     loss_tmp = (
         -alpha * pos_weight * probs_neg.pow(gamma) * target * probs_pos.log()


### PR DESCRIPTION
#### Changes

* Use pre-computed probs_pos and probs_neg rather than calling sigmoid function again (performance boost by skipping two calls to `torch.sigmoid`)
* Standardize use of tensor method vs torch function to increase readability (make symmetry in code more apparent)

#### Type of change

Performance / code readability

<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
