### PR TITLE
BUGFIX: `RandomMotionBlur` is not deterministic when using `self._params`

### DIFF
--- a/kornia/augmentation/_2d/intensity/motion_blur.py
+++ b/kornia/augmentation/_2d/intensity/motion_blur.py
@@ -81,12 +81,17 @@ class RandomMotionBlur(IntensityAugmentationBase2D):
         self._param_generator = rg.MotionBlurGenerator(kernel_size, angle, direction)
         self.flags = dict(border_type=BorderType.get(border_type), resample=Resample.get(resample))
 
+    def generate_parameters(self, batch_shape: torch.Size) -> Dict[str, Tensor]:
+        params = super().generate_parameters(batch_shape)
+        params["idx"] = torch.randint(batch_shape[0], (1,)).item()
+        return params
+
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
         # sample a kernel size
         kernel_size_list: List[int] = params["ksize_factor"].tolist()
-        idx: int = cast(int, torch.randint(len(kernel_size_list), (1,)).item())
+        idx: int = cast(int, params["idx"])
         return motion_blur(
             input,
             kernel_size=kernel_size_list[idx],


### PR DESCRIPTION
#### Changes
When applying the same augmentation several times with `self._params` - it should behave deterministically. However, for `RandomMotionBlur` is was not the case due to random sampling inside `apply_transform`!
This PR fixes the problem by moving the sampling operation to `generate_parameters`.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
