### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/kornia/augmentation/_2d/geometric/crop.py
+++ b/kornia/augmentation/_2d/geometric/crop.py
@@ -127,7 +127,7 @@ class RandomCrop(GeometricAugmentationBase2D):
         return padding
 
     def precrop_padding(
-        self, input: Tensor, padding: List[int] = None, flags: Optional[Dict[str, Any]] = None
+        self, input: Tensor, padding: Optional[List[int]] = None, flags: Optional[Dict[str, Any]] = None
     ) -> Tensor:
         flags = self.flags if flags is None else flags
         if padding is None:

--- a/kornia/augmentation/_3d/geometric/affine.py
+++ b/kornia/augmentation/_3d/geometric/affine.py
@@ -97,7 +97,8 @@ class RandomAffine3D(AugmentationBase3D):
         scale: Optional[
             Union[Tensor, Tuple[float, float], Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float]]]
         ] = None,
-        shears: Optional[Union[
+        shears: Union[
+            None,
             Tensor,
             float,
             Tuple[float, float],
@@ -110,7 +111,7 @@ class RandomAffine3D(AugmentationBase3D):
                 Tuple[float, float],
                 Tuple[float, float],
             ],
-        ]] = None,
+        ] = None,
         resample: Union[str, int, Resample] = Resample.BILINEAR.name,
         same_on_batch: bool = False,
         align_corners: bool = False,

--- a/kornia/augmentation/_3d/geometric/affine.py
+++ b/kornia/augmentation/_3d/geometric/affine.py
@@ -97,7 +97,7 @@ class RandomAffine3D(AugmentationBase3D):
         scale: Optional[
             Union[Tensor, Tuple[float, float], Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float]]]
         ] = None,
-        shears: Union[
+        shears: Optional[Union[
             Tensor,
             float,
             Tuple[float, float],
@@ -110,7 +110,7 @@ class RandomAffine3D(AugmentationBase3D):
                 Tuple[float, float],
                 Tuple[float, float],
             ],
-        ] = None,
+        ]] = None,
         resample: Union[str, int, Resample] = Resample.BILINEAR.name,
         same_on_batch: bool = False,
         align_corners: bool = False,

--- a/kornia/augmentation/random_generator/_3d/affine.py
+++ b/kornia/augmentation/random_generator/_3d/affine.py
@@ -72,7 +72,7 @@ class AffineGenerator3D(RandomGeneratorBase):
                 torch.Tensor, Tuple[float, float], Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float]]
             ]
         ] = None,
-        shears: Union[
+        shears: Optional[Union[
             torch.Tensor,
             float,
             Tuple[float, float],
@@ -85,7 +85,7 @@ class AffineGenerator3D(RandomGeneratorBase):
                 Tuple[float, float],
                 Tuple[float, float],
             ],
-        ] = None,
+        ]] = None,
     ) -> None:
         super().__init__()
         self.degrees = degrees

--- a/kornia/augmentation/random_generator/_3d/affine.py
+++ b/kornia/augmentation/random_generator/_3d/affine.py
@@ -72,7 +72,8 @@ class AffineGenerator3D(RandomGeneratorBase):
                 torch.Tensor, Tuple[float, float], Tuple[Tuple[float, float], Tuple[float, float], Tuple[float, float]]
             ]
         ] = None,
-        shears: Optional[Union[
+        shears: Union[
+            None,
             torch.Tensor,
             float,
             Tuple[float, float],
@@ -85,7 +86,7 @@ class AffineGenerator3D(RandomGeneratorBase):
                 Tuple[float, float],
                 Tuple[float, float],
             ],
-        ]] = None,
+        ] = None,
     ) -> None:
         super().__init__()
         self.degrees = degrees

--- a/kornia/feature/adalam/adalam.py
+++ b/kornia/feature/adalam/adalam.py
@@ -91,7 +91,7 @@ def match_adalam(
 class AdalamFilter:
     DEFAULT_CONFIG = get_adalam_default_config()
 
-    def __init__(self, custom_config: dict = None):
+    def __init__(self, custom_config: Optional[dict] = None):
         """This class acts as a wrapper to the method AdaLAM for outlier filtering.
 
         init args:
@@ -116,13 +116,13 @@ class AdalamFilter:
         k2: torch.Tensor,
         putative_matches: torch.Tensor,
         scores: torch.Tensor,
-        mnn: torch.Tensor = None,
-        im1shape: tuple = None,
-        im2shape: tuple = None,
-        o1: torch.Tensor = None,
-        o2: torch.Tensor = None,
-        s1: torch.Tensor = None,
-        s2: torch.Tensor = None,
+        mnn: Optional[torch.Tensor] = None,
+        im1shape: Optional[tuple] = None,
+        im2shape: Optional[tuple] = None,
+        o1: Optional[torch.Tensor] = None,
+        o2: Optional[torch.Tensor] = None,
+        s1: Optional[torch.Tensor] = None,
+        s2: Optional[torch.Tensor] = None,
         return_dist: bool = False,
     ) -> Union[Tuple[Tensor, Tensor], Tensor]:
         """Call the core functionality of AdaLAM, i.e. just outlier filtering. No sanity check is performed on the

--- a/kornia/feature/sold2/backbones.py
+++ b/kornia/feature/sold2/backbones.py
@@ -1,5 +1,5 @@
 """Implements several backbone networks."""
-from typing import Dict, List, Tuple, Union
+from typing import Optional, Dict, List, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -63,7 +63,7 @@ class MultitaskHead(nn.Module):
 
 class Bottleneck2D(nn.Module):
     def __init__(
-        self, inplanes: int, planes: int, stride: Union[int, Tuple[int, int]] = 1, downsample: torch.nn.Module = None
+        self, inplanes: int, planes: int, stride: Union[int, Tuple[int, int]] = 1, downsample: Optional[torch.nn.Module] = None
     ):
         super().__init__()
 

--- a/kornia/feature/sold2/backbones.py
+++ b/kornia/feature/sold2/backbones.py
@@ -1,5 +1,5 @@
 """Implements several backbone networks."""
-from typing import Optional, Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -63,7 +63,11 @@ class MultitaskHead(nn.Module):
 
 class Bottleneck2D(nn.Module):
     def __init__(
-        self, inplanes: int, planes: int, stride: Union[int, Tuple[int, int]] = 1, downsample: Optional[torch.nn.Module] = None
+        self,
+        inplanes: int,
+        planes: int,
+        stride: Union[int, Tuple[int, int]] = 1,
+        downsample: Optional[torch.nn.Module] = None,
     ):
         super().__init__()
 

--- a/kornia/feature/sold2/sold2_detector.py
+++ b/kornia/feature/sold2/sold2_detector.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional, Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn

--- a/kornia/feature/sold2/sold2_detector.py
+++ b/kornia/feature/sold2/sold2_detector.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Tuple
+from typing import Optional, Dict, Tuple
 
 import torch
 import torch.nn as nn
@@ -62,7 +62,7 @@ class SOLD2_detector(nn.Module):
         >>> line_segments = sold2_detector(img)["line_segments"]
     """
 
-    def __init__(self, pretrained: bool = True, config: Dict = None):
+    def __init__(self, pretrained: bool = True, config: Optional[Dict] = None):
         super().__init__()
         # Initialize some parameters
         self.config = default_detector_cfg if config is None else config

--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -28,7 +28,7 @@ def get_cuda_device_if_available(index: int = 0) -> torch.device:
     return dev
 
 
-def _deprecated(func: Callable = None, replace_with: Optional[str] = None):
+def _deprecated(func: Optional[Callable] = None, replace_with: Optional[str] = None):
     if func is None:
         return partial(_deprecated, replace_with=replace_with)
 

--- a/kornia/x/trainers.py
+++ b/kornia/x/trainers.py
@@ -70,7 +70,7 @@ class ObjectDetectionTrainer(Trainer):
         scheduler: torch.optim.lr_scheduler.CosineAnnealingLR,
         config: Configuration,
         num_classes: int,
-        callbacks: Dict[str, Callable] = None,
+        callbacks: Optional[Dict[str, Callable]] = None,
         loss_computed_by_model: Optional[bool] = None,
     ) -> None:
         if callbacks is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ files = kornia, test
 pretty = True
 show_error_codes = True
 ignore_missing_imports = True
+no_implicit_optional = True
 
 [pydocstyle]
 match = .*\.py


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/hauntsaninja/no_implicit_optional
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401