### PR TITLE
add rotation and translation classmethods in se3 and so3

### DIFF
--- a/kornia/geometry/liegroup/se3.py
+++ b/kornia/geometry/liegroup/se3.py
@@ -256,7 +256,7 @@ class Se3(Module):
             x: the x-axis rotation angle.
         """
         zs = zeros_like(x)
-        return cls(So3.rot_x(x), stack([zs, zs, zs], -1))
+        return cls(So3.rot_x(x), stack((zs, zs, zs), -1))
 
     @classmethod
     def rot_y(cls, y: Tensor) -> "Se3":
@@ -266,7 +266,7 @@ class Se3(Module):
             y: the y-axis rotation angle.
         """
         zs = zeros_like(y)
-        return cls(So3.rot_y(y), stack([zs, zs, zs], -1))
+        return cls(So3.rot_y(y), stack((zs, zs, zs), -1))
 
     @classmethod
     def rot_z(cls, z: Tensor) -> "Se3":
@@ -276,7 +276,7 @@ class Se3(Module):
             z: the z-axis rotation angle.
         """
         zs = zeros_like(z)
-        return cls(So3.rot_z(z), stack([zs, zs, zs], -1))
+        return cls(So3.rot_z(z), stack((zs, zs, zs), -1))
 
     @classmethod
     def trans(cls, x: Tensor, y: Tensor, z: Tensor) -> "Se3":

--- a/kornia/geometry/liegroup/se3.py
+++ b/kornia/geometry/liegroup/se3.py
@@ -2,7 +2,7 @@
 # https://github.com/strasdat/Sophus/blob/master/sympy/sophus/se3.py
 from typing import Optional
 
-from kornia.core import Module, Parameter, Tensor, concatenate, eye, pad, tensor, where
+from kornia.core import Module, Parameter, Tensor, concatenate, eye, pad, stack, tensor, where, zeros_like
 from kornia.geometry.liegroup.so3 import So3
 from kornia.geometry.linalg import batched_dot_product
 from kornia.testing import KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
@@ -247,3 +247,8 @@ class Se3(Module):
         """
         r_inv = self.r.inverse()
         return Se3(r_inv, r_inv * (-1 * self.t))
+
+    @classmethod
+    def rot_x(cls, x: Tensor) -> "Se3":
+        z = zeros_like(x)
+        return Se3(So3.rot_x(x), stack([z, z, z], -1))

--- a/kornia/geometry/liegroup/se3.py
+++ b/kornia/geometry/liegroup/se3.py
@@ -291,10 +291,8 @@ class Se3(Module):
         KORNIA_CHECK(y.shape == z.shape)
         KORNIA_CHECK_SAME_DEVICES([x, y, z])
         batch_size = x.shape[0] if len(x.shape) > 0 else None
-        device, dtype = x.device, x.dtype
-        rotation = So3.identity(batch_size, device, dtype)
-        translation = stack((x, y, z), -1)
-        return cls(rotation, translation)
+        rotation = So3.identity(batch_size, x.device, x.dtype)
+        return cls(rotation, stack((x, y, z), -1))
 
     @classmethod
     def trans_x(cls, x: Tensor) -> "Se3":

--- a/kornia/geometry/liegroup/se3.py
+++ b/kornia/geometry/liegroup/se3.py
@@ -5,7 +5,7 @@ from typing import Optional
 from kornia.core import Module, Parameter, Tensor, concatenate, eye, pad, stack, tensor, where, zeros_like
 from kornia.geometry.liegroup.so3 import So3
 from kornia.geometry.linalg import batched_dot_product
-from kornia.testing import KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
+from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_SAME_DEVICES, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
 
 
 class Se3(Module):
@@ -250,5 +250,78 @@ class Se3(Module):
 
     @classmethod
     def rot_x(cls, x: Tensor) -> "Se3":
-        z = zeros_like(x)
-        return Se3(So3.rot_x(x), stack([z, z, z], -1))
+        """Construct a x-axis rotation.
+
+        Args:
+            x: the x-axis rotation angle.
+        """
+        zs = zeros_like(x)
+        return cls(So3.rot_x(x), stack([zs, zs, zs], -1))
+
+    @classmethod
+    def rot_y(cls, y: Tensor) -> "Se3":
+        """Construct a y-axis rotation.
+
+        Args:
+            y: the y-axis rotation angle.
+        """
+        zs = zeros_like(y)
+        return cls(So3.rot_y(y), stack([zs, zs, zs], -1))
+
+    @classmethod
+    def rot_z(cls, z: Tensor) -> "Se3":
+        """Construct a z-axis rotation.
+
+        Args:
+            z: the z-axis rotation angle.
+        """
+        zs = zeros_like(z)
+        return cls(So3.rot_z(z), stack([zs, zs, zs], -1))
+
+    @classmethod
+    def trans(cls, x: Tensor, y: Tensor, z: Tensor) -> "Se3":
+        """Construct a translation only Se3 instance.
+
+        Args:
+            x: the x-axis translation.
+            y: the y-axis translation.
+            z: the z-axis translation.
+        """
+        KORNIA_CHECK(x.shape == y.shape)
+        KORNIA_CHECK(y.shape == z.shape)
+        KORNIA_CHECK_SAME_DEVICES([x, y, z])
+        batch_size = x.shape[0] if len(x.shape) > 0 else None
+        device, dtype = x.device, x.dtype
+        rotation = So3.identity(batch_size, device, dtype)
+        translation = stack((x, y, z), -1)
+        return cls(rotation, translation)
+
+    @classmethod
+    def trans_x(cls, x: Tensor) -> "Se3":
+        """Construct a x-axis translation.
+
+        Args:
+            x: the x-axis translation.
+        """
+        zs = zeros_like(x)
+        return cls.trans(x, zs, zs)
+
+    @classmethod
+    def trans_y(cls, y: Tensor) -> "Se3":
+        """Construct a y-axis translation.
+
+        Args:
+            y: the y-axis translation.
+        """
+        zs = zeros_like(y)
+        return cls.trans(zs, y, zs)
+
+    @classmethod
+    def trans_z(cls, z: Tensor) -> "Se3":
+        """Construct a z-axis translation.
+
+        Args:
+            z: the z-axis translation.
+        """
+        zs = zeros_like(z)
+        return cls.trans(zs, zs, z)

--- a/kornia/geometry/liegroup/so3.py
+++ b/kornia/geometry/liegroup/so3.py
@@ -253,5 +253,30 @@ class So3(Module):
 
     @classmethod
     def rot_x(cls, x: Tensor) -> "So3":
-        zeros_vec = zeros_like(x)
-        return cls.exp(stack([x, zeros_vec, zeros_vec], -1))
+        """Construct a x-axis rotation.
+
+        Args:
+            x: the x-axis rotation angle.
+        """
+        zs = zeros_like(x)
+        return cls.exp(stack([x, zs, zs], -1))
+
+    @classmethod
+    def rot_y(cls, y: Tensor) -> "So3":
+        """Construct a z-axis rotation.
+
+        Args:
+            y: the y-axis rotation angle.
+        """
+        zs = zeros_like(y)
+        return cls.exp(stack([zs, y, zs], -1))
+
+    @classmethod
+    def rot_z(cls, z: Tensor) -> "So3":
+        """Construct a z-axis rotation.
+
+        Args:
+            z: the z-axis rotation angle.
+        """
+        zs = zeros_like(z)
+        return cls.exp(stack([zs, zs, z], -1))

--- a/kornia/geometry/liegroup/so3.py
+++ b/kornia/geometry/liegroup/so3.py
@@ -259,7 +259,7 @@ class So3(Module):
             x: the x-axis rotation angle.
         """
         zs = zeros_like(x)
-        return cls.exp(stack([x, zs, zs], -1))
+        return cls.exp(stack((x, zs, zs), -1))
 
     @classmethod
     def rot_y(cls, y: Tensor) -> "So3":
@@ -269,7 +269,7 @@ class So3(Module):
             y: the y-axis rotation angle.
         """
         zs = zeros_like(y)
-        return cls.exp(stack([zs, y, zs], -1))
+        return cls.exp(stack((zs, y, zs), -1))
 
     @classmethod
     def rot_z(cls, z: Tensor) -> "So3":
@@ -279,4 +279,4 @@ class So3(Module):
             z: the z-axis rotation angle.
         """
         zs = zeros_like(z)
-        return cls.exp(stack([zs, zs, z], -1))
+        return cls.exp(stack((zs, zs, z), -1))

--- a/kornia/geometry/liegroup/so3.py
+++ b/kornia/geometry/liegroup/so3.py
@@ -250,3 +250,8 @@ class So3(Module):
             tensor([1., -0., -0., -0.], requires_grad=True)
         """
         return So3(self.q.conj())
+
+    @classmethod
+    def rot_x(cls, x: Tensor) -> "So3":
+        zeros_vec = zeros_like(x)
+        return cls.exp(stack([x, zeros_vec, zeros_vec], -1))

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -159,12 +159,9 @@ class Quaternion(Module):
         return self._data
 
     @property
-    def coeffs(self) -> Tensor:
-        """Return the underlying data with shape :math:`(B, 4)`.
-
-        Alias for :func:`~kornia.geometry.quaternion.Quaternion.data`
-        """
-        return self._data
+    def coeffs(self) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Return a tuple with the underlying coefficients in WXYZ order."""
+        return self.w, self.x, self.y, self.z
 
     @property
     def real(self) -> Tensor:

--- a/test/geometry/liegroup/test_se3.py
+++ b/test/geometry/liegroup/test_se3.py
@@ -157,7 +157,7 @@ class TestSe3(BaseTester):
         se3 = Se3.rot_x(x)
         quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
         quat = Quaternion(quat)
-        roll, _, _ = euler_from_quaternion(quat.w, quat.x, quat.y, quat.z)
+        roll, _, _ = euler_from_quaternion(*quat.coeffs)
         self.assert_close(x, roll)
         self.assert_close(se3.t, torch.zeros_like(se3.t))
 
@@ -167,7 +167,7 @@ class TestSe3(BaseTester):
         se3 = Se3.rot_y(y)
         quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
         quat = Quaternion(quat)
-        _, pitch, _ = euler_from_quaternion(quat.w, quat.x, quat.y, quat.z)
+        _, pitch, _ = euler_from_quaternion(*quat.coeffs)
         self.assert_close(y, pitch)
         self.assert_close(se3.t, torch.zeros_like(se3.t))
 
@@ -177,7 +177,7 @@ class TestSe3(BaseTester):
         se3 = Se3.rot_z(z)
         quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
         quat = Quaternion(quat)
-        _, _, yaw = euler_from_quaternion(quat.w, quat.x, quat.y, quat.z)
+        _, _, yaw = euler_from_quaternion(*quat.coeffs)
         self.assert_close(z, yaw)
         self.assert_close(se3.t, torch.zeros_like(se3.t))
 

--- a/test/geometry/liegroup/test_se3.py
+++ b/test/geometry/liegroup/test_se3.py
@@ -149,3 +149,13 @@ class TestSe3(BaseTester):
         sinv = Se3(rot, t).inverse()
         self.assert_close(sinv.r.inverse().q.data, q.data)
         self.assert_close(sinv.t, sinv.r * (-1 * t))
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_rot_x(self, device, dtype, batch_size):
+        x = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        se3 = Se3.rot_x(x)
+        print(se3)
+        import pdb
+
+        pdb.set_trace()
+        pass

--- a/test/geometry/liegroup/test_se3.py
+++ b/test/geometry/liegroup/test_se3.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from kornia.geometry.conversions import QuaternionCoeffOrder, euler_from_quaternion, rotation_matrix_to_quaternion
 from kornia.geometry.liegroup import Se3, So3
 from kornia.geometry.quaternion import Quaternion
 from kornia.testing import BaseTester
@@ -154,8 +155,60 @@ class TestSe3(BaseTester):
     def test_rot_x(self, device, dtype, batch_size):
         x = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         se3 = Se3.rot_x(x)
-        print(se3)
-        import pdb
+        quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
+        quat = Quaternion(quat)
+        roll, _, _ = euler_from_quaternion(quat.w, quat.x, quat.y, quat.z)
+        self.assert_close(x, roll)
+        self.assert_close(se3.t, torch.zeros_like(se3.t))
 
-        pdb.set_trace()
-        pass
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_rot_y(self, device, dtype, batch_size):
+        y = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        se3 = Se3.rot_y(y)
+        quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
+        quat = Quaternion(quat)
+        _, pitch, _ = euler_from_quaternion(quat.w, quat.x, quat.y, quat.z)
+        self.assert_close(y, pitch)
+        self.assert_close(se3.t, torch.zeros_like(se3.t))
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_rot_z(self, device, dtype, batch_size):
+        z = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        se3 = Se3.rot_z(z)
+        quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
+        quat = Quaternion(quat)
+        _, _, yaw = euler_from_quaternion(quat.w, quat.x, quat.y, quat.z)
+        self.assert_close(z, yaw)
+        self.assert_close(se3.t, torch.zeros_like(se3.t))
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_trans(self, device, dtype, batch_size):
+        trans = self._make_rand_data(device, dtype, batch_size, dims=3)
+        x, y, z = trans[..., 0], trans[..., 1], trans[..., 2]
+        se3 = Se3.trans(x, y, z)
+        self.assert_close(se3.t, trans)
+        self.assert_close(se3.so3.matrix(), So3.identity(batch_size, device, dtype).matrix())
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_trans_x(self, device, dtype, batch_size):
+        x = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        zs = torch.zeros_like(x)
+        se3 = Se3.trans_x(x)
+        self.assert_close(se3.t, torch.stack((x, zs, zs), -1))
+        self.assert_close(se3.so3.matrix(), So3.identity(batch_size, device, dtype).matrix())
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_trans_y(self, device, dtype, batch_size):
+        y = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        zs = torch.zeros_like(y)
+        se3 = Se3.trans_y(y)
+        self.assert_close(se3.t, torch.stack((zs, y, zs), -1))
+        self.assert_close(se3.so3.matrix(), So3.identity(batch_size, device, dtype).matrix())
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_trans_z(self, device, dtype, batch_size):
+        z = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        zs = torch.zeros_like(z)
+        se3 = Se3.trans_z(z)
+        self.assert_close(se3.t, torch.stack((zs, zs, z), -1))
+        self.assert_close(se3.so3.matrix(), So3.identity(batch_size, device, dtype).matrix())

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -192,19 +192,19 @@ class TestSo3(BaseTester):
     def test_rot_x(self, device, dtype, batch_size):
         x = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         so3 = So3.rot_x(x)
-        roll, _, _ = euler_from_quaternion(so3.q.w, so3.q.x, so3.q.y, so3.q.z)
+        roll, _, _ = euler_from_quaternion(*so3.q.coeffs)
         self.assert_close(x, roll)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_rot_y(self, device, dtype, batch_size):
         y = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         so3 = So3.rot_y(y)
-        _, pitch, _ = euler_from_quaternion(so3.q.w, so3.q.x, so3.q.y, so3.q.z)
+        _, pitch, _ = euler_from_quaternion(*so3.q.coeffs)
         self.assert_close(y, pitch)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_rot_z(self, device, dtype, batch_size):
         z = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         so3 = So3.rot_z(z)
-        _, _, yaw = euler_from_quaternion(so3.q.w, so3.q.x, so3.q.y, so3.q.z)
+        _, _, yaw = euler_from_quaternion(*so3.q.coeffs)
         self.assert_close(z, yaw)

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from kornia.geometry.conversions import euler_from_quaternion
 from kornia.geometry.liegroup import So3
 from kornia.geometry.quaternion import Quaternion
 from kornia.testing import BaseTester
@@ -191,4 +192,19 @@ class TestSo3(BaseTester):
     def test_rot_x(self, device, dtype, batch_size):
         x = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         so3 = So3.rot_x(x)
-        print(so3)
+        roll, _, _ = euler_from_quaternion(so3.q.w, so3.q.x, so3.q.y, so3.q.z)
+        self.assert_close(x, roll)
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_rot_y(self, device, dtype, batch_size):
+        y = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        so3 = So3.rot_y(y)
+        _, pitch, _ = euler_from_quaternion(so3.q.w, so3.q.x, so3.q.y, so3.q.z)
+        self.assert_close(y, pitch)
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_rot_z(self, device, dtype, batch_size):
+        z = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        so3 = So3.rot_z(z)
+        _, _, yaw = euler_from_quaternion(so3.q.w, so3.q.x, so3.q.y, so3.q.z)
+        self.assert_close(z, yaw)

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -186,3 +186,9 @@ class TestSo3(BaseTester):
         q = Quaternion.random(batch_size, device, dtype)
         self.assert_close(So3(q).inverse().inverse().q.data, q.data)
         self.assert_close(So3(q).inverse().inverse().matrix(), So3(q).matrix())
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_rot_x(self, device, dtype, batch_size):
+        x = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
+        so3 = So3.rot_x(x)
+        print(so3)


### PR DESCRIPTION
#### Changes

Adds:
- `rot_x` , `rot_y` , `rot_z` in `So3` and `Se3`
- `trans`, `trans_x`, `trans_y` and `trans_z` in `Se3`


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
