### PR TITLE
Set padding mode to zeros for inverse of resize aug via crop

### DIFF
--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -85,7 +85,7 @@ class Resize(GeometricAugmentationBase2D):
             raise TypeError(f'Expected the transform be a Tensor. Gotcha {type(transform)}')
 
         return crop_by_transform_mat(
-            input, transform[:, :2, :], size, flags["resample"], flags["padding_mode"], flags["align_corners"]
+            input, transform[:, :2, :], size, flags["resample"].name.lower(), "zeros", flags["align_corners"]
         )
 
 

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -3628,6 +3628,7 @@ class TestResize:
         aug = Resize(size=(4, 5))
         out = aug(img)
         assert out.shape == (1, 1, 4, 5)
+        assert aug.inverse(out).shape == (1, 1, 4, 6)
 
 
 class TestSmallestMaxSize:


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2053 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
