### PR TITLE
add default python and update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -40,7 +40,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,8 +111,8 @@ per-file-ignores =
     __init__.py: F401, F403
 verbose = 2
 ignore =
-    W503  # Ignore "Line break occurred before a binary operator"
-    E203  # Ignore "whitespace before ':'"
+    W503
+    E203
 
 [mypy]
 files = kornia/


### PR DESCRIPTION
This patch goes ahead of pre-commit CI update, and fix the flake8 config (can't have comments in the same line of the arg). Also update the hooks.

- https://github.com/pre-commit/pre-commit-hooks: v4.3.0 → v4.4.0
- https://github.com/PyCQA/flake8: 5.0.4 → 6.0.0