### PR TITLE
Fixes typo bug that influences LoFTR training

### DIFF
--- a/kornia/feature/loftr/utils/coarse_matching.py
+++ b/kornia/feature/loftr/utils/coarse_matching.py
@@ -203,7 +203,7 @@ class CoarseMatching(nn.Module):
             num_matches_train = num_candidates_max * self.train_coarse_percent
             num_matches_train = int(num_matches_train)
             num_matches_pred = len(b_ids)
-            if self.train_pad_num_gt_min < num_matches_train:
+            if self.train_pad_num_gt_min >= num_matches_train:
                 msg = "min-num-gt-pad should be less than num-train-matches"
                 raise ValueError(msg)
 


### PR DESCRIPTION
#### Changes
A typo bug fix for LoFTR training.

Compare original LoFTR code:

https://github.com/zju3dv/LoFTR/blob/6d4b63e87bfba7b4b085b8f9c7f9f554fb8bc6d5/src/loftr/utils/coarse_matching.py#L213
```python     
        assert self.train_pad_num_gt_min < num_matches_train, "min-num-gt-pad should be less than num-train-matches"
```

with current Kornia code:
https://github.com/kornia/kornia/blob/5bc7fac1f6a8ba15dbc3469a8531aa8c5d012679/kornia/feature/loftr/utils/coarse_matching.py#L206-L208

This should be `>=` instead.

#### Type of change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)



#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
