### PR TITLE
lts is not supported on mac-os, separate it

### DIFF
--- a/.github/workflows/tests_lts.yml
+++ b/.github/workflows/tests_lts.yml
@@ -19,9 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
-        pytorch-version: [1.10.2, 1.12.1]
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Setup conda dependencies
@@ -33,7 +32,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install curl -c conda-forge
-        conda install pytorch=${{ matrix.pytorch-version }} cpuonly -c pytorch
+        conda install pytorch-lts cpuonly -c pytorch
         pip install .[all]
     - name: Run Tests
       shell: bash -l {0}
@@ -43,5 +42,5 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
-        flags: cpu,pytest, torch${{ matrix.pytorch-version }}
+        flags: cpu,pytest,torch-lts-1.8.2
         name: cpu-coverage


### PR DESCRIPTION
#### Changes

As we have added PyTorch-LTS into tests instead of 1.8.1, it is not supported with whole test matrix, so I have separated it

https://pytorch.org/get-started/locally/
"# macOS is not currently supported for lts"
"NOTE: Pytorch LTS version 1.8.2 is only supported for Python <= 3.8
conda install pytorch torchvision torchaudio cpuonly -c pytorch-lts"

#### Type of change
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
