### PR TITLE
Fix an error in `match_smnn`

### DIFF
--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -189,8 +189,8 @@ def match_smnn(desc1: Tensor, desc2: Tensor, th: float = 0.95, dm: Optional[Tens
         if not is_mps_tensor_safe(idx1):
             idxs_dm = torch.cdist(idx1.float(), idx2.float(), p=1.0)
         else:
-            idxs1_rep = idx1.float().repeat_interleave(idx2.size(0), dim=0)
-            idxs_dm = (idx2.float().repeat(idx1.size(0), 1) - idxs1_rep).abs().sum(dim=1)
+            idxs1_rep = idx1.to(desc1).repeat_interleave(idx2.size(0), dim=0)
+            idxs_dm = (idx2.to(desc2).repeat(idx1.size(0), 1) - idxs1_rep).abs().sum(dim=1)
             idxs_dm = idxs_dm.reshape(idx1.size(0), idx2.size(0))
         mutual_idxs1 = idxs_dm.min(dim=1)[0] < 1e-8
         mutual_idxs2 = idxs_dm.min(dim=0)[0] < 1e-8

--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -189,8 +189,8 @@ def match_smnn(desc1: Tensor, desc2: Tensor, th: float = 0.95, dm: Optional[Tens
         if not is_mps_tensor_safe(idx1):
             idxs_dm = torch.cdist(idx1.float(), idx2.float(), p=1.0)
         else:
-            idxs2_rep = idx2.float().repeat_interleave(idx1.size(0), dim=0)
-            idxs_dm = (idx1.float().repeat(idx2.size(0), 1) - idxs2_rep).abs().sum(dim=1)
+            idxs1_rep = idx1.float().repeat_interleave(idx2.size(0), dim=0)
+            idxs_dm = (idx2.float().repeat(idx1.size(0), 1) - idxs1_rep).abs().sum(dim=1)
             idxs_dm = idxs_dm.reshape(idx1.size(0), idx2.size(0))
         mutual_idxs1 = idxs_dm.min(dim=1)[0] < 1e-8
         mutual_idxs2 = idxs_dm.min(dim=0)[0] < 1e-8


### PR DESCRIPTION
There was a typo in a code, related to the implementation of `cdist` for M1. With the previous implementation, I got an error
```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In [25], line 1
----> 1 dists, matches = KF.match_smnn(desc1, desc2)

File ~/.virtualenvs/masters/lib/python3.10/site-packages/kornia/feature/matching.py:204, in match_smnn(desc1, desc2, th, dm)
    202 _, idx_upl2 = torch.sort(good_idxs2[:, 0])
    203 good_idxs1 = good_idxs1[idx_upl1]
--> 204 match_dists = torch.max(dists1_good[idx_upl1], dists2_good[idx_upl2])
    205 matches_idxs = good_idxs1
    206 match_dists, matches_idxs = match_dists.view(-1, 1), matches_idxs.view(-1, 2)

RuntimeError: The size of tensor a (2496) must match the size of tensor b (2541) at non-singleton dimension 0
```

With the current implementation, everything works :)

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
