### PR TITLE
[Docs] Refactor the embedded Gradio demos

### DIFF
--- a/docs/source/_templates/page.html
+++ b/docs/source/_templates/page.html
@@ -3,6 +3,7 @@
     {{ super() }}
     <!-- DocsQA integration start -->
     <script src="https://jina-docqa-ui.netlify.app/dist/qabot.js"></script>
+    <script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.3.1/gradio.js"></script>
     <script>
       // This prevents the global search interfere with qa-bot internal text input.
       document.addEventListener('DOMContentLoaded', () => {

--- a/docs/source/applications/image_stitching.rst
+++ b/docs/source/applications/image_stitching.rst
@@ -25,6 +25,7 @@ Explore with your data: https://colab.research.google.com/github/kornia/tutorial
 Interactive Demo
 ----------------
 .. raw:: html
-   :file: gradio/stitching_gradio.html
+
+    <gradio-app space="kornia/Image-Stitching"></gradio-app>
 
 Visit the demo on `Hugging Face Spaces <https://huggingface.co/spaces/kornia/Image-Stitching>`_.

--- a/docs/source/enhance.rst
+++ b/docs/source/enhance.rst
@@ -5,8 +5,6 @@ kornia.enhance
 
 The functions in this section perform normalisations and intensity transformations.
 
-* `Interactive Demo`_
-
 Adjustment
 ----------
 
@@ -23,6 +21,14 @@ Adjustment
 .. autofunction:: posterize
 .. autofunction:: sharpness
 .. autofunction:: solarize
+
+Interactive Demo
+~~~~~~~~~~~~~~~~
+.. raw:: html
+
+    <gradio-app space="kornia/kornia-image-enhancement"></gradio-app>
+
+Visit the demo on `Hugging Face Spaces <https://huggingface.co/spaces/kornia/kornia-image-enhancement>`_.
 
 Equalization
 ------------
@@ -64,11 +70,3 @@ Modules
 .. autoclass:: AddWeighted
 
 .. autoclass:: Invert
-
-
-Interactive Demo
-----------------
-.. raw:: html
-   :file: gradio/enhance_gradio.html
-
-Visit the demo on `Hugging Face Spaces <https://huggingface.co/spaces/kornia/kornia-image-enhancement>`_.

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -76,5 +76,3 @@ Module
 .. autoclass:: SpatialGradient3d
 .. autoclass:: MotionBlur
 .. autoclass:: UnsharpMask
-
-

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -8,8 +8,6 @@ The functions in this sections perform various image filtering operations.
 Blurring
 --------
 
-* `Interactive Demo`_
-
 .. autofunction:: blur_pool2d
 .. autofunction:: box_blur
 .. autofunction:: gaussian_blur2d
@@ -18,10 +16,16 @@ Blurring
 .. autofunction:: motion_blur
 .. autofunction:: unsharp_mask
 
+Interactive Demo
+~~~~~~~~~~~~~~~~
+.. raw:: html
+
+    <gradio-app space="kornia/kornia-image-filtering"></gradio-app>
+
+Visit the demo on `Hugging Face Spaces <https://huggingface.co/spaces/kornia/kornia-image-filtering>`_.
+
 Edge detection
 --------------
-
-* `Interactive Demo`_
 
 .. autofunction:: canny
 .. autofunction:: laplacian
@@ -29,6 +33,13 @@ Edge detection
 .. autofunction:: spatial_gradient
 .. autofunction:: spatial_gradient3d
 
+Interactive Demo
+~~~~~~~~~~~~~~~~
+.. raw:: html
+
+    <gradio-app space="kornia/edge_detector"></gradio-app>
+
+Visit the demo on `Hugging Face Spaces <https://huggingface.co/spaces/kornia/edge_detector>`_.
 
 Filtering API
 -------------
@@ -67,8 +78,3 @@ Module
 .. autoclass:: UnsharpMask
 
 
-Interactive Demo
-----------------
-
-.. raw:: html
-    :file: gradio/edge_detector_gradio.html

--- a/docs/source/geometry.line.rst
+++ b/docs/source/geometry.line.rst
@@ -11,4 +11,5 @@ kornia.geometry.line
 
 .. autoclass:: Hyperplane
 .. raw:: html
-    :file: gradio/line_fitting.html
+
+    <gradio-app space="kornia/Line-Fitting"></gradio-app>

--- a/docs/source/geometry.transform.rst
+++ b/docs/source/geometry.transform.rst
@@ -73,7 +73,6 @@ Module
 .. autoclass:: Vflip
 .. autoclass:: Rot180
 .. autoclass:: Resize
-* `Interactive Demo`_
 .. autoclass:: Rescale
 .. autoclass:: Affine
 .. autoclass:: HomographyWarper
@@ -88,9 +87,3 @@ Image registration
 
 .. automodule:: kornia.geometry.transform.image_registrator
     :members:
-
-Interactive Demo
-----------------
-
-.. raw:: html
-    :file: gradio/resize_antialias.html

--- a/docs/source/gradio/edge_detector_gradio.html
+++ b/docs/source/gradio/edge_detector_gradio.html
@@ -1,4 +1,0 @@
-<script type="module"
-src="https://gradio.s3-us-west-2.amazonaws.com/3.3/gradio.js">
-</script>
-<gradio-app space="kornia/edge_detector"></gradio-app>

--- a/docs/source/gradio/edge_filter_gradio.html
+++ b/docs/source/gradio/edge_filter_gradio.html
@@ -1,3 +1,0 @@
-<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.2/gradio.js">
-</script>
-<gradio-app space="kornia/kornia-edge-detection"></gradio-app>

--- a/docs/source/gradio/enhance_gradio.html
+++ b/docs/source/gradio/enhance_gradio.html
@@ -1,4 +1,0 @@
-<script type="module"
-src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js">
-</script>
-<gradio-app space="kornia/kornia-image-enhancement" src="https://hf.space/embed/kornia/kornia-image-enhancement/+"></gradio-app>

--- a/docs/source/gradio/filtering_operators_gradio.html
+++ b/docs/source/gradio/filtering_operators_gradio.html
@@ -1,2 +1,0 @@
-<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.3/gradio.js"></script>
-<gradio-app space="kornia/kornia-image-filtering"></gradio-app>

--- a/docs/source/gradio/line_fitting.html
+++ b/docs/source/gradio/line_fitting.html
@@ -1,2 +1,0 @@
-<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js"></script>
-<gradio-app space="kornia/Line-Fitting"></gradio-app>

--- a/docs/source/gradio/morphological_operators.html
+++ b/docs/source/gradio/morphological_operators.html
@@ -1,5 +1,0 @@
-
-<script type="module"
-src="https://gradio.s3-us-west-2.amazonaws.com/3.3/gradio.js">
-</script>
-<gradio-app space="kornia/morphological_operators"></gradio-app>

--- a/docs/source/gradio/resize_antialias.html
+++ b/docs/source/gradio/resize_antialias.html
@@ -1,4 +1,0 @@
-<script type="module"
-src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js">
-</script>
-<gradio-app space="kornia/kornia-resize-antialias" src="https://hf.space/embed/kornia/kornia-resize-antialias/+"></gradio-app>

--- a/docs/source/gradio/stitching_gradio.html
+++ b/docs/source/gradio/stitching_gradio.html
@@ -1,2 +1,0 @@
-<script type="module" src="https://gradio.s3-us-west-2.amazonaws.com/3.1.7/gradio.js"></script>
-<gradio-app space="kornia/Image-Stitching"></gradio-app>

--- a/docs/source/morphology.rst
+++ b/docs/source/morphology.rst
@@ -12,6 +12,9 @@ kornia.morphology
 .. autofunction:: bottom_hat
 
 Interactive Demo
-----------------
+~~~~~~~~~~~~~~~~
 .. raw:: html
-   :file: gradio/morphological_operators.html
+
+    <gradio-app space="kornia/morphological_operators"></gradio-app>
+
+Visit the demo on `Hugging Face Spaces <https://huggingface.co/spaces/kornia/morphological_operators>`_.

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -668,6 +668,10 @@ class Resize(nn.Module):
         >>> out = Resize((6, 8))(img)
         >>> print(out.shape)
         torch.Size([1, 3, 6, 8])
+
+    .. raw:: html
+
+        <gradio-app space="kornia/kornia-resize-antialias"></gradio-app>
     """
 
     def __init__(


### PR DESCRIPTION
#### Changes
Related to  #53

This PR simplifies the way that Gradio demos are embedded by:

1. Adding the Gradio JS file to the `page` template so that it doesn't need to be added every time
2. Updating the Gradio Spaces on Hugging Face to use Gradio v. 3.3.1, so they're all consistent
3. Removing the HTML files, and instead embedding the demos directly under the `raw` directive
4. Where a demo is specifically only for one class in a module, putting the embedded demo directly in the docstring.

If you like these changes, I can make changes to the instructions over on the issue so that people can follow this new format. It should be easier, since people won't have to worry about multiple files.

CC: @edgarriba 

#### Type of change
- [x] 📚  Documentation Update