### PR TITLE
Pass along data_keys or extra_args in *ApplyInverse with containers

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -199,16 +199,13 @@ class AugmentationSequential(ImageSequential):
         Number of input tensors must align with the number of``data_keys``. If ``data_keys`` is not set, use
         ``self.data_keys`` by default.
         """
+        _data_keys: List[DataKey]
         if data_keys is None:
-            data_keys = cast(List[Union[str, int, DataKey]], self.data_keys)
+            _data_keys = self.data_keys
+        else:
+            _data_keys = [DataKey.get(inp) for inp in data_keys]
 
-        _data_keys: List[DataKey] = [DataKey.get(inp) for inp in data_keys]
-
-        if len(args) != len(data_keys):
-            raise AssertionError(
-                "The number of inputs must align with the number of data_keys, "
-                f"Got {len(args)} and {len(data_keys)}."
-            )
+        self._validate_args_datakeys(*args, data_keys=_data_keys)
 
         args = self._arguments_preproc(*args, data_keys=_data_keys)
 
@@ -220,11 +217,11 @@ class AugmentationSequential(ImageSequential):
                 )
             params = self._params
 
-        outputs: List[Tensor] = [None] * len(data_keys)  # type: ignore
-        for idx, (arg, dcate) in enumerate(zip(args, data_keys)):
+        outputs: List[Tensor] = [None] * len(_data_keys)  # type: ignore
+        for idx, (arg, dcate) in enumerate(zip(args, _data_keys)):
 
-            if DataKey.INPUT in self.extra_args:
-                extra_args = self.extra_args[DataKey.INPUT]
+            if dcate in self.extra_args:
+                extra_args = self.extra_args[dcate]
             else:
                 extra_args = {}
 
@@ -329,7 +326,7 @@ class AugmentationSequential(ImageSequential):
             _data_keys = self.data_keys
         else:
             _data_keys = [DataKey.get(inp) for inp in data_keys]
-            self.data_keys = _data_keys
+
         self._validate_args_datakeys(*args, data_keys=_data_keys)
 
         args = self._arguments_preproc(*args, data_keys=_data_keys)

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -156,7 +156,7 @@ class AugmentationSequential(ImageSequential):
             random_apply_weights=random_apply_weights,
         )
 
-        self.data_keys = [DataKey.get(inp) for inp in data_keys]
+        self.data_keys: List[DataKey] = [DataKey.get(inp) for inp in data_keys]
 
         if not all(in_type in DataKey for in_type in self.data_keys):
             raise AssertionError(f"`data_keys` must be in {DataKey}. Got {data_keys}.")
@@ -199,7 +199,6 @@ class AugmentationSequential(ImageSequential):
         Number of input tensors must align with the number of``data_keys``. If ``data_keys`` is not set, use
         ``self.data_keys`` by default.
         """
-        _data_keys: List[DataKey]
         if data_keys is None:
             _data_keys = self.data_keys
         else:
@@ -321,7 +320,6 @@ class AugmentationSequential(ImageSequential):
         data_keys: Optional[List[Union[str, int, DataKey]]] = None,
     ) -> Union[Tensor, Tuple[Tensor, Optional[Tensor]], List[Tensor], Tuple[List[Tensor], Optional[Tensor]]]:
         """Compute multiple tensors simultaneously according to ``self.data_keys``."""
-        _data_keys: List[DataKey]
         if data_keys is None:
             _data_keys = self.data_keys
         else:

--- a/kornia/augmentation/container/utils.py
+++ b/kornia/augmentation/container/utils.py
@@ -213,7 +213,12 @@ class InputApplyInverse(ApplyInverseImpl):
             temp = module.apply_inverse_func
             module.apply_inverse_func = InputApplyInverse
             if isinstance(module, kornia.augmentation.AugmentationSequential):
-                input = cast(Tensor, module.inverse(input, params=None if param is None else cast(List, param.data)))
+                input = cast(
+                    Tensor,
+                    module.inverse(
+                        input, params=None if param is None else cast(List, param.data), data_keys=[cls.data_key]
+                    ),
+                )
             else:
                 input = module.inverse(
                     input, params=None if param is None else cast(List, param.data), extra_args=extra_args
@@ -275,7 +280,14 @@ class MaskApplyInverse(ApplyInverseImpl):
             temp = module.apply_inverse_func
             module.apply_inverse_func = MaskApplyInverse
             geo_param: List[ParamItem] = _get_geometric_only_param(module, _param)
-            input = cls.make_input_only_sequential(module)(input, label=None, params=geo_param)
+            if isinstance(module, kornia.augmentation.AugmentationSequential):
+                input = cls.make_input_only_sequential(module)(
+                    input, label=None, params=geo_param, data_keys=[cls.data_key]
+                )
+            else:
+                input = cls.make_input_only_sequential(module)(
+                    input, label=None, params=geo_param, extra_args=extra_args
+                )
             module.apply_inverse_func = temp
         else:
             pass  # No need to update anything
@@ -299,7 +311,17 @@ class MaskApplyInverse(ApplyInverseImpl):
         elif isinstance(module, kornia.augmentation.ImageSequential):
             temp = module.apply_inverse_func
             module.apply_inverse_func = MaskApplyInverse
-            input = module.inverse(input, params=None if param is None else cast(List, param.data))
+            if isinstance(module, kornia.augmentation.AugmentationSequential):
+                input = cast(
+                    Tensor,
+                    module.inverse(
+                        input, params=None if param is None else cast(List, param.data), data_keys=[cls.data_key]
+                    ),
+                )
+            else:
+                input = module.inverse(
+                    input, params=None if param is None else cast(List, param.data), extra_args=extra_args
+                )
             module.apply_inverse_func = temp
         return input
 

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -440,12 +440,14 @@ class TestAugmentationSequential:
         assert out[1].shape == mask.shape
         assert out[2].shape == bbox.shape
         assert out[3].shape == keypoints.shape
+        assert set(out[1].unique().tolist()).issubset(set(mask.unique().tolist()))
 
         out_inv = aug.inverse(*out)
         assert out_inv[0].shape == inp.shape
         assert out_inv[1].shape == mask.shape
         assert out_inv[2].shape == bbox.shape
         assert out_inv[3].shape == keypoints.shape
+        assert set(out_inv[1].unique().tolist()).issubset(set(mask.unique().tolist()))
 
         if random_apply is False:
             reproducibility_test((inp, mask, bbox, keypoints), aug)


### PR DESCRIPTION
#### Changes
- Pass along `data_keys` in `apply_trans` and `inverse` of `InputApplyInverse` and `MaskApplyInverse` for `AugmentationSequential`
- Pass along `extra_args` for others
- Get `extra_args` for all data keys in `AugmentationSequential.inverse`, not only for `Input`
- Do not overwrite `data_keys` stored in `AugmentationSequential.forward` when explicitly passing a list of keys.

Fixes #2037 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
