### PR TITLE
No crash in local feature matching if empty tensor output

### DIFF
--- a/kornia/feature/adalam/adalam.py
+++ b/kornia/feature/adalam/adalam.py
@@ -235,7 +235,7 @@ class AdalamFilter:
                     "Please either provide orientations or set 'orientation_difference_threshold' to None to disable orientations filtering"  # noqa: E501
                 )
         k1, k2, d1, d2, o1, o2, s1, s2 = self.__to_torch(k1, k2, d1, d2, o1, o2, s1, s2)
-        if len(d2) <= 1:
+        if (len(d2) <= 1) or (len(d1) <= 1):
             idxs, dists = _no_match(d1)
             if return_dist:
                 return idxs, dists

--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -61,7 +61,8 @@ def match_nn(desc1: Tensor, desc2: Tensor, dm: Optional[Tensor] = None) -> Tuple
     """
     KORNIA_CHECK_SHAPE(desc1, ["B", "DIM"])
     KORNIA_CHECK_SHAPE(desc2, ["B", "DIM"])
-
+    if (len(desc1) == 0) or (len(desc2) == 0):
+        return _no_match(desc1)
     distance_matrix: Tensor = _get_lazy_distance_matrix(desc1, desc2, dm)
     match_dists, idxs_in_2 = torch.min(distance_matrix, dim=1)
     idxs_in1: Tensor = torch.arange(0, idxs_in_2.size(0), device=idxs_in_2.device)
@@ -87,7 +88,8 @@ def match_mnn(desc1: Tensor, desc2: Tensor, dm: Optional[Tensor] = None) -> Tupl
     """
     KORNIA_CHECK_SHAPE(desc1, ["B", "DIM"])
     KORNIA_CHECK_SHAPE(desc2, ["B", "DIM"])
-
+    if (len(desc1) == 0) or (len(desc2) == 0):
+        return _no_match(desc1)
     distance_matrix = _get_lazy_distance_matrix(desc1, desc2, dm)
 
     ms = min(distance_matrix.size(0), distance_matrix.size(1))

--- a/test/feature/test_matching.py
+++ b/test/feature/test_matching.py
@@ -188,6 +188,18 @@ class TestMatchSMNN:
         assert_close(dists1, expected_dists)
         assert_close(idxs1, expected_idx)
 
+    @pytest.mark.parametrize("match_type, d1, d2", [("nn", 0, 10), ("nn", 10, 0), ("nn", 0, 0),
+                                                    ("snn", 0, 10), ("snn", 10, 0), ("snn", 0, 0),
+                                                    ("mnn", 0, 10), ("mnn", 10, 0), ("mnn", 0, 0),
+                                                    ("smnn", 0, 10), ("smnn", 10, 0), ("smnn", 0, 0)])
+    def test_empty_nocrash(self, match_type, d1, d2, device, dtype):
+        desc1 = torch.empty(d1, 8, device=device, dtype=dtype)
+        desc2 = torch.empty(d2, 8, device=device, dtype=dtype)
+        matcher = DescriptorMatcher(match_type, 0.8).to(device)
+        dists, idxs = matcher(desc1, desc2)
+        assert dists is not None
+        assert idxs is not None
+
     def test_gradcheck(self, device):
         desc1 = torch.rand(5, 8, device=device)
         desc2 = torch.rand(7, 8, device=device)
@@ -358,10 +370,16 @@ class TestAdalam:
         data_dev = utils.dict_to(data, device, dtype)
         with torch.no_grad():
             dists, idxs = match_adalam(
-                data_dev['descs1'], torch.empty(0, 128, device=device, dtype=dtype), data_dev['lafs1'], torch.empty(0, 0, 2, 3, device=device, dtype=dtype)
+                data_dev['descs1'],
+                torch.empty(0, 128, device=device, dtype=dtype),
+                data_dev['lafs1'],
+                torch.empty(0, 0, 2, 3, device=device, dtype=dtype)
             )
             dists, idxs = match_adalam(
-                torch.empty(0, 128, device=device, dtype=dtype), data_dev['descs2'], torch.empty(0, 0, 2, 3, device=device, dtype=dtype), data_dev['lafs2']
+                torch.empty(0, 128, device=device, dtype=dtype),
+                data_dev['descs2'],
+                torch.empty(0, 0, 2, 3, device=device, dtype=dtype),
+                data_dev['lafs2']
             )
 
     @pytest.mark.parametrize("data", ["adalam_idxs"], indirect=True)

--- a/test/feature/test_matching.py
+++ b/test/feature/test_matching.py
@@ -347,6 +347,32 @@ class TestAdalam:
             dists, idxs = match_adalam(
                 data_dev['descs1'], data_dev['descs2'][:1], data_dev['lafs1'], data_dev['lafs2'][:, :1]
             )
+            dists, idxs = match_adalam(
+                data_dev['descs1'][:1], data_dev['descs2'], data_dev['lafs1'][:, :1], data_dev['lafs2']
+            )
+
+    @pytest.mark.parametrize("data", ["adalam_idxs"], indirect=True)
+    def test_empty_nocrash(self, device, dtype, data):
+        torch.random.manual_seed(0)
+        # This is not unit test, but that is quite good integration test
+        data_dev = utils.dict_to(data, device, dtype)
+        with torch.no_grad():
+            dists, idxs = match_adalam(
+                data_dev['descs1'], torch.empty(0, 128, device=device, dtype=dtype), data_dev['lafs1'], torch.empty(0, 0, 2, 3, device=device, dtype=dtype)
+            )
+            dists, idxs = match_adalam(
+                torch.empty(0, 128, device=device, dtype=dtype), data_dev['descs2'], torch.empty(0, 0, 2, 3, device=device, dtype=dtype), data_dev['lafs2']
+            )
+
+    @pytest.mark.parametrize("data", ["adalam_idxs"], indirect=True)
+    def test_small(self, device, dtype, data):
+        torch.random.manual_seed(0)
+        # This is not unit test, but that is quite good integration test
+        data_dev = utils.dict_to(data, device, dtype)
+        with torch.no_grad():
+            dists, idxs = match_adalam(
+                data_dev['descs1'][:4], data_dev['descs2'][:4], data_dev['lafs1'][:, :4], data_dev['lafs2'][:, :4]
+            )
 
     @pytest.mark.parametrize("data", ["adalam_idxs"], indirect=True)
     def test_seeds_fail(self, device, dtype, data):

--- a/test/feature/test_matching.py
+++ b/test/feature/test_matching.py
@@ -188,10 +188,23 @@ class TestMatchSMNN:
         assert_close(dists1, expected_dists)
         assert_close(idxs1, expected_idx)
 
-    @pytest.mark.parametrize("match_type, d1, d2", [("nn", 0, 10), ("nn", 10, 0), ("nn", 0, 0),
-                                                    ("snn", 0, 10), ("snn", 10, 0), ("snn", 0, 0),
-                                                    ("mnn", 0, 10), ("mnn", 10, 0), ("mnn", 0, 0),
-                                                    ("smnn", 0, 10), ("smnn", 10, 0), ("smnn", 0, 0)])
+    @pytest.mark.parametrize(
+        "match_type, d1, d2",
+        [
+            ("nn", 0, 10),
+            ("nn", 10, 0),
+            ("nn", 0, 0),
+            ("snn", 0, 10),
+            ("snn", 10, 0),
+            ("snn", 0, 0),
+            ("mnn", 0, 10),
+            ("mnn", 10, 0),
+            ("mnn", 0, 0),
+            ("smnn", 0, 10),
+            ("smnn", 10, 0),
+            ("smnn", 0, 0),
+        ],
+    )
     def test_empty_nocrash(self, match_type, d1, d2, device, dtype):
         desc1 = torch.empty(d1, 8, device=device, dtype=dtype)
         desc2 = torch.empty(d2, 8, device=device, dtype=dtype)
@@ -373,13 +386,13 @@ class TestAdalam:
                 data_dev['descs1'],
                 torch.empty(0, 128, device=device, dtype=dtype),
                 data_dev['lafs1'],
-                torch.empty(0, 0, 2, 3, device=device, dtype=dtype)
+                torch.empty(0, 0, 2, 3, device=device, dtype=dtype),
             )
             dists, idxs = match_adalam(
                 torch.empty(0, 128, device=device, dtype=dtype),
                 data_dev['descs2'],
                 torch.empty(0, 0, 2, 3, device=device, dtype=dtype),
-                data_dev['lafs2']
+                data_dev['lafs2'],
             )
 
     @pytest.mark.parametrize("data", ["adalam_idxs"], indirect=True)


### PR DESCRIPTION
#### Changes
For AdaLAM and vanilla matching

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

