### PR TITLE
Remove redudant casts

### DIFF
--- a/kornia/augmentation/_2d/geometric/base.py
+++ b/kornia/augmentation/_2d/geometric/base.py
@@ -1,10 +1,9 @@
 import warnings
-from typing import Any, Dict, Optional, Tuple, cast
-
-from torch import Tensor, as_tensor
+from typing import Any, Dict, Optional, Tuple
 
 from kornia.augmentation._2d.base import AugmentationBase2D
 from kornia.augmentation.utils import override_parameters
+from kornia.core import Tensor, as_tensor
 from kornia.utils.helpers import _torch_inverse_cast
 
 
@@ -110,4 +109,7 @@ class GeometricAugmentationBase2D(AugmentationBase2D):
             output[to_apply] = self.inverse_transform(
                 in_tensor[to_apply], transform=transform[to_apply], size=size, flags=flags
             )
-        return cast(Tensor, self.transform_output_tensor(output, input_shape)) if self.keepdim else output
+        if self.keepdim:
+            return self.transform_output_tensor(output, input_shape)
+
+        return output

--- a/kornia/augmentation/_2d/geometric/crop.py
+++ b/kornia/augmentation/_2d/geometric/crop.py
@@ -90,7 +90,7 @@ class RandomCrop(GeometricAugmentationBase2D):
         super().__init__(
             p=1.0, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=p, keepdim=keepdim
         )
-        self._param_generator = cast(rg.CropGenerator, rg.CropGenerator(size))
+        self._param_generator = rg.CropGenerator(size)
         self.flags = dict(
             size=size,
             padding=padding,
@@ -246,7 +246,6 @@ class RandomCrop(GeometricAugmentationBase2D):
             _input = (self.precrop_padding(input_temp, input_pad, flags), input[1])
             _input = _transform_output_shape(_input, ori_shape) if self.keepdim else _input
         else:
-            input = cast(Tensor, input)
             ori_shape = input.shape
             input_temp = _transform_input(input)
             input_pad = self.compute_padding(input_temp.shape, flags) if input_pad is None else input_pad

--- a/kornia/augmentation/_2d/geometric/fisheye.py
+++ b/kornia/augmentation/_2d/geometric/fisheye.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
+from kornia.core import Tensor
 from kornia.geometry.transform import remap
 from kornia.utils import create_meshgrid
 
@@ -55,13 +54,10 @@ class RandomFisheye(GeometricAugmentationBase2D):
         self._check_tensor(center_x)
         self._check_tensor(center_y)
         self._check_tensor(gamma)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator,
-            rg.PlainUniformGenerator(
-                (center_x[:, None], "center_x", None, None),
-                (center_y[:, None], "center_y", None, None),
-                (gamma[:, None], "gamma", None, None),
-            ),
+        self._param_generator = rg.PlainUniformGenerator(
+            (center_x[:, None], "center_x", None, None),
+            (center_y[:, None], "center_y", None, None),
+            (gamma[:, None], "gamma", None, None),
         )
 
     def _check_tensor(self, data: Tensor) -> None:

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -1,11 +1,9 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
-
-import torch
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
 from kornia.constants import Resample
+from kornia.core import Tensor, as_tensor
 from kornia.geometry.transform import get_perspective_transform, warp_perspective
 
 
@@ -69,9 +67,8 @@ class RandomPerspective(GeometricAugmentationBase2D):
         return_transform: Optional[bool] = None,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
-        self._param_generator = cast(
-            rg.PerspectiveGenerator, rg.PerspectiveGenerator(distortion_scale, sampling_method=sampling_method)
-        )
+        self._param_generator = rg.PerspectiveGenerator(distortion_scale, sampling_method=sampling_method)
+
         self.flags: Dict[str, Any] = dict(align_corners=align_corners, resample=Resample.get(resample))
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
@@ -81,7 +78,8 @@ class RandomPerspective(GeometricAugmentationBase2D):
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
         _, _, height, width = input.shape
-        transform = cast(Tensor, transform)
+        if not isinstance(transform, Tensor):
+            raise TypeError(f'Expected the transform be a Tensor. Gotcha {type(transform)}')
 
         return warp_perspective(
             input, transform, (height, width), mode=flags["resample"].name.lower(), align_corners=flags["align_corners"]
@@ -97,6 +95,6 @@ class RandomPerspective(GeometricAugmentationBase2D):
         return self.apply_transform(
             input,
             params=self._params,
-            transform=torch.as_tensor(transform, device=input.device, dtype=input.dtype),
+            transform=as_tensor(transform, device=input.device, dtype=input.dtype),
             flags=flags,
         )

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -1,11 +1,11 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
-from torch import Tensor
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
 from kornia.constants import Resample
+from kornia.core import Tensor
 from kornia.geometry.transform import crop_by_transform_mat, get_perspective_transform, resize
 from kornia.utils import eye_like
 
@@ -35,7 +35,7 @@ class Resize(GeometricAugmentationBase2D):
         keepdim: bool = False,
     ) -> None:
         super().__init__(p=1.0, return_transform=return_transform, same_on_batch=True, p_batch=p, keepdim=keepdim)
-        self._param_generator = cast(rg.ResizeGenerator, rg.ResizeGenerator(resize_to=size, side=side))
+        self._param_generator = rg.ResizeGenerator(resize_to=size, side=side)
         self.flags = dict(
             size=size, side=side, resample=Resample.get(resample), align_corners=align_corners, antialias=antialias
         )
@@ -76,8 +76,12 @@ class Resize(GeometricAugmentationBase2D):
         transform: Optional[Tensor] = None,
         size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
-        size = cast(Tuple[int, int], size)
-        transform = cast(Tensor, transform)
+        if not isinstance(size, tuple):
+            raise TypeError(f'Expected the size be a tuple. Gotcha {type(size)}')
+
+        if not isinstance(transform, Tensor):
+            raise TypeError(f'Expected the transform be a Tensor. Gotcha {type(transform)}')
+
         return crop_by_transform_mat(
             input, transform[:, :2, :], size, flags["resample"], flags["padding_mode"], flags["align_corners"]
         )

--- a/kornia/augmentation/_2d/geometric/rotation.py
+++ b/kornia/augmentation/_2d/geometric/rotation.py
@@ -1,11 +1,9 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
-
-import torch
-from torch import Tensor
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
 from kornia.constants import Resample
+from kornia.core import Tensor, as_tensor, eye
 from kornia.geometry.transform import affine
 from kornia.geometry.transform.affwarp import _compute_rotation_matrix, _compute_tensor_center
 
@@ -71,9 +69,8 @@ class RandomRotation(GeometricAugmentationBase2D):
         return_transform: Optional[bool] = None,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator, rg.PlainUniformGenerator((degrees, "degrees", 0.0, (-360.0, 360.0)))
-        )
+        self._param_generator = rg.PlainUniformGenerator((degrees, "degrees", 0.0, (-360.0, 360.0)))
+
         self.flags = dict(resample=Resample.get(resample), align_corners=align_corners)
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
@@ -84,7 +81,7 @@ class RandomRotation(GeometricAugmentationBase2D):
         rotation_mat: Tensor = _compute_rotation_matrix(angles, center.expand(angles.shape[0], -1))
 
         # rotation_mat is B x 2 x 3 and we need a B x 3 x 3 matrix
-        trans_mat: Tensor = torch.eye(3, device=input.device, dtype=input.dtype).repeat(input.shape[0], 1, 1)
+        trans_mat: Tensor = eye(3, device=input.device, dtype=input.dtype).repeat(input.shape[0], 1, 1)
         trans_mat[:, 0] = rotation_mat[:, 0]
         trans_mat[:, 1] = rotation_mat[:, 1]
 
@@ -93,7 +90,8 @@ class RandomRotation(GeometricAugmentationBase2D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        transform = cast(Tensor, transform)
+        if not isinstance(transform, Tensor):
+            raise TypeError(f'Expected the transform be a Tensor. Gotcha {type(transform)}')
 
         return affine(input, transform[..., :2, :3], flags["resample"].name.lower(), "zeros", flags["align_corners"])
 
@@ -107,6 +105,6 @@ class RandomRotation(GeometricAugmentationBase2D):
         return self.apply_transform(
             input,
             params=self._params,
-            transform=torch.as_tensor(transform, device=input.device, dtype=input.dtype),
+            transform=as_tensor(transform, device=input.device, dtype=input.dtype),
             flags=flags,
         )

--- a/kornia/augmentation/_2d/intensity/brightness.py
+++ b/kornia/augmentation/_2d/intensity/brightness.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, Optional, Tuple, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.augmentation.utils import _range_bound
+from kornia.core import Tensor
 from kornia.enhance.adjust import adjust_brightness
 
 
@@ -65,9 +64,8 @@ class RandomBrightness(IntensityAugmentationBase2D):
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         self.brightness: Tensor = _range_bound(brightness, 'brightness', center=1.0, bounds=(0.0, 2.0))
-        self._param_generator = cast(
-            rg.PlainUniformGenerator, rg.PlainUniformGenerator((self.brightness, "brightness_factor", None, None))
-        )
+        self._param_generator = rg.PlainUniformGenerator((self.brightness, "brightness_factor", None, None))
+
         self.clip_output = clip_output
 
     def apply_transform(

--- a/kornia/augmentation/_2d/intensity/color_jiggle.py
+++ b/kornia/augmentation/_2d/intensity/color_jiggle.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.constants import pi
+from kornia.core import Tensor
 from kornia.enhance import adjust_brightness, adjust_contrast, adjust_hue, adjust_saturation
 
 
@@ -71,9 +70,7 @@ class ColorJiggle(IntensityAugmentationBase2D):
         self.contrast = contrast
         self.saturation = saturation
         self.hue = hue
-        self._param_generator = cast(
-            rg.ColorJiggleGenerator, rg.ColorJiggleGenerator(brightness, contrast, saturation, hue)
-        )
+        self._param_generator = rg.ColorJiggleGenerator(brightness, contrast, saturation, hue)
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None

--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -1,11 +1,10 @@
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.constants import pi
+from kornia.core import Tensor
 from kornia.enhance import (
     adjust_brightness_accumulative,
     adjust_contrast_with_mean_subtraction,
@@ -92,9 +91,7 @@ class ColorJitter(IntensityAugmentationBase2D):
         self.contrast = contrast
         self.saturation = saturation
         self.hue = hue
-        self._param_generator = cast(
-            rg.ColorJitterGenerator, rg.ColorJitterGenerator(brightness, contrast, saturation, hue)
-        )
+        self._param_generator = rg.ColorJitterGenerator(brightness, contrast, saturation, hue)
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None

--- a/kornia/augmentation/_2d/intensity/contrast.py
+++ b/kornia/augmentation/_2d/intensity/contrast.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, Optional, Tuple, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.augmentation.utils import _range_bound
+from kornia.core import Tensor
 from kornia.enhance.adjust import adjust_contrast
 
 
@@ -65,9 +64,8 @@ class RandomContrast(IntensityAugmentationBase2D):
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         self.contrast: Tensor = _range_bound(contrast, 'contrast', center=1.0)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator, rg.PlainUniformGenerator((self.contrast, "contrast_factor", None, None))
-        )
+        self._param_generator = rg.PlainUniformGenerator((self.contrast, "contrast_factor", None, None))
+
         self.clip_output = clip_output
 
     def apply_transform(

--- a/kornia/augmentation/_2d/intensity/erasing.py
+++ b/kornia/augmentation/_2d/intensity/erasing.py
@@ -1,10 +1,8 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
-
-import torch
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
+from kornia.core import Tensor, where
 from kornia.geometry.bbox import bbox_generator, bbox_to_mask
 
 
@@ -69,7 +67,7 @@ class RandomErasing(IntensityAugmentationBase2D):
         self.scale = scale
         self.ratio = ratio
         self.value: float = float(value)
-        self._param_generator = cast(rg.RectangleEraseGenerator, rg.RectangleEraseGenerator(scale, ratio, float(value)))
+        self._param_generator = rg.RectangleEraseGenerator(scale, ratio, float(value))
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
@@ -80,5 +78,5 @@ class RandomErasing(IntensityAugmentationBase2D):
         bboxes = bbox_generator(params["xs"], params["ys"], params["widths"], params["heights"])
         mask = bbox_to_mask(bboxes, w, h)  # Returns B, H, W
         mask = mask.unsqueeze(1).repeat(1, c, 1, 1).to(input)  # Transform to B, c, H, W
-        transformed = torch.where(mask == 1.0, values, input)
+        transformed = where(mask == 1.0, values, input)
         return transformed

--- a/kornia/augmentation/_2d/intensity/gamma.py
+++ b/kornia/augmentation/_2d/intensity/gamma.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, Tuple, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
+from kornia.core import Tensor
 from kornia.enhance.adjust import adjust_gamma
 
 
@@ -63,9 +62,8 @@ class RandomGamma(IntensityAugmentationBase2D):
         return_transform: Optional[bool] = None,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator,
-            rg.PlainUniformGenerator((gamma, "gamma_factor", None, None), (gain, "gain_factor", None, None)),
+        self._param_generator = rg.PlainUniformGenerator(
+            (gamma, "gamma_factor", None, None), (gain, "gain_factor", None, None)
         )
 
     def apply_transform(

--- a/kornia/augmentation/_2d/intensity/hue.py
+++ b/kornia/augmentation/_2d/intensity/hue.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict, Optional, Tuple, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.augmentation.utils import _range_bound
 from kornia.constants import pi
+from kornia.core import Tensor
 from kornia.enhance.adjust import adjust_hue
 
 
@@ -64,9 +63,7 @@ class RandomHue(IntensityAugmentationBase2D):
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         self.hue: Tensor = _range_bound(hue, 'hue', bounds=(-0.5, 0.5))
-        self._param_generator = cast(
-            rg.PlainUniformGenerator, rg.PlainUniformGenerator((self.hue, "hue_factor", None, None))
-        )
+        self._param_generator = rg.PlainUniformGenerator((self.hue, "hue_factor", None, None))
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None

--- a/kornia/augmentation/_2d/intensity/plasma.py
+++ b/kornia/augmentation/_2d/intensity/plasma.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, Optional, Tuple, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.contrib import diamond_square
+from kornia.core import Tensor
 
 
 class RandomPlasmaBrightness(IntensityAugmentationBase2D):
@@ -47,9 +46,8 @@ class RandomPlasmaBrightness(IntensityAugmentationBase2D):
         super().__init__(
             p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim
         )
-        self._param_generator = cast(
-            rg.PlainUniformGenerator,
-            rg.PlainUniformGenerator((roughness, "roughness", None, None), (intensity, "intensity", None, None)),
+        self._param_generator = rg.PlainUniformGenerator(
+            (roughness, "roughness", None, None), (intensity, "intensity", None, None)
         )
 
     def apply_transform(
@@ -101,9 +99,7 @@ class RandomPlasmaContrast(IntensityAugmentationBase2D):
         super().__init__(
             p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim
         )
-        self._param_generator = cast(
-            rg.PlainUniformGenerator, rg.PlainUniformGenerator((roughness, "roughness", None, None))
-        )
+        self._param_generator = rg.PlainUniformGenerator((roughness, "roughness", None, None))
 
     def apply_transform(
         self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
@@ -156,13 +152,10 @@ class RandomPlasmaShadow(IntensityAugmentationBase2D):
         super().__init__(
             p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim
         )
-        self._param_generator = cast(
-            rg.PlainUniformGenerator,
-            rg.PlainUniformGenerator(
-                (roughness, "roughness", None, None),
-                (shade_intensity, "shade_intensity", None, None),
-                (shade_quantity, "shade_quantity", None, None),
-            ),
+        self._param_generator = rg.PlainUniformGenerator(
+            (roughness, "roughness", None, None),
+            (shade_intensity, "shade_intensity", None, None),
+            (shade_quantity, "shade_quantity", None, None),
         )
 
     def apply_transform(

--- a/kornia/augmentation/_2d/intensity/posterize.py
+++ b/kornia/augmentation/_2d/intensity/posterize.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
+from kornia.core import Tensor
 from kornia.enhance import posterize
 
 
@@ -56,7 +55,7 @@ class RandomPosterize(IntensityAugmentationBase2D):
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         # TODO: the generator should receive the device
-        self._param_generator = cast(rg.PosterizeGenerator, rg.PosterizeGenerator(bits))
+        self._param_generator = rg.PosterizeGenerator(bits)
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None

--- a/kornia/augmentation/_2d/intensity/random_rgb_shift.py
+++ b/kornia/augmentation/_2d/intensity/random_rgb_shift.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
+from kornia.core import Tensor
 from kornia.enhance import shift_rgb
 
 
@@ -85,13 +84,10 @@ class RandomRGBShift(IntensityAugmentationBase2D):
         return_transform: Optional[bool] = None,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator,
-            rg.PlainUniformGenerator(
-                (r_shift_limit, "r_shift", 0, (-r_shift_limit, r_shift_limit)),
-                (g_shift_limit, "g_shift", 0, (-g_shift_limit, g_shift_limit)),
-                (b_shift_limit, "b_shift", 0, (-b_shift_limit, b_shift_limit)),
-            ),
+        self._param_generator = rg.PlainUniformGenerator(
+            (r_shift_limit, "r_shift", 0, (-r_shift_limit, r_shift_limit)),
+            (g_shift_limit, "g_shift", 0, (-g_shift_limit, g_shift_limit)),
+            (b_shift_limit, "b_shift", 0, (-b_shift_limit, b_shift_limit)),
         )
 
     def apply_transform(

--- a/kornia/augmentation/_2d/intensity/saturation.py
+++ b/kornia/augmentation/_2d/intensity/saturation.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, Optional, Tuple, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.augmentation.utils import _range_bound
+from kornia.core import Tensor
 from kornia.enhance.adjust import adjust_saturation
 
 
@@ -63,9 +62,7 @@ class RandomSaturation(IntensityAugmentationBase2D):
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         self.saturation: Tensor = _range_bound(saturation, 'saturation', center=1.0)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator, rg.PlainUniformGenerator((self.saturation, "saturation_factor", None, None))
-        )
+        self._param_generator = rg.PlainUniformGenerator((self.saturation, "saturation_factor", None, None))
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None

--- a/kornia/augmentation/_2d/intensity/sharpness.py
+++ b/kornia/augmentation/_2d/intensity/sharpness.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
+from kornia.core import Tensor
 from kornia.enhance import sharpness
 
 
@@ -53,9 +52,7 @@ class RandomSharpness(IntensityAugmentationBase2D):
         return_transform: Optional[bool] = None,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator, rg.PlainUniformGenerator((sharpness, "sharpness", 0.0, (0, float("inf"))))
-        )
+        self._param_generator = rg.PlainUniformGenerator((sharpness, "sharpness", 0.0, (0, float("inf"))))
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None

--- a/kornia/augmentation/_2d/intensity/solarize.py
+++ b/kornia/augmentation/_2d/intensity/solarize.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
+from kornia.core import Tensor
 from kornia.enhance import solarize
 
 
@@ -59,11 +58,8 @@ class RandomSolarize(IntensityAugmentationBase2D):
         return_transform: Optional[bool] = None,
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
-        self._param_generator = cast(
-            rg.PlainUniformGenerator,
-            rg.PlainUniformGenerator(
-                (thresholds, "thresholds", 0.5, (0.0, 1.0)), (additions, "additions", 0.0, (-0.5, 0.5))
-            ),
+        self._param_generator = rg.PlainUniformGenerator(
+            (thresholds, "thresholds", 0.5, (0.0, 1.0)), (additions, "additions", 0.0, (-0.5, 0.5))
         )
 
     def apply_transform(

--- a/kornia/augmentation/_2d/mix/jigsaw.py
+++ b/kornia/augmentation/_2d/mix/jigsaw.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -48,7 +48,7 @@ class RandomJigsaw(MixAugmentationBaseV2):
         ensure_perm: bool = True,
     ) -> None:
         super().__init__(p=p, p_batch=1.0, same_on_batch=same_on_batch, keepdim=keepdim, data_keys=data_keys)
-        self._param_generator = cast(rg.JigsawGenerator, rg.JigsawGenerator(grid, ensure_perm))
+        self._param_generator = rg.JigsawGenerator(grid, ensure_perm)
         self.flags = dict(grid=grid)
 
     def apply_transform(

--- a/kornia/augmentation/_3d/geometric/affine.py
+++ b/kornia/augmentation/_3d/geometric/affine.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._3d.base import AugmentationBase3D
 from kornia.constants import Resample
+from kornia.core import Tensor
 from kornia.geometry import deg2rad, get_affine_matrix3d, warp_affine3d
 
 
@@ -126,7 +125,7 @@ class RandomAffine3D(AugmentationBase3D):
         self.scale = scale
 
         self.flags = dict(resample=Resample.get(resample), align_corners=align_corners)
-        self._param_generator = cast(rg.AffineGenerator3D, rg.AffineGenerator3D(degrees, translate, scale, shears))
+        self._param_generator = rg.AffineGenerator3D(degrees, translate, scale, shears)
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         transform: Tensor = get_affine_matrix3d(
@@ -146,7 +145,9 @@ class RandomAffine3D(AugmentationBase3D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        transform = cast(Tensor, transform)
+        if not isinstance(transform, Tensor):
+            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+
         return warp_affine3d(
             input,
             transform[:, :3, :],

--- a/kornia/augmentation/_3d/geometric/crop.py
+++ b/kornia/augmentation/_3d/geometric/crop.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._3d.base import AugmentationBase3D
@@ -91,7 +91,7 @@ class RandomCrop3D(AugmentationBase3D):
             resample=Resample.get(resample),
             align_corners=align_corners,
         )
-        self._param_generator = cast(rg.CropGenerator3D, rg.CropGenerator3D(size, None))
+        self._param_generator = rg.CropGenerator3D(size, None)
 
     def precrop_padding(self, input: Tensor, flags: Optional[Dict[str, Any]] = None) -> Tensor:
         flags = self.flags if flags is None else flags
@@ -129,7 +129,9 @@ class RandomCrop3D(AugmentationBase3D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        transform = cast(Tensor, transform)
+        if not isinstance(transform, Tensor):
+            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+
         return crop_by_transform_mat3d(
             input, transform, flags["size"], mode=flags["resample"].name.lower(), align_corners=flags["align_corners"]
         )

--- a/kornia/augmentation/_3d/geometric/perspective.py
+++ b/kornia/augmentation/_3d/geometric/perspective.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, Optional, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._3d.base import AugmentationBase3D
 from kornia.constants import Resample
+from kornia.core import Tensor
 from kornia.geometry import get_perspective_transform3d, warp_perspective3d
 
 
@@ -76,7 +75,7 @@ class RandomPerspective3D(AugmentationBase3D):
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         self.flags = dict(resample=Resample.get(resample), align_corners=align_corners)
-        self._param_generator = cast(rg.PerspectiveGenerator3D, rg.PerspectiveGenerator3D(distortion_scale))
+        self._param_generator = rg.PerspectiveGenerator3D(distortion_scale)
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return get_perspective_transform3d(params["start_points"], params["end_points"]).to(input)
@@ -84,7 +83,9 @@ class RandomPerspective3D(AugmentationBase3D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        transform = cast(Tensor, transform)
+        if not isinstance(transform, Tensor):
+            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+
         return warp_perspective3d(
             input,
             transform,

--- a/kornia/augmentation/_3d/geometric/rotation.py
+++ b/kornia/augmentation/_3d/geometric/rotation.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple, Union
 
 import kornia
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._3d.base import AugmentationBase3D
 from kornia.constants import Resample
+from kornia.core import Tensor
 from kornia.geometry import affine3d
 from kornia.geometry.transform.affwarp import _compute_rotation_matrix3d, _compute_tensor_center3d
 
@@ -88,7 +87,7 @@ class RandomRotation3D(AugmentationBase3D):
     ) -> None:
         super().__init__(p=p, return_transform=return_transform, same_on_batch=same_on_batch, keepdim=keepdim)
         self.flags = dict(resample=Resample.get(resample), align_corners=align_corners)
-        self._param_generator = cast(rg.RotationGenerator3D, rg.RotationGenerator3D(degrees))
+        self._param_generator = rg.RotationGenerator3D(degrees)
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         yaw: Tensor = params["yaw"].to(input)
@@ -109,5 +108,7 @@ class RandomRotation3D(AugmentationBase3D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        transform = cast(Tensor, transform)
+        if not isinstance(transform, Tensor):
+            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+
         return affine3d(input, transform[..., :3, :4], flags["resample"].name.lower(), "zeros", flags["align_corners"])

--- a/kornia/augmentation/_3d/intensity/motion_blur.py
+++ b/kornia/augmentation/_3d/intensity/motion_blur.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, Optional, Tuple, Union, cast
-
-from torch import Tensor
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._3d.base import AugmentationBase3D
 from kornia.constants import BorderType, Resample
+from kornia.core import Tensor
 from kornia.filters import motion_blur3d
 
 
@@ -96,7 +95,7 @@ class RandomMotionBlur3D(AugmentationBase3D):
             p=p, return_transform=return_transform, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim
         )
         self.flags = dict(border_type=BorderType.get(border_type), resample=Resample.get(resample))
-        self._param_generator = cast(rg.MotionBlurGenerator3D, rg.MotionBlurGenerator3D(kernel_size, angle, direction))
+        self._param_generator = rg.MotionBlurGenerator3D(kernel_size, angle, direction)
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return self.identity_matrix(input)
@@ -104,7 +103,7 @@ class RandomMotionBlur3D(AugmentationBase3D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        kernel_size: int = cast(int, params["ksize_factor"].unique().item())
+        kernel_size = int(params["ksize_factor"].unique().item())
         angle = params["angle_factor"]
         direction = params["direction_factor"]
         return motion_blur3d(

--- a/kornia/augmentation/random_generator/_2d/affine.py
+++ b/kornia/augmentation/random_generator/_2d/affine.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Union, cast
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 from torch.distributions import Uniform
@@ -126,8 +126,8 @@ class AffineGenerator(RandomGeneratorBase):
             else:
                 raise ValueError(f"'scale' expected to be either 2 or 4 elements. Got {self.scale}")
         if _shear is not None:
-            _joint_range_check(cast(Tensor, _shear)[0], "shear")
-            _joint_range_check(cast(Tensor, _shear)[1], "shear")
+            _joint_range_check(_shear[0], "shear")
+            _joint_range_check(_shear[1], "shear")
             shear_x_sampler = Uniform(_shear[0][0], _shear[0][1], validate_args=False)
             shear_y_sampler = Uniform(_shear[1][0], _shear[1][1], validate_args=False)
 
@@ -246,10 +246,10 @@ def random_affine_generator(
         scale = scale.to(device=device, dtype=dtype)
         if not (len(scale.shape) == 1 and len(scale) in (2, 4)):
             raise AssertionError(f"`scale` shall have 2 or 4 elements. Got {scale}.")
-        _joint_range_check(cast(Tensor, scale[:2]), "scale")
+        _joint_range_check(scale[:2], "scale")
         _scale = _adapted_uniform((batch_size,), scale[0], scale[1], same_on_batch).unsqueeze(1).repeat(1, 2)
         if len(scale) == 4:
-            _joint_range_check(cast(Tensor, scale[2:]), "scale_y")
+            _joint_range_check(scale[2:], "scale_y")
             _scale[:, 1] = _adapted_uniform((batch_size,), scale[2], scale[3], same_on_batch)
         _scale = _scale.to(device=_device, dtype=_dtype)
     else:
@@ -277,8 +277,8 @@ def random_affine_generator(
 
     if shear is not None:
         shear = shear.to(device=device, dtype=dtype)
-        _joint_range_check(cast(Tensor, shear)[0], "shear")
-        _joint_range_check(cast(Tensor, shear)[1], "shear")
+        _joint_range_check(shear[0], "shear")
+        _joint_range_check(shear[1], "shear")
         sx = _adapted_uniform((batch_size,), shear[0][0], shear[0][1], same_on_batch)
         sy = _adapted_uniform((batch_size,), shear[1][0], shear[1][1], same_on_batch)
         sx = sx.to(device=_device, dtype=_dtype)

--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch.distributions import Beta, Uniform
@@ -147,8 +147,7 @@ def _transform_output_shape(output: Tensor, shape: Tuple) -> Tensor:
     Returns:
         Tensor
     """
-    out_tensor: Tensor
-    out_tensor = cast(Tensor, output)
+    out_tensor = output.clone()
 
     for dim in range(len(out_tensor.shape) - len(shape)):
         if out_tensor.shape[0] != 1:

--- a/kornia/filters/kernels_geometry.py
+++ b/kornia/filters/kernels_geometry.py
@@ -1,17 +1,15 @@
-from typing import Tuple, Union, cast
+from typing import Tuple, Union
 
 import torch
 
+from kornia.core import Tensor, pad, stack, tensor, zeros
 from kornia.geometry.transform import rotate, rotate3d
 from kornia.utils import _extract_device_dtype
 
 
 def get_motion_kernel2d(
-    kernel_size: int,
-    angle: Union[torch.Tensor, float],
-    direction: Union[torch.Tensor, float] = 0.0,
-    mode: str = 'nearest',
-) -> torch.Tensor:
+    kernel_size: int, angle: Union[Tensor, float], direction: Union[Tensor, float] = 0.0, mode: str = 'nearest'
+) -> Tensor:
     r"""Return 2D motion blur filter.
 
     Args:
@@ -40,16 +38,14 @@ def get_motion_kernel2d(
                  [0.5000, 0.0000, 0.0000]]])
     """
     device, dtype = _extract_device_dtype(
-        [angle if isinstance(angle, torch.Tensor) else None, direction if isinstance(direction, torch.Tensor) else None]
+        [angle if isinstance(angle, Tensor) else None, direction if isinstance(direction, Tensor) else None]
     )
 
     if not isinstance(kernel_size, int) or kernel_size % 2 == 0 or kernel_size < 3:
         raise TypeError("ksize must be an odd integer >= than 3")
 
-    if not isinstance(angle, torch.Tensor):
-        angle = torch.tensor([angle], device=device, dtype=dtype)
-
-    angle = cast(torch.Tensor, angle)
+    if not isinstance(angle, Tensor):
+        angle = tensor([angle], device=device, dtype=dtype)
 
     if angle.dim() == 0:
         angle = angle.unsqueeze(0)
@@ -57,10 +53,8 @@ def get_motion_kernel2d(
     if angle.dim() != 1:
         raise AssertionError(f"angle must be a 1-dim tensor. Got {angle}.")
 
-    if not isinstance(direction, torch.Tensor):
-        direction = torch.tensor([direction], device=device, dtype=dtype)
-
-    direction = cast(torch.Tensor, direction)
+    if not isinstance(direction, Tensor):
+        direction = tensor([direction], device=device, dtype=dtype)
 
     if direction.dim() == 0:
         direction = direction.unsqueeze(0)
@@ -83,8 +77,8 @@ def get_motion_kernel2d(
     # Alternatively
     # m = ((1 - 2 * direction)[:, None].repeat(1, kernel_size) / (kernel_size - 1))
     # kernel[:, kernel_size // 2, :] = direction[:, None].repeat(1, kernel_size) + m * torch.arange(0, kernel_size)
-    k = torch.stack([(direction + ((1 - 2 * direction) / (kernel_size - 1)) * i) for i in range(kernel_size)], dim=-1)
-    kernel = torch.nn.functional.pad(k[:, None], [0, 0, kernel_size // 2, kernel_size // 2, 0, 0])
+    k = stack([(direction + ((1 - 2 * direction) / (kernel_size - 1)) * i) for i in range(kernel_size)], -1)
+    kernel = pad(k[:, None], [0, 0, kernel_size // 2, kernel_size // 2, 0, 0])
 
     if kernel.shape != torch.Size([direction.size(0), *kernel_tuple]):
         raise AssertionError
@@ -99,10 +93,10 @@ def get_motion_kernel2d(
 
 def get_motion_kernel3d(
     kernel_size: int,
-    angle: Union[torch.Tensor, Tuple[float, float, float]],
-    direction: Union[torch.Tensor, float] = 0.0,
+    angle: Union[Tensor, Tuple[float, float, float]],
+    direction: Union[Tensor, float] = 0.0,
     mode: str = 'nearest',
-) -> torch.Tensor:
+) -> Tensor:
     r"""Return 3D motion blur filter.
 
     Args:
@@ -150,13 +144,11 @@ def get_motion_kernel3d(
         raise TypeError(f"ksize must be an odd integer >= than 3. Got {kernel_size}.")
 
     device, dtype = _extract_device_dtype(
-        [angle if isinstance(angle, torch.Tensor) else None, direction if isinstance(direction, torch.Tensor) else None]
+        [angle if isinstance(angle, Tensor) else None, direction if isinstance(direction, Tensor) else None]
     )
 
-    if not isinstance(angle, torch.Tensor):
-        angle = torch.tensor([angle], device=device, dtype=dtype)
-
-    angle = cast(torch.Tensor, angle)
+    if not isinstance(angle, Tensor):
+        angle = tensor([angle], device=device, dtype=dtype)
 
     if angle.dim() == 1:
         angle = angle.unsqueeze(0)
@@ -164,10 +156,8 @@ def get_motion_kernel3d(
     if not (len(angle.shape) == 2 and angle.size(1) == 3):
         raise AssertionError(f"angle must be (B, 3). Got {angle}.")
 
-    if not isinstance(direction, torch.Tensor):
-        direction = torch.tensor([direction], device=device, dtype=dtype)
-
-    direction = cast(torch.Tensor, direction)
+    if not isinstance(direction, Tensor):
+        direction = tensor([direction], device=device, dtype=dtype)
 
     if direction.dim() == 0:
         direction = direction.unsqueeze(0)
@@ -182,15 +172,13 @@ def get_motion_kernel3d(
 
     # direction from [-1, 1] to [0, 1] range
     direction = (torch.clamp(direction, -1.0, 1.0) + 1.0) / 2.0
-    kernel = torch.zeros((direction.size(0), *kernel_tuple), device=device, dtype=dtype)
+    kernel = zeros((direction.size(0), *kernel_tuple), device=device, dtype=dtype)
 
     # Element-wise linspace
     # kernel[:, kernel_size // 2, kernel_size // 2, :] = torch.stack(
     #     [(direction + ((1 - 2 * direction) / (kernel_size - 1)) * i) for i in range(kernel_size)], dim=-1)
-    k = torch.stack([(direction + ((1 - 2 * direction) / (kernel_size - 1)) * i) for i in range(kernel_size)], dim=-1)
-    kernel = torch.nn.functional.pad(
-        k[:, None, None], [0, 0, kernel_size // 2, kernel_size // 2, kernel_size // 2, kernel_size // 2, 0, 0]
-    )
+    k = stack([(direction + ((1 - 2 * direction) / (kernel_size - 1)) * i) for i in range(kernel_size)], -1)
+    kernel = pad(k[:, None, None], [0, 0, kernel_size // 2, kernel_size // 2, kernel_size // 2, kernel_size // 2, 0, 0])
 
     if kernel.shape != torch.Size([direction.size(0), *kernel_tuple]):
         raise AssertionError

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,6 +122,7 @@ show_error_codes = True
 ignore_missing_imports = True
 no_implicit_optional = True
 warn_unused_ignores = True
+warn_redundant_casts = True
 
 [pydocstyle]
 match = .*\.py


### PR DESCRIPTION
Add `warn_redundant_casts = True` to setup.cfg and remove all redundant casts. Also ensure to use `kornia.core`. Related to #1992 

Also, fix some `casts` being used "wrongly", in places where there should be something like `if not isinstance(...): raise ...` -- maybe have in other places this standard