### PR TITLE
making `RandomGaussianNoise` play nicely on GPU

### DIFF
--- a/kornia/augmentation/_2d/intensity/gaussian_noise.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_noise.py
@@ -58,20 +58,11 @@ class RandomGaussianNoise(IntensityAugmentationBase2D):
     def generate_parameters(self, shape: torch.Size) -> Dict[str, Tensor]:
         return {}
 
-    @staticmethod
-    def randomize(input: Tensor, flags: Dict[str, Any]) -> Tensor:
-        additive_noise = torch.randn_like(input)  # Generating on GPU is fastest with `torch.randn_like(...)`
-        if flags["std"] != 1.0:  # `if` is cheaper than multiplication
-            additive_noise *= flags["std"]
-        if flags["mean"] != 0.0:  # `if` is cheaper than addition
-            additive_noise += flags["mean"]
-        return additive_noise
-
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        if "gaussian_noise" in self._params:
-            gaussian_noise = self._params["gaussian_noise"]
+        if "gaussian_noise" in params:
+            gaussian_noise = params["gaussian_noise"]
         else:
             gaussian_noise = _randn_like(input, mean=flags["mean"], std=flags["std"])
             self._params["gaussian_noise"] = gaussian_noise


### PR DESCRIPTION
#### Changes
`torch.randn` is much slower on GPU than `torch.randn_like` hence changing the internal implementation of `RandomGaussianNoise` to use the latter.

#### Evidence
```
>>> %timeit 1.0 * torch.randn(24, 2, 3, 384, 384).cuda() + 0.0
159 ms ± 1.21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

>>> %timeit torch.randn(24, 2, 3, 384, 384).cuda()
159 ms ± 151 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

>>> tcuda = torch.randn(24, 2, 3, 384, 384).cuda()

>>>  %timeit 1.0 * torch.randn_like(tcuda) + 0.0
547 µs ± 127 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>>  %timeit torch.randn_like(tcuda)
127 µs ± 435 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

#### Notes
Hi @edgarriba 
This is a theoretical PR. The current design can't allow it. I'll explain:
- The design of the augmentations states that they are reproducible, i.e: the internal `params` allow calling the augmentation again and getting the same result. Overall makes sense.
- However, the implementation of this specific augmentation is significantly slow on GPU! see the above demonstration. This is because `torch.randn_like` is ~1000 faster than `torch.randn`.
- The issue is this --- we can call  `torch.randn_like` only in `apply_transform` since it requires the reference tensor. We can't "prepare" it in `generate_parameters` as the current implementation.
- I would love us to figure out a way to add this capability to kornia --- having non-reproducible augmentations, especially when it has great merit.

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
