### PR TITLE
Quaternion pow bug fix (div by zero)

### DIFF
--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -5,7 +5,7 @@
 from math import pi
 from typing import Tuple, Union
 
-from kornia.core import Module, Parameter, Tensor, as_tensor, concatenate, rand, stack
+from kornia.core import Module, Parameter, Tensor, as_tensor, concatenate, rand, stack, where
 from kornia.geometry.conversions import (
     QuaternionCoeffOrder,
     angle_axis_to_quaternion,
@@ -149,7 +149,8 @@ class Quaternion(Module):
             >>> q_pow = q**2
         """
         theta = self.polar_angle
-        n = self.vec / self.vec.norm(dim=-1, keepdim=True)
+        vec_norm = self.vec.norm(dim=-1, keepdim=True)
+        n = where(vec_norm != 0, self.vec / vec_norm, self.vec * 0)
         w = (t * theta).cos()
         xyz = (t * theta).sin() * n
         return Quaternion(concatenate((w, xyz), -1))

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -163,6 +163,7 @@ class Quaternion(Module):
     @property
     def coeffs(self) -> Tensor:
         """Return the underlying data with shape :math:`(B,4)`.
+
         Alias for :func:`~kornia.geometry.quaternion.Quaternion.data`
         """
         return self._data

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -163,7 +163,6 @@ class Quaternion(Module):
     @property
     def coeffs(self) -> Tensor:
         """Return the underlying data with shape :math:`(B,4)`.
-
         Alias for :func:`~kornia.geometry.quaternion.Quaternion.data`
         """
         return self._data

--- a/test/geometry/test_quaternion.py
+++ b/test/geometry/test_quaternion.py
@@ -134,11 +134,17 @@ class TestQuaternion:
     def test_pow(self, device, dtype, batch_size):
         q = Quaternion.random(batch_size)
         q = q.to(device, dtype)
-        self.assert_close(q**0, Quaternion.identity(batch_size).to(device, dtype))
+        q1 = Quaternion.identity(batch_size)
+        q1 = q1.to(device, dtype)
+        self.assert_close(q**0, q1)
         self.assert_close(q**1, q)
         self.assert_close(q**2, q * q)
         self.assert_close(q**-1, q.inv())
         self.assert_close((q**0.5) * (q**0.5), q)
+        self.assert_close((q1**1), q1)
+        self.assert_close((q1**2), q1)
+        self.assert_close((q1**-1), q1)
+        self.assert_close((q1**0.5), q1)
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_inverse(self, device, dtype, batch_size):

--- a/test/geometry/test_quaternion.py
+++ b/test/geometry/test_quaternion.py
@@ -143,8 +143,6 @@ class TestQuaternion:
         self.assert_close((q**0.5) * (q**0.5), q)
         self.assert_close((q1**1), q1)
         self.assert_close((q1**2), q1)
-        self.assert_close((q1**-1), q1)
-        self.assert_close((q1**0.5), q1)
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_inverse(self, device, dtype, batch_size):


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Divide by zero error in case of zero vector inside pow. Can causes issues in dependent functions like slerp.


#### Type of change
<!-- Please delete options that are not relevant. -->

- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

