### PR TITLE
fix pep561 and remove deprecated `license_file`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ url = https://www.kornia.org
 author = Edgar Riba
 author_email = edgar@kornia.org
 license = Apache-2.0
-license_file = LICENSE
 license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
@@ -82,6 +81,9 @@ docs =
     torchvision
 x =
     accelerate==0.14.0
+
+[options.package_data]
+kornia = py.typed
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION

The `license_file` have [been deprecated](https://github.com/pypa/setuptools/blob/fbe659b74cbccbb095dd469a15324eb73285b714/docs/references/keywords.rst)

and without the following config
```
[options.package_data]
kornia = py.typed
```
the lib stubs will not be distributed

Example:
```python
# t.py
import kornia as K

def ex(s: str):
    K.augmentation.Resize(s)
```
Before this patch:
```bash
$ mypy t.py 
t.py:1: error: Cannot find implementation or library stub for module named "kornia"  [import]
t.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

after:
```bash
$ mypy t.py 
t.py:4: error: Argument 1 to "Resize" has incompatible type "str";
expected "Union[int, Tuple[int, int]]"  [arg-type]
        K.augmentation.Resize(s)
```

#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
