### PR TITLE
Fix warning in AdaLAM

### DIFF
--- a/kornia/feature/adalam/adalam.py
+++ b/kornia/feature/adalam/adalam.py
@@ -104,8 +104,8 @@ class AdalamFilter:
             for key, val in custom_config.items():
                 if key not in self.config.keys():
                     print(
-                        "WARNING: custom configuration contains a key which is not recognized ({key}). "
-                        "Known configurations are {list(self.config.keys())}."
+                        f"WARNING: custom configuration contains a key which is not recognized ({key}). "
+                        f"Known configurations are {list(self.config.keys())}."
                     )
                     continue
                 self.config[key] = val


### PR DESCRIPTION
#### Changes
A warning does not print properly because of missing f-strings.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
