### PR TITLE
Quaternion.norm bug fix

### DIFF
--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -309,7 +309,8 @@ class Quaternion(Module):
         Example:
             >>> q = Quaternion.random(batch_size=2)
             >>> q.norm()
-            tensor([1.0000, 1.0000], grad_fn=<NormBackward1>)
+            tensor([[1.],
+                    [1.]], grad_fn=<NormBackward1>)
         """
         r1, r2, r3 = rand(3, batch_size)
         q1 = (1.0 - r1).sqrt() * ((2 * pi * r2).sin())

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -319,7 +319,7 @@ class Quaternion(Module):
         return cls(stack((q1, q2, q3, q4), -1))
 
     def norm(self) -> Tensor:
-        return self.data.norm(p=2, dim=-1)
+        return self.data.norm(p=2, dim=-1, keepdim=True)
 
     def normalize(self) -> 'Quaternion':
         return Quaternion(normalize_quaternion(self.data))

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -309,8 +309,8 @@ class Quaternion(Module):
         Example:
             >>> q = Quaternion.random(batch_size=2)
             >>> q.norm()
-            tensor([[1.],
-                    [1.]], grad_fn=<NormBackward1>)
+            tensor([[1.0000],
+                    [1.0000]], grad_fn=<NormBackward1>)
         """
         r1, r2, r3 = rand(3, batch_size)
         q1 = (1.0 - r1).sqrt() * ((2 * pi * r2).sin())

--- a/test/geometry/test_quaternion.py
+++ b/test/geometry/test_quaternion.py
@@ -161,6 +161,12 @@ class TestQuaternion:
         self.assert_close((q1 * q2).norm(), q1.norm() * q2.norm())
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_norm_shape(self, device, dtype, batch_size):
+        q = Quaternion.random(batch_size)
+        q = q.to(device, dtype)
+        self.assert_close(q.norm().shape, torch.Size([batch_size, 1]))
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_normalize(self, device, dtype, batch_size):
         q1 = Quaternion.random(batch_size)
         q1 = q1.to(device, dtype)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

norm() returns tensor of shape (B,). This can cause issues in dependent functions like polar_angle(). Eg:
```
>>> q = Quaternion.random(2)
>>> q.polar_angle
tensor([[1.5901, 1.5901],
        [1.9572, 1.9572]], grad_fn=<AcosBackward0>)

```



#### Type of change
<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
