### PR TITLE
remove conv3d from spatial_gradient

### DIFF
--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .kernels import get_spatial_gradient_kernel2d, get_spatial_gradient_kernel3d, normalize_kernel2d
-from .filter import filter2d
+
 
 def spatial_gradient(input: torch.Tensor, mode: str = 'sobel', order: int = 1, normalized: bool = True) -> torch.Tensor:
     r"""Compute the first order image derivative in both x and y using a Sobel operator.

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .kernels import get_spatial_gradient_kernel2d, get_spatial_gradient_kernel3d, normalize_kernel2d
-
+from .filter import filter2d
 
 def spatial_gradient(input: torch.Tensor, mode: str = 'sobel', order: int = 1, normalized: bool = True) -> torch.Tensor:
     r"""Compute the first order image derivative in both x and y using a Sobel operator.
@@ -42,17 +42,14 @@ def spatial_gradient(input: torch.Tensor, mode: str = 'sobel', order: int = 1, n
     # prepare kernel
     b, c, h, w = input.shape
     tmp_kernel: torch.Tensor = kernel.to(input).detach()
-    tmp_kernel = tmp_kernel.unsqueeze(1).unsqueeze(1)
-
-    # convolve input tensor with sobel kernel
-    kernel_flip: torch.Tensor = tmp_kernel.flip(-3)
+    tmp_kernel = tmp_kernel.unsqueeze(1)
 
     # Pad with "replicate for spatial dims, but with zeros for channel
     spatial_pad = [kernel.size(1) // 2, kernel.size(1) // 2, kernel.size(2) // 2, kernel.size(2) // 2]
     out_channels: int = 3 if order == 2 else 2
-    padded_inp: torch.Tensor = F.pad(input.reshape(b * c, 1, h, w), spatial_pad, 'replicate')[:, :, None]
-
-    return F.conv3d(padded_inp, kernel_flip, padding=0).view(b, c, out_channels, h, w)
+    padded_inp: torch.Tensor = F.pad(input.reshape(b * c, 1, h, w), spatial_pad, 'replicate')
+    out = F.conv2d(padded_inp, tmp_kernel, groups=1, padding=0, stride=1)
+    return out.reshape(b, c, out_channels, h, w)
 
 
 def spatial_gradient3d(input: torch.Tensor, mode: str = 'diff', order: int = 1) -> torch.Tensor:


### PR DESCRIPTION
#### Changes
conv3d is not supported by MPS  and is adecdotically known to be slower than conv2d (https://github.com/kornia/kornia/issues/1717#issuecomment-1249293780)
