### PR TITLE
Ensure support to Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -18,9 +18,14 @@ jobs:
       fail-fast: false # TODO: enable it when CI be stable
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.9', '3.10']
         pytorch-version: ['1.9.1', '1.13.1']
         pytorch-dtype: ['float16', 'float32', 'float64']
+        exclude:
+            - pytorch-version: '1.9.1'
+              python-version: '3.10'
+            - pytorch-version: '1.13.1'
+              python-version: '3.9'
 
     steps:
       - name: Checkout kornia

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false # TODO: enable it when CI be stable
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.8']
+        python-version: ['3.7', '3.10']
         pytorch-version: ['1.9.1', '1.13.1']
         pytorch-dtype: ['float16', 'float32', 'float64']
 

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -9,19 +9,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # You can use PyPy versions in python-version.
-        # For example, pypy2 and pypy3
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Download Kornia binary
-      run: |
-        pip install torch -f https://download.pytorch.org/whl/torch_stable.html
-        pip install kornia
-        python -c "import kornia"
+      - name: Checkout kornia
+        uses: actions/checkout@v3
+
+      - name: Config Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download Kornia binary
+        run: |
+          pip install torch -f https://download.pytorch.org/whl/torch_stable.html
+          pip install kornia
+          python -c "import kornia"

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.8']
+        python-version: ['3.7', '3.10']
         pytorch-version: ['1.9.1', '1.10.2', '1.12.1', '1.13.1']
         pytorch-dtype: ['float16', 'float32', 'float64']
 

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -19,9 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.10']
-        pytorch-version: ['1.9.1', '1.10.2', '1.12.1', '1.13.1']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        pytorch-version: ['1.9.1', '1.10.2', '1.11.0', '1.12.1', '1.13.1']
         pytorch-dtype: ['float16', 'float32', 'float64']
+        exclude:
+            - pytorch-version: '1.9.1'
+              python-version: '3.10'
+            - pytorch-version: '1.10.2'
+              python-version: '3.10'
 
     steps:
       - name: Checkout kornia

--- a/.github/workflows/tests_nightly.yml
+++ b/.github/workflows/tests_nightly.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         pytorch-version: ['nightly']
         pytorch-dtype: ['float32', 'float64']
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ exclude =
 [options.extras_require]
 dev =
     isort
-    kornia-rs==0.0.5
+    kornia-rs==0.0.8
     mypy[reports]
     numpy
     opencv-python


### PR DESCRIPTION
Closes #1979 

CI for Python 3.10 is expected to fail until `kornia-rs` have support for Python 3.10


**This should be merged after** https://github.com/kornia/kornia-rs/pull/22 be merged -- maybe needs to update into setup.cfg to `kornia-rs==0.0.6`