### PR TITLE
modifying `add_weighted` to accept Tensors for `alpha`/`beta`/`gamma`

### DIFF
--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -22,6 +22,11 @@ def torch_version_lt(major: int, minor: int, patch: int) -> bool:
     return _version < version.parse(f"{major}.{minor}.{patch}")
 
 
+def torch_version_le(major: int, minor: int, patch: int) -> bool:
+    _version = version.parse(torch_version())
+    return _version <= version.parse(f"{major}.{minor}.{patch}")
+
+
 def torch_version_ge(major: int, minor: int, patch: int) -> bool:
     _version = version.parse(torch_version())
     return _version >= version.parse(f"{major}.{minor}.{patch}")

--- a/test/enhance/test_core.py
+++ b/test/enhance/test_core.py
@@ -6,7 +6,9 @@ from torch.autograd import gradcheck
 
 import kornia
 import kornia.testing as utils  # test utils
+from kornia.core import Tensor
 from kornia.testing import assert_close
+from kornia.utils._compat import torch_version_le
 
 
 def random_shape(dim, min_elem=1, max_elem=10):
@@ -31,6 +33,31 @@ class TestAddWeighted:
         src1, src2, alpha, beta, gamma = self.get_input(device, dtype, size=3)
         assert_close(TestAddWeighted.fcn(src1, alpha, src2, beta, gamma), src1 * alpha + src2 * beta + gamma)
 
+    @pytest.mark.parametrize("size1, size2", [((2, 5, 5), (4, 5, 5)), ((2, 5, 5), (2, 3, 5, 5))])
+    def test_shape_mismatch(self, device, dtype, size1, size2):
+        src1 = torch.randn(size1, device=device, dtype=dtype)
+        src2 = torch.randn(size2, device=device, dtype=dtype)
+        with pytest.raises(Exception):
+            TestAddWeighted.fcn(src1, 1.0, src2, 1.0, 0.0)
+
+    @pytest.mark.parametrize("size1, size2", [((2, 3, 5, 5), (2, 3, 5, 5)), ((2, 3, 5, 5), (2, 3, 5, 5))])
+    @pytest.mark.parametrize("alpha", [torch.randn(2, 3, 5, 5), 1.0])
+    @pytest.mark.parametrize("beta", [torch.randn(2, 3, 5, 5), 1.0])
+    @pytest.mark.parametrize("gamma", [torch.randn(2, 3, 5, 5), 1.0])
+    def test_shape(self, device, dtype, size1, size2, alpha, beta, gamma):
+        src1 = torch.randn(size1, device=device, dtype=dtype)
+        src2 = torch.randn(size2, device=device, dtype=dtype)
+        if isinstance(alpha, Tensor):
+            alpha = alpha.to(src1)
+        if isinstance(beta, Tensor):
+            beta = beta.to(src2)
+        if isinstance(gamma, Tensor):
+            gamma = gamma.to(src1)
+        assert_close(TestAddWeighted.fcn(src1, alpha, src2, beta, gamma), src1 * alpha + src2 * beta + gamma)
+
+    @pytest.mark.skipif(
+        torch_version_le(1, 11, 0), reason="`Union` type hint not supported in JIT with PyTorch <= 1.11.0"
+    )
     def test_jit(self, device, dtype):
         src1, src2, alpha, beta, gamma = self.get_input(device, dtype, size=3)
         inputs = (src1, alpha, src2, beta, gamma)


### PR DESCRIPTION
#### Changes
Enhancing `add_weighted` to weight the tensors with tensors or floats.

Fixes # [(issue)](https://github.com/kornia/kornia/issues/1824)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
