### PR TITLE
Improves performance of the slowest CPU tests

### DIFF
--- a/test/augmentation/test_motionblur.py
+++ b/test/augmentation/test_motionblur.py
@@ -7,6 +7,7 @@ from kornia.filters import motion_blur, motion_blur3d
 from kornia.testing import assert_close, tensor_to_gradcheck_var
 
 
+# TODO: add kornia.testing.BaseTester
 class TestRandomMotionBlur:
 
     # TODO: improve and implement more meaningful smoke tests e.g check for a consistent
@@ -77,6 +78,7 @@ class TestRandomMotionBlur:
         )
 
 
+# TODO: add kornia.testing.BaseTester
 class TestRandomMotionBlur3D:
     # TODO: improve and implement more meaningful smoke tests e.g check for a consistent
     # return values such a torch.Tensor variable.
@@ -128,7 +130,7 @@ class TestRandomMotionBlur3D:
 
     def test_gradcheck(self, device, dtype):
         torch.manual_seed(0)  # for random reproductibility
-        inp = torch.rand((1, 3, 11, 7)).to(device)
+        inp = torch.rand((1, 3, 6, 7), device=device, dtype=dtype)
         inp = tensor_to_gradcheck_var(inp)  # to var
         params = {
             'batch_prob': torch.tensor([True]),

--- a/test/feature/test_affine_shape_estimator.py
+++ b/test/feature/test_affine_shape_estimator.py
@@ -7,6 +7,7 @@ from kornia.feature.affine_shape import LAFAffineShapeEstimator, LAFAffNetShapeE
 from kornia.testing import assert_close
 
 
+# TODO: add kornia.testing.BaseTester
 class TestPatchAffineShapeEstimator:
     def test_shape(self, device):
         inp = torch.rand(1, 1, 32, 32, device=device)
@@ -47,6 +48,7 @@ class TestPatchAffineShapeEstimator:
         assert_close(tfeat_jit(patches), tfeat(patches))
 
 
+# TODO: add kornia.testing.BaseTester
 class TestLAFAffineShapeEstimator:
     def test_shape(self, device):
         inp = torch.rand(1, 1, 32, 32, device=device)
@@ -120,6 +122,7 @@ class TestLAFAffineShapeEstimator:
         assert_close(tfeat_jit(laf, inp), tfeat(laf, inp))
 
 
+# TODO: add kornia.testing.BaseTester
 class TestLAFAffNetShapeEstimator:
     def test_shape(self, device):
         inp = torch.rand(1, 1, 32, 32, device=device)

--- a/test/feature/test_integrated.py
+++ b/test/feature/test_integrated.py
@@ -27,6 +27,7 @@ from kornia.geometry import RANSAC, resize, transform_points
 from kornia.testing import assert_close
 
 
+# TODO: add kornia.testing.BaseTester
 class TestGetLAFDescriptors:
     def test_same(self, device, dtype):
         B, C, H, W = 1, 3, 64, 64
@@ -70,6 +71,7 @@ class TestGetLAFDescriptors:
         )
 
 
+# TODO: add kornia.testing.BaseTester
 class TestLAFDescriptor:
     def test_same(self, device, dtype):
         B, C, H, W = 1, 3, 64, 64
@@ -119,6 +121,7 @@ class TestLAFDescriptor:
         assert gradcheck(lafdesc, (img, lafs), eps=1e-3, atol=1e-3, raise_exception=True, nondet_tol=1e-3)
 
 
+# TODO: add kornia.testing.BaseTester
 class TestLocalFeature:
     def test_smoke(self, device, dtype):
         det = ScaleSpaceDetector(10)
@@ -168,6 +171,7 @@ class TestLocalFeature:
         assert gradcheck(local_feature, img, eps=1e-4, atol=1e-4, raise_exception=True)
 
 
+# TODO: add kornia.testing.BaseTester
 class TestSIFTFeature:
     # The real test is in TestLocalFeatureMatcher
     def test_smoke(self, device, dtype):
@@ -183,6 +187,7 @@ class TestSIFTFeature:
         assert gradcheck(local_feature, img, eps=1e-4, atol=1e-4, raise_exception=True)
 
 
+# TODO: add kornia.testing.BaseTester
 class TestKeyNetHardNetFeature:
     # The real test is in TestLocalFeatureMatcher
     def test_smoke(self, device, dtype):
@@ -201,6 +206,7 @@ class TestKeyNetHardNetFeature:
         assert gradcheck(local_feature, img, eps=1e-4, atol=1e-4, raise_exception=True)
 
 
+# TODO: add kornia.testing.BaseTester
 class TestGFTTAffNetHardNet:
     # The real test is in TestLocalFeatureMatcher
     def test_smoke(self, device, dtype):
@@ -216,6 +222,7 @@ class TestGFTTAffNetHardNet:
         assert gradcheck(local_feature, img, eps=1e-4, atol=1e-4, raise_exception=True)
 
 
+# TODO: add kornia.testing.BaseTester
 class TestLocalFeatureMatcher:
     def test_smoke(self, device):
         matcher = LocalFeatureMatcher(SIFTFeature(5), DescriptorMatcher('snn', 0.8)).to(device)
@@ -246,8 +253,8 @@ class TestLocalFeatureMatcher:
     def test_real_sift(self, device, dtype, data):
         torch.random.manual_seed(0)
         # This is not unit test, but that is quite good integration test
-        matcher = LocalFeatureMatcher(SIFTFeature(2000), DescriptorMatcher('snn', 0.8)).to(device, dtype)
-        ransac = RANSAC('homography', 1.0, 2048, 10).to(device, dtype)
+        matcher = LocalFeatureMatcher(SIFTFeature(1000), DescriptorMatcher('snn', 0.8)).to(device, dtype)
+        ransac = RANSAC('homography', 1.0, 1024, 5).to(device, dtype)
         data_dev = utils.dict_to(data, device, dtype)
         pts_src = data_dev['pts0']
         pts_dst = data_dev['pts1']
@@ -262,9 +269,9 @@ class TestLocalFeatureMatcher:
     def test_real_sift_preextract(self, device, dtype, data):
         torch.random.manual_seed(0)
         # This is not unit test, but that is quite good integration test
-        feat = SIFTFeature(2000)
+        feat = SIFTFeature(1000)
         matcher = LocalFeatureMatcher(feat, DescriptorMatcher('snn', 0.8)).to(device)
-        ransac = RANSAC('homography', 1.0, 2048, 10).to(device, dtype)
+        ransac = RANSAC('homography', 1.0, 1024, 5).to(device, dtype)
         data_dev = utils.dict_to(data, device, dtype)
         pts_src = data_dev['pts0']
         pts_dst = data_dev['pts1']
@@ -289,8 +296,8 @@ class TestLocalFeatureMatcher:
     def test_real_gftt(self, device, dtype, data):
         torch.random.manual_seed(0)
         # This is not unit test, but that is quite good integration test
-        matcher = LocalFeatureMatcher(GFTTAffNetHardNet(2000), DescriptorMatcher('snn', 0.8)).to(device, dtype)
-        ransac = RANSAC('homography', 1.0, 2048, 10).to(device, dtype)
+        matcher = LocalFeatureMatcher(GFTTAffNetHardNet(1000), DescriptorMatcher('snn', 0.8)).to(device, dtype)
+        ransac = RANSAC('homography', 1.0, 1024, 5).to(device, dtype)
         data_dev = utils.dict_to(data, device, dtype)
         pts_src = data_dev['pts0']
         pts_dst = data_dev['pts1']
@@ -307,7 +314,7 @@ class TestLocalFeatureMatcher:
         torch.random.manual_seed(0)
         # This is not unit test, but that is quite good integration test
         matcher = LocalFeatureMatcher(KeyNetHardNet(500), DescriptorMatcher('snn', 0.9)).to(device, dtype)
-        ransac = RANSAC('homography', 1.0, 2048, 10).to(device, dtype)
+        ransac = RANSAC('homography', 1.0, 1024, 5).to(device, dtype)
         data_dev = utils.dict_to(data, device, dtype)
         pts_src = data_dev['pts0']
         pts_dst = data_dev['pts1']

--- a/test/feature/test_siftdesc.py
+++ b/test/feature/test_siftdesc.py
@@ -24,6 +24,7 @@ def test_get_sift_bin_ksize_stride_pad(ps, n_bins, ksize, stride, pad):
     assert out == (ksize, stride, pad)
 
 
+# TODO: add kornia.testing.BaseTester
 class TestSIFTDescriptor:
     def test_shape(self, device, dtype):
         inp = torch.ones(1, 1, 32, 32, device=device, dtype=dtype)
@@ -68,9 +69,10 @@ class TestSIFTDescriptor:
         assert_close(model(patches), model_jit(patches))
 
 
+# TODO: add kornia.testing.BaseTester
 class TestDenseSIFTDescriptor:
     def test_shape_default(self, device, dtype):
-        bs, h, w = 1, 40, 30
+        bs, h, w = 1, 20, 15
         inp = torch.rand(1, 1, h, w, device=device, dtype=dtype)
         sift = DenseSIFTDescriptor().to(device, dtype)
         out = sift(inp)
@@ -95,8 +97,8 @@ class TestDenseSIFTDescriptor:
         sift.__repr__()
 
     @pytest.mark.xfail(reason='May raise checkIfNumericalAnalyticAreClose.')
-    def test_gradcheck(self, device):
-        batch_size, channels, height, width = 1, 1, 32, 32
-        patches = torch.rand(batch_size, channels, height, width, device=device)
+    def test_gradcheck(self, device, dtype):
+        batch_size, channels, height, width = 1, 1, 16, 16
+        patches = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         assert gradcheck(DenseSIFTDescriptor(4, 2, 2), (patches), raise_exception=True, nondet_tol=1e-4)

--- a/test/feature/test_sold2.py
+++ b/test/feature/test_sold2.py
@@ -7,15 +7,15 @@ from kornia.feature.sold2 import SOLD2, SOLD2_detector
 from kornia.testing import assert_close
 
 
+# TODO: add kornia.testing.BaseTester
 class TestSOLD2_detector:
     @pytest.mark.parametrize("batch_size", [1, 2])
-    def test_shape(self, device, batch_size):
-        inp = torch.ones(batch_size, 1, 128, 128, device=device)
-        sold2 = SOLD2_detector(pretrained=False).to(device)
-        sold2.eval()
+    def test_shape(self, device, batch_size, dtype):
+        inp = torch.ones(batch_size, 1, 64, 64, device=device, dtype=dtype)
+        sold2 = SOLD2_detector(pretrained=False).to(device, dtype)
         out = sold2(inp)
-        assert out["junction_heatmap"].shape == (batch_size, 128, 128)
-        assert out["line_heatmap"].shape == (batch_size, 128, 128)
+        assert out["junction_heatmap"].shape == (batch_size, 64, 64)
+        assert out["line_heatmap"].shape == (batch_size, 64, 64)
 
     @pytest.mark.skip("Takes ages to run")
     def test_gradcheck(self, device):
@@ -37,14 +37,14 @@ class TestSOLD2_detector:
         assert_close(model(img), model_jit(img))
 
 
+# TODO: add kornia.testing.BaseTester
 class TestSOLD2:
     @pytest.mark.parametrize("batch_size", [1, 2])
-    def test_shape(self, device, batch_size):
-        inp = torch.ones(batch_size, 1, 256, 256, device=device)
-        sold2 = SOLD2(pretrained=False).to(device)
-        sold2.eval()
+    def test_shape(self, device, batch_size, dtype):
+        inp = torch.ones(batch_size, 1, 64, 64, device=device, dtype=dtype)
+        sold2 = SOLD2(pretrained=False).to(device, dtype)
         out = sold2(inp)
-        assert out["dense_desc"].shape == (batch_size, 128, 64, 64)
+        assert out["dense_desc"].shape == (batch_size, 128, 16, 16)
 
     @pytest.mark.skip("Takes ages to run")
     def test_gradcheck(self, device):


### PR DESCRIPTION
Small enhancement to slightly improve the test duration on the CI
 
- Decreases the size of some input tensors
- add `TODO:` to add `kornia.testing.BaseTester` in some tests in the future

#### Type of change
- [x] 🧪 Tests Cases
