### PR TITLE
None for align_corners arg of resize op with nearest mode

### DIFF
--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -64,7 +64,9 @@ class Resize(GeometricAugmentationBase2D):
                 input[i : i + 1, :, y1:y2, x1:x2],
                 out_size,
                 interpolation=flags["resample"].name.lower(),
-                align_corners=flags["align_corners"],
+                align_corners=flags["align_corners"]
+                if flags["resample"] in [Resample.BILINEAR, Resample.BICUBIC]
+                else None,
                 antialias=flags["antialias"],
             )
         return out

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -357,6 +357,18 @@ class TestAugmentationSequential:
         out = aug(input, input)
         assert torch.all(out[1][out[0] == fill_value] == 0.0)
 
+    def test_resize(self, device, dtype):
+        size = 50
+        input = torch.randn(3, 3, 100, 100, device=device, dtype=dtype)
+        mask = torch.randn(3, 1, 100, 100, device=device, dtype=dtype)
+        aug = K.AugmentationSequential(K.Resize((size, size), p=1.0), data_keys=["input", "mask"])
+
+        reproducibility_test((input, mask), aug)
+
+        out = aug(input, mask)
+        assert out[0].shape == (3, 3, size, size)
+        assert out[1].shape == (3, 1, size, size)
+
     def test_random_crops(self, device, dtype):
         torch.manual_seed(233)
         input = torch.randn(3, 3, 3, 3, device=device, dtype=dtype)


### PR DESCRIPTION
Fixes #2048 
 
Pass only `align_corners` arg to `resize` when using `Resample.BILINEAR` and `Resample.BICUBIC`.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
