### PR TITLE
facedetector now returns a list of tensors containing the boxes x image

### DIFF
--- a/examples/face_detection/main.py
+++ b/examples/face_detection/main.py
@@ -51,7 +51,7 @@ def my_app(args):
 
     with torch.no_grad():
         dets = face_detection(img)
-    dets = [FaceDetectorResult(o) for o in dets]
+    dets = [FaceDetectorResult(o) for o in dets[0]]
 
     # show image
 

--- a/examples/face_detection/main_video.py
+++ b/examples/face_detection/main_video.py
@@ -65,7 +65,7 @@ def my_app():
         # detect !
         with torch.no_grad():
             dets = face_detection(img)
-        dets = [FaceDetectorResult(o) for o in dets]
+        dets = [FaceDetectorResult(o) for o in dets[0]]
 
         fps: float = cv2.getTickFrequency() / (cv2.getTickCount() - start)
 

--- a/kornia/contrib/face_detection.py
+++ b/kornia/contrib/face_detection.py
@@ -213,10 +213,10 @@ class FaceDetector(nn.Module):
         r"""Detect faces in a given batch of images.
 
         Args:
-            image (torch.Tensor): batch of images :math:`(B,3,H,W)`
+            image: batch of images :math:`(B,3,H,W)`
 
         Return:
-            List[torch.Tensor]: list with the boxes found on each image. :math:`Bx(N,15)`
+            List[torch.Tensor]: list with the boxes found on each image. :math:`Bx(N,15)`.
 
         """
         img = self.preprocess(image)
@@ -326,11 +326,7 @@ class YuFaceDetectNet(nn.Module):
         loc_data, conf_data, iou_data = head_data.split((14, 2, 1), dim=-1)
 
         if self.phase == "test":
-            # trick to make it work with batches
-            # loc_data = loc_data.view(-1, 14)
-            # conf_data = torch.softmax(conf_data.view(-1, self.num_classes), dim=-1)
             conf_data = torch.softmax(conf_data, dim=-1)
-            # iou_data = iou_data.view(-1, 1)
         else:
             loc_data = loc_data.view(loc_data.size(0), -1, 14)
             conf_data = conf_data.view(conf_data.size(0), -1, self.num_classes)

--- a/kornia/contrib/face_detection.py
+++ b/kornia/contrib/face_detection.py
@@ -210,6 +210,15 @@ class FaceDetector(nn.Module):
         return batched_dets
 
     def forward(self, image: torch.Tensor) -> List[torch.Tensor]:
+        r"""Detect faces in a given batch of images.
+
+        Args:
+            image (torch.Tensor): batch of images :math:`(B,3,H,W)`
+
+        Return:
+            List[torch.Tensor]: list with the boxes found on each image. :math:`Bx(N,15)`
+
+        """
         img = self.preprocess(image)
         out = self.model(img)
         return self.postprocess(out, img.shape[-2], img.shape[-1])

--- a/kornia/contrib/face_detection.py
+++ b/kornia/contrib/face_detection.py
@@ -217,7 +217,6 @@ class FaceDetector(nn.Module):
 
         Return:
             List[torch.Tensor]: list with the boxes found on each image. :math:`Bx(N,15)`.
-
         """
         img = self.preprocess(image)
         out = self.model(img)

--- a/kornia/contrib/face_detection.py
+++ b/kornia/contrib/face_detection.py
@@ -136,7 +136,7 @@ class FaceDetector(nn.Module):
         keep_top_k: the maximum number of detections to return after the nms.
 
     Return:
-        A tensor of shape :math:`(N,15)` to be used with :py:class:`kornia.contrib.FaceDetectorResult`.
+        A list of B tensors with shape :math:`(N,15)` to be used with :py:class:`kornia.contrib.FaceDetectorResult`.
 
     Example:
         >>> img = torch.rand(1, 3, 320, 320)
@@ -169,7 +169,7 @@ class FaceDetector(nn.Module):
     def preprocess(self, image: torch.Tensor) -> torch.Tensor:
         return image
 
-    def postprocess(self, data: Dict[str, torch.Tensor], height: int, width: int) -> torch.Tensor:
+    def postprocess(self, data: Dict[str, torch.Tensor], height: int, width: int) -> List[torch.Tensor]:
         loc, conf, iou = data['loc'], data['conf'], data['iou']
 
         scale = torch.tensor(
@@ -181,32 +181,35 @@ class FaceDetector(nn.Module):
         priors = _PriorBox(self.min_sizes, self.steps, self.clip, image_size=(height, width))
         priors = priors.to(loc.device, loc.dtype)
 
-        boxes = _decode(loc, priors(), self.variance)  # Nx14
-        boxes = boxes * scale
+        batched_dets: List[torch.Tensor] = []
+        for batch_elem in range(loc.shape[0]):
+            boxes = _decode(loc[batch_elem], priors(), self.variance)  # Nx14
+            boxes = boxes * scale
 
-        # clamp here for the compatibility for ONNX
-        cls_scores, iou_scores = conf[:, 1], iou[:, 0]
-        scores = (cls_scores * iou_scores.clamp(0.0, 1.0)).sqrt()
+            # clamp here for the compatibility for ONNX
+            cls_scores, iou_scores = conf[batch_elem, :, 1], iou[batch_elem, :, 0]
+            scores = (cls_scores * iou_scores.clamp(0.0, 1.0)).sqrt()
 
-        # ignore low scores
-        inds = scores > self.confidence_threshold
-        boxes, scores = boxes[inds], scores[inds]
+            # ignore low scores
+            inds = scores > self.confidence_threshold
+            boxes, scores = boxes[inds], scores[inds]
 
-        # keep top-K before NMS
-        order = scores.sort(descending=True)[1][: self.top_k]
-        boxes, scores = boxes[order], scores[order]
+            # keep top-K before NMS
+            order = scores.sort(descending=True)[1][: self.top_k]
+            boxes, scores = boxes[order], scores[order]
 
-        # performd NMS
-        # NOTE: nms need to be revise since does not export well to onnx
-        dets = torch.cat((boxes, scores[:, None]), dim=-1)  # Nx15
-        keep = self.nms(boxes[:, :4], scores, self.nms_threshold)
-        if len(keep) > 0:
-            dets = dets[keep, :]
+            # performd NMS
+            # NOTE: nms need to be revise since does not export well to onnx
+            dets = torch.cat((boxes, scores[:, None]), dim=-1)  # Nx15
+            keep = self.nms(boxes[:, :4], scores, self.nms_threshold)
+            if len(keep) > 0:
+                dets = dets[keep, :]
 
-        # keep top-K faster NMS
-        return dets[: self.keep_top_k]
+            # keep top-K faster NMS
+            batched_dets.append(dets[: self.keep_top_k])
+        return batched_dets
 
-    def forward(self, image: torch.Tensor) -> torch.Tensor:
+    def forward(self, image: torch.Tensor) -> List[torch.Tensor]:
         img = self.preprocess(image)
         out = self.model(img)
         return self.postprocess(out, img.shape[-2], img.shape[-1])
@@ -314,9 +317,11 @@ class YuFaceDetectNet(nn.Module):
         loc_data, conf_data, iou_data = head_data.split((14, 2, 1), dim=-1)
 
         if self.phase == "test":
-            loc_data = loc_data.view(-1, 14)
-            conf_data = torch.softmax(conf_data.view(-1, self.num_classes), dim=-1)
-            iou_data = iou_data.view(-1, 1)
+            # trick to make it work with batches
+            # loc_data = loc_data.view(-1, 14)
+            # conf_data = torch.softmax(conf_data.view(-1, self.num_classes), dim=-1)
+            conf_data = torch.softmax(conf_data, dim=-1)
+            # iou_data = iou_data.view(-1, 1)
         else:
             loc_data = loc_data.view(loc_data.size(0), -1, 14)
             conf_data = conf_data.view(conf_data.size(0), -1, self.num_classes)

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -583,7 +583,7 @@ class TestFaceDetection:
         face_detection = kornia.contrib.FaceDetector().to(device, dtype)
         dets = face_detection(img)
         assert isinstance(dets, list)
-        assert len(dets) == batch_size # same as the number of images
+        assert len(dets) == batch_size  # same as the number of images
         assert isinstance(dets[0], torch.Tensor)
         assert dets[0].shape[0] >= 0  # number of detections
         assert dets[0].shape[1] == 15  # dims of each detection

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -579,9 +579,9 @@ class TestFaceDetection:
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_valid(self, batch_size, device, dtype):
         torch.manual_seed(44)
-        img = torch.rand(3, 320, 320, device=device, dtype=dtype)
+        img = torch.rand(batch_size, 3, 320, 320, device=device, dtype=dtype)
         face_detection = kornia.contrib.FaceDetector().to(device, dtype)
-        dets = face_detection(torch.stack([img] * batch_size))
+        dets = face_detection(img)
         assert isinstance(dets, list)
         assert len(dets) == batch_size # same as the number of images
         assert isinstance(dets[0], torch.Tensor)

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -576,12 +576,17 @@ class TestFaceDetection:
     def test_smoke(self, device, dtype):
         assert kornia.contrib.FaceDetector().to(device, dtype) is not None
 
-    def test_valid(self, device, dtype):
+    @pytest.mark.parametrize("batch_size", [1, 2, 4])
+    def test_valid(self, batch_size, device, dtype):
         torch.manual_seed(44)
-        img = torch.rand(1, 3, 320, 320, device=device, dtype=dtype)
+        img = torch.rand(3, 320, 320, device=device, dtype=dtype)
         face_detection = kornia.contrib.FaceDetector().to(device, dtype)
-        dets = face_detection(img)
-        assert len(dets) == 1
+        dets = face_detection(torch.stack([img] * batch_size))
+        assert isinstance(dets, list)
+        assert len(dets) == batch_size # same as the number of images
+        assert isinstance(dets[0], torch.Tensor)
+        assert dets[0].shape[0] >= 0  # number of detections
+        assert dets[0].shape[1] == 15  # dims of each detection
 
     def test_jit(self, device, dtype):
         op = kornia.contrib.FaceDetector().to(device, dtype)


### PR DESCRIPTION
#### Changes
Now the FaceDetector returns lists of tensors instead of a tensor. It returns a list because not in all the images the number of boxes is the same.

Fixes # (issue)
When passing batches to the face detector the code failed because was partially not ready to support them.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
