### PR TITLE
Enlargen LoFTR positional encoding map if large images are input

### DIFF
--- a/kornia/feature/loftr/utils/position_encoding.py
+++ b/kornia/feature/loftr/utils/position_encoding.py
@@ -17,25 +17,58 @@ class PositionEncodingSine(nn.Module):
                 We will remove the buggy impl after re-training all variants of our released models.
         """
         super().__init__()
+        self.d_model = d_model
+        self.temp_bug_fix = temp_bug_fix
 
-        pe = torch.zeros((d_model, *max_shape))
+        pe = self._create_position_encoding(max_shape)
+        self.register_buffer('pe', pe, persistent=False)  # [1, C, H, W]
+
+    def _create_position_encoding(self, max_shape):
+        """
+            Creates a position encoding from scratch.
+            For 1/8 feature map (which is standard):
+            If the input image size is H, W (both divisible by 8),
+            the max_shape should be (H//8, W//8).
+        """
+        pe = torch.zeros((self.d_model, *max_shape))
         y_position = torch.ones(max_shape).cumsum(0).float().unsqueeze(0)
         x_position = torch.ones(max_shape).cumsum(1).float().unsqueeze(0)
-        if temp_bug_fix:
-            div_term = torch.exp(torch.arange(0, d_model // 2, 2).float() * (-math.log(10000.0) / (d_model // 2)))
+        if self.temp_bug_fix:
+            div_term = torch.exp(
+                torch.arange(0, self.d_model // 2, 2).float()
+                * (-math.log(10000.0) / (self.d_model // 2))
+            )
         else:  # a buggy implementation (for backward compatibility only)
-            div_term = torch.exp(torch.arange(0, d_model // 2, 2).float() * (-math.log(10000.0) / d_model // 2))
+            div_term = torch.exp(
+                torch.arange(0, self.d_model // 2, 2).float()
+                * (-math.log(10000.0) / self.d_model // 2)
+            )
         div_term = div_term[:, None, None]  # [C//4, 1, 1]
         pe[0::4, :, :] = torch.sin(x_position * div_term)
         pe[1::4, :, :] = torch.cos(x_position * div_term)
         pe[2::4, :, :] = torch.sin(y_position * div_term)
         pe[3::4, :, :] = torch.cos(y_position * div_term)
+        return pe.unsqueeze(0)
 
-        self.register_buffer('pe', pe.unsqueeze(0), persistent=False)  # [1, C, H, W]
+    def update_position_encoding_size(self, max_shape):
+        """
+            Updates position encoding to new max_shape.
+            For 1/8 feature map (which is standard):
+            If the input image size is H, W (both divisible by 8),
+            the max_shape should be (H//8, W//8).
+        """
+        self.pe = self._create_position_encoding(max_shape).to(self.pe.device)
 
     def forward(self, x):
         """
         Args:
             x: [N, C, H, W]
         """
-        return x + self.pe[:, :, : x.size(2), : x.size(3)]
+        if x.size(2) > self.pe.size(2) or x.size(3) > self.pe.size(3):
+            max_shape = (
+                max(x.size(2), self.pe.size(2)),
+                max(x.size(3), self.pe.size(3))
+            )
+            self.update_position_encoding_size(max_shape)
+
+        return x + self.pe[:, :, :x.size(2), :x.size(3)]

--- a/kornia/feature/loftr/utils/position_encoding.py
+++ b/kornia/feature/loftr/utils/position_encoding.py
@@ -24,24 +24,21 @@ class PositionEncodingSine(nn.Module):
         self.register_buffer('pe', pe, persistent=False)  # [1, C, H, W]
 
     def _create_position_encoding(self, max_shape):
-        """
-            Creates a position encoding from scratch.
-            For 1/8 feature map (which is standard):
-            If the input image size is H, W (both divisible by 8),
-            the max_shape should be (H//8, W//8).
+        """Creates a position encoding from scratch.
+
+        For 1/8 feature map (which is standard): If the input image size is H, W (both divisible by 8), the max_shape
+        should be (H//8, W//8).
         """
         pe = torch.zeros((self.d_model, *max_shape))
         y_position = torch.ones(max_shape).cumsum(0).float().unsqueeze(0)
         x_position = torch.ones(max_shape).cumsum(1).float().unsqueeze(0)
         if self.temp_bug_fix:
             div_term = torch.exp(
-                torch.arange(0, self.d_model // 2, 2).float()
-                * (-math.log(10000.0) / (self.d_model // 2))
+                torch.arange(0, self.d_model // 2, 2).float() * (-math.log(10000.0) / (self.d_model // 2))
             )
         else:  # a buggy implementation (for backward compatibility only)
             div_term = torch.exp(
-                torch.arange(0, self.d_model // 2, 2).float()
-                * (-math.log(10000.0) / self.d_model // 2)
+                torch.arange(0, self.d_model // 2, 2).float() * (-math.log(10000.0) / self.d_model // 2)
             )
         div_term = div_term[:, None, None]  # [C//4, 1, 1]
         pe[0::4, :, :] = torch.sin(x_position * div_term)
@@ -51,11 +48,10 @@ class PositionEncodingSine(nn.Module):
         return pe.unsqueeze(0)
 
     def update_position_encoding_size(self, max_shape):
-        """
-            Updates position encoding to new max_shape.
-            For 1/8 feature map (which is standard):
-            If the input image size is H, W (both divisible by 8),
-            the max_shape should be (H//8, W//8).
+        """Updates position encoding to new max_shape.
+
+        For 1/8 feature map (which is standard): If the input image size is H, W (both divisible by 8), the max_shape
+        should be (H//8, W//8).
         """
         self.pe = self._create_position_encoding(max_shape).to(self.pe.device)
 
@@ -65,10 +61,7 @@ class PositionEncodingSine(nn.Module):
             x: [N, C, H, W]
         """
         if x.size(2) > self.pe.size(2) or x.size(3) > self.pe.size(3):
-            max_shape = (
-                max(x.size(2), self.pe.size(2)),
-                max(x.size(3), self.pe.size(3))
-            )
+            max_shape = (max(x.size(2), self.pe.size(2)), max(x.size(3), self.pe.size(3)))
             self.update_position_encoding_size(max_shape)
 
-        return x + self.pe[:, :, :x.size(2), :x.size(3)]
+        return x + self.pe[:, :, : x.size(2), : x.size(3)]


### PR DESCRIPTION
#### Changes
Fixes #1746 by recomputing a larger LoFTR position encoding if input images are larger than the default max.


#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
