### PR TITLE
update torch seed

### DIFF
--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -415,6 +415,7 @@ class TestLambdaModule:
 class TestImageStitcher:
     @pytest.mark.parametrize("estimator", ['ransac', 'vanilla'])
     def test_smoke(self, estimator, device, dtype):
+        torch.manual_seed(7)  # issue kornia#2027
         B, C, H, W = 1, 3, 224, 224
         sample1 = torch.rand(B, C, H, W, device=device, dtype=dtype)
         sample2 = torch.rand(B, C, H, W, device=device, dtype=dtype)

--- a/test/tracking/test_planar_tracking.py
+++ b/test/tracking/test_planar_tracking.py
@@ -38,11 +38,15 @@ class TestHomographyTracker:
             if isinstance(data[k], torch.Tensor):
                 data[k] = data[k].to(device, dtype)
         h0, w0 = data["image0"].shape[2:]
-        data["image0"] = resize(data["image0"], (int(h0 // 2), int(w0 // 2)))
-        data["image1"] = resize(data["image1"], (int(h0 // 2), int(w0 // 2)))
+        data["image0"] = resize(
+            data["image0"], (int(h0 // 2), int(w0 // 2)), interpolation='bilinear', align_corners=False
+        )
+        data["image1"] = resize(
+            data["image1"], (int(h0 // 2), int(w0 // 2)), interpolation='bilinear', align_corners=False
+        )
         with torch.no_grad():
             tracker.set_target(data["image0"])
-            torch.random.manual_seed(0)
+            torch.manual_seed(3)  # issue kornia#2027
             homography, success = tracker(data["image1"])
         assert success
         pts_src = data['pts0'].to(device, dtype) / 2.0
@@ -51,7 +55,7 @@ class TestHomographyTracker:
         assert_close(transform_points(homography[None], pts_src[None]), pts_dst[None], rtol=5e-2, atol=5)
         # next frame
         with torch.no_grad():
-            torch.random.manual_seed(0)
+            torch.manual_seed(3)  # issue kornia#2027
             homography, success = tracker(data["image1"])
         assert success
         assert_close(transform_points(homography[None], pts_src[None]), pts_dst[None], rtol=5e-2, atol=5)

--- a/test/utils/test_helpers.py
+++ b/test/utils/test_helpers.py
@@ -116,6 +116,7 @@ class TestSolveCast:
 
 class TestSolveWithMask:
     def test_smoke(self, device, dtype):
+        torch.manual_seed(0)  # issue kornia#2027
         A = torch.randn(2, 3, 1, 4, 4, device=device, dtype=dtype)
         B = torch.randn(2, 3, 1, 4, 6, device=device, dtype=dtype)
 


### PR DESCRIPTION
Related to #2027 -- I think this patch doesn't cover all the failed tests, but that's what I can find in the logs of the last PR (if failures continue to occur related to this case, we should try to note in the issue #2027)

The issue is with `_torch_solve_cast` which will fail [if the A matrix is not invertible or any matrix in a batched A is not invertible.](https://pytorch.org/docs/stable/generated/torch.linalg.solve.html)