### PR TITLE
Remove type ignore from the codebase

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ def get_test_devices() -> Dict[str, torch.device]:
 
         devices["tpu"] = xm.xla_device()
     if hasattr(torch.backends, 'mps'):
-        if torch.backends.mps.is_available():  # type: ignore
+        if torch.backends.mps.is_available():
             devices["mps"] = torch.device("mps")
     return devices
 

--- a/kornia/augmentation/_2d/mix/base.py
+++ b/kornia/augmentation/_2d/mix/base.py
@@ -5,7 +5,7 @@ import torch
 from kornia.augmentation.base import _BasicAugmentationBase
 from kornia.augmentation.utils import _transform_input, _transform_output_shape, _validate_input_dtype
 from kornia.constants import DataKey, DType
-from kornia.core import Tensor
+from kornia.core import Tensor, tensor
 from kornia.geometry.boxes import Boxes
 from kornia.testing import KORNIA_UNWRAP
 
@@ -130,7 +130,7 @@ class MixAugmentationBaseV2(_BasicAugmentationBase):
     def apply_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         raise NotImplementedError
 
-    def forward(  # type: ignore
+    def forward(  # type: ignore[override]
         self,
         *input: Tensor,
         params: Optional[Dict[str, Tensor]] = None,
@@ -147,11 +147,11 @@ class MixAugmentationBaseV2(_BasicAugmentationBase):
             in_tensor: Tensor = input[in_tensor_idx]
             in_tensor = self.transform_tensor(in_tensor)
             self._params = self.forward_parameters(in_tensor.shape)
-            self._params.update({"dtype": torch.tensor(DType.get(in_tensor.dtype).value)})
+            self._params.update({"dtype": tensor(DType.get(in_tensor.dtype).value)})
         else:
             self._params = params
 
-        outputs = []
+        outputs: List[Tensor] = []
         for dcate, _input in zip(keys, input):
             output: Tensor
             if dcate == DataKey.INPUT:

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -1,6 +1,6 @@
 import warnings
 from itertools import zip_longest
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from kornia.augmentation import (
     AugmentationBase3D,

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -156,7 +156,7 @@ class AugmentationSequential(ImageSequential):
             random_apply_weights=random_apply_weights,
         )
 
-        self.data_keys: List[DataKey] = [DataKey.get(inp) for inp in data_keys]
+        self.data_keys = [DataKey.get(inp) for inp in data_keys]
 
         if not all(in_type in DataKey for in_type in self.data_keys):
             raise AssertionError(f"`data_keys` must be in {DataKey}. Got {data_keys}.")
@@ -188,7 +188,7 @@ class AugmentationSequential(ImageSequential):
     def transform_matrix(self) -> Optional[Tensor]:
         return self._transform_matrix
 
-    def inverse(  # type: ignore
+    def inverse(  # type: ignore[override]
         self,
         *args: Tensor,
         params: Optional[List[ParamItem]] = None,
@@ -216,7 +216,7 @@ class AugmentationSequential(ImageSequential):
                 )
             params = self._params
 
-        outputs: List[Tensor] = [None] * len(_data_keys)  # type: ignore
+        outputs: List[Optional[Tensor]] = [None] * len(_data_keys)
         for idx, (arg, dcate) in enumerate(zip(args, _data_keys)):
 
             if dcate in self.extra_args:
@@ -231,12 +231,18 @@ class AugmentationSequential(ImageSequential):
                 input = arg.data  # all boxes are in (B, N, 4, 2) format now.
             else:
                 input = arg
-            for (name, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
+            for (name, module), _param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
                 if isinstance(module, (_AugmentationBase, ImageSequential)):
-                    # TODO(jian): verify what's happening here. Mypy was complaining,
-                    param = params[name] if name in params else param  # type: ignore
+                    _mb = [p for p in params if name in p]
+                    if len(_mb) > 0:
+                        param = _mb[0]
+                    elif isinstance(_param, ParamItem):
+                        param = _param
+                    else:
+                        param = None
                 else:
                     param = None
+
                 if (
                     isinstance(module, IntensityAugmentationBase2D)
                     and dcate in DataKey
@@ -270,21 +276,28 @@ class AugmentationSequential(ImageSequential):
             else:
                 outputs[idx] = input
 
-        if len(outputs) == 1 and isinstance(outputs, (tuple, list)):
-            return outputs[0]
+        _outputs = [i for i in outputs if isinstance(i, Tensor)]
 
-        return outputs
+        if len(_outputs) == 1 and isinstance(_outputs, list):
+            return _outputs[0]
 
-    def __packup_output__(  # type: ignore
+        return _outputs
+
+    def __packup_output__(  # type: ignore[override]
         self, output: List[Tensor], label: Optional[Tensor] = None
-    ) -> Union[Tensor, Tuple[Tensor, Optional[Tensor]], List[Tensor], Tuple[List[Tensor], Optional[Tensor]]]:
-        if len(output) == 1 and isinstance(output, (tuple, list)) and self.return_label:
-            return output[0], label
-        if len(output) == 1 and isinstance(output, (tuple, list)):
-            return output[0]
+    ) -> Union[Tensor, List[Tensor], Tuple[Union[Tensor, List[Tensor]], Optional[Tensor]]]:
+
+        _out: Union[Tensor, List[Tensor]]
+
+        if len(output) == 1 and isinstance(output, list):
+            _out = output[0]
+        else:
+            _out = output
+
         if self.return_label:
-            return output, label
-        return output
+            return _out, label
+
+        return _out
 
     def _validate_args_datakeys(self, *args: Tensor, data_keys: List[DataKey]):
         if len(args) != len(data_keys):
@@ -312,13 +325,13 @@ class AugmentationSequential(ImageSequential):
                 raise NotImplementedError(f"input type of {dcate} is not implemented.")
         return inp
 
-    def forward(  # type: ignore
+    def forward(  # type: ignore[override]
         self,
         *args: Tensor,
         label: Optional[Tensor] = None,
         params: Optional[List[ParamItem]] = None,
         data_keys: Optional[List[Union[str, int, DataKey]]] = None,
-    ) -> Union[Tensor, Tuple[Tensor, Optional[Tensor]], List[Tensor], Tuple[List[Tensor], Optional[Tensor]]]:
+    ) -> Union[Tensor, List[Tensor], Tuple[Union[Tensor, List[Tensor]], Optional[Tensor]]]:
         """Compute multiple tensors simultaneously according to ``self.data_keys``."""
         if data_keys is None:
             _data_keys = self.data_keys
@@ -332,8 +345,7 @@ class AugmentationSequential(ImageSequential):
         if params is None:
             # image data must exist if params is not provided.
             if DataKey.INPUT in _data_keys:
-                _input = args[_data_keys.index(DataKey.INPUT)]
-                inp = _input
+                inp = args[_data_keys.index(DataKey.INPUT)]
                 if isinstance(inp, (tuple, list)):
                     raise ValueError(f"`INPUT` should be a tensor but `{type(inp)}` received.")
                 # A video input shall be BCDHW while an image input shall be BCHW
@@ -345,7 +357,7 @@ class AugmentationSequential(ImageSequential):
             else:
                 raise ValueError("`params` must be provided whilst INPUT is not in data_keys.")
 
-        outputs: List[Tensor] = [None] * len(_data_keys)  # type: ignore
+        outputs: List[Optional[Tensor]] = [None] * len(_data_keys)
 
         self.return_label = self.return_label or label is not None or self.contains_label_operations(params)
 
@@ -361,10 +373,12 @@ class AugmentationSequential(ImageSequential):
 
                 _out = super().forward(_inp, label, params=params, extra_args=extra_args)
                 self._transform_matrix = self.get_transformation_matrix(_inp, params=params)
-                if self.return_label:
-                    _input, label = cast(Tuple[Tensor, Tensor], _out)
-                else:
-                    _input = cast(Tensor, _out)
+
+                if self.return_label and isinstance(_out, tuple):
+                    _input, label = _out
+                elif isinstance(_out, Tensor):
+                    _input = _out
+
                 outputs[idx] = _input
                 # NOTE: Skip the rest here.
                 continue
@@ -411,5 +425,5 @@ class AugmentationSequential(ImageSequential):
                 outputs[idx] = arg.to_tensor()
             else:
                 outputs[idx] = input
-
-        return self.__packup_output__(outputs, label)
+        _outputs = [i for i in outputs if isinstance(i, Tensor)]
+        return self.__packup_output__(_outputs, label)

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -1,18 +1,19 @@
 from collections import OrderedDict
-from typing import Any, Iterator, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
 from kornia.augmentation import MixAugmentationBaseV2
 from kornia.augmentation.base import _AugmentationBase
+from kornia.core import Module, Tensor
 
 __all__ = ["SequentialBase", "ParamItem"]
 
 
 class ParamItem(NamedTuple):
     name: str
-    data: Optional[Union[dict, list]]
+    data: Optional[Union[Dict[str, Tensor], List['ParamItem']]]
 
 
 class SequentialBase(nn.Sequential):
@@ -28,12 +29,12 @@ class SequentialBase(nn.Sequential):
             to the batch form (False). If None, it will not overwrite the function-wise settings.
     """
 
-    def __init__(self, *args: nn.Module, same_on_batch: Optional[bool] = None, keepdim: Optional[bool] = None) -> None:
+    def __init__(self, *args: Module, same_on_batch: Optional[bool] = None, keepdim: Optional[bool] = None) -> None:
         # To name the modules properly
         _args = OrderedDict()
         for idx, mod in enumerate(args):
-            if not isinstance(mod, nn.Module):
-                raise NotImplementedError(f"Only nn.Module are supported at this moment. Got {mod}.")
+            if not isinstance(mod, Module):
+                raise NotImplementedError(f"Only Module are supported at this moment. Got {mod}.")
             _args.update({f"{mod.__class__.__name__}_{idx}": mod})
         super().__init__(_args)
         self._same_on_batch = same_on_batch
@@ -60,7 +61,7 @@ class SequentialBase(nn.Sequential):
             if isinstance(mod, SequentialBase):
                 mod.update_attribute(same_on_batch, return_transform, keepdim)
 
-    def get_submodule(self, target: str) -> nn.Module:
+    def get_submodule(self, target: str) -> Module:
         """Get submodule.
 
         This code is taken from torch 1.9.0 since it is not introduced
@@ -73,18 +74,18 @@ class SequentialBase(nn.Sequential):
                 fully-qualified string.)
 
         Returns:
-            torch.nn.Module: The submodule referenced by ``target``
+            Module: The submodule referenced by ``target``
 
         Raises:
             AttributeError: If the target string references an invalid
                 path or resolves to something that is not an
-                ``nn.Module``
+                ``Module``
         """
         if target == "":
             return self
 
         atoms: List[str] = target.split(".")
-        mod: torch.nn.Module = self
+        mod: Module = self
 
         for item in atoms:
 
@@ -93,8 +94,8 @@ class SequentialBase(nn.Sequential):
 
             mod = getattr(mod, item)
 
-            if not isinstance(mod, torch.nn.Module):
-                raise AttributeError("`" + item + "` is not " "an nn.Module")
+            if not isinstance(mod, Module):
+                raise AttributeError("`" + item + "` is not " "an Module")
 
         return mod
 
@@ -131,18 +132,18 @@ class SequentialBase(nn.Sequential):
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
         raise NotImplementedError
 
-    def get_children_by_indices(self, indices: torch.Tensor) -> Iterator[Tuple[str, nn.Module]]:
+    def get_children_by_indices(self, indices: Tensor) -> Iterator[Tuple[str, Module]]:
         modules = list(self.named_children())
         for idx in indices:
             yield modules[idx]
 
-    def get_children_by_params(self, params: List[ParamItem]) -> Iterator[Tuple[str, nn.Module]]:
+    def get_children_by_params(self, params: List[ParamItem]) -> Iterator[Tuple[str, Module]]:
         modules = list(self.named_children())
         # TODO: Wrong params passed here when nested ImageSequential
         for param in params:
             yield modules[list(dict(self.named_children()).keys()).index(param.name)]
 
-    def get_params_by_module(self, named_modules: Iterator[Tuple[str, nn.Module]]) -> Iterator[ParamItem]:
+    def get_params_by_module(self, named_modules: Iterator[Tuple[str, Module]]) -> Iterator[ParamItem]:
         # This will not take module._params
         for name, _ in named_modules:
             yield ParamItem(name, None)
@@ -150,7 +151,7 @@ class SequentialBase(nn.Sequential):
     def contains_label_operations(self, params: List) -> bool:
         raise NotImplementedError
 
-    def autofill_dim(self, input: torch.Tensor, dim_range: Tuple[int, int] = (2, 4)) -> Tuple[torch.Size, torch.Size]:
+    def autofill_dim(self, input: Tensor, dim_range: Tuple[int, int] = (2, 4)) -> Tuple[torch.Size, torch.Size]:
         """Fill tensor dim to the upper bound of dim_range.
 
         If input tensor dim is smaller than the lower bound of dim_range, an error will be thrown out.

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -13,6 +13,7 @@ __all__ = ["SequentialBase", "ParamItem"]
 
 class ParamItem(NamedTuple):
     name: str
+    # TODO: add type List['ParamItem'] when mypy > 0.991 be available (see python/mypy#14200)
     data: Optional[Union[Dict[str, Tensor], list]]
 
 

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -13,7 +13,7 @@ __all__ = ["SequentialBase", "ParamItem"]
 
 class ParamItem(NamedTuple):
     name: str
-    data: Optional[Union[Dict[str, Tensor], List['ParamItem']]]
+    data: Optional[Union[Dict[str, Tensor], list]]
 
 
 class SequentialBase(nn.Sequential):

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -244,7 +244,7 @@ class VideoSequential(ImageSequential):
         label: Optional[Tensor] = None,
         params: Optional[List[ParamItem]] = None,
         extra_args: Dict[str, Any] = {},
-    ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+    ) -> Union[Tensor, Tuple[Tensor, Optional[Tensor]]]:
         """Define the video computation performed."""
         if len(input.shape) != 5:
             raise AssertionError(f"Input must be a 5-dim tensor. Got {input.shape}.")

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -1,10 +1,9 @@
 from typing import Callable, Dict, Optional
 
 import torch
-import torch.nn as nn
 from torch.distributions import Distribution
 
-from kornia.core import Device, Tensor
+from kornia.core import Device, Module, Tensor
 
 
 class _PostInitInjectionMetaClass(type):
@@ -16,7 +15,7 @@ class _PostInitInjectionMetaClass(type):
         return obj
 
 
-class RandomGeneratorBase(nn.Module, metaclass=_PostInitInjectionMetaClass):
+class RandomGeneratorBase(Module, metaclass=_PostInitInjectionMetaClass):
     """Base class for generating random augmentation parameters."""
 
     device: Optional[Device] = None

--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -196,8 +196,11 @@ def _adapted_rsampling(
     If same_on_batch is True, all values generated will be exactly same given a batch_size (shape[0]). By default,
     same_on_batch is set to False.
     """
+    if isinstance(shape, tuple):
+        shape = torch.Size(shape)
+
     if same_on_batch:
-        return dist.rsample((1, *shape[1:])).repeat(shape[0], *[1] * (len(shape) - 1))
+        return dist.rsample(torch.Size((1, *shape[1:]))).repeat(shape[0], *[1] * (len(shape) - 1))
     return dist.rsample(shape)
 
 
@@ -209,8 +212,11 @@ def _adapted_sampling(
     If same_on_batch is True, all values generated will be exactly same given a batch_size (shape[0]). By default,
     same_on_batch is set to False.
     """
+    if isinstance(shape, tuple):
+        shape = torch.Size(shape)
+
     if same_on_batch:
-        return dist.sample((1, *shape[1:])).repeat(shape[0], *[1] * (len(shape) - 1))
+        return dist.sample(torch.Size((1, *shape[1:]))).repeat(shape[0], *[1] * (len(shape) - 1))
     return dist.sample(shape)
 
 

--- a/kornia/color/hls.py
+++ b/kornia/color/hls.py
@@ -1,10 +1,12 @@
 import math
+from typing import Tuple
 
 import torch
-import torch.nn as nn
+
+from kornia.core import Module, Tensor, stack, tensor, where
 
 
-def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+def rgb_to_hls(image: Tensor, eps: float = 1e-8) -> Tensor:
     r"""Convert a RGB image to HLS.
 
     .. image:: _static/img/rgb_to_hls.png
@@ -24,30 +26,19 @@ def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
         >>> input = torch.rand(2, 3, 4, 5)
         >>> output = rgb_to_hls(input)  # 2x3x4x5
     """
-    if not isinstance(image, torch.Tensor):
-        raise TypeError(f"Input type is not a torch.Tensor. Got {type(image)}")
+    if not isinstance(image, Tensor):
+        raise TypeError(f"Input type is not a Tensor. Got {type(image)}")
 
     if len(image.shape) < 3 or image.shape[-3] != 3:
         raise ValueError(f"Input size must have a shape of (*, 3, H, W). Got {image.shape}")
 
-    if not torch.jit.is_scripting():
-        # weird way to use globals compiling with JIT even in the code not used by JIT...
-        # __setattr__ can be removed if pytorch version is > 1.6.0 and then use:
-        # rgb_to_hls.RGB2HSL_IDX = hls_to_rgb.RGB2HSL_IDX.to(image.device)
-        rgb_to_hls.__setattr__('RGB2HSL_IDX', rgb_to_hls.RGB2HSL_IDX.to(image))  # type: ignore
-        _RGB2HSL_IDX: torch.Tensor = rgb_to_hls.RGB2HSL_IDX  # type: ignore
-    else:
-        _RGB2HSL_IDX = torch.tensor([[[0.0]], [[1.0]], [[2.0]]], device=image.device, dtype=image.dtype)  # 3x1x1
+    _RGB2HSL_IDX = tensor([[[0.0]], [[1.0]], [[2.0]]], device=image.device, dtype=image.dtype)  # 3x1x1
 
-    # maxc: torch.Tensor  # not supported by JIT
-    # imax: torch.Tensor  # not supported by JIT
-    maxc, imax = image.max(-3)
-    minc: torch.Tensor = image.min(-3)[0]
+    _img_max: Tuple[Tensor, Tensor] = image.max(-3)
+    maxc = _img_max[0]
+    imax = _img_max[1]
+    minc: Tensor = image.min(-3)[0]
 
-    # h: torch.Tensor  # not supported by JIT
-    # l: torch.Tensor  # not supported by JIT
-    # s: torch.Tensor  # not supported by JIT
-    # image_hls: torch.Tensor  # not supported by JIT
     if image.requires_grad:
         l_ = maxc + minc
         s = maxc - minc
@@ -67,20 +58,20 @@ def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
         torch.sub(maxc, minc, out=s)  # s = max - min
 
     # precompute image / (max - min)
-    im: torch.Tensor = image / (s + eps).unsqueeze(-3)
+    im = image / (s + eps).unsqueeze(-3)
 
     # epsilon cannot be inside the torch.where to avoid precision issues
-    s /= torch.where(l_ < 1.0, l_, 2.0 - l_) + eps  # saturation
+    s /= where(l_ < 1.0, l_, 2.0 - l_) + eps  # saturation
     l_ /= 2  # luminance
 
     # note that r,g and b were previously div by (max - min)
-    r: torch.Tensor = torch.select(im, -3, 0)
-    g: torch.Tensor = torch.select(im, -3, 1)
-    b: torch.Tensor = torch.select(im, -3, 2)
+    r = torch.select(im, -3, 0)
+    g = torch.select(im, -3, 1)
+    b = torch.select(im, -3, 2)
     # h[imax == 0] = (((g - b) / (max - min)) % 6)[imax == 0]
     # h[imax == 1] = (((b - r) / (max - min)) + 2)[imax == 1]
     # h[imax == 2] = (((r - g) / (max - min)) + 4)[imax == 2]
-    cond: torch.Tensor = imax.unsqueeze(-3) == _RGB2HSL_IDX
+    cond = imax.unsqueeze(-3) == _RGB2HSL_IDX
     if image.requires_grad:
         h = torch.mul((g - b) % 6, torch.select(cond, -3, 0))
     else:
@@ -91,11 +82,11 @@ def rgb_to_hls(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     h *= math.pi / 3.0  # hue [0, 2*pi]
 
     if image.requires_grad:
-        return torch.stack([h, l_, s], dim=-3)
+        return stack([h, l_, s], -3)
     return image_hls
 
 
-def hls_to_rgb(image: torch.Tensor) -> torch.Tensor:
+def hls_to_rgb(image: Tensor) -> Tensor:
     r"""Convert a HLS image to RGB.
 
     The image data is assumed to be in the range of (0, 1).
@@ -110,45 +101,32 @@ def hls_to_rgb(image: torch.Tensor) -> torch.Tensor:
         >>> input = torch.rand(2, 3, 4, 5)
         >>> output = hls_to_rgb(input)  # 2x3x4x5
     """
-    if not isinstance(image, torch.Tensor):
-        raise TypeError(f"Input type is not a torch.Tensor. Got {type(image)}")
+    if not isinstance(image, Tensor):
+        raise TypeError(f"Input type is not a Tensor. Got {type(image)}")
 
     if len(image.shape) < 3 or image.shape[-3] != 3:
         raise ValueError(f"Input size must have a shape of (*, 3, H, W). Got {image.shape}")
 
-    if not torch.jit.is_scripting():
-        # weird way to use globals compiling with JIT even in the code not used by JIT...
-        # __setattr__ can be removed if pytorch version is > 1.6.0 and then use:
-        # hls_to_rgb.HLS2RGB = hls_to_rgb.HLS2RGB.to(image.device)
-        hls_to_rgb.__setattr__('HLS2RGB', hls_to_rgb.HLS2RGB.to(image))  # type: ignore
-        _HLS2RGB: torch.Tensor = hls_to_rgb.HLS2RGB  # type: ignore
-    else:
-        _HLS2RGB = torch.tensor([[[0.0]], [[8.0]], [[4.0]]], device=image.device, dtype=image.dtype)  # 3x1x1
+    _HLS2RGB = tensor([[[0.0]], [[8.0]], [[4.0]]], device=image.device, dtype=image.dtype)  # 3x1x1
 
-    im: torch.Tensor = image.unsqueeze(-4)
-    h: torch.Tensor = torch.select(im, -3, 0)
-    l: torch.Tensor = torch.select(im, -3, 1)
-    s: torch.Tensor = torch.select(im, -3, 2)
+    im: Tensor = image.unsqueeze(-4)
+    h: Tensor = torch.select(im, -3, 0)
+    l: Tensor = torch.select(im, -3, 1)
+    s: Tensor = torch.select(im, -3, 2)
     h = h * (6 / math.pi)  # h * 360 / (2 * math.pi) / 30
     a = s * torch.min(l, 1.0 - l)
 
     # kr = (0 + h) % 12
     # kg = (8 + h) % 12
     # kb = (4 + h) % 12
-    k: torch.Tensor = (h + _HLS2RGB) % 12
+    k: Tensor = (h + _HLS2RGB) % 12
 
     # l - a * max(min(min(k - 3.0, 9.0 - k), 1), -1)
     mink = torch.min(k - 3.0, 9.0 - k)
     return torch.addcmul(l, a, mink.clamp_(min=-1.0, max=1.0), value=-1)
 
 
-# tricks to speed up a little bit the conversions by presetting small tensors
-# (in the functions they are moved to the proper device)
-hls_to_rgb.__setattr__('HLS2RGB', torch.tensor([[[0.0]], [[8.0]], [[4.0]]]))  # 3x1x1
-rgb_to_hls.__setattr__('RGB2HSL_IDX', torch.tensor([[[0.0]], [[1.0]], [[2.0]]]))  # 3x1x1
-
-
-class RgbToHls(nn.Module):
+class RgbToHls(Module):
     r"""Convert an image from RGB to HLS.
 
     The image data is assumed to be in the range of (0, 1).
@@ -166,11 +144,11 @@ class RgbToHls(nn.Module):
         >>> output = hls(input)  # 2x3x4x5
     """
 
-    def forward(self, image: torch.Tensor) -> torch.Tensor:
+    def forward(self, image: Tensor) -> Tensor:
         return rgb_to_hls(image)
 
 
-class HlsToRgb(nn.Module):
+class HlsToRgb(Module):
     r"""Convert an image from HLS to RGB.
 
     The image data is assumed to be in the range of (0, 1).
@@ -191,5 +169,5 @@ class HlsToRgb(nn.Module):
         >>> output = rgb(input)  # 2x3x4x5
     """
 
-    def forward(self, image: torch.Tensor) -> torch.Tensor:
+    def forward(self, image: Tensor) -> Tensor:
         return hls_to_rgb(image)

--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -128,6 +128,7 @@ class ScaleSpaceDetector(Module):
     def detect(self, img: Tensor, num_feats: int, mask: Optional[Tensor] = None) -> Tuple[Tensor, Tensor]:
         dev: Device = img.device
         dtype: torch.dtype = img.dtype
+        sigmas: List[Tensor]
         sp, sigmas, _ = self.scale_pyr(img)
         all_responses: List[Tensor] = []
         all_lafs: List[Tensor] = []
@@ -144,7 +145,7 @@ class ScaleSpaceDetector(Module):
                 # We want nms for scale responses, so reorder to (B, CH, L, H, W)
                 oct_resp = oct_resp.permute(0, 2, 1, 3, 4)
                 # 3rd extra level is required for DoG only
-                if self.scale_pyr.extra_levels % 2 != 0:  # type: ignore
+                if isinstance(self.scale_pyr.extra_levels, Tensor) and self.scale_pyr.extra_levels % 2 != 0:
                     oct_resp = oct_resp[:, :, :-1]
 
             if mask is not None:
@@ -152,6 +153,8 @@ class ScaleSpaceDetector(Module):
                 oct_resp = oct_mask * oct_resp
 
             # Differentiable nms
+            coord_max: Tensor
+            response_max: Tensor
             coord_max, response_max = self.nms(oct_resp)
             if self.minima_are_also_good:
                 coord_min, response_min = self.nms(-oct_resp)
@@ -172,9 +175,18 @@ class ScaleSpaceDetector(Module):
             B, N = resp_flat_best.size()
 
             # Converts scale level index from ConvSoftArgmax3d to the actual scale, using the sigmas
-            max_coords_best = _scale_index_to_scale(
-                max_coords_best, sigmas_oct, self.scale_pyr.n_levels  # type: ignore
-            )
+
+            if isinstance(self.scale_pyr.n_levels, Tensor):
+                num_levels = int(self.scale_pyr.n_levels.item())
+            elif isinstance(self.scale_pyr.n_levels, int):
+                num_levels = self.scale_pyr.n_levels
+            else:
+                raise TypeError(
+                    'Expected the scale pyramid module to have `n_levels` as a Tensor or int.'
+                    f'Gotcha {type(self.scale_pyr.n_leve)}'
+                )
+
+            max_coords_best = _scale_index_to_scale(max_coords_best, sigmas_oct, num_levels)
 
             # Create local affine frames (LAFs)
             rotmat = eye(2, dtype=dtype, device=dev).view(1, 1, 2, 2)

--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -183,7 +183,7 @@ class ScaleSpaceDetector(Module):
             else:
                 raise TypeError(
                     'Expected the scale pyramid module to have `n_levels` as a Tensor or int.'
-                    f'Gotcha {type(self.scale_pyr.n_leve)}'
+                    f'Gotcha {type(self.scale_pyr.n_levels)}'
                 )
 
             max_coords_best = _scale_index_to_scale(max_coords_best, sigmas_oct, num_levels)

--- a/kornia/geometry/epipolar/projection.py
+++ b/kornia/geometry/epipolar/projection.py
@@ -49,7 +49,7 @@ def random_intrinsics(low: Union[float, torch.Tensor], high: Union[float, torch.
         the random camera matrix with the shape of :math:`(1, 3, 3)`.
     """
     sampler = torch.distributions.Uniform(low, high)
-    fx, fy, cx, cy = (sampler.sample((1,)) for _ in range(4))
+    fx, fy, cx, cy = (sampler.sample(torch.Size((1,))) for _ in range(4))
     zeros, ones = torch.zeros_like(fx), torch.ones_like(fx)
     camera_matrix: torch.Tensor = torch.cat([fx, zeros, cx, zeros, fy, cy, zeros, zeros, ones])
     return camera_matrix.view(1, 3, 3)

--- a/kornia/geometry/ransac.py
+++ b/kornia/geometry/ransac.py
@@ -1,6 +1,6 @@
 """Module containing RANSAC modules."""
 import math
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import torch
 
@@ -54,23 +54,28 @@ class RANSAC(Module):
         self.confidence = confidence
         self.max_lo_iters = max_lo_iters
         self.model_type = model_type
+
+        self.error_fn: Callable[..., Tensor]
+        self.minimal_solver: Callable[..., Tensor]
+        self.polisher_solver: Callable[..., Tensor]
+
         if model_type == 'homography':
             self.error_fn = oneway_transfer_error
             self.minimal_solver = find_homography_dlt
             self.polisher_solver = find_homography_dlt_iterated
             self.minimal_sample_size = 4
         elif model_type == 'homography_from_linesegments':
-            self.error_fn = line_segment_transfer_error_one_way  # type: ignore
-            self.minimal_solver = find_homography_lines_dlt  # type: ignore
-            self.polisher_solver = find_homography_lines_dlt_iterated  # type: ignore
+            self.error_fn = line_segment_transfer_error_one_way
+            self.minimal_solver = find_homography_lines_dlt
+            self.polisher_solver = find_homography_lines_dlt_iterated
             self.minimal_sample_size = 4
         elif model_type == 'fundamental':
-            self.error_fn = symmetrical_epipolar_distance  # type: ignore
-            self.minimal_solver = find_fundamental  # type: ignore
+            self.error_fn = symmetrical_epipolar_distance
+            self.minimal_solver = find_fundamental
             self.minimal_sample_size = 8
             # ToDo: implement 7pt solver instead of 8pt minimal_solver
             # https://github.com/opencv/opencv/blob/master/modules/calib3d/src/fundam.cpp#L498
-            self.polisher_solver = find_fundamental  # type: ignore
+            self.polisher_solver = find_fundamental
         else:
             raise NotImplementedError(f"{model_type} is unknown. Try one of {self.supported_models}")
 

--- a/kornia/geometry/subpix/nms.py
+++ b/kornia/geometry/subpix/nms.py
@@ -26,6 +26,7 @@ def _get_nms_kernel3d(kd: int, ky: int, kx: int) -> Tensor:
 
 class NonMaximaSuppression2d(Module):
     r"""Apply non maxima suppression to filter."""
+    kernel: Tensor
 
     def __init__(self, kernel_size: Tuple[int, int]):
         super().__init__()
@@ -55,7 +56,7 @@ class NonMaximaSuppression2d(Module):
         B, CH, HP, WP = x_padded.size()
 
         max_non_center = (
-            F.conv2d(x_padded.view(B * CH, 1, HP, WP), self.kernel.to(x.device, x.dtype), stride=1)  # type: ignore
+            F.conv2d(x_padded.view(B * CH, 1, HP, WP), self.kernel.to(x.device, x.dtype), stride=1)
             .view(B, CH, -1, H, W)
             .max(dim=2)[0]
         )

--- a/kornia/geometry/transform/crop2d.py
+++ b/kornia/geometry/transform/crop2d.py
@@ -325,7 +325,7 @@ def crop_by_indices(
         == len(y2.unique(sorted=False))
         == 1
     ):
-        out = input_tensor[..., y1[0] : y2[0], x1[0] : x2[0]]  # type: ignore[misc]
+        out = input_tensor[..., int(y1[0]) : int(y2[0]), int(x1[0]) : int(x2[0])]
         if size is not None and out.shape[-2:] != size:
             return resize(
                 out, size, interpolation=interpolation, align_corners=align_corners, side="short", antialias=antialias
@@ -337,7 +337,7 @@ def crop_by_indices(
     out = torch.empty(B, C, *size, device=input_tensor.device, dtype=input_tensor.dtype)
     # Find out the cropped shapes that need to be resized.
     for i, _ in enumerate(out):
-        _out = input_tensor[i : i + 1, :, y1[i] : y2[i], x1[i] : x2[i]]  # type: ignore[misc]
+        _out = input_tensor[i : i + 1, :, int(y1[i]) : int(y2[i]), int(x1[i]) : int(x2[i])]
         if _out.shape[-2:] != size:
             if shape_compensation == "resize":
                 out[i] = resize(

--- a/kornia/geometry/transform/pyramid.py
+++ b/kornia/geometry/transform/pyramid.py
@@ -166,7 +166,7 @@ class ScalePyramid(Module):
             ksize += 1
         return ksize
 
-    def get_first_level(self, input):
+    def get_first_level(self, input: Tensor) -> Tuple[Tensor, float, float]:
         pixel_distance = 1.0
         cur_sigma = 0.5
         # Same as in OpenCV up to interpolation difference
@@ -176,6 +176,7 @@ class ScalePyramid(Module):
             cur_sigma *= 2.0
         else:
             x = input
+
         if self.init_sigma > cur_sigma:
             sigma = max(math.sqrt(self.init_sigma**2 - cur_sigma**2), 0.01)
             ksize = self.get_kernel_size(sigma)
@@ -223,9 +224,10 @@ class ScalePyramid(Module):
             sigmas.append(cur_sigma * torch.ones(bs, self.n_levels + self.extra_levels).to(x.device))
             pixel_dists.append(pixel_distance * torch.ones(bs, self.n_levels + self.extra_levels).to(x.device))
             oct_idx += 1
-        for i in range(len(pyr)):
-            pyr[i] = stack(pyr[i], 2)  # type: ignore
-        return pyr, sigmas, pixel_dists
+
+        output_pyr = [stack(i, 2) for i in pyr]
+
+        return output_pyr, sigmas, pixel_dists
 
 
 def pyrdown(input: Tensor, border_type: str = 'reflect', align_corners: bool = False, factor: float = 2.0) -> Tensor:

--- a/kornia/losses/hausdorff.py
+++ b/kornia/losses/hausdorff.py
@@ -3,6 +3,8 @@ from typing import Callable
 import torch
 import torch.nn as nn
 
+from kornia.core import Tensor, as_tensor, stack, tensor, where, zeros_like
+
 
 class _HausdorffERLossBase(torch.jit.ScriptModule):
     """Base class for binary Hausdorff loss based on morphological erosion.
@@ -33,15 +35,15 @@ class _HausdorffERLossBase(torch.jit.ScriptModule):
         self.reduction = reduction
         self.register_buffer("kernel", self.get_kernel())
 
-    def get_kernel(self) -> torch.Tensor:
+    def get_kernel(self) -> Tensor:
         """Get kernel for image morphology convolution."""
         raise NotImplementedError
 
-    def perform_erosion(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    def perform_erosion(self, pred: Tensor, target: Tensor) -> Tensor:
         bound = (pred - target) ** 2
 
-        kernel = torch.as_tensor(self.kernel, device=pred.device, dtype=pred.dtype)
-        eroded = torch.zeros_like(bound, device=pred.device, dtype=pred.dtype)
+        kernel = as_tensor(self.kernel, device=pred.device, dtype=pred.dtype)
+        eroded = zeros_like(bound, device=pred.device, dtype=pred.dtype)
         mask = torch.ones_like(bound, device=pred.device, dtype=torch.bool)
 
         # Same padding, assuming kernel is odd and square (cube) shaped.
@@ -65,7 +67,7 @@ class _HausdorffERLossBase(torch.jit.ScriptModule):
                 #       erosion[to_norm] = (erosion[to_norm] - erosion_min[to_norm]) / (
                 #           erosion_max[to_norm] - erosion_min[to_norm])
                 _erosion_to_fill = (erosion - erosion_min) / (erosion_max - erosion_min)
-                erosion = torch.where(mask * _to_norm, _erosion_to_fill, erosion)
+                erosion = where(mask * _to_norm, _erosion_to_fill, erosion)
 
             # save erosion and add to loss
             eroded = eroded + erosion * (k + 1) ** self.alpha
@@ -74,7 +76,7 @@ class _HausdorffERLossBase(torch.jit.ScriptModule):
         return eroded
 
     # NOTE: we add type ignore because the forward pass does not work well with subclassing
-    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:  # type: ignore
+    def forward(self, pred: Tensor, target: Tensor) -> Tensor:  # type: ignore[override]
         """Compute Hausdorff loss.
 
         Args:
@@ -94,14 +96,14 @@ class _HausdorffERLossBase(torch.jit.ScriptModule):
         if pred.size(1) < target.max().item():
             raise ValueError("Invalid target value.")
 
-        out = torch.stack(
+        out = stack(
             [
                 self.perform_erosion(
                     pred[:, i : i + 1],
-                    torch.where(
+                    where(
                         target == i,
-                        torch.tensor(1, device=target.device, dtype=target.dtype),
-                        torch.tensor(0, device=target.device, dtype=target.dtype),
+                        tensor(1, device=target.device, dtype=target.dtype),
+                        tensor(0, device=target.device, dtype=target.dtype),
                     ),
                 )
                 for i in range(pred.size(1))
@@ -159,14 +161,14 @@ class HausdorffERLoss(_HausdorffERLossBase):
     conv = torch.conv2d
     max_pool = nn.AdaptiveMaxPool2d(1)
 
-    def get_kernel(self) -> torch.Tensor:
+    def get_kernel(self) -> Tensor:
         """Get kernel for image morphology convolution."""
-        cross = torch.tensor([[[0, 1, 0], [1, 1, 1], [0, 1, 0]]])
+        cross = tensor([[[0, 1, 0], [1, 1, 1], [0, 1, 0]]])
         kernel = cross * 0.2
         return kernel[None]
 
     # NOTE: we add type ignore because the forward pass does not work well with subclassing
-    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:  # type: ignore
+    def forward(self, pred: Tensor, target: Tensor) -> Tensor:  # type: ignore[override]
         """Compute Hausdorff loss.
 
         Args:
@@ -226,18 +228,18 @@ class HausdorffERLoss3D(_HausdorffERLossBase):
     conv = torch.conv3d
     max_pool = nn.AdaptiveMaxPool3d(1)
 
-    def get_kernel(self) -> torch.Tensor:
+    def get_kernel(self) -> Tensor:
         """Get kernel for image morphology convolution."""
-        cross = torch.tensor([[[0, 1, 0], [1, 1, 1], [0, 1, 0]]])
-        bound = torch.tensor([[[0, 0, 0], [0, 1, 0], [0, 0, 0]]])
+        cross = tensor([[[0, 1, 0], [1, 1, 1], [0, 1, 0]]])
+        bound = tensor([[[0, 0, 0], [0, 1, 0], [0, 0, 0]]])
         # NOTE: The original repo claimed it shaped as (3, 1, 3, 3)
         #    which Jian suspect it is wrongly implemented.
         # https://github.com/PatRyg99/HausdorffLoss/blob/9f580acd421af648e74b45d46555ccb7a876c27c/hausdorff_loss.py#L94
-        kernel = torch.stack([bound, cross, bound], dim=1) * (1 / 7)
+        kernel = stack([bound, cross, bound], 1) * (1 / 7)
         return kernel[None]
 
     # NOTE: we add type ignore because the forward pass does not work well with subclassing
-    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:  # type: ignore
+    def forward(self, pred: Tensor, target: Tensor) -> Tensor:  # type: ignore[override]
         """Compute 3D Hausdorff loss.
 
         Args:

--- a/kornia/tracking/planar_tracker.py
+++ b/kornia/tracking/planar_tracker.py
@@ -1,8 +1,8 @@
 from typing import Dict, Optional, Tuple
 
 import torch
-import torch.nn as nn
 
+from kornia.core import Module, Tensor
 from kornia.feature import DescriptorMatcher, GFTTAffNetHardNet, LocalFeatureMatcher, LoFTR
 from kornia.feature.integrated import LocalFeature
 from kornia.geometry.linalg import transform_points
@@ -10,7 +10,7 @@ from kornia.geometry.ransac import RANSAC
 from kornia.geometry.transform import warp_perspective
 
 
-class HomographyTracker(nn.Module):
+class HomographyTracker(Module):
     r"""Module, which performs local-feature-based tracking of the target planar object in the sequence of the
     frames.
 
@@ -26,8 +26,8 @@ class HomographyTracker(nn.Module):
     def __init__(
         self,
         initial_matcher: Optional[LocalFeature] = None,
-        fast_matcher: Optional[nn.Module] = None,
-        ransac: Optional[nn.Module] = None,
+        fast_matcher: Optional[Module] = None,
+        ransac: Optional[Module] = None,
         minimum_inliers_num: int = 30,
     ) -> None:
         super().__init__()
@@ -39,10 +39,10 @@ class HomographyTracker(nn.Module):
         self.minimum_inliers_num = minimum_inliers_num
 
         # placeholders
-        self.target: torch.Tensor
-        self.target_initial_representation: Dict[str, torch.Tensor] = {}
-        self.target_fast_representation: Dict[str, torch.Tensor] = {}
-        self.previous_homography: Optional[torch.Tensor] = None
+        self.target: Tensor
+        self.target_initial_representation: Dict[str, Tensor] = {}
+        self.target_fast_representation: Dict[str, Tensor] = {}
+        self.previous_homography: Optional[Tensor] = None
 
         self.inliers_num: int = 0
         self.keypoints0_num: int = 0
@@ -59,32 +59,34 @@ class HomographyTracker(nn.Module):
         return self.target.dtype
 
     @torch.no_grad()
-    def set_target(self, target: torch.Tensor) -> None:
+    def set_target(self, target: Tensor) -> None:
         self.target = target
         self.target_initial_representation = {}
         self.target_fast_representation = {}
-        if hasattr(self.initial_matcher, 'extract_features'):
-            self.target_initial_representation = self.initial_matcher.extract_features(target)  # type: ignore
-        if hasattr(self.fast_matcher, 'extract_features'):
-            self.target_fast_representation = self.fast_matcher.extract_features(target)  # type: ignore
+        if hasattr(self.initial_matcher, 'extract_features') and isinstance(
+            self.initial_matcher.extract_features, Module
+        ):
+            self.target_initial_representation = self.initial_matcher.extract_features(target)
+        if hasattr(self.fast_matcher, 'extract_features') and isinstance(self.fast_matcher.extract_features, Module):
+            self.target_fast_representation = self.fast_matcher.extract_features(target)
 
     def reset_tracking(self) -> None:
         self.previous_homography = None
 
-    def no_match(self) -> Tuple[torch.Tensor, bool]:
+    def no_match(self) -> Tuple[Tensor, bool]:
         self.inliers_num = 0
         self.keypoints0_num = 0
         self.keypoints1_num = 0
         return torch.empty(3, 3, device=self.device, dtype=self.dtype), False
 
-    def match_initial(self, x: torch.Tensor) -> Tuple[torch.Tensor, bool]:
+    def match_initial(self, x: Tensor) -> Tuple[Tensor, bool]:
         """The frame `x` is matched with initial_matcher and  verified with ransac."""
-        input_dict: Dict[str, torch.Tensor] = {"image0": self.target, "image1": x}
+        input_dict: Dict[str, Tensor] = {"image0": self.target, "image1": x}
 
         for k, v in self.target_initial_representation.items():
             input_dict[f'{k}0'] = v
 
-        match_dict: Dict[str, torch.Tensor] = self.initial_matcher(input_dict)
+        match_dict: Dict[str, Tensor] = self.initial_matcher(input_dict)
         keypoints0 = match_dict['keypoints0'][match_dict['batch_indexes'] == 0]
         keypoints1 = match_dict['keypoints1'][match_dict['batch_indexes'] == 0]
 
@@ -103,7 +105,7 @@ class HomographyTracker(nn.Module):
 
         return H, True
 
-    def track_next_frame(self, x: torch.Tensor) -> Tuple[torch.Tensor, bool]:
+    def track_next_frame(self, x: Tensor) -> Tuple[Tensor, bool]:
         """The frame `x` is prewarped according to the previous frame homography, matched with fast_matcher
         verified with ransac."""
         if self.previous_homography is not None:  # mypy, shut up
@@ -114,7 +116,7 @@ class HomographyTracker(nn.Module):
         Hinv = torch.inverse(Hwarp)
         h, w = self.target.shape[2:]
         frame_warped = warp_perspective(x, Hinv, (h, w))
-        input_dict: Dict[str, torch.Tensor] = {"image0": self.target, "image1": frame_warped}
+        input_dict: Dict[str, Tensor] = {"image0": self.target, "image1": frame_warped}
         for k, v in self.target_fast_representation.items():
             input_dict[f'{k}0'] = v
 
@@ -140,7 +142,7 @@ class HomographyTracker(nn.Module):
         self.previous_homography = H.clone()
         return H, True
 
-    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, bool]:
+    def forward(self, x: Tensor) -> Tuple[Tensor, bool]:
         if self.previous_homography is not None:
             return self.track_next_frame(x)
         return self.match_initial(x)

--- a/kornia/x/utils.py
+++ b/kornia/x/utils.py
@@ -2,11 +2,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict
 
-import torch.nn as nn
-
+from kornia.core import Module
 from kornia.metrics.average_meter import AverageMeter
 
-# import yaml  # type: ignore
+# import yaml
 
 
 class TrainerState(Enum):
@@ -39,8 +38,8 @@ class Configuration:
     #     return cls(**data)
 
 
-class Lambda(nn.Module):
-    """Module to create a lambda function as nn.Module.
+class Lambda(Module):
+    """Module to create a lambda function as Module.
 
     Args:
         fcn: a pointer to any function.

--- a/test/geometry/test_boxes.py
+++ b/test/geometry/test_boxes.py
@@ -150,19 +150,19 @@ class TestBoxes2D:
         boxes_vertices = box.to_tensor(mode='vertices')
         boxes_vertices_plus = box.to_tensor(mode='vertices_plus')
 
-        assert boxes_xyxy.shape == expected_box_xyxy.shape  # type: ignore
+        assert boxes_xyxy.shape == expected_box_xyxy.shape
         assert_allclose(boxes_xyxy, expected_box_xyxy)
 
-        assert boxes_xyxy_plus.shape == expected_box_xyxy_plus.shape  # type: ignore
+        assert boxes_xyxy_plus.shape == expected_box_xyxy_plus.shape
         assert_allclose(boxes_xyxy_plus, expected_box_xyxy_plus)
 
-        assert boxes_xywh.shape == expected_box_xywh.shape  # type: ignore
+        assert boxes_xywh.shape == expected_box_xywh.shape
         assert_allclose(boxes_xywh, expected_box_xywh)
 
-        assert boxes_vertices.shape == expected_vertices.shape  # type: ignore
+        assert boxes_vertices.shape == expected_vertices.shape
         assert_allclose(boxes_vertices, expected_vertices)
 
-        assert boxes_vertices_plus.shape == expected_vertices_plus.shape  # type: ignore
+        assert boxes_vertices_plus.shape == expected_vertices_plus.shape
         assert_allclose(boxes_vertices_plus, expected_vertices_plus)
 
     @pytest.mark.parametrize('mode', ['xyxy', 'xyxy_plus', 'xywh', 'vertices', 'vertices_plus'])


### PR DESCRIPTION
Closes #1992 -- this patch should remove the `# type: ignore` from the codebase, just in methods of a specific we need the `# type: ignore[override]`

