### PR TITLE
Add some ortho tests for so3

### DIFF
--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -154,6 +154,8 @@ class TestSo3(BaseTester):
         a_R_b = So3(q).inverse().matrix()
         a_R_a = (So3(q) * So3(q).inverse()).matrix()
 
+        self.assert_close(a_R_a, torch.eye(3).repeat(batch_size, 1, 1))
+
         for i in range(batch_size):
             self.assert_close(a_R_a[i, :, :], torch.eye(3))
             self.assert_close(a_R_b[i, :, :] @ b_R_a[i, :, :], torch.eye(3))

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -156,8 +156,8 @@ class TestSo3(BaseTester):
 
         for i in range(batch_size):
             self.assert_close(a_R_a[i, :, :], torch.eye(3))
-            self.assert_close(a_R_b[i, :, :] * b_R_a[i, :, :], torch.eye(3))
-            self.assert_close(b_R_a[i, :, :] * a_R_b[i, :, :], torch.eye(3))
+            self.assert_close(a_R_b[i, :, :] @ b_R_a[i, :, :], torch.eye(3))
+            self.assert_close(b_R_a[i, :, :] @ a_R_b[i, :, :], torch.eye(3))
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_inverse(self, device, dtype, batch_size):

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -79,7 +79,7 @@ class TestSo3(BaseTester):
         s6 = s3.inverse()
         for i in range(batch_size):
             self.assert_close(s1[i].q.norm(), torch.Tensor([[1.0]]))
-            self.assert_close(s2[i].q.norm(), torch.Tensor([[1.0]]))
+            self.assert_close(s2[i].q.norm(), torch.tensor([[1.0]], device=device, dtype=dtype))
             self.assert_close(s3[i].q.norm(), torch.Tensor([[1.0]]))
             self.assert_close(s4[i].q.norm(), torch.Tensor([[1.0]]))
             self.assert_close(s5[i].q.norm(), torch.Tensor([[1.0]]))
@@ -154,7 +154,7 @@ class TestSo3(BaseTester):
         a_R_b = So3(q).inverse().matrix()
         a_R_a = (So3(q) * So3(q).inverse()).matrix()
 
-        self.assert_close(a_R_a, torch.eye(3).repeat(batch_size, 1, 1))
+        self.assert_close(a_R_a, torch.eye(3, device=device, dtype=dtype).repeat(batch_size, 1, 1))
 
         for i in range(batch_size):
             self.assert_close(a_R_a[i, :, :], torch.eye(3))

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -66,6 +66,26 @@ class TestSo3(BaseTester):
         self.assert_close((s1 * t), t)
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_unit_norm(self, device, dtype, batch_size):
+        q1 = Quaternion.random(batch_size)
+        q1 = q1.to(device, dtype)
+        q2 = Quaternion.random(batch_size)
+        q2 = q2.to(device, dtype)
+        s1 = So3(q1)
+        s2 = So3(q2)
+        s3 = s1 * s2
+        s4 = s1.inverse()
+        s5 = s2.inverse()
+        s6 = s3.inverse()
+        for i in range(batch_size):
+            self.assert_close(s1[i].q.norm(), torch.Tensor([[1.0]]))
+            self.assert_close(s2[i].q.norm(), torch.Tensor([[1.0]]))
+            self.assert_close(s3[i].q.norm(), torch.Tensor([[1.0]]))
+            self.assert_close(s4[i].q.norm(), torch.Tensor([[1.0]]))
+            self.assert_close(s5[i].q.norm(), torch.Tensor([[1.0]]))
+            self.assert_close(s6[i].q.norm(), torch.Tensor([[1.0]]))
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_exp(self, device, dtype, batch_size):
         q = Quaternion.identity(batch_size)
         q = q.to(device, dtype)
@@ -124,6 +144,7 @@ class TestSo3(BaseTester):
             qp_ = q1 * pquat * q1.inv()
             rp_ = torch.matmul(r1, pvec)[None, :]
             self.assert_close(rp_, qp_.vec)  # p_ = R*p = q*p*q_inv
+            self.assert_close(rp_.norm(), pvec.norm())
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_ortho(self, device, dtype, batch_size):
@@ -135,8 +156,6 @@ class TestSo3(BaseTester):
 
         for i in range(batch_size):
             self.assert_close(a_R_a[i, :, :], torch.eye(3))
-            self.assert_close(b_R_a[i, :, :].inverse() * b_R_a[i, :, :], torch.eye(3))
-            self.assert_close(a_R_b[i, :, :].inverse() * a_R_b[i, :, :], torch.eye(3))
             self.assert_close(a_R_b[i, :, :] * b_R_a[i, :, :], torch.eye(3))
             self.assert_close(b_R_a[i, :, :] * a_R_b[i, :, :], torch.eye(3))
 
@@ -145,3 +164,4 @@ class TestSo3(BaseTester):
         q = Quaternion.random(batch_size)
         q = q.to(device, dtype)
         self.assert_close(So3(q).inverse().inverse().q.data, q.data)
+        self.assert_close(So3(q).inverse().inverse().matrix(), So3(q).matrix())

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -126,6 +126,21 @@ class TestSo3(BaseTester):
             self.assert_close(rp_, qp_.vec)  # p_ = R*p = q*p*q_inv
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_ortho(self, device, dtype, batch_size):
+        q = Quaternion.random(batch_size)
+        q = q.to(device, dtype)
+        b_R_a = So3(q).matrix()
+        a_R_b = So3(q).inverse().matrix()
+        a_R_a = (So3(q) * So3(q).inverse()).matrix()
+
+        for i in range(batch_size):
+            self.assert_close(a_R_a[i,:,:], torch.eye(3))
+            self.assert_close(b_R_a[i,:,:].inverse() * b_R_a[i,:,:], torch.eye(3))
+            self.assert_close(a_R_b[i,:,:].inverse() * a_R_b[i,:,:], torch.eye(3))
+            self.assert_close(a_R_b[i,:,:] * b_R_a[i,:,:], torch.eye(3))
+            self.assert_close(b_R_a[i,:,:] * a_R_b[i,:,:], torch.eye(3))
+
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_inverse(self, device, dtype, batch_size):
         q = Quaternion.random(batch_size)
         q = q.to(device, dtype)

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -77,13 +77,15 @@ class TestSo3(BaseTester):
         s4 = s1.inverse()
         s5 = s2.inverse()
         s6 = s3.inverse()
+
+        ones_vec = torch.tensor([[1.0]], device=device, dtype=dtype)
         for i in range(batch_size):
-            self.assert_close(s1[i].q.norm(), torch.Tensor([[1.0]]))
-            self.assert_close(s2[i].q.norm(), torch.tensor([[1.0]], device=device, dtype=dtype))
-            self.assert_close(s3[i].q.norm(), torch.Tensor([[1.0]]))
-            self.assert_close(s4[i].q.norm(), torch.Tensor([[1.0]]))
-            self.assert_close(s5[i].q.norm(), torch.Tensor([[1.0]]))
-            self.assert_close(s6[i].q.norm(), torch.Tensor([[1.0]]))
+            self.assert_close(s1[i].q.norm(), ones_vec)
+            self.assert_close(s2[i].q.norm(), ones_vec)
+            self.assert_close(s3[i].q.norm(), ones_vec)
+            self.assert_close(s4[i].q.norm(), ones_vec)
+            self.assert_close(s5[i].q.norm(), ones_vec)
+            self.assert_close(s6[i].q.norm(), ones_vec)
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_exp(self, device, dtype, batch_size):
@@ -154,12 +156,14 @@ class TestSo3(BaseTester):
         a_R_b = So3(q).inverse().matrix()
         a_R_a = (So3(q) * So3(q).inverse()).matrix()
 
-        self.assert_close(a_R_a, torch.eye(3, device=device, dtype=dtype).repeat(batch_size, 1, 1))
+        eye_mat = torch.eye(3, device=device, dtype=dtype)
+
+        self.assert_close(a_R_a, eye_mat[None].repeat(batch_size, 1, 1))
 
         for i in range(batch_size):
-            self.assert_close(a_R_a[i, :, :], torch.eye(3))
-            self.assert_close(a_R_b[i, :, :] @ b_R_a[i, :, :], torch.eye(3))
-            self.assert_close(b_R_a[i, :, :] @ a_R_b[i, :, :], torch.eye(3))
+            self.assert_close(a_R_a[i, :, :], eye_mat)
+            self.assert_close(a_R_b[i, :, :] @ b_R_a[i, :, :], eye_mat)
+            self.assert_close(b_R_a[i, :, :] @ a_R_b[i, :, :], eye_mat)
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_inverse(self, device, dtype, batch_size):

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -134,11 +134,11 @@ class TestSo3(BaseTester):
         a_R_a = (So3(q) * So3(q).inverse()).matrix()
 
         for i in range(batch_size):
-            self.assert_close(a_R_a[i,:,:], torch.eye(3))
-            self.assert_close(b_R_a[i,:,:].inverse() * b_R_a[i,:,:], torch.eye(3))
-            self.assert_close(a_R_b[i,:,:].inverse() * a_R_b[i,:,:], torch.eye(3))
-            self.assert_close(a_R_b[i,:,:] * b_R_a[i,:,:], torch.eye(3))
-            self.assert_close(b_R_a[i,:,:] * a_R_b[i,:,:], torch.eye(3))
+            self.assert_close(a_R_a[i, :, :], torch.eye(3))
+            self.assert_close(b_R_a[i, :, :].inverse() * b_R_a[i, :, :], torch.eye(3))
+            self.assert_close(a_R_b[i, :, :].inverse() * a_R_b[i, :, :], torch.eye(3))
+            self.assert_close(a_R_b[i, :, :] * b_R_a[i, :, :], torch.eye(3))
+            self.assert_close(b_R_a[i, :, :] * a_R_b[i, :, :], torch.eye(3))
 
     @pytest.mark.parametrize("batch_size", (1, 2, 5))
     def test_inverse(self, device, dtype, batch_size):


### PR DESCRIPTION
There appears to be a problem with some aspect of the So3 class. I'm not sure where yet, but I believe these unit tests demonstrate the issue.

Running causes test failures, the first of which is:
>           self.assert_close(b_R_a[i,:,:].inverse() * b_R_a[i,:,:], torch.eye(3))

which suggests that the matrices produced by the So3 class are not orthonormal as they should be.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 🧪 Tests Cases

#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
