### PR TITLE
enable `fast_mode` on grandchecks

### DIFF
--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -264,7 +264,12 @@ class CommonTests(BaseTester):
     def _test_gradcheck_implementation(self, params):
         input_tensor = torch.rand((3, 5, 5), device=self.device, dtype=self.dtype)  # 3 x 3
         input_tensor = utils.tensor_to_gradcheck_var(input_tensor)  # to var
-        assert gradcheck(self._create_augmentation_from_params(**params, p=1.0), (input_tensor,), raise_exception=True)
+        assert gradcheck(
+            self._create_augmentation_from_params(**params, p=1.0),
+            (input_tensor,),
+            raise_exception=True,
+            fast_mode=True,
+        )
 
 
 class TestRandomEqualizeAlternative(CommonTests):
@@ -825,7 +830,7 @@ class TestRandomHorizontalFlip:
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 3), device=device, dtype=dtype)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomHorizontalFlip(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomHorizontalFlip(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestRandomVerticalFlip(BaseTester):
@@ -1294,7 +1299,7 @@ class TestColorJiggle(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype).unsqueeze(0)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(ColorJiggle(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(ColorJiggle(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -1622,7 +1627,7 @@ class TestColorJitter(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype).unsqueeze(0)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(ColorJitter(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(ColorJitter(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -1726,7 +1731,7 @@ class TestRandomBrightness(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype).unsqueeze(0)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomBrightness(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomBrightness(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -1828,7 +1833,7 @@ class TestRandomContrast(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype).unsqueeze(0)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomContrast(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomContrast(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -1938,7 +1943,7 @@ class TestRandomHue(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype).unsqueeze(0)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomHue(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomHue(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -2048,7 +2053,7 @@ class TestRandomSaturation(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype).unsqueeze(0)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomSaturation(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomSaturation(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -2105,7 +2110,7 @@ class TestRectangleRandomErasing(BaseTester):
         # evaluate function gradient
         input = torch.rand(batch_shape, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(rand_rec, (input, rect_params), raise_exception=True)
+        assert gradcheck(rand_rec, (input, rect_params), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_smoke(self, device, dtype):
@@ -2235,7 +2240,7 @@ class TestRandomGamma(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype).unsqueeze(0)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomGamma(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomGamma(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -2494,8 +2499,8 @@ class TestRandomGrayscale(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand((3, 5, 5), device=device, dtype=dtype)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomGrayscale(p=1.0), (input,), raise_exception=True)
-        assert gradcheck(RandomGrayscale(p=0.0), (input,), raise_exception=True)
+        assert gradcheck(RandomGrayscale(p=1.0), (input,), raise_exception=True, fast_mode=True)
+        assert gradcheck(RandomGrayscale(p=0.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -2559,7 +2564,7 @@ class TestCenterCrop(BaseTester):
     def test_gradcheck(self, device, dtype):
         input = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(CenterCrop(3), (input,), raise_exception=True)
+        assert gradcheck(CenterCrop(3), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_smoke(self, device, dtype):
@@ -2733,7 +2738,7 @@ class TestRandomRotation(BaseTester):
 
         input = torch.rand((3, 3), device=device, dtype=dtype)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomRotation(degrees=(15.0, 15.0), p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomRotation(degrees=(15.0, 15.0), p=1.0), (input,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -2965,7 +2970,7 @@ class TestRandomCrop(BaseTester):
         torch.manual_seed(0)  # for random reproductibility
         inp = torch.rand((3, 3, 3), device=device, dtype=dtype)  # 3 x 3
         inp = utils.tensor_to_gradcheck_var(inp)  # to var
-        assert gradcheck(RandomCrop(size=(3, 3), p=1.0), (inp,), raise_exception=True)
+        assert gradcheck(RandomCrop(size=(3, 3), p=1.0), (inp,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip("Need to fix Union type")
     def test_jit(self, device, dtype):
@@ -3159,7 +3164,10 @@ class TestRandomResizedCrop(BaseTester):
         inp = torch.rand((1, 3, 3), device=device, dtype=dtype)  # 3 x 3
         inp = utils.tensor_to_gradcheck_var(inp)  # to var
         assert gradcheck(
-            RandomResizedCrop(size=(3, 3), scale=(1.0, 1.0), ratio=(1.0, 1.0)), (inp,), raise_exception=True
+            RandomResizedCrop(size=(3, 3), scale=(1.0, 1.0), ratio=(1.0, 1.0)),
+            (inp,),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     @pytest.mark.skip(reason="not implemented yet")
@@ -3282,7 +3290,7 @@ class TestRandomEqualize(BaseTester):
 
         input = torch.rand((3, 3, 3), device=device, dtype=dtype)  # 3 x 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomEqualize(p=0.5), (input,), raise_exception=True)
+        assert gradcheck(RandomEqualize(p=0.5), (input,), raise_exception=True, fast_mode=True)
 
     @staticmethod
     def build_input(channels, height, width, bs=1, row=None, device='cpu', dtype=torch.float32):
@@ -3459,7 +3467,10 @@ class TestNormalize(BaseTester):
         input = torch.rand((3, 3, 3), device=device, dtype=dtype)  # 3 x 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
         assert gradcheck(
-            Normalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0), (input,), raise_exception=True
+            Normalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0),
+            (input,),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     @pytest.mark.skip(reason="not implemented yet")
@@ -3525,7 +3536,10 @@ class TestDenormalize(BaseTester):
         input = torch.rand((3, 3, 3), device=device, dtype=dtype)  # 3 x 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
         assert gradcheck(
-            Denormalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0), (input,), raise_exception=True
+            Denormalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0),
+            (input,),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     @pytest.mark.skip(reason="not implemented yet")
@@ -3565,7 +3579,7 @@ class TestRandomFisheye:
         center_x = utils.tensor_to_gradcheck_var(center_x)  # to var
         center_y = utils.tensor_to_gradcheck_var(center_y)  # to var
         gamma = utils.tensor_to_gradcheck_var(gamma)  # to var
-        assert gradcheck(RandomFisheye(center_x, center_y, gamma), (img,), raise_exception=True)
+        assert gradcheck(RandomFisheye(center_x, center_y, gamma), (img,), raise_exception=True, fast_mode=True)
 
 
 class TestRandomElasticTransform:

--- a/test/augmentation/test_augmentation_3d.py
+++ b/test/augmentation/test_augmentation_3d.py
@@ -123,7 +123,7 @@ class TestRandomHorizontalFlip3D:
     def test_gradcheck(self, device):
         input = torch.rand((1, 3, 3)).to(device)  # 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomHorizontalFlip3D(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomHorizontalFlip3D(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestRandomVerticalFlip3D:
@@ -241,7 +241,7 @@ class TestRandomVerticalFlip3D:
     def test_gradcheck(self, device):
         input = torch.rand((1, 3, 3)).to(device)  # 4 x 4
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomVerticalFlip3D(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomVerticalFlip3D(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestRandomDepthicalFlip3D:
@@ -379,7 +379,7 @@ class TestRandomDepthicalFlip3D:
     def test_gradcheck(self, device):
         input = torch.rand((1, 3, 3)).to(device)  # 4 x 4
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomDepthicalFlip3D(p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomDepthicalFlip3D(p=1.0), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestRandomRotation3D:
@@ -628,7 +628,7 @@ class TestRandomRotation3D:
 
         input = torch.rand((3, 3, 3)).to(device)  # 3 x 3 x 3
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(RandomRotation3D(degrees=(15.0, 15.0), p=1.0), (input,), raise_exception=True)
+        assert gradcheck(RandomRotation3D(degrees=(15.0, 15.0), p=1.0), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestRandomCrop3D:
@@ -774,7 +774,7 @@ class TestRandomCrop3D:
         torch.manual_seed(0)  # for random reproductibility
         inp = torch.rand((3, 3, 3), device=device, dtype=dtype)  # 3 x 3
         inp = utils.tensor_to_gradcheck_var(inp)  # to var
-        assert gradcheck(RandomCrop3D(size=(3, 3, 3), p=1.0), (inp,), raise_exception=True)
+        assert gradcheck(RandomCrop3D(size=(3, 3, 3), p=1.0), (inp,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip("Need to fix Union type")
     def test_jit(self, device, dtype):
@@ -827,7 +827,7 @@ class TestCenterCrop3D:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(CenterCrop3D(3), (input,), raise_exception=True)
+        assert gradcheck(CenterCrop3D(3), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestRandomEqualize3D:
@@ -891,7 +891,7 @@ class TestRandomEqualize3D:
 
         inputs3d = torch.rand((3, 3, 3), device=device, dtype=dtype)  # 3 x 3 x 3
         inputs3d = utils.tensor_to_gradcheck_var(inputs3d)  # to var
-        assert gradcheck(RandomEqualize3D(p=0.5), (inputs3d,), raise_exception=True)
+        assert gradcheck(RandomEqualize3D(p=0.5), (inputs3d,), raise_exception=True, fast_mode=True)
 
     @staticmethod
     def build_input(channels, depth, height, width, bs=1, row=None, device='cpu', dtype=torch.float32):

--- a/test/augmentation/test_base.py
+++ b/test/augmentation/test_base.py
@@ -167,4 +167,4 @@ class TestAugmentationBase2D:
 
             apply_transform.return_value = output
             compute_transformation.return_value = other_transform
-            assert gradcheck(augmentation, ((input, input_param)), raise_exception=True)
+            assert gradcheck(augmentation, ((input, input_param)), raise_exception=True, fast_mode=True)

--- a/test/augmentation/test_perspective_rand.py
+++ b/test/augmentation/test_perspective_rand.py
@@ -136,6 +136,7 @@ class TestRandomPerspective:
             kornia.augmentation.RandomPerspective(torch.tensor(0.5, device=device, dtype=dtype), p=0.0),
             (input,),
             raise_exception=True,
+            fast_mode=True,
         )
 
 
@@ -196,4 +197,4 @@ class TestRandomAffine:
         input = torch.rand(1, 2, 5, 7).to(device)
         input = utils.tensor_to_gradcheck_var(input)  # to var
         # TODO: turned off with p=0
-        assert gradcheck(kornia.augmentation.RandomAffine(10, p=0.0), (input,), raise_exception=True)
+        assert gradcheck(kornia.augmentation.RandomAffine(10, p=0.0), (input,), raise_exception=True, fast_mode=True)

--- a/test/color/test_gray.py
+++ b/test/color/test_gray.py
@@ -85,7 +85,7 @@ class TestGrayscaleToRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.grayscale_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.grayscale_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -200,7 +200,7 @@ class TestRgbToGrayscale(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_grayscale, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_grayscale, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -292,7 +292,7 @@ class TestBgrToGrayscale(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.bgr_to_grayscale, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.bgr_to_grayscale, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_hls.py
+++ b/test/color/test_hls.py
@@ -128,7 +128,7 @@ class TestRgbToHls(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_hls, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_hls, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -254,7 +254,7 @@ class TestHlsToRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.hls_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.hls_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_hsv.py
+++ b/test/color/test_hsv.py
@@ -102,7 +102,7 @@ class TestRgbToHsv(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_hsv, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_hsv, (img,), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
@@ -217,7 +217,7 @@ class TestHsvToRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.hsv_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.hsv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_lab.py
+++ b/test/color/test_lab.py
@@ -101,7 +101,7 @@ class TestRgbToLab(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_lab, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_lab, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -247,7 +247,7 @@ class TestLabToRgb(BaseTester):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         img = kornia.color.rgb_to_lab(img)
-        assert gradcheck(kornia.color.lab_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.lab_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_luv.py
+++ b/test/color/test_luv.py
@@ -101,7 +101,7 @@ class TestRgbToLuv(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_luv, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_luv, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -219,7 +219,7 @@ class TestLuvToRgb(BaseTester):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         img = kornia.color.rgb_to_luv(img)
-        assert gradcheck(kornia.color.luv_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.luv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_raw.py
+++ b/test/color/test_raw.py
@@ -122,7 +122,7 @@ class TestRawToRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.raw_to_rgb, (img, kornia.color.raw.CFA.BG), raise_exception=True)
+        assert gradcheck(kornia.color.raw_to_rgb, (img, kornia.color.raw.CFA.BG), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -173,7 +173,7 @@ class TestRgbToRaw(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_raw, (img, kornia.color.raw.CFA.BG), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_raw, (img, kornia.color.raw.CFA.BG), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_rgb.py
+++ b/test/color/test_rgb.py
@@ -62,7 +62,7 @@ class TestRgbToBgr(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_bgr, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_bgr, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -194,14 +194,14 @@ class TestRgbToRgba(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_rgba, (img, 1.0), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_rgba, (img, 1.0), raise_exception=True, fast_mode=True)
 
     @pytest.mark.grad
     def test_gradcheck_th(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         aval = torch.ones(B, 1, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_rgba, (img, aval), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_rgba, (img, aval), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="unsupported Union type")
     @pytest.mark.jit
@@ -325,8 +325,8 @@ class TestLinearRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_linear_rgb, (img,), raise_exception=True)
-        assert gradcheck(kornia.color.linear_rgb_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_linear_rgb, (img,), raise_exception=True, fast_mode=True)
+        assert gradcheck(kornia.color.linear_rgb_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_sepia.py
+++ b/test/color/test_sepia.py
@@ -66,7 +66,7 @@ class TestSepia(BaseTester):
         # evaluate function gradient
         input_tensor = torch.rand(batch_shape, device=device, dtype=dtype)
         input_tensor = utils.tensor_to_gradcheck_var(input_tensor)
-        assert gradcheck(kornia.color.sepia, (input_tensor,), raise_exception=True)
+        assert gradcheck(kornia.color.sepia, (input_tensor,), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         op = kornia.color.sepia

--- a/test/color/test_xyz.py
+++ b/test/color/test_xyz.py
@@ -99,7 +99,7 @@ class TestRgbToXyz(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_xyz, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_xyz, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -210,7 +210,7 @@ class TestXyzToRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.xyz_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.xyz_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_ycbcr.py
+++ b/test/color/test_ycbcr.py
@@ -108,7 +108,7 @@ class TestRgbToYcbcr(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_ycbcr, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_ycbcr, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -221,7 +221,7 @@ class TestYcbcrToRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.ycbcr_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.ycbcr_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/color/test_yuv.py
+++ b/test/color/test_yuv.py
@@ -47,7 +47,7 @@ class TestRgbToYuv(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_yuv, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_yuv, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -202,7 +202,7 @@ class TestRgbToYuv420(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_yuv420, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_yuv420, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -272,7 +272,7 @@ class TestRgbToYuv422(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.rgb_to_yuv422, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.rgb_to_yuv422, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -332,7 +332,7 @@ class TestYuvToRgb(BaseTester):
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.yuv_to_rgb, (img,), raise_exception=True)
+        assert gradcheck(kornia.color.yuv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -436,7 +436,7 @@ class TestYuv420ToRgb(BaseTester):
         B, H, W = 2, 4, 4
         imgy = torch.rand(B, 1, H, W, device=device, dtype=torch.float64, requires_grad=True)
         imguv = torch.rand(B, 2, int(H / 2), int(W / 2), device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.yuv420_to_rgb, (imgy, imguv), raise_exception=True)
+        assert gradcheck(kornia.color.yuv420_to_rgb, (imgy, imguv), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -515,7 +515,7 @@ class TestYuv422ToRgb(BaseTester):
         B, H, W = 2, 4, 4
         imgy = torch.rand(B, 1, H, W, device=device, dtype=torch.float64, requires_grad=True)
         imguv = torch.rand(B, 2, H, int(W / 2), device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.color.yuv422_to_rgb, (imgy, imguv), raise_exception=True)
+        assert gradcheck(kornia.color.yuv422_to_rgb, (imgy, imguv), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/enhance/test_adjust.py
+++ b/test/enhance/test_adjust.py
@@ -34,7 +34,7 @@ class TestInvert(BaseTester):
         B, C, H, W = 1, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         max_val = torch.tensor(1.0, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.enhance.invert, (img, max_val), raise_exception=True)
+        assert gradcheck(kornia.enhance.invert, (img, max_val), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -125,13 +125,15 @@ class TestAdjustSaturation(BaseTester):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_saturation, (img, 2.0), raise_exception=True)
+        assert gradcheck(kornia.enhance.adjust_saturation, (img, 2.0), raise_exception=True, fast_mode=True)
 
     def test_gradcheck_with_gray_subtraction(self, device, dtype):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_saturation_with_gray_subtraction, (img, 2.0), raise_exception=True)
+        assert gradcheck(
+            kornia.enhance.adjust_saturation_with_gray_subtraction, (img, 2.0), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_exception(self, device, dtype):
@@ -203,7 +205,7 @@ class TestAdjustHue(BaseTester):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_hue, (img, 2.0), raise_exception=True)
+        assert gradcheck(kornia.enhance.adjust_hue, (img, 2.0), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_exception(self, device, dtype):
@@ -312,7 +314,7 @@ class TestAdjustGamma(BaseTester):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.ones(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_gamma, (img, 1.0, 2.0), raise_exception=True)
+        assert gradcheck(kornia.enhance.adjust_gamma, (img, 1.0, 2.0), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_exception(self, device, dtype):
@@ -606,13 +608,15 @@ class TestAdjustContrast(BaseTester):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_contrast, (img, 2.0), raise_exception=True)
+        assert gradcheck(kornia.enhance.adjust_contrast, (img, 2.0), raise_exception=True, fast_mode=True)
 
     def test_gradcheck_with_mean_subtraction(self, device, dtype):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_contrast_with_mean_subtraction, (img, 2.0), raise_exception=True)
+        assert gradcheck(
+            kornia.enhance.adjust_contrast_with_mean_subtraction, (img, 2.0), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_exception(self, device, dtype):
@@ -702,13 +706,15 @@ class TestAdjustBrightness(BaseTester):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_brightness, (img, 1.0), raise_exception=True)
+        assert gradcheck(kornia.enhance.adjust_brightness, (img, 1.0), raise_exception=True, fast_mode=True)
 
     def test_gradcheck_accumulative(self, device, dtype):
         batch_size, channels, height, width = 2, 3, 4, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.enhance.adjust_brightness_accumulative, (img, 2.0), raise_exception=True)
+        assert gradcheck(
+            kornia.enhance.adjust_brightness_accumulative, (img, 2.0), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_gradcheck(self, device, dtype):
@@ -781,7 +787,7 @@ class TestAdjustSigmoid(BaseTester):
         bs, channels, height, width = 1, 2, 3, 3
         inputs = torch.ones(bs, channels, height, width, device=device, dtype=dtype)
         inputs = tensor_to_gradcheck_var(inputs)
-        assert gradcheck(kornia.enhance.adjust_sigmoid, inputs, raise_exception=True)
+        assert gradcheck(kornia.enhance.adjust_sigmoid, inputs, raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -851,7 +857,7 @@ class TestAdjustLog(BaseTester):
         bs, channels, height, width = 1, 2, 3, 3
         inputs = torch.ones(bs, channels, height, width, device=device, dtype=dtype)
         inputs = tensor_to_gradcheck_var(inputs)
-        assert gradcheck(kornia.enhance.adjust_log, (inputs, 0.1), raise_exception=True)
+        assert gradcheck(kornia.enhance.adjust_log, (inputs, 0.1), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_cardinality(self, device, dtype):
@@ -1184,7 +1190,7 @@ class TestSharpness(BaseTester):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=dtype)
         inputs = tensor_to_gradcheck_var(inputs)
-        assert gradcheck(TestSharpness.f, (inputs, 0.8), raise_exception=True)
+        assert gradcheck(TestSharpness.f, (inputs, 0.8), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="union type input")
     @pytest.mark.jit
@@ -1274,7 +1280,7 @@ class TestSolarize(BaseTester):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=dtype)
         inputs = tensor_to_gradcheck_var(inputs)
-        assert gradcheck(TestSolarize.f, (inputs, 0.8), raise_exception=True)
+        assert gradcheck(TestSolarize.f, (inputs, 0.8), raise_exception=True, fast_mode=True)
 
     # TODO: implement me
     @pytest.mark.skip(reason="union type input")
@@ -1355,7 +1361,7 @@ class TestPosterize(BaseTester):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=dtype)
         inputs = tensor_to_gradcheck_var(inputs)
-        assert gradcheck(TestPosterize.f, (inputs, 0), raise_exception=True)
+        assert gradcheck(TestPosterize.f, (inputs, 0), raise_exception=True, fast_mode=True)
 
     # TODO: implement me
     @pytest.mark.skip(reason="union type input")

--- a/test/enhance/test_core.py
+++ b/test/enhance/test_core.py
@@ -72,7 +72,9 @@ class TestAddWeighted:
         src1, src2, alpha, beta, gamma = self.get_input(device, dtype, size=3, max_elem=5)  # to shave time on gradcheck
         src1 = utils.tensor_to_gradcheck_var(src1)  # to var
         src2 = utils.tensor_to_gradcheck_var(src2)  # to var
-        assert gradcheck(kornia.enhance.AddWeighted(alpha, beta, gamma), (src1, src2), raise_exception=True)
+        assert gradcheck(
+            kornia.enhance.AddWeighted(alpha, beta, gamma), (src1, src2), raise_exception=True, fast_mode=True
+        )
 
     def test_module(self, device, dtype):
         src1, src2, alpha, beta, gamma = self.get_input(device, dtype, size=3)

--- a/test/enhance/test_equalization.py
+++ b/test/enhance/test_equalization.py
@@ -79,7 +79,7 @@ class TestEqualization(BaseTester):
             rot = rotate(input, torch.tensor(30.0, dtype=input.dtype, device=device))
             return enhance.equalize_clahe(rot, a, b, c)
 
-        assert gradcheck(grad_rot, (inputs, 40.0, (2, 2), True), nondet_tol=1e-4, raise_exception=True)
+        assert gradcheck(grad_rot, (inputs, 40.0, (2, 2), True), nondet_tol=1e-4, raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="args and kwargs in decorator")
     def test_jit(self, device, dtype):

--- a/test/enhance/test_histogram.py
+++ b/test/enhance/test_histogram.py
@@ -36,7 +36,10 @@ class TestImageHistogram2d:
         centers = torch.linspace(0, 255, 8, device=device, dtype=dtype)
         centers = utils.tensor_to_gradcheck_var(centers)
         assert gradcheck(
-            TestImageHistogram2d.fcn, (input, 0.0, 255.0, 256, None, centers, True, kernel), raise_exception=True
+            TestImageHistogram2d.fcn,
+            (input, 0.0, 255.0, 256, None, centers, True, kernel),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     @pytest.mark.skipif(
@@ -115,7 +118,7 @@ class TestHistogram2d:
         bins = utils.tensor_to_gradcheck_var(bins)
         bandwidth = torch.tensor(0.9, device=device, dtype=dtype)
         bandwidth = utils.tensor_to_gradcheck_var(bandwidth)
-        assert gradcheck(TestHistogram2d.fcn, (inp1, inp2, bins, bandwidth), raise_exception=True)
+        assert gradcheck(TestHistogram2d.fcn, (inp1, inp2, bins, bandwidth), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         input1 = torch.linspace(0, 255, 10, device=device, dtype=dtype).unsqueeze(0)
@@ -165,7 +168,7 @@ class TestHistogram:
         bins = utils.tensor_to_gradcheck_var(bins)
         bandwidth = torch.tensor(0.9, device=device, dtype=dtype)
         bandwidth = utils.tensor_to_gradcheck_var(bandwidth)
-        assert gradcheck(TestHistogram.fcn, (inp, bins, bandwidth), raise_exception=True)
+        assert gradcheck(TestHistogram.fcn, (inp, bins, bandwidth), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         input1 = torch.linspace(0, 255, 10, device=device, dtype=dtype).unsqueeze(0)

--- a/test/enhance/test_normalize.py
+++ b/test/enhance/test_normalize.py
@@ -93,7 +93,7 @@ class TestNormalize(BaseTester):
         mean = utils.tensor_to_gradcheck_var(mean)  # to var
         std = utils.tensor_to_gradcheck_var(std)  # to var
 
-        assert gradcheck(kornia.enhance.Normalize(mean, std), (data,), raise_exception=True)
+        assert gradcheck(kornia.enhance.Normalize(mean, std), (data,), raise_exception=True, fast_mode=True)
 
     def test_single_value(self, device, dtype):
         # prepare input data
@@ -233,7 +233,7 @@ class TestDenormalize(BaseTester):
         mean = utils.tensor_to_gradcheck_var(mean)  # to var
         std = utils.tensor_to_gradcheck_var(std)  # to var
 
-        assert gradcheck(kornia.enhance.Denormalize(mean, std), (data,), raise_exception=True)
+        assert gradcheck(kornia.enhance.Denormalize(mean, std), (data,), raise_exception=True, fast_mode=True)
 
     def test_single_value(self, device, dtype):
 
@@ -316,7 +316,7 @@ class TestNormalizeMinMax(BaseTester):
     @pytest.mark.grad
     def test_gradcheck(self, device, dtype):
         x = torch.ones(1, 1, 1, 1, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.enhance.normalize_min_max, (x,), raise_exception=True)
+        assert gradcheck(kornia.enhance.normalize_min_max, (x,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="not implemented yet")
     def test_module(self, device, dtype):

--- a/test/enhance/test_shift_rgb.py
+++ b/test/enhance/test_shift_rgb.py
@@ -41,7 +41,9 @@ class TestRGBShift:
         r_shift, g_shift, b_shift = torch.Tensor([0.4]), torch.Tensor([0.5]), torch.Tensor([0.2])
         image = torch.randn(2, 3, 5, 5, device=device, dtype=dtype)
         image = utils.tensor_to_gradcheck_var(image)  # to var
-        assert gradcheck(kornia.enhance.shift_rgb, (image, r_shift, g_shift, b_shift), raise_exception=True)
+        assert gradcheck(
+            kornia.enhance.shift_rgb, (image, r_shift, g_shift, b_shift), raise_exception=True, fast_mode=True
+        )
 
     def test_rgb_shift(self, device, dtype):
         r_shift, g_shift, b_shift = torch.Tensor([0.1]), torch.Tensor([0.3]), torch.Tensor([-0.3])

--- a/test/feature/test_affine_shape_estimator.py
+++ b/test/feature/test_affine_shape_estimator.py
@@ -38,7 +38,7 @@ class TestPatchAffineShapeEstimator:
         ori = PatchAffineShapeEstimator(width).to(device)
         patches = torch.rand(batch_size, channels, height, width, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
-        assert gradcheck(ori, (patches,), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(ori, (patches,), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 13, 13
@@ -108,6 +108,7 @@ class TestLAFAffineShapeEstimator:
             rtol=1e-3,
             atol=1e-3,
             nondet_tol=1e-4,
+            fast_mode=True,
         )
 
     @pytest.mark.jit
@@ -158,7 +159,6 @@ class TestLAFAffNetShapeEstimator:
         expected = torch.tensor([[[[40.8758, 0.0, 16.0], [-0.3824, 9.7857, 16.0]]]], device=device, dtype=dtype)
         assert_close(new_laf, expected, atol=1e-4, rtol=1e-4)
 
-    @pytest.mark.skip("jacobian not well computed")
     def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 1, 35, 35
         patches = torch.rand(batch_size, channels, height, width, device=device)
@@ -172,6 +172,7 @@ class TestLAFAffNetShapeEstimator:
             rtol=1e-3,
             atol=1e-3,
             nondet_tol=1e-4,
+            fast_mode=True,
         )
 
     @pytest.mark.jit

--- a/test/feature/test_defmo.py
+++ b/test/feature/test_defmo.py
@@ -22,12 +22,11 @@ class TestDeFMO:
         with torch.no_grad():
             assert out.shape == (2, 24, 4, 128, 160)
 
-    @pytest.mark.skip("jacobian not well computed")
     def test_gradcheck(self, device, dtype):
-        patches = torch.rand(2, 6, 128, 128, device=device, dtype=dtype)
+        patches = torch.rand(2, 6, 64, 64, device=device, dtype=dtype)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         defmo = DeFMO().to(patches.device, patches.dtype)
-        assert gradcheck(defmo, (patches,), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(defmo, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/feature/test_hardnet.py
+++ b/test/feature/test_hardnet.py
@@ -21,12 +21,13 @@ class TestHardNet:
         out = hardnet(inp)
         assert out.shape == (16, 128)
 
-    @pytest.mark.skip("jacobian not well computed")
     def test_gradcheck(self, device):
         patches = torch.rand(2, 1, 32, 32, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         hardnet = HardNet().to(patches.device, patches.dtype)
-        assert gradcheck(hardnet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(
+            hardnet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -56,7 +57,7 @@ class TestHardNet8:
         patches = torch.rand(2, 1, 32, 32, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         hardnet = HardNet8().to(patches.device, patches.dtype)
-        assert gradcheck(hardnet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(hardnet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/feature/test_hynet.py
+++ b/test/feature/test_hynet.py
@@ -20,12 +20,11 @@ class TestHyNet:
         out = hynet(inp)
         assert out.shape == (16, 128)
 
-    @pytest.mark.skip("jacobian not well computed")
     def test_gradcheck(self, device):
         patches = torch.rand(2, 1, 32, 32, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         hynet = HyNet().to(patches.device, patches.dtype)
-        assert gradcheck(hynet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(hynet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/feature/test_keynet.py
+++ b/test/feature/test_keynet.py
@@ -20,12 +20,11 @@ class TestKeyNet:
         out = keynet(inp)
         assert out.shape == inp.shape
 
-    @pytest.mark.skip("jacobian not well computed")
     def test_gradcheck(self, device):
         patches = torch.rand(2, 1, 16, 16, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         keynet = KeyNet().to(patches.device, patches.dtype)
-        assert gradcheck(keynet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(keynet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/feature/test_laf.py
+++ b/test/feature/test_laf.py
@@ -24,7 +24,9 @@ class TestAngleToRotationMatrix:
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.geometry.transform.imgwarp.angle_to_rotation_matrix, (img,), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.imgwarp.angle_to_rotation_matrix, (img,), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.jit
     @pytest.mark.skip("Problems with kornia.pi")
@@ -53,7 +55,7 @@ class TestGetLAFScale:
         batch_size, channels, height, width = 1, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.get_laf_scale, (img,), raise_exception=True)
+        assert gradcheck(kornia.feature.get_laf_scale, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -81,7 +83,7 @@ class TestGetLAFCenter:
         batch_size, channels, height, width = 1, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.get_laf_center, (img,), raise_exception=True)
+        assert gradcheck(kornia.feature.get_laf_center, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -109,7 +111,7 @@ class TestGetLAFOri:
         batch_size, channels, height, width = 1, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.get_laf_orientation, (img,), raise_exception=True)
+        assert gradcheck(kornia.feature.get_laf_orientation, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     @pytest.mark.skip("Union")
@@ -146,7 +148,7 @@ class TestScaleLAF:
         scale = torch.rand(batch_size, device=device)
         scale = utils.tensor_to_gradcheck_var(scale)  # to var
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
-        assert gradcheck(kornia.feature.scale_laf, (laf, scale), raise_exception=True, atol=1e-4)
+        assert gradcheck(kornia.feature.scale_laf, (laf, scale), raise_exception=True, atol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     @pytest.mark.skip("Union")
@@ -179,7 +181,9 @@ class TestSetLAFOri:
         ori = torch.rand(batch_size, channels, 1, 1, device=device)
         ori = utils.tensor_to_gradcheck_var(ori)  # to var
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
-        assert gradcheck(kornia.feature.set_laf_orientation, (laf, ori), raise_exception=True, atol=1e-4)
+        assert gradcheck(
+            kornia.feature.set_laf_orientation, (laf, ori), raise_exception=True, atol=1e-4, fast_mode=True
+        )
 
     @pytest.mark.jit
     @pytest.mark.skip("Union")
@@ -222,7 +226,7 @@ class TestMakeUpright:
         batch_size, channels, height, width = 14, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.make_upright, (img,), raise_exception=True)
+        assert gradcheck(kornia.feature.make_upright, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     @pytest.mark.skip("Union")
@@ -256,7 +260,7 @@ class TestELL2LAF:
         img[:, :, 4] += 1.0
         # assure it is positive definite
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.ellipse_to_laf, (img,), raise_exception=True)
+        assert gradcheck(kornia.feature.ellipse_to_laf, (img,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -291,7 +295,7 @@ class TestNormalizeLAF:
         img = torch.rand(batch_size, 3, 10, 32)
         img = utils.tensor_to_gradcheck_var(img)  # to var
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
-        assert gradcheck(kornia.feature.normalize_laf, (laf, img), raise_exception=True)
+        assert gradcheck(kornia.feature.normalize_laf, (laf, img), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -322,7 +326,7 @@ class TestLAF2pts:
         batch_size, channels, height, width = 3, 2, 2, 3
         laf = torch.rand(batch_size, channels, height, width, device=device)
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
-        assert gradcheck(kornia.feature.laf_to_boundary_points, (laf), raise_exception=True)
+        assert gradcheck(kornia.feature.laf_to_boundary_points, (laf), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -355,7 +359,7 @@ class TestDenormalizeLAF:
         img = torch.rand(batch_size, 3, 10, 32, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
-        assert gradcheck(kornia.feature.denormalize_laf, (laf, img), raise_exception=True)
+        assert gradcheck(kornia.feature.denormalize_laf, (laf, img), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -386,7 +390,7 @@ class TestGenPatchGrid:
 
         img = utils.tensor_to_gradcheck_var(img)  # to var
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
-        assert gradcheck(generate_patch_grid_from_normalized_LAF, (img, laf, PS), raise_exception=True)
+        assert gradcheck(generate_patch_grid_from_normalized_LAF, (img, laf, PS), raise_exception=True, fast_mode=True)
 
 
 class TestExtractPatchesSimple:
@@ -397,8 +401,6 @@ class TestExtractPatchesSimple:
         patches = kornia.feature.extract_patches_simple(img, laf, PS)
         assert patches.shape == (5, 4, 3, PS, PS)
 
-    # TODO: check what to do to improve timing
-    # @pytest.mark.skip("The test takes too long to finish.")
     def test_gradcheck(self, device):
         nlaf = torch.tensor([[0.1, 0.001, 0.5], [0, 0.1, 0.5]], device=device).float()
         nlaf = nlaf.view(1, 1, 2, 3)
@@ -417,8 +419,6 @@ class TestExtractPatchesPyr:
         patches = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
         assert patches.shape == (5, 4, 3, PS, PS)
 
-    # TODO: check what to do to improve timing
-    # @pytest.mark.skip("The test takes too long to finish.")
     def test_gradcheck(self, device):
         nlaf = torch.tensor([[0.1, 0.001, 0.5], [0, 0.1, 0.5]], device=device).float()
         nlaf = nlaf.view(1, 1, 2, 3)
@@ -426,7 +426,13 @@ class TestExtractPatchesPyr:
         PS = 11
         img = utils.tensor_to_gradcheck_var(img)  # to var
         nlaf = utils.tensor_to_gradcheck_var(nlaf)  # to var
-        assert gradcheck(kornia.feature.extract_patches_from_pyramid, (img, nlaf, PS, False), raise_exception=True)
+        assert gradcheck(
+            kornia.feature.extract_patches_from_pyramid,
+            (img, nlaf, PS, False),
+            nondet_tol=1e-8,
+            raise_exception=True,
+            fast_mode=True,
+        )
 
 
 class TestLAFIsTouchingBoundary:
@@ -492,7 +498,9 @@ class TestGetCreateLAF:
         xy = utils.tensor_to_gradcheck_var(torch.rand(batch_size, channels, 2, device=device))
         ori = utils.tensor_to_gradcheck_var(torch.rand(batch_size, channels, 1, device=device))
         scale = utils.tensor_to_gradcheck_var(torch.abs(torch.rand(batch_size, channels, 1, 1, device=device)))
-        assert gradcheck(kornia.feature.laf_from_center_scale_ori, (xy, scale, ori), raise_exception=True)
+        assert gradcheck(
+            kornia.feature.laf_from_center_scale_ori, (xy, scale, ori), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.skip("Depends on angle-to-rotation-matric")
     @pytest.mark.jit
@@ -527,7 +535,7 @@ class TestGetLAF3pts:
         batch_size, channels, height, width = 3, 2, 2, 3
         inp = torch.rand(batch_size, channels, height, width, device=device)
         inp = utils.tensor_to_gradcheck_var(inp)  # to var
-        assert gradcheck(kornia.feature.laf_to_three_points, (inp,), raise_exception=True)
+        assert gradcheck(kornia.feature.laf_to_three_points, (inp,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -566,7 +574,7 @@ class TestGetLAFFrom3pts:
         batch_size, channels, height, width = 3, 2, 2, 3
         inp = torch.rand(batch_size, channels, height, width, device=device)
         inp = utils.tensor_to_gradcheck_var(inp)  # to var
-        assert gradcheck(kornia.feature.laf_from_three_points, (inp,), raise_exception=True)
+        assert gradcheck(kornia.feature.laf_from_three_points, (inp,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -606,4 +614,6 @@ class TestTransformLAFs:
         # evaluate function gradient
         points_src = utils.tensor_to_gradcheck_var(points_src)  # to var
         dst_homo_src = utils.tensor_to_gradcheck_var(dst_homo_src)  # to var
-        assert gradcheck(kornia.feature.perspective_transform_lafs, (dst_homo_src, points_src), raise_exception=True)
+        assert gradcheck(
+            kornia.feature.perspective_transform_lafs, (dst_homo_src, points_src), raise_exception=True, fast_mode=True
+        )

--- a/test/feature/test_local_features_orientation.py
+++ b/test/feature/test_local_features_orientation.py
@@ -39,7 +39,7 @@ class TestPassLAF:
         patches = torch.rand(batch_size, channels, height, width, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         laf = torch.rand(batch_size, 4, 2, 3)
-        assert gradcheck(PassLAF().to(device), (patches, laf), raise_exception=True)
+        assert gradcheck(PassLAF().to(device), (patches, laf), raise_exception=True, fast_mode=True)
 
 
 class TestPatchDominantGradientOrientation:
@@ -72,7 +72,7 @@ class TestPatchDominantGradientOrientation:
         ori = PatchDominantGradientOrientation(width).to(device)
         patches = torch.rand(batch_size, channels, height, width, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
-        assert gradcheck(ori, (patches,), raise_exception=True)
+        assert gradcheck(ori, (patches,), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     @pytest.mark.skip(" Compiled functions can't take variable number")
@@ -168,4 +168,6 @@ class TestLAFOrienter:
         laf[:, :, 0, 1] = 0
         laf[:, :, 1, 0] = 0
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
-        assert gradcheck(LAFOrienter(8).to(device), (laf, patches), raise_exception=True, rtol=1e-3, atol=1e-3)
+        assert gradcheck(
+            LAFOrienter(8).to(device), (laf, patches), raise_exception=True, rtol=1e-3, atol=1e-3, fast_mode=True
+        )

--- a/test/feature/test_loftr.py
+++ b/test/feature/test_loftr.py
@@ -51,7 +51,6 @@ class TestLoFTR:
             out = loftr(input)
         assert out is not None
 
-    @pytest.mark.skip("Takes too long time (but works)")
     def test_gradcheck(self, device):
         patches = torch.rand(1, 1, 32, 32, device=device)
         patches05 = resize(patches, (48, 48))
@@ -62,7 +61,7 @@ class TestLoFTR:
         def proxy_forward(x, y):
             return loftr.forward({"image0": x, "image1": y})["keypoints0"]
 
-        assert gradcheck(proxy_forward, (patches, patches05), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(proxy_forward, (patches, patches05), eps=1e-4, atol=1e-4, raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip("does not like transformer.py:L99, zip iteration")
     def test_jit(self, device, dtype):

--- a/test/feature/test_matching.py
+++ b/test/feature/test_matching.py
@@ -46,7 +46,7 @@ class TestMatchNN:
         desc2 = torch.rand(7, 8, device=device)
         desc1 = utils.tensor_to_gradcheck_var(desc1)  # to var
         desc2 = utils.tensor_to_gradcheck_var(desc2)  # to var
-        assert gradcheck(match_mnn, (desc1, desc2), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(match_mnn, (desc1, desc2), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
 
 class TestMatchMNN:
@@ -80,7 +80,7 @@ class TestMatchMNN:
         desc2 = torch.rand(7, 8, device=device)
         desc1 = utils.tensor_to_gradcheck_var(desc1)  # to var
         desc2 = utils.tensor_to_gradcheck_var(desc2)  # to var
-        assert gradcheck(match_mnn, (desc1, desc2), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(match_mnn, (desc1, desc2), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
 
 class TestMatchSNN:
@@ -136,7 +136,7 @@ class TestMatchSNN:
         desc2 = torch.rand(7, 8, device=device)
         desc1 = utils.tensor_to_gradcheck_var(desc1)  # to var
         desc2 = utils.tensor_to_gradcheck_var(desc2)  # to var
-        assert gradcheck(match_snn, (desc1, desc2, 0.8), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(match_snn, (desc1, desc2, 0.8), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
 
 class TestMatchSMNN:
@@ -219,8 +219,8 @@ class TestMatchSMNN:
         desc1 = utils.tensor_to_gradcheck_var(desc1)  # to var
         desc2 = utils.tensor_to_gradcheck_var(desc2)  # to var
         matcher = DescriptorMatcher('smnn', 0.8).to(device)
-        assert gradcheck(match_smnn, (desc1, desc2, 0.8), raise_exception=True, nondet_tol=1e-4)
-        assert gradcheck(matcher, (desc1, desc2), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(match_smnn, (desc1, desc2, 0.8), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
+        assert gradcheck(matcher, (desc1, desc2), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     @pytest.mark.parametrize("match_type", ["nn", "snn", "mnn", "smnn"])
@@ -330,7 +330,9 @@ class TestMatchFGINN:
         desc2 = utils.tensor_to_gradcheck_var(desc2)  # to var
         lafs1 = utils.tensor_to_gradcheck_var(lafs1)  # to var
         lafs2 = utils.tensor_to_gradcheck_var(lafs2)  # to var
-        assert gradcheck(match_fginn, (desc1, desc2, lafs1, lafs2, 0.8, 0.05), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(
+            match_fginn, (desc1, desc2, lafs1, lafs2, 0.8, 0.05), raise_exception=True, nondet_tol=1e-4, fast_mode=True
+        )
 
     @pytest.mark.jit
     @pytest.mark.skip("keyword-arg expansion is not supported")

--- a/test/feature/test_mkd.py
+++ b/test/feature/test_mkd.py
@@ -77,7 +77,7 @@ class TestMKDGradients:
             mkd_grads.to(device)
             return mkd_grads(patches)
 
-        assert gradcheck(grad_describe, (patches), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(grad_describe, (patches), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -140,7 +140,7 @@ class TestVonMisesKernel:
             vmkernel.to(device)
             return vmkernel(patches.double())
 
-        assert gradcheck(vm_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(vm_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -182,7 +182,7 @@ class TestEmbedGradients:
         assert_close(out[0, 0, :, 3:], expected * 0, atol=1e-3, rtol=1e-3)
 
     # TODO: review this test implementation
-    @pytest.mark.xfail(reason="RuntimeError: Jacobian mismatch for output 0 with respect to input 0,")
+    # @pytest.mark.xfail(reason="RuntimeError: Jacobian mismatch for output 0 with respect to input 0,")
     def test_gradcheck(self, device):
         batch_size, channels, ps = 1, 2, 13
         patches = torch.rand(batch_size, channels, ps, ps).to(device)
@@ -193,7 +193,7 @@ class TestEmbedGradients:
             emb_grads.to(device)
             return emb_grads(patches.double())
 
-        assert gradcheck(emb_grads_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(emb_grads_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -265,7 +265,9 @@ class TestExplicitSpacialEncoding:
             ese.to(device)
             return ese(patches)
 
-        assert gradcheck(explicit_spatial_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(
+            explicit_spatial_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True
+        )
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -327,7 +329,7 @@ class TestWhitening:
             wh.to(device)
             return wh(patches.double())
 
-        assert gradcheck(whitening_describe, (patches, in_dims), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(whitening_describe, (patches, in_dims), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):
@@ -390,7 +392,6 @@ class TestMKDDescriptor:
         expected = torch.zeros_like(out_part).to(device)
         assert_close(out_part, expected, atol=1e-3, rtol=1e-3)
 
-    @pytest.mark.skip("Just because")
     @pytest.mark.parametrize("whitening", [None, 'lw', 'pca'])
     def test_gradcheck(self, whitening, device):
         batch_size, channels, ps = 1, 1, 19
@@ -402,7 +403,7 @@ class TestMKDDescriptor:
             mkd.to(device)
             return mkd(patches.double())
 
-        assert gradcheck(mkd_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(mkd_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.skip("neither dict, nor nn.ModuleDict works")
     @pytest.mark.jit
@@ -449,7 +450,7 @@ class TestSimpleKD:
             skd.to(device)
             return skd(patches.double())
 
-        assert gradcheck(skd_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(skd_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/feature/test_responces_local_features.py
+++ b/test/feature/test_responces_local_features.py
@@ -114,7 +114,9 @@ class TestCornerHarris:
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.harris_response, (img, k), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(
+            kornia.feature.harris_response, (img, k), raise_exception=True, nondet_tol=1e-4, fast_mode=True
+        )
 
     @pytest.mark.skip(reason="turn off all jit for a while")
     def test_jit(self, device):
@@ -233,7 +235,7 @@ class TestCornerGFTT:
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.gftt_response, (img), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(kornia.feature.gftt_response, (img), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.skip(reason="turn off all jit for a while")
     def test_jit(self, device):
@@ -313,7 +315,7 @@ class TestBlobHessian:
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.feature.hessian_response, (img), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(kornia.feature.hessian_response, (img), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device):

--- a/test/feature/test_scale_space_detector.py
+++ b/test/feature/test_scale_space_detector.py
@@ -54,4 +54,6 @@ class TestScaleSpaceDetector:
         batch_size, channels, height, width = 1, 1, 7, 7
         patches = torch.rand(batch_size, channels, height, width, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
-        assert gradcheck(ScaleSpaceDetector(2).to(device), patches, raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(
+            ScaleSpaceDetector(2).to(device), patches, raise_exception=True, nondet_tol=1e-4, fast_mode=True
+        )

--- a/test/feature/test_siftdesc.py
+++ b/test/feature/test_siftdesc.py
@@ -58,7 +58,7 @@ class TestSIFTDescriptor:
         patches = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         sift = SIFTDescriptor(15).to(device, dtype)
-        assert gradcheck(sift, (patches,), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(sift, (patches,), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.skip("Compiled functions can't take variable number")
     def test_jit(self, device, dtype):
@@ -96,9 +96,8 @@ class TestDenseSIFTDescriptor:
         sift = DenseSIFTDescriptor()
         sift.__repr__()
 
-    @pytest.mark.xfail(reason='May raise checkIfNumericalAnalyticAreClose.')
     def test_gradcheck(self, device, dtype):
         batch_size, channels, height, width = 1, 1, 16, 16
         patches = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
-        assert gradcheck(DenseSIFTDescriptor(4, 2, 2), (patches), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(DenseSIFTDescriptor(4, 2, 2), (patches), raise_exception=True, nondet_tol=1e-4, fast_mode=True)

--- a/test/feature/test_sold2.py
+++ b/test/feature/test_sold2.py
@@ -26,7 +26,7 @@ class TestSOLD2_detector:
         def proxy_forward(x):
             return sold2.forward(x)["junction_heatmap"]
 
-        assert gradcheck(proxy_forward, (img,), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(proxy_forward, (img,), eps=1e-4, atol=1e-4, raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip("Does not like recursive definition of Hourglass in backbones.py l.134.")
     def test_jit(self, device, dtype):

--- a/test/feature/test_sosnet.py
+++ b/test/feature/test_sosnet.py
@@ -26,7 +26,7 @@ class TestSOSNet:
         patches = torch.rand(2, 1, 32, 32, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         sosnet = SOSNet(pretrained=False).to(patches.device, patches.dtype)
-        assert gradcheck(sosnet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True)
+        assert gradcheck(sosnet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/feature/test_tfeat.py
+++ b/test/feature/test_tfeat.py
@@ -33,7 +33,7 @@ class TestTFeat:
         patches = torch.rand(2, 1, 32, 32, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         tfeat = TFeat().to(patches.device, patches.dtype)
-        assert gradcheck(tfeat, (patches,), eps=1e-2, atol=1e-2, raise_exception=True)
+        assert gradcheck(tfeat, (patches,), eps=1e-2, atol=1e-2, raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/filters/test_blur_pool.py
+++ b/test/filters/test_blur_pool.py
@@ -32,7 +32,7 @@ class TestMaxBlurPool:
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.max_blur_pool2d, (img, 3), raise_exception=True)
+        assert gradcheck(kornia.filters.max_blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         op = kornia.filters.max_blur_pool2d
@@ -82,7 +82,7 @@ class TestBlurPool:
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.blur_pool2d, (img, 3), raise_exception=True)
+        assert gradcheck(kornia.filters.blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         op = kornia.filters.blur_pool2d
@@ -119,7 +119,7 @@ class TestEdgeAwareBlurPool:
     def test_gradcheck(self, device, dtype):
         img = torch.rand((1, 2, 5, 4), device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.edge_aware_blur_pool2d, (img, 3), raise_exception=True)
+        assert gradcheck(kornia.filters.edge_aware_blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         op = kornia.filters.edge_aware_blur_pool2d

--- a/test/filters/test_canny.py
+++ b/test/filters/test_canny.py
@@ -267,7 +267,7 @@ class TestCanny:
         batch_size, channels, height, width = 1, 1, 3, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.canny, img, raise_exception=True)
+        assert gradcheck(kornia.filters.canny, img, raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -285,7 +285,9 @@ class TestFilter2D:
         # evaluate function gradient
         input = utils.tensor_to_gradcheck_var(input)  # to var
         kernel = utils.tensor_to_gradcheck_var(kernel)  # to var
-        assert gradcheck(kornia.filters.filter2d, (input, kernel), raise_exception=True)
+        assert gradcheck(
+            kornia.filters.filter2d, (input, kernel), nondet_tol=1e-8, raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_jit(self, padding, device, dtype):
@@ -611,7 +613,9 @@ class TestFilter3D:
         # evaluate function gradient
         input = utils.tensor_to_gradcheck_var(input)  # to var
         kernel = utils.tensor_to_gradcheck_var(kernel)  # to var
-        assert gradcheck(kornia.filters.filter3d, (input, kernel), raise_exception=True)
+        assert gradcheck(
+            kornia.filters.filter3d, (input, kernel), nondet_tol=1e-8, raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         op = kornia.filters.filter3d

--- a/test/filters/test_gaussian.py
+++ b/test/filters/test_gaussian.py
@@ -78,7 +78,12 @@ class TestGaussianBlur2d:
         # evaluate function gradient
         input = torch.rand(batch_shape, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.filters.gaussian_blur2d, (input, kernel_size, sigma, "replicate"), raise_exception=True)
+        assert gradcheck(
+            kornia.filters.gaussian_blur2d,
+            (input, kernel_size, sigma, "replicate"),
+            raise_exception=True,
+            fast_mode=True,
+        )
 
     def test_jit(self, device, dtype):
         op = kornia.filters.gaussian_blur2d

--- a/test/filters/test_laplacian.py
+++ b/test/filters/test_laplacian.py
@@ -58,7 +58,7 @@ class TestLaplacian:
         # evaluate function gradient
         input = torch.rand(batch_shape, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)
-        assert gradcheck(kornia.filters.laplacian, (input, kernel_size), raise_exception=True)
+        assert gradcheck(kornia.filters.laplacian, (input, kernel_size), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         op = kornia.filters.laplacian

--- a/test/filters/test_median.py
+++ b/test/filters/test_median.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from torch.autograd import gradcheck
 
@@ -51,12 +50,11 @@ class TestMedianBlur:
         actual = kornia.filters.median_blur(inp, kernel_size)
         assert_close(actual, actual)
 
-    @pytest.mark.xfail(reason="this tests is a bit unstable")
     def test_gradcheck(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.median_blur, (img, (5, 3)), raise_exception=True)
+        assert gradcheck(kornia.filters.median_blur, (img, (5, 3)), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         kernel_size = (3, 5)

--- a/test/filters/test_motion.py
+++ b/test/filters/test_motion.py
@@ -52,7 +52,11 @@ class TestMotionBlur:
         input = torch.rand(batch_shape, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)
         assert gradcheck(
-            kornia.filters.motion_blur, (input, ksize, angle, direction, "replicate"), raise_exception=True
+            kornia.filters.motion_blur,
+            (input, ksize, angle, direction, "replicate"),
+            nondet_tol=1e-8,
+            raise_exception=True,
+            fast_mode=True,
         )
 
     @pytest.mark.skip("angle can be Union")

--- a/test/filters/test_sobel.py
+++ b/test/filters/test_sobel.py
@@ -218,7 +218,7 @@ class TestSpatialGradient:
         batch_size, channels, height, width = 1, 1, 3, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.spatial_gradient, (img,), raise_exception=True)
+        assert gradcheck(kornia.filters.spatial_gradient, (img,), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
@@ -452,7 +452,7 @@ class TestSobel:
         batch_size, channels, height, width = 1, 1, 3, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.sobel, (img, False), raise_exception=True)
+        assert gradcheck(kornia.filters.sobel, (img, False), raise_exception=True, fast_mode=True)
 
     def test_gradcheck(self, device, dtype):
         if "cuda" in str(device):
@@ -460,7 +460,7 @@ class TestSobel:
         batch_size, channels, height, width = 1, 1, 3, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.sobel, (img, True), raise_exception=True)
+        assert gradcheck(kornia.filters.sobel, (img, True), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)

--- a/test/filters/test_unsharp_mask.py
+++ b/test/filters/test_unsharp_mask.py
@@ -35,7 +35,9 @@ class Testunsharp:
         # evaluate function gradient
         input = torch.rand(batch_shape, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.filters.unsharp_mask, (input, kernel_size, sigma, "replicate"), raise_exception=True)
+        assert gradcheck(
+            kornia.filters.unsharp_mask, (input, kernel_size, sigma, "replicate"), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         op = kornia.filters.unsharp_mask

--- a/test/geometry/calibration/test_distort.py
+++ b/test/geometry/calibration/test_distort.py
@@ -49,7 +49,7 @@ class TestDistortPoints:
         new_K = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         distCoeff = torch.rand(1, 4, device=device, dtype=torch.float64)
 
-        assert gradcheck(distort_points, (points, K, distCoeff, new_K), raise_exception=True)
+        assert gradcheck(distort_points, (points, K, distCoeff, new_K), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         points = torch.rand(1, 1, 2, device=device, dtype=dtype)

--- a/test/geometry/calibration/test_pnp.py
+++ b/test/geometry/calibration/test_pnp.py
@@ -106,7 +106,9 @@ class TestSolvePnpDlt:
         img_points = tensor_to_gradcheck_var(img_points)
         intrinsics = tensor_to_gradcheck_var(intrinsics)
 
-        assert gradcheck(kornia.geometry.solve_pnp_dlt, (world_points, img_points, intrinsics), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.solve_pnp_dlt, (world_points, img_points, intrinsics), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.parametrize("num_points", (6, 20))
     def test_pred_world_to_cam(self, num_points, device, dtype):
@@ -152,4 +154,4 @@ class TestNormalization:
         points = torch.rand((batch_size, num_points, dimension), device=device, dtype=dtype)
         points = tensor_to_gradcheck_var(points)
 
-        assert gradcheck(_mean_isotropic_scale_normalize, (points,), raise_exception=True)
+        assert gradcheck(_mean_isotropic_scale_normalize, (points,), raise_exception=True, fast_mode=True)

--- a/test/geometry/calibration/test_undistort.py
+++ b/test/geometry/calibration/test_undistort.py
@@ -232,7 +232,7 @@ class TestUndistortPoints:
         new_K = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         distCoeff = torch.rand(1, 4, device=device, dtype=torch.float64)
 
-        assert gradcheck(undistort_points, (points, K, distCoeff, new_K), raise_exception=True)
+        assert gradcheck(undistort_points, (points, K, distCoeff, new_K), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         points = torch.rand(1, 1, 2, device=device, dtype=dtype)
@@ -341,7 +341,7 @@ class TestUndistortImage:
         K = torch.rand(3, 3, device=device, dtype=torch.float64)
         distCoeff = torch.rand(4, device=device, dtype=torch.float64)
 
-        assert gradcheck(undistort_image, (im, K, distCoeff), raise_exception=True)
+        assert gradcheck(undistort_image, (im, K, distCoeff), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         im = torch.rand(1, 3, 5, 5, device=device, dtype=dtype)

--- a/test/geometry/camera/test_perspective.py
+++ b/test/geometry/camera/test_perspective.py
@@ -42,7 +42,9 @@ class TestProjectPoints:
         # evaluate function gradient
         points_3d = tensor_to_gradcheck_var(points_3d)
         camera_matrix = tensor_to_gradcheck_var(camera_matrix)
-        assert gradcheck(kornia.geometry.camera.project_points, (points_3d, camera_matrix), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.camera.project_points, (points_3d, camera_matrix), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         points_3d = torch.zeros(1, 3, device=device, dtype=dtype)
@@ -108,7 +110,10 @@ class TestUnprojectPoints:
         depth = tensor_to_gradcheck_var(depth)
         camera_matrix = tensor_to_gradcheck_var(camera_matrix)
         assert gradcheck(
-            kornia.geometry.camera.unproject_points, (points_2d, depth, camera_matrix), raise_exception=True
+            kornia.geometry.camera.unproject_points,
+            (points_2d, depth, camera_matrix),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     def test_jit(self, device, dtype):

--- a/test/geometry/camera/test_pinhole.py
+++ b/test/geometry/camera/test_pinhole.py
@@ -116,6 +116,7 @@ class TestCam2Pixel:
             raise_exception=True,
             atol=atol,
             rtol=rtol,
+            fast_mode=True,
         )
 
 

--- a/test/geometry/epipolar/test_epipolar_metrics.py
+++ b/test/geometry/epipolar/test_epipolar_metrics.py
@@ -41,7 +41,9 @@ class TestSymmetricalEpipolarDistance:
         points1 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64, requires_grad=True)
         points2 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64)
         Fm = utils.create_random_fundamental_matrix(batch_size).type_as(points2)
-        assert gradcheck(epi.symmetrical_epipolar_distance, (points1, points2, Fm), raise_exception=True)
+        assert gradcheck(
+            epi.symmetrical_epipolar_distance, (points1, points2, Fm), raise_exception=True, fast_mode=True
+        )
 
     def test_shift(self, device, dtype):
         pts1 = torch.zeros(3, 2, device=device, dtype=dtype)[None]
@@ -90,7 +92,7 @@ class TestSampsonEpipolarDistance:
         points1 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64, requires_grad=True)
         points2 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64)
         Fm = utils.create_random_fundamental_matrix(batch_size).type_as(points2)
-        assert gradcheck(epi.sampson_epipolar_distance, (points1, points2, Fm), raise_exception=True)
+        assert gradcheck(epi.sampson_epipolar_distance, (points1, points2, Fm), raise_exception=True, fast_mode=True)
 
 
 class TestLeftToRightEpipolarDistance:
@@ -135,7 +137,9 @@ class TestLeftToRightEpipolarDistance:
         points1 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64, requires_grad=True)
         points2 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64)
         Fm = utils.create_random_fundamental_matrix(batch_size).type_as(points2)
-        assert gradcheck(epi.left_to_right_epipolar_distance, (points1, points2, Fm), raise_exception=True)
+        assert gradcheck(
+            epi.left_to_right_epipolar_distance, (points1, points2, Fm), raise_exception=True, fast_mode=True
+        )
 
 
 class TestRightToLeftEpipolarDistance:
@@ -180,4 +184,6 @@ class TestRightToLeftEpipolarDistance:
         points1 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64, requires_grad=True)
         points2 = torch.rand(batch_size, num_points, num_dims, device=device, dtype=torch.float64)
         Fm = utils.create_random_fundamental_matrix(batch_size).type_as(points2)
-        assert gradcheck(epi.right_to_left_epipolar_distance, (points1, points2, Fm), raise_exception=True)
+        assert gradcheck(
+            epi.right_to_left_epipolar_distance, (points1, points2, Fm), raise_exception=True, fast_mode=True
+        )

--- a/test/geometry/epipolar/test_essential.py
+++ b/test/geometry/epipolar/test_essential.py
@@ -61,7 +61,7 @@ class TestEssentialFromFundamental:
         F_mat = torch.rand(1, 3, 3, device=device, dtype=torch.float64, requires_grad=True)
         K1 = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         K2 = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
-        assert gradcheck(epi.essential_from_fundamental, (F_mat, K1, K2), raise_exception=True)
+        assert gradcheck(epi.essential_from_fundamental, (F_mat, K1, K2), raise_exception=True, fast_mode=True)
 
 
 class TestRelativeCameraMotion:
@@ -120,7 +120,7 @@ class TestRelativeCameraMotion:
         R2 = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         t1 = torch.rand(1, 3, 1, device=device, dtype=torch.float64)
         t2 = torch.rand(1, 3, 1, device=device, dtype=torch.float64)
-        assert gradcheck(epi.relative_camera_motion, (R1, t1, R2, t2), raise_exception=True)
+        assert gradcheck(epi.relative_camera_motion, (R1, t1, R2, t2), raise_exception=True, fast_mode=True)
 
 
 class TestEssentalFromRt:
@@ -161,7 +161,7 @@ class TestEssentalFromRt:
         R2 = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         t1 = torch.rand(1, 3, 1, device=device, dtype=torch.float64)
         t2 = torch.rand(1, 3, 1, device=device, dtype=torch.float64)
-        assert gradcheck(epi.essential_from_Rt, (R1, t1, R2, t2), raise_exception=True)
+        assert gradcheck(epi.essential_from_Rt, (R1, t1, R2, t2), raise_exception=True, fast_mode=True)
 
 
 class TestDecomposeEssentialMatrix:
@@ -192,9 +192,9 @@ class TestDecomposeEssentialMatrix:
         def eval_vec(input):
             return epi.decompose_essential_matrix(input)[2]
 
-        assert gradcheck(eval_rot1, (E_mat,), raise_exception=True)
-        assert gradcheck(eval_rot2, (E_mat,), raise_exception=True)
-        assert gradcheck(eval_vec, (E_mat,), raise_exception=True)
+        assert gradcheck(eval_rot1, (E_mat,), raise_exception=True, fast_mode=True)
+        assert gradcheck(eval_rot2, (E_mat,), raise_exception=True, fast_mode=True)
+        assert gradcheck(eval_vec, (E_mat,), raise_exception=True, fast_mode=True)
 
 
 class TestMotionFromEssential:
@@ -239,8 +239,8 @@ class TestMotionFromEssential:
         def eval_vec(input):
             return epi.motion_from_essential(input)[1]
 
-        assert gradcheck(eval_rot, (E_mat,), raise_exception=True)
-        assert gradcheck(eval_vec, (E_mat,), raise_exception=True)
+        assert gradcheck(eval_rot, (E_mat,), raise_exception=True, fast_mode=True)
+        assert gradcheck(eval_vec, (E_mat,), raise_exception=True, fast_mode=True)
 
 
 class TestMotionFromEssentialChooseSolution:
@@ -330,4 +330,6 @@ class TestMotionFromEssentialChooseSolution:
         x1 = torch.rand(1, 2, 2, device=device, dtype=torch.float64)
         x2 = torch.rand(1, 2, 2, device=device, dtype=torch.float64)
 
-        assert gradcheck(epi.motion_from_essential_choose_solution, (E_mat, K1, K2, x1, x2), raise_exception=True)
+        assert gradcheck(
+            epi.motion_from_essential_choose_solution, (E_mat, K1, K2, x1, x2), raise_exception=True, fast_mode=True
+        )

--- a/test/geometry/epipolar/test_fundamental.py
+++ b/test/geometry/epipolar/test_fundamental.py
@@ -37,7 +37,7 @@ class TestNormalizePoints:
 
     def test_gradcheck(self, device):
         points = torch.rand(2, 3, 2, device=device, requires_grad=True, dtype=torch.float64)
-        assert gradcheck(epi.normalize_points, (points,), raise_exception=True)
+        assert gradcheck(epi.normalize_points, (points,), raise_exception=True, fast_mode=True)
 
 
 class TestNormalizeTransformation:
@@ -71,7 +71,7 @@ class TestNormalizeTransformation:
 
     def test_gradcheck(self, device):
         trans = torch.rand(2, 3, 3, device=device, requires_grad=True, dtype=torch.float64)
-        assert gradcheck(epi.normalize_transformation, (trans,), raise_exception=True)
+        assert gradcheck(epi.normalize_transformation, (trans,), raise_exception=True, fast_mode=True)
 
 
 class TestFindFundamental:
@@ -180,7 +180,7 @@ class TestFindFundamental:
         points1 = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
         points2 = torch.rand(1, 10, 2, device=device, dtype=torch.float64)
         weights = torch.ones(1, 10, device=device, dtype=torch.float64)
-        assert gradcheck(epi.find_fundamental, (points1, points2, weights), raise_exception=True)
+        assert gradcheck(epi.find_fundamental, (points1, points2, weights), raise_exception=True, fast_mode=True)
 
 
 class TestComputeCorrespondEpilines:
@@ -240,7 +240,7 @@ class TestComputeCorrespondEpilines:
     def test_gradcheck(self, device):
         point = torch.rand(1, 4, 2, device=device, dtype=torch.float64, requires_grad=True)
         F_mat = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
-        assert gradcheck(epi.compute_correspond_epilines, (point, F_mat), raise_exception=True)
+        assert gradcheck(epi.compute_correspond_epilines, (point, F_mat), raise_exception=True, fast_mode=True)
 
 
 class TestFundamentlFromEssential:
@@ -282,7 +282,7 @@ class TestFundamentlFromEssential:
         E_mat = torch.rand(1, 3, 3, device=device, dtype=torch.float64, requires_grad=True)
         K1 = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         K2 = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
-        assert gradcheck(epi.fundamental_from_essential, (E_mat, K1, K2), raise_exception=True)
+        assert gradcheck(epi.fundamental_from_essential, (E_mat, K1, K2), raise_exception=True, fast_mode=True)
 
 
 class TestFundamentalFromProjections:
@@ -326,7 +326,7 @@ class TestFundamentalFromProjections:
     def test_gradcheck(self, device):
         P1 = torch.rand(1, 3, 4, device=device, dtype=torch.float64, requires_grad=True)
         P2 = torch.rand(1, 3, 4, device=device, dtype=torch.float64)
-        assert gradcheck(epi.fundamental_from_projections, (P1, P2), raise_exception=True)
+        assert gradcheck(epi.fundamental_from_projections, (P1, P2), raise_exception=True, fast_mode=True)
 
     def test_batch_support_check(self, device, dtype):
         P1_batch = torch.tensor(
@@ -386,7 +386,7 @@ class TestFundamentalFromProjections:
 
         F_batch = epi.fundamental_from_projections(P1_batch, P2_batch)
         F = epi.fundamental_from_projections(P1, P2)
-        assert (F_batch[0] == F[0]).all()
+        assert_close(F_batch[0], F[0])
 
 
 class TestPerpendicular:
@@ -407,7 +407,7 @@ class TestPerpendicular:
     def test_gradcheck(self, device):
         pt = torch.rand(1, 3, 3, device=device, dtype=torch.float64, requires_grad=True)
         line = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
-        assert gradcheck(epi.get_perpendicular, (pt, line), raise_exception=True)
+        assert gradcheck(epi.get_perpendicular, (pt, line), raise_exception=True, fast_mode=True)
 
 
 class TestGetClosestPointOnEpipolarLine:
@@ -430,4 +430,4 @@ class TestGetClosestPointOnEpipolarLine:
         pts1 = torch.rand(2, 4, 2, device=device, dtype=torch.float64, requires_grad=True)
         pts2 = torch.rand(2, 4, 2, device=device, dtype=torch.float64)
         Fm = utils2.create_random_fundamental_matrix(1).type_as(pts1)
-        assert gradcheck(epi.get_closest_point_on_epipolar_line, (pts1, pts2, Fm), raise_exception=True)
+        assert gradcheck(epi.get_closest_point_on_epipolar_line, (pts1, pts2, Fm), raise_exception=True, fast_mode=True)

--- a/test/geometry/epipolar/test_numeric.py
+++ b/test/geometry/epipolar/test_numeric.py
@@ -53,7 +53,7 @@ class TestSkewSymmetric:
 
     def test_gradcheck(self, device):
         vec = torch.ones(2, 3, device=device, requires_grad=True, dtype=torch.float64)
-        assert gradcheck(epi.cross_product_matrix, (vec,), raise_exception=True)
+        assert gradcheck(epi.cross_product_matrix, (vec,), raise_exception=True, fast_mode=True)
 
 
 class TestEyeLike:

--- a/test/geometry/epipolar/test_projection.py
+++ b/test/geometry/epipolar/test_projection.py
@@ -61,7 +61,7 @@ class TestScaleIntrinsics:
     def test_gradcheck(self, device):
         scale_factor = torch.ones(1, device=device, dtype=torch.float64, requires_grad=True)
         camera_matrix = torch.ones(1, 3, 3, device=device, dtype=torch.float64)
-        assert gradcheck(epi.scale_intrinsics, (camera_matrix, scale_factor), raise_exception=True)
+        assert gradcheck(epi.scale_intrinsics, (camera_matrix, scale_factor), raise_exception=True, fast_mode=True)
 
 
 class TestProjectionFromKRt:
@@ -115,7 +115,7 @@ class TestProjectionFromKRt:
         K = torch.rand(1, 3, 3, device=device, dtype=torch.float64, requires_grad=True)
         R = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         t = torch.rand(1, 3, 1, device=device, dtype=torch.float64)
-        assert gradcheck(epi.projection_from_KRt, (K, R, t), raise_exception=True)
+        assert gradcheck(epi.projection_from_KRt, (K, R, t), raise_exception=True, fast_mode=True)
 
 
 class TestProjectionsFromFundamental:
@@ -133,7 +133,7 @@ class TestProjectionsFromFundamental:
 
     def test_gradcheck(self, device):
         F_mat = torch.rand(1, 3, 3, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(epi.projections_from_fundamental, (F_mat,), raise_exception=True)
+        assert gradcheck(epi.projections_from_fundamental, (F_mat,), raise_exception=True, fast_mode=True)
 
 
 class TestKRtFromProjection:
@@ -206,4 +206,4 @@ class TestKRtFromProjection:
 
     def test_gradcheck(self, device):
         P_mat = torch.rand(1, 3, 4, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(epi.KRt_from_projection, (P_mat,), raise_exception=True)
+        assert gradcheck(epi.KRt_from_projection, (P_mat,), raise_exception=True, fast_mode=True)

--- a/test/geometry/epipolar/test_triangulation.py
+++ b/test/geometry/epipolar/test_triangulation.py
@@ -52,4 +52,4 @@ class TestTriangulation:
         P1 = torch.nn.functional.pad(P1, [0, 1])
         P2 = kornia.eye_like(3, points2)
         P2 = torch.nn.functional.pad(P2, [0, 1])
-        assert gradcheck(epi.triangulate_points, (P1, P2, points1, points2), raise_exception=True)
+        assert gradcheck(epi.triangulate_points, (P1, P2, points1, points2), raise_exception=True, fast_mode=True)

--- a/test/geometry/subpix/test_nms.py
+++ b/test/geometry/subpix/test_nms.py
@@ -53,7 +53,9 @@ class TestNMS2d:
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.geometry.subpix.nms2d, (img, (3, 3)), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(
+            kornia.geometry.subpix.nms2d, (img, (3, 3)), raise_exception=True, nondet_tol=1e-4, fast_mode=True
+        )
 
 
 class TestNMS3d:
@@ -135,4 +137,6 @@ class TestNMS3d:
         batch_size, channels, depth, height, width = 1, 1, 4, 5, 4
         img = torch.rand(batch_size, channels, depth, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.geometry.subpix.nms3d, (img, (3, 3, 3)), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(
+            kornia.geometry.subpix.nms3d, (img, (3, 3, 3)), raise_exception=True, nondet_tol=1e-4, fast_mode=True
+        )

--- a/test/geometry/subpix/test_spatial_softargmax.py
+++ b/test/geometry/subpix/test_spatial_softargmax.py
@@ -125,7 +125,7 @@ class TestSpatialSoftArgmax2d:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(2, 3, 3, 2, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.geometry.subpix.spatial_soft_argmax2d, (input), raise_exception=True)
+        assert gradcheck(kornia.geometry.subpix.spatial_soft_argmax2d, (input), raise_exception=True, fast_mode=True)
 
     def test_end_to_end(self, device, dtype):
         input = torch.full((1, 2, 7, 7), 1.0, requires_grad=True, device=device, dtype=dtype)
@@ -195,7 +195,9 @@ class TestConvSoftArgmax2d:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(2, 3, 5, 5, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.geometry.subpix.conv_soft_argmax2d, (input), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.subpix.conv_soft_argmax2d, (input), nondet_tol=1e-8, raise_exception=True, fast_mode=True
+        )
 
     def test_cold_diag(self, device, dtype):
         input = torch.tensor(
@@ -322,7 +324,9 @@ class TestConvSoftArgmax3d:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(1, 2, 3, 5, 5, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.geometry.subpix.conv_soft_argmax3d, (input), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.subpix.conv_soft_argmax3d, (input), nondet_tol=1e-8, raise_exception=True, fast_mode=True
+        )
 
     def test_cold_diag(self, device, dtype):
         input = torch.tensor(
@@ -450,10 +454,6 @@ class TestConvSoftArgmax3d:
 
 
 class TestConvQuadInterp3d:
-    @pytest.mark.skipif(
-        (int(torch.__version__.split('.')[0]) == 1) and (int(torch.__version__.split('.')[1]) < 9),
-        reason='<1.9.0 not supporting',
-    )
     def test_smoke(self, device, dtype):
         input = torch.randn(2, 3, 3, 4, 4, device=device, dtype=dtype)
         nms = kornia.geometry.ConvQuadInterp3d(1)
@@ -461,16 +461,17 @@ class TestConvQuadInterp3d:
         assert coord.shape == (2, 3, 3, 3, 4, 4)
         assert val.shape == (2, 3, 3, 4, 4)
 
-    @pytest.mark.skipif(
-        (int(torch.__version__.split('.')[0]) == 1) and (int(torch.__version__.split('.')[1]) < 9),
-        reason='<1.9.0 not supporting',
-    )
     def test_gradcheck(self, device, dtype):
         input = torch.rand(1, 1, 3, 5, 5, device=device, dtype=dtype)
         input[0, 0, 1, 2, 2] += 20.0
         input = utils.tensor_to_gradcheck_var(input)  # to var
         assert gradcheck(
-            kornia.geometry.ConvQuadInterp3d(strict_maxima_bonus=0), (input), raise_exception=True, atol=1e-3, rtol=1e-3
+            kornia.geometry.ConvQuadInterp3d(strict_maxima_bonus=0),
+            (input),
+            raise_exception=True,
+            atol=1e-3,
+            rtol=1e-3,
+            fast_mode=True,
         )
 
     def test_diag(self, device, dtype):

--- a/test/geometry/test_bbox.py
+++ b/test/geometry/test_bbox.py
@@ -49,7 +49,7 @@ class TestBbox2D:
     def test_gradcheck(self, device, dtype):
         boxes = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
         boxes = utils.tensor_to_gradcheck_var(boxes)
-        assert gradcheck(infer_bbox_shape, (boxes,), raise_exception=True)
+        assert gradcheck(infer_bbox_shape, (boxes,), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         # Define script
@@ -169,7 +169,7 @@ class TestTransformBoxes2D:
         trans_mat = utils.tensor_to_gradcheck_var(trans_mat)
         boxes = utils.tensor_to_gradcheck_var(boxes)
 
-        assert gradcheck(transform_bbox, (trans_mat, boxes, "xyxy", True), raise_exception=True)
+        assert gradcheck(transform_bbox, (trans_mat, boxes, "xyxy", True), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         boxes = torch.tensor([[139.2640, 103.0150, 258.0480, 307.5075]], device=device, dtype=dtype)
@@ -233,7 +233,7 @@ class TestBbox3D:
             dtype=dtype,
         )
         boxes = utils.tensor_to_gradcheck_var(boxes)
-        assert gradcheck(infer_bbox_shape3d, (boxes,), raise_exception=True)
+        assert gradcheck(infer_bbox_shape3d, (boxes,), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         # Define script

--- a/test/geometry/test_boxes.py
+++ b/test/geometry/test_boxes.py
@@ -271,16 +271,30 @@ class TestBoxes2D:
         t_boxes_xyxy = utils.tensor_to_gradcheck_var(torch.tensor([[1.0, 3.0, 5.0, 6.0]]))
         t_boxes_xyxy1 = utils.tensor_to_gradcheck_var(t_boxes_xyxy.detach().clone())
 
-        assert gradcheck(partial(apply_boxes_method, method='to_tensor'), (t_boxes2,), raise_exception=True)
         assert gradcheck(
-            partial(apply_boxes_method, method='to_tensor', mode='xyxy_plus'), (t_boxes3,), raise_exception=True
+            partial(apply_boxes_method, method='to_tensor'), (t_boxes2,), raise_exception=True, fast_mode=True
         )
         assert gradcheck(
-            partial(apply_boxes_method, method='to_tensor', mode='vertices_plus'), (t_boxes4,), raise_exception=True
+            partial(apply_boxes_method, method='to_tensor', mode='xyxy_plus'),
+            (t_boxes3,),
+            raise_exception=True,
+            fast_mode=True,
         )
-        assert gradcheck(partial(apply_boxes_method, method='get_boxes_shape'), (t_boxes1,), raise_exception=True)
-        assert gradcheck(lambda x: Boxes.from_tensor(x, mode='xyxy_plus').data, (t_boxes_xyxy,), raise_exception=True)
-        assert gradcheck(lambda x: Boxes.from_tensor(x, mode='xywh').data, (t_boxes_xyxy1,), raise_exception=True)
+        assert gradcheck(
+            partial(apply_boxes_method, method='to_tensor', mode='vertices_plus'),
+            (t_boxes4,),
+            raise_exception=True,
+            fast_mode=True,
+        )
+        assert gradcheck(
+            partial(apply_boxes_method, method='get_boxes_shape'), (t_boxes1,), raise_exception=True, fast_mode=True
+        )
+        assert gradcheck(
+            lambda x: Boxes.from_tensor(x, mode='xyxy_plus').data, (t_boxes_xyxy,), raise_exception=True, fast_mode=True
+        )
+        assert gradcheck(
+            lambda x: Boxes.from_tensor(x, mode='xywh').data, (t_boxes_xyxy1,), raise_exception=True, fast_mode=True
+        )
 
 
 class TestTransformBoxes2D:
@@ -387,7 +401,7 @@ class TestTransformBoxes2D:
             boxes = boxes.transform_boxes(M)
             return boxes.data
 
-        assert gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat), raise_exception=True)
+        assert gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat), raise_exception=True, fast_mode=True)
 
 
 class TestBbox3D:
@@ -756,9 +770,17 @@ class TestBbox3D:
         # )
         # assert gradcheck(partial(apply_boxes_method, method='get_boxes_shape'), (t_boxes1,), raise_exception=True)
         assert gradcheck(
-            lambda x: Boxes3D.from_tensor(x, mode='xyzxyz_plus').data, (t_boxes_xyzxyz,), raise_exception=True
+            lambda x: Boxes3D.from_tensor(x, mode='xyzxyz_plus').data,
+            (t_boxes_xyzxyz,),
+            raise_exception=True,
+            fast_mode=True,
         )
-        assert gradcheck(lambda x: Boxes3D.from_tensor(x, mode='xyzwhd').data, (t_boxes_xyzxyz1,), raise_exception=True)
+        assert gradcheck(
+            lambda x: Boxes3D.from_tensor(x, mode='xyzwhd').data,
+            (t_boxes_xyzxyz1,),
+            raise_exception=True,
+            fast_mode=True,
+        )
 
 
 class TestTransformBoxes3D:
@@ -885,4 +907,4 @@ class TestTransformBoxes3D:
             boxes = boxes.transform_boxes(M)
             return boxes.data
 
-        assert gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat), raise_exception=True)
+        assert gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat), raise_exception=True, fast_mode=True)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -200,6 +200,7 @@ class TestAngleAxisToQuaternion:
                 partial(kornia.geometry.conversions.angle_axis_to_quaternion, order=QuaternionCoeffOrder.XYZW),
                 (angle_axis,),
                 raise_exception=True,
+                fast_mode=True,
             )
 
     def test_gradcheck(self, device, dtype):
@@ -211,6 +212,7 @@ class TestAngleAxisToQuaternion:
             partial(kornia.geometry.conversions.angle_axis_to_quaternion, order=QuaternionCoeffOrder.WXYZ),
             (angle_axis,),
             raise_exception=True,
+            fast_mode=True,
         )
 
 
@@ -364,6 +366,7 @@ class TestQuaternionToAngleAxis:
                 partial(kornia.geometry.conversions.quaternion_to_angle_axis, order=QuaternionCoeffOrder.XYZW),
                 (quaternion,),
                 raise_exception=True,
+                fast_mode=True,
             )
 
     def test_gradcheck(self, device, dtype):
@@ -375,6 +378,7 @@ class TestQuaternionToAngleAxis:
             partial(kornia.geometry.conversions.quaternion_to_angle_axis, order=QuaternionCoeffOrder.WXYZ),
             (quaternion,),
             raise_exception=True,
+            fast_mode=True,
         )
 
 
@@ -502,6 +506,7 @@ class TestRotationMatrixToQuaternion:
                 ),
                 (matrix,),
                 raise_exception=True,
+                fast_mode=True,
             )
 
     def test_gradcheck(self, device, dtype):
@@ -515,9 +520,9 @@ class TestRotationMatrixToQuaternion:
             ),
             (matrix,),
             raise_exception=True,
+            fast_mode=True,
         )
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit_xyzw(self, device, dtype):
         op = kornia.geometry.conversions.quaternion_log_to_exp
         op_script = torch.jit.script(op)
@@ -528,7 +533,6 @@ class TestRotationMatrixToQuaternion:
             expected = op(quaternion)
         assert_close(actual, expected)
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit(self, device, dtype):
         eps = torch.finfo(dtype).eps
         op = kornia.geometry.conversions.quaternion_log_to_exp
@@ -625,6 +629,7 @@ class TestQuaternionToRotationMatrix:
                 partial(kornia.geometry.conversions.quaternion_to_rotation_matrix, order=QuaternionCoeffOrder.XYZW),
                 (quaternion,),
                 raise_exception=True,
+                fast_mode=True,
             )
 
     def test_gradcheck(self, device, dtype):
@@ -635,9 +640,9 @@ class TestQuaternionToRotationMatrix:
             partial(kornia.geometry.conversions.quaternion_to_rotation_matrix, order=QuaternionCoeffOrder.WXYZ),
             (quaternion,),
             raise_exception=True,
+            fast_mode=True,
         )
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit_xyzw(self, device, dtype):
         op = kornia.geometry.conversions.quaternion_to_rotation_matrix
         op_jit = torch.jit.script(op)
@@ -645,7 +650,6 @@ class TestQuaternionToRotationMatrix:
         with pytest.warns(UserWarning):
             assert_close(op(quaternion), op_jit(quaternion))
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit(self, device, dtype):
         op = kornia.geometry.conversions.quaternion_to_rotation_matrix
         op_jit = torch.jit.script(op)
@@ -792,6 +796,7 @@ class TestQuaternionLogToExp:
                 partial(kornia.geometry.conversions.quaternion_log_to_exp, eps=eps, order=QuaternionCoeffOrder.XYZW),
                 (quaternion,),
                 raise_exception=True,
+                fast_mode=True,
             )
 
     def test_gradcheck(self, device, dtype):
@@ -803,9 +808,9 @@ class TestQuaternionLogToExp:
             partial(kornia.geometry.conversions.quaternion_log_to_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ),
             (quaternion,),
             raise_exception=True,
+            fast_mode=True,
         )
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit_xyzw(self, device, dtype):
         op = kornia.geometry.conversions.quaternion_log_to_exp
         op_jit = torch.jit.script(op)
@@ -815,7 +820,6 @@ class TestQuaternionLogToExp:
                 op(quaternion, order=QuaternionCoeffOrder.XYZW), op_jit(quaternion, order=QuaternionCoeffOrder.XYZW)
             )
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit(self, device, dtype):
         op = kornia.geometry.conversions.quaternion_log_to_exp
         op_jit = torch.jit.script(op)
@@ -956,6 +960,7 @@ class TestQuaternionExpToLog:
                 partial(kornia.geometry.conversions.quaternion_exp_to_log, eps=eps, order=QuaternionCoeffOrder.XYZW),
                 (quaternion,),
                 raise_exception=True,
+                fast_mode=True,
             )
 
     def test_gradcheck(self, device, dtype):
@@ -967,9 +972,9 @@ class TestQuaternionExpToLog:
             partial(kornia.geometry.conversions.quaternion_exp_to_log, eps=eps, order=QuaternionCoeffOrder.WXYZ),
             (quaternion,),
             raise_exception=True,
+            fast_mode=True,
         )
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit_xyzw(self, device, dtype, atol, rtol):
         op = kornia.geometry.conversions.quaternion_exp_to_log
         op_jit = torch.jit.script(op)
@@ -977,7 +982,6 @@ class TestQuaternionExpToLog:
         with pytest.warns(UserWarning):
             assert_close(op(quaternion), op_jit(quaternion), atol=atol, rtol=rtol)
 
-    @pytest.mark.skipif(torch.__version__.startswith('1.6'), reason='JIT Enum not handled.')
     def test_jit(self, device, dtype, atol, rtol):
         op = kornia.geometry.conversions.quaternion_exp_to_log
         op_script = torch.jit.script(op)
@@ -1003,7 +1007,12 @@ class TestAngleAxisToRotationMatrix:
 
         # evaluate function gradient
         angle_axis = tensor_to_gradcheck_var(angle_axis)  # to var
-        assert gradcheck(kornia.geometry.conversions.angle_axis_to_rotation_matrix, (angle_axis,), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.conversions.angle_axis_to_rotation_matrix,
+            (angle_axis,),
+            raise_exception=True,
+            fast_mode=True,
+        )
 
     def test_angle_axis_to_rotation_matrix(self, device, dtype, atol, rtol):
         rmat_1 = torch.tensor(
@@ -1051,7 +1060,10 @@ class TestRotationMatrixToAngleAxis:
         # evaluate function gradient
         rotation_matrix = tensor_to_gradcheck_var(rotation_matrix)  # to var
         assert gradcheck(
-            kornia.geometry.conversions.rotation_matrix_to_angle_axis, (rotation_matrix,), raise_exception=True
+            kornia.geometry.conversions.rotation_matrix_to_angle_axis,
+            (rotation_matrix,),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     def test_rotation_matrix_to_angle_axis(self, device, dtype, atol, rtol):
@@ -1099,7 +1111,9 @@ def test_rad2deg(batch_shape, device, dtype):
     assert_close(x_rad, x_deg_to_rad)
 
     # evaluate function gradient
-    assert gradcheck(kornia.geometry.conversions.rad2deg, (tensor_to_gradcheck_var(x_rad),), raise_exception=True)
+    assert gradcheck(
+        kornia.geometry.conversions.rad2deg, (tensor_to_gradcheck_var(x_rad),), raise_exception=True, fast_mode=True
+    )
 
 
 @pytest.mark.parametrize("batch_shape", [(2, 3), (1, 2, 3), (2, 3, 3), (5, 5, 3)])
@@ -1113,7 +1127,9 @@ def test_deg2rad(batch_shape, device, dtype, atol, rtol):
 
     assert_close(x_deg, x_rad_to_deg, atol=atol, rtol=rtol)
 
-    assert gradcheck(kornia.geometry.conversions.deg2rad, (tensor_to_gradcheck_var(x_deg),), raise_exception=True)
+    assert gradcheck(
+        kornia.geometry.conversions.deg2rad, (tensor_to_gradcheck_var(x_deg),), raise_exception=True, fast_mode=True
+    )
 
 
 class TestPolCartConversions:
@@ -1141,6 +1157,7 @@ class TestPolCartConversions:
             kornia.geometry.conversions.pol2cart,
             (tensor_to_gradcheck_var(rho), tensor_to_gradcheck_var(phi)),
             raise_exception=True,
+            fast_mode=True,
         )
 
     @pytest.mark.parametrize("batch_shape", [(2, 3), (1, 2, 3), (2, 3, 3), (5, 5, 3)])
@@ -1162,6 +1179,7 @@ class TestPolCartConversions:
             kornia.geometry.conversions.cart2pol,
             (tensor_to_gradcheck_var(x), tensor_to_gradcheck_var(y)),
             raise_exception=True,
+            fast_mode=True,
         )
 
 
@@ -1208,7 +1226,9 @@ class TestConvertPointsToHomogeneous:
 
         # evaluate function gradient
         points_h = tensor_to_gradcheck_var(points_h)  # to var
-        assert gradcheck(kornia.geometry.conversions.convert_points_to_homogeneous, (points_h,), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.conversions.convert_points_to_homogeneous, (points_h,), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         op = kornia.geometry.conversions.convert_points_to_homogeneous
@@ -1237,7 +1257,10 @@ class TestConvertAtoH:
         # evaluate function gradient
         points_h = tensor_to_gradcheck_var(points_h)  # to var
         assert gradcheck(
-            kornia.geometry.conversions.convert_affinematrix_to_homography, (points_h,), raise_exception=True
+            kornia.geometry.conversions.convert_affinematrix_to_homography,
+            (points_h,),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     def test_jit(self, device, dtype):
@@ -1285,7 +1308,12 @@ class TestConvertPointsFromHomogeneous:
 
         # evaluate function gradient
         points_h = tensor_to_gradcheck_var(points_h)  # to var
-        assert gradcheck(kornia.geometry.conversions.convert_points_from_homogeneous, (points_h,), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.conversions.convert_points_from_homogeneous,
+            (points_h,),
+            raise_exception=True,
+            fast_mode=True,
+        )
 
     @pytest.mark.skip("RuntimeError: Jacobian mismatch for output 0 with respect to input 0,")
     def test_gradcheck_zvec_zeros(self, device, dtype):
@@ -1294,7 +1322,12 @@ class TestConvertPointsFromHomogeneous:
 
         # evaluate function gradient
         points_h = tensor_to_gradcheck_var(points_h)  # to var
-        assert gradcheck(kornia.geometry.conversions.convert_points_from_homogeneous, (points_h,), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.conversions.convert_points_from_homogeneous,
+            (points_h,),
+            raise_exception=True,
+            fast_mode=True,
+        )
 
     def test_jit(self, device, dtype):
         op = kornia.geometry.conversions.convert_points_from_homogeneous
@@ -1421,7 +1454,9 @@ class TestProjectPoints:
         # evaluate function gradient
         points_3d = tensor_to_gradcheck_var(points_3d)
         camera_matrix = tensor_to_gradcheck_var(camera_matrix)
-        assert gradcheck(kornia.geometry.camera.project_points, (points_3d, camera_matrix), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.camera.project_points, (points_3d, camera_matrix), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         points_3d = torch.zeros(1, 3, device=device, dtype=dtype)
@@ -1464,6 +1499,7 @@ class TestDenormalizePointsWithIntrinsics:
             kornia.geometry.conversions.denormalize_points_with_intrinsics,
             (points_2d, camera_matrix),
             raise_exception=True,
+            fast_mode=True,
         )
 
     def test_jit(self, device, dtype):
@@ -1520,6 +1556,7 @@ class TestNormalizePointsWithIntrinsics:
             kornia.geometry.conversions.normalize_points_with_intrinsics,
             (points_2d, camera_matrix),
             raise_exception=True,
+            fast_mode=True,
         )
 
     def test_jit(self, device, dtype):
@@ -1551,6 +1588,7 @@ class TestRt2Extrinsics:
             kornia.geometry.conversions.Rt_to_matrix4x4,
             (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)),
             raise_exception=True,
+            fast_mode=True,
         )
 
 
@@ -1584,8 +1622,12 @@ class TestCamtoworldGraphicsToVision:
         R_vis_back, t_vis_back = camtoworld_graphics_to_vision_Rt(R_graf, t_graf)
         assert_close(R_vis_back, R_vis, rtol=1e-4, atol=1e-5)
         assert_close(t_vis_back, t_vis, rtol=1e-4, atol=1e-5)
-        assert gradcheck(camtoworld_graphics_to_vision_4x4, (tensor_to_gradcheck_var(K_vis)), raise_exception=True)
-        assert gradcheck(camtoworld_vision_to_graphics_4x4, (tensor_to_gradcheck_var(K_vis)), raise_exception=True)
+        assert gradcheck(
+            camtoworld_graphics_to_vision_4x4, (tensor_to_gradcheck_var(K_vis)), raise_exception=True, fast_mode=True
+        )
+        assert gradcheck(
+            camtoworld_vision_to_graphics_4x4, (tensor_to_gradcheck_var(K_vis)), raise_exception=True, fast_mode=True
+        )
 
 
 class TestCamtoworldRtToPoseRt:
@@ -1610,10 +1652,16 @@ class TestCamtoworldRtToPoseRt:
         assert_close(tback, t, rtol=1e-4, atol=1e-5)
 
         assert gradcheck(
-            camtoworld_to_worldtocam_Rt, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
+            camtoworld_to_worldtocam_Rt,
+            (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)),
+            raise_exception=True,
+            fast_mode=True,
         )
         assert gradcheck(
-            worldtocam_to_camtoworld_Rt, (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)), raise_exception=True
+            worldtocam_to_camtoworld_Rt,
+            (tensor_to_gradcheck_var(R), tensor_to_gradcheck_var(t)),
+            raise_exception=True,
+            fast_mode=True,
         )
 
 
@@ -1661,7 +1709,7 @@ class TestEulerFromQuaternion(BaseTester):
 
     def test_gradcheck(self, device):
         q = Quaternion.random(batch_size=1).to(device, torch.float64)
-        assert gradcheck(euler_from_quaternion, (q.w, q.x, q.y, q.z), raise_exception=True)
+        assert gradcheck(euler_from_quaternion, (q.w, q.x, q.y, q.z), raise_exception=True, fast_mode=True)
 
     def test_module(self, device, dtype):
         pass
@@ -1709,7 +1757,7 @@ class TestQuaternionFromEuler(BaseTester):
 
     def test_gradcheck(self, device):
         roll, pitch, yaw = torch.rand(3, 2, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(quaternion_from_euler, (roll, pitch, yaw), raise_exception=True)
+        assert gradcheck(quaternion_from_euler, (roll, pitch, yaw), raise_exception=True, fast_mode=True)
 
     def test_module(self, device, dtype):
         pass

--- a/test/geometry/test_depth.py
+++ b/test/geometry/test_depth.py
@@ -113,7 +113,9 @@ class TestDepthTo3d:
         camera_matrix = utils.tensor_to_gradcheck_var(camera_matrix)  # to var
 
         # evaluate function gradient
-        assert gradcheck(kornia.geometry.depth.depth_to_3d, (depth, camera_matrix), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.depth.depth_to_3d, (depth, camera_matrix), raise_exception=True, fast_mode=True
+        )
 
 
 class TestDepthToNormals:
@@ -210,7 +212,9 @@ class TestDepthToNormals:
         camera_matrix = utils.tensor_to_gradcheck_var(camera_matrix)  # to var
 
         # evaluate function gradient
-        assert gradcheck(kornia.geometry.depth.depth_to_normals, (depth, camera_matrix), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.depth.depth_to_normals, (depth, camera_matrix), raise_exception=True, fast_mode=True
+        )
 
 
 class TestWarpFrameDepth:
@@ -323,4 +327,5 @@ class TestWarpFrameDepth:
             kornia.geometry.depth.warp_frame_depth,
             (image_src, depth_dst, src_trans_dst, camera_matrix),
             raise_exception=True,
+            fast_mode=True,
         )

--- a/test/geometry/test_depth_warper.py
+++ b/test/geometry/test_depth_warper.py
@@ -172,6 +172,7 @@ class TestDepthWarper:
             kornia.geometry.depth.depth_warp,
             (pinhole_dst, pinhole_src, depth_src, img_dst, height, width),
             raise_exception=True,
+            fast_mode=True,
         )
 
     # TODO(edgar): we should include a test showing some kind of occlusion

--- a/test/geometry/test_linalg.py
+++ b/test/geometry/test_linalg.py
@@ -112,7 +112,9 @@ class TestTransformPoints:
         # evaluate function gradient
         points_src = utils.tensor_to_gradcheck_var(points_src)  # to var
         dst_homo_src = utils.tensor_to_gradcheck_var(dst_homo_src)  # to var
-        assert gradcheck(kornia.geometry.transform_points, (dst_homo_src, points_src), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform_points, (dst_homo_src, points_src), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         points = torch.ones(1, 2, 2, device=device, dtype=dtype)
@@ -187,7 +189,7 @@ class TestComposeTransforms:
 
         trans_01 = utils.tensor_to_gradcheck_var(trans_01)  # to var
         trans_12 = utils.tensor_to_gradcheck_var(trans_12)  # to var
-        assert gradcheck(kgl.compose_transformations, (trans_01, trans_12), raise_exception=True)
+        assert gradcheck(kgl.compose_transformations, (trans_01, trans_12), raise_exception=True, fast_mode=True)
 
 
 class TestInverseTransformation:
@@ -256,7 +258,7 @@ class TestInverseTransformation:
     def test_gradcheck(self, batch_size, device, dtype):
         trans_01 = identity_matrix(batch_size, device=device, dtype=dtype)
         trans_01 = utils.tensor_to_gradcheck_var(trans_01)  # to var
-        assert gradcheck(kgl.inverse_transformation, (trans_01,), raise_exception=True)
+        assert gradcheck(kgl.inverse_transformation, (trans_01,), raise_exception=True, fast_mode=True)
 
 
 class TestRelativeTransformation:
@@ -329,7 +331,7 @@ class TestRelativeTransformation:
 
         trans_01 = utils.tensor_to_gradcheck_var(trans_01)  # to var
         trans_02 = utils.tensor_to_gradcheck_var(trans_02)  # to var
-        assert gradcheck(kgl.relative_transformation, (trans_01, trans_02), raise_exception=True)
+        assert gradcheck(kgl.relative_transformation, (trans_01, trans_02), raise_exception=True, fast_mode=True)
 
 
 class TestPointsLinesDistances:
@@ -389,7 +391,7 @@ class TestPointsLinesDistances:
     def test_gradcheck(self, device):
         pts = torch.rand(2, 3, 2, device=device, requires_grad=True, dtype=torch.float64)
         lines = torch.rand(2, 3, 3, device=device, requires_grad=True, dtype=torch.float64)
-        assert gradcheck(kgl.point_line_distance, (pts, lines), raise_exception=True)
+        assert gradcheck(kgl.point_line_distance, (pts, lines), raise_exception=True, fast_mode=True)
 
 
 class TestEuclideanDistance(BaseTester):
@@ -415,7 +417,7 @@ class TestEuclideanDistance(BaseTester):
     def test_gradcheck(self, device):
         pt1 = torch.rand(2, 3, device=device, dtype=torch.float64, requires_grad=True)
         pt2 = torch.rand(2, 3, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kgl.euclidean_distance, (pt1, pt2), raise_exception=True)
+        assert gradcheck(kgl.euclidean_distance, (pt1, pt2), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         pt1 = torch.rand(2, 3, device=device, dtype=dtype)

--- a/test/geometry/transform/test_affine.py
+++ b/test/geometry/transform/test_affine.py
@@ -178,7 +178,10 @@ class TestResize:
         input = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
         assert gradcheck(
-            kornia.geometry.transform.Resize(new_size, align_corners=False), (input,), raise_exception=True
+            kornia.geometry.transform.Resize(new_size, align_corners=False),
+            (input,),
+            raise_exception=True,
+            fast_mode=True,
         )
 
 
@@ -250,7 +253,13 @@ class TestRescale:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)
-        assert gradcheck(kornia.geometry.transform.Rescale(2.0, align_corners=False), (input,), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.Rescale(2.0, align_corners=False),
+            (input,),
+            nondet_tol=1e-8,
+            raise_exception=True,
+            fast_mode=True,
+        )
 
 
 class TestRotate:
@@ -301,7 +310,7 @@ class TestRotate:
         # evaluate function gradient
         input = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.geometry.transform.rotate, (input, angle), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.rotate, (input, angle), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip('Need deep look into it since crashes everywhere.')
     @pytest.mark.skip(reason="turn off all jit for a while")
@@ -362,7 +371,9 @@ class TestTranslate:
         # evaluate function gradient
         input = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.geometry.transform.translate, (input, translation), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.translate, (input, translation), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.skip('Need deep look into it since crashes everywhere.')
     @pytest.mark.skip(reason="turn off all jit for a while")
@@ -447,7 +458,7 @@ class TestScale:
         # evaluate function gradient
         input = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.geometry.transform.scale, (input, scale_factor), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.scale, (input, scale_factor), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip('Need deep look into it since crashes everywhere.')
     @pytest.mark.skip(reason="turn off all jit for a while")
@@ -546,7 +557,7 @@ class TestShear:
         # evaluate function gradient
         input = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(kornia.geometry.transform.shear, (input, shear), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.shear, (input, shear), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip('Need deep look into it since crashes everywhere.')
     @pytest.mark.skip(reason="turn off all jit for a while")

--- a/test/geometry/transform/test_crop2d.py
+++ b/test/geometry/transform/test_crop2d.py
@@ -88,7 +88,9 @@ class TestCropAndResize:
         boxes = torch.tensor([[[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)  # 1x4x2
         boxes = utils.tensor_to_gradcheck_var(boxes, requires_grad=False)  # to var
 
-        assert gradcheck(kornia.geometry.transform.crop_and_resize, (img, boxes, (4, 2)), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.crop_and_resize, (img, boxes, (4, 2)), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         # Define script
@@ -160,7 +162,7 @@ class TestCenterCrop:
         img = torch.rand(1, 2, 5, 4, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
 
-        assert gradcheck(kornia.geometry.transform.center_crop, (img, (4, 2)), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.center_crop, (img, (4, 2)), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         # Define script
@@ -227,7 +229,7 @@ class TestCropByBoxes:
 
         inp = utils.tensor_to_gradcheck_var(inp, requires_grad=True)  # to var
 
-        assert gradcheck(kornia.geometry.transform.crop_by_boxes, (inp, src, dst), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.crop_by_boxes, (inp, src, dst), raise_exception=True, fast_mode=True)
 
 
 class TestCropByTransform:
@@ -272,5 +274,8 @@ class TestCropByTransform:
         inp = utils.tensor_to_gradcheck_var(inp, requires_grad=True)  # to var
 
         assert gradcheck(
-            kornia.geometry.transform.crop_by_transform_mat, (inp, transform, (2, 2)), raise_exception=True
+            kornia.geometry.transform.crop_by_transform_mat,
+            (inp, transform, (2, 2)),
+            raise_exception=True,
+            fast_mode=True,
         )

--- a/test/geometry/transform/test_crop3d.py
+++ b/test/geometry/transform/test_crop3d.py
@@ -69,7 +69,9 @@ class TestCropAndResize3D:
         )  # 1x8x3
         boxes = utils.tensor_to_gradcheck_var(boxes, requires_grad=False)  # to var
 
-        assert gradcheck(kornia.geometry.transform.crop_and_resize3d, (img, boxes, (4, 3, 2)), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.crop_and_resize3d, (img, boxes, (4, 3, 2)), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         # Define script
@@ -125,7 +127,9 @@ class TestCenterCrop3D:
         img = torch.arange(0.0, 343.0, device=device, dtype=dtype).view(1, 1, 7, 7, 7)
         img = utils.tensor_to_gradcheck_var(img)  # to var
 
-        assert gradcheck(kornia.geometry.transform.center_crop3d, (img, (3, 5, 7)), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.center_crop3d, (img, (3, 5, 7)), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         # Define script
@@ -303,4 +307,6 @@ class TestCropByBoxes3D:
 
         inp = utils.tensor_to_gradcheck_var(inp, requires_grad=True)  # to var
 
-        assert gradcheck(kornia.geometry.transform.crop_by_boxes3d, (inp, src_box, dst_box), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.crop_by_boxes3d, (inp, src_box, dst_box), raise_exception=True, fast_mode=True
+        )

--- a/test/geometry/transform/test_elastic_transform.py
+++ b/test/geometry/transform/test_elastic_transform.py
@@ -76,7 +76,7 @@ class TestElasticTransform:
     def test_gradcheck(self, device, dtype, requires_grad):
         image = torch.rand(1, 1, 3, 3, device=device, dtype=torch.float64, requires_grad=requires_grad)
         noise = torch.rand(1, 2, 3, 3, device=device, dtype=torch.float64, requires_grad=not requires_grad)
-        assert gradcheck(elastic_transform2d, (image, noise), raise_exception=True)
+        assert gradcheck(elastic_transform2d, (image, noise), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         image = torch.rand(1, 4, 5, 5, device=device, dtype=dtype)

--- a/test/geometry/transform/test_flip.py
+++ b/test/geometry/transform/test_flip.py
@@ -72,7 +72,7 @@ class TestVflip:
 
         input = utils.tensor_to_gradcheck_var(input)  # to var
 
-        assert gradcheck(kornia.geometry.transform.Vflip(), (input,), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.Vflip(), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestHflip:
@@ -142,7 +142,7 @@ class TestHflip:
 
         input = utils.tensor_to_gradcheck_var(input)  # to var
 
-        assert gradcheck(kornia.geometry.transform.Hflip(), (input,), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.Hflip(), (input,), raise_exception=True, fast_mode=True)
 
 
 class TestRot180:
@@ -210,4 +210,4 @@ class TestRot180:
 
         input = utils.tensor_to_gradcheck_var(input)  # to var
 
-        assert gradcheck(kornia.geometry.transform.Rot180(), (input,), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.Rot180(), (input,), raise_exception=True, fast_mode=True)

--- a/test/geometry/transform/test_homography_warper.py
+++ b/test/geometry/transform/test_homography_warper.py
@@ -251,7 +251,7 @@ class TestHomographyWarper:
         warper = kornia.geometry.transform.HomographyWarper(height, width, align_corners=True)
 
         # evaluate function gradient
-        assert gradcheck(warper, (patch_src, dst_homo_src), raise_exception=True)
+        assert gradcheck(warper, (patch_src, dst_homo_src), nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 3])
     @pytest.mark.parametrize("align_corners", [True, False])

--- a/test/geometry/transform/test_imgwarp.py
+++ b/test/geometry/transform/test_imgwarp.py
@@ -86,7 +86,9 @@ class TestGetPerspectiveTransform:
         # compute gradient check
         points_src = torch.rand(1, 4, 2, device=device, dtype=torch.float64, requires_grad=True)
         points_dst = torch.rand(1, 4, 2, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.geometry.get_perspective_transform, (points_src, points_dst), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.get_perspective_transform, (points_src, points_dst), raise_exception=True, fast_mode=True
+        )
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 5])
@@ -136,7 +138,9 @@ def test_rotation_matrix2d(batch_size, device, dtype):
     center = utils.tensor_to_gradcheck_var(center)  # to var
     angle = utils.tensor_to_gradcheck_var(angle)  # to var
     scale = utils.tensor_to_gradcheck_var(scale)  # to var
-    assert gradcheck(kornia.geometry.get_rotation_matrix2d, (center, angle, scale), raise_exception=True)
+    assert gradcheck(
+        kornia.geometry.get_rotation_matrix2d, (center, angle, scale), raise_exception=True, fast_mode=True
+    )
 
 
 class TestWarpAffine:
@@ -226,7 +230,9 @@ class TestWarpAffine:
         img_b = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         aff_ab = utils.tensor_to_gradcheck_var(aff_ab)  # to var
         img_b = utils.tensor_to_gradcheck_var(img_b)  # to var
-        assert gradcheck(kornia.geometry.warp_affine, (img_b, aff_ab, (height, width)), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.warp_affine, (img_b, aff_ab, (height, width)), raise_exception=True, fast_mode=True
+        )
 
     def test_fill_padding_translation(self, device, dtype):
         offset = 1.0
@@ -424,7 +430,9 @@ class TestWarpPerspective:
         img_b = utils.tensor_to_gradcheck_var(img_b)  # to var
         # TODO(dmytro/edgar): firgure out why gradient don't propagate for the tranaform
         H_ab = utils.tensor_to_gradcheck_var(H_ab, requires_grad=False)  # to var
-        assert gradcheck(kornia.geometry.warp_perspective, (img_b, H_ab, (height, width)), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.warp_perspective, (img_b, H_ab, (height, width)), raise_exception=True, fast_mode=True
+        )
 
     def test_fill_padding_translation(self, device, dtype):
         offset = 1.0
@@ -545,7 +553,10 @@ class TestRemap:
         grid = utils.tensor_to_gradcheck_var(grid, requires_grad=False)  # to var
 
         assert gradcheck(
-            kornia.geometry.remap, (img, grid[..., 0], grid[..., 1], 'bilinear', 'zeros', True), raise_exception=True
+            kornia.geometry.remap,
+            (img, grid[..., 0], grid[..., 1], 'bilinear', 'zeros', True),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     def test_jit(self, device, dtype):
@@ -591,7 +602,7 @@ class TestInvertAffineTransform:
     def test_gradcheck(self, device, dtype):
         matrix = torch.eye(2, 3, device=device, dtype=dtype)[None]
         matrix = utils.tensor_to_gradcheck_var(matrix)  # to var
-        assert gradcheck(kornia.geometry.invert_affine_transform, (matrix,), raise_exception=True)
+        assert gradcheck(kornia.geometry.invert_affine_transform, (matrix,), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         op = kornia.geometry.invert_affine_transform

--- a/test/geometry/transform/test_imgwarp3d.py
+++ b/test/geometry/transform/test_imgwarp3d.py
@@ -30,7 +30,7 @@ class TestWarpAffine3d:
         # generate input data
         input = torch.rand(1, 3, 3, 4, 5, device=device, dtype=torch.float64, requires_grad=True)
         P = torch.rand(1, 3, 4, device=device, dtype=torch.float64)
-        assert gradcheck(proj.warp_affine3d, (input, P, (3, 3, 3)), raise_exception=True)
+        assert gradcheck(proj.warp_affine3d, (input, P, (3, 3, 3)), raise_exception=True, fast_mode=True)
 
     def test_forth_back(self, device, dtype):
         out_shape = (3, 4, 5)
@@ -271,7 +271,7 @@ class TestGetRotationMatrix3d:
         center = torch.rand(1, 3, device=device, dtype=torch.float64, requires_grad=True)
         angle = torch.rand(1, 3, device=device, dtype=torch.float64)
         scales: torch.Tensor = torch.ones_like(angle, device=device, dtype=torch.float64)
-        assert gradcheck(proj.get_projective_transform, (center, angle, scales), raise_exception=True)
+        assert gradcheck(proj.get_projective_transform, (center, angle, scales), raise_exception=True, fast_mode=True)
 
 
 class TestPerspectiveTransform3D:
@@ -363,5 +363,8 @@ class TestPerspectiveTransform3D:
         points_src = utils.tensor_to_gradcheck_var(src)  # to var
         points_dst = utils.tensor_to_gradcheck_var(dst)  # to var
         assert gradcheck(
-            kornia.geometry.transform.get_perspective_transform3d, (points_src, points_dst), raise_exception=True
+            kornia.geometry.transform.get_perspective_transform3d,
+            (points_src, points_dst),
+            raise_exception=True,
+            fast_mode=True,
         )

--- a/test/geometry/transform/test_pyramid.py
+++ b/test/geometry/transform/test_pyramid.py
@@ -21,7 +21,7 @@ class TestPyrUp:
     def test_gradcheck(self, device, dtype):
         img = torch.rand(1, 2, 5, 4, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.geometry.pyrup, (img,), raise_exception=True)
+        assert gradcheck(kornia.geometry.pyrup, (img,), nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
@@ -56,7 +56,7 @@ class TestPyrDown:
     def test_gradcheck(self, device, dtype):
         img = torch.rand(1, 2, 5, 4, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.geometry.pyrdown, (img,), raise_exception=True)
+        assert gradcheck(kornia.geometry.pyrdown, (img,), nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
@@ -125,7 +125,7 @@ class TestScalePyramid:
             sp, _, _ = SP()(img)
             return tuple(sp)
 
-        assert gradcheck(sp_tuple, (img,), raise_exception=True, nondet_tol=1e-4)
+        assert gradcheck(sp_tuple, (img,), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
 
 class TestBuildPyramid:
@@ -154,7 +154,9 @@ class TestBuildPyramid:
         batch_size, channels, height, width = 1, 2, 7, 9
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.geometry.transform.build_pyramid, (img, max_level), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.build_pyramid, (img, max_level), raise_exception=True, fast_mode=True
+        )
 
 
 class TestBuildLaplacianPyramid:
@@ -183,4 +185,10 @@ class TestBuildLaplacianPyramid:
         batch_size, channels, height, width = 1, 2, 7, 9
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.geometry.transform.build_laplacian_pyramid, (img, max_level), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.build_laplacian_pyramid,
+            (img, max_level),
+            nondet_tol=1e-8,
+            raise_exception=True,
+            fast_mode=True,
+        )

--- a/test/geometry/transform/test_thin_plate_spline.py
+++ b/test/geometry/transform/test_thin_plate_spline.py
@@ -58,7 +58,7 @@ class TestTransformParameters:
         src, dst = _sample_points(batch_size, **opts)
         src.requires_grad_(requires_grad)
         dst.requires_grad_(not requires_grad)
-        assert gradcheck(kornia.geometry.transform.get_tps_transform, (src, dst), raise_exception=True)
+        assert gradcheck(kornia.geometry.transform.get_tps_transform, (src, dst), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     @pytest.mark.parametrize('batch_size', [1, 3])
@@ -130,7 +130,9 @@ class TestWarpPoints:
         kernel, affine = kornia.geometry.transform.get_tps_transform(src, dst)
         kernel.requires_grad_(requires_grad)
         affine.requires_grad_(not requires_grad)
-        assert gradcheck(kornia.geometry.transform.warp_points_tps, (src, dst, kernel, affine), raise_exception=True)
+        assert gradcheck(
+            kornia.geometry.transform.warp_points_tps, (src, dst, kernel, affine), raise_exception=True, fast_mode=True
+        )
 
     @pytest.mark.jit
     @pytest.mark.parametrize('batch_size', [1, 3])
@@ -221,6 +223,8 @@ class TestWarpImage:
             raise_exception=True,
             atol=1e-4,
             rtol=1e-4,
+            nondet_tol=1e-8,
+            fast_mode=True,
         )
 
     @pytest.mark.jit

--- a/test/losses/test_hd.py
+++ b/test/losses/test_hd.py
@@ -140,4 +140,4 @@ class TestHausdorffLoss:
         loss = hd(k=2)
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
-        assert gradcheck(loss, (logits, labels), raise_exception=True)
+        assert gradcheck(loss, (logits, labels), raise_exception=True, fast_mode=True)

--- a/test/losses/test_losses.py
+++ b/test/losses/test_losses.py
@@ -83,7 +83,10 @@ class TestBinaryFocalLossWithLogits:
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
         assert gradcheck(
-            kornia.losses.binary_focal_loss_with_logits, (logits, labels, alpha, gamma), raise_exception=True
+            kornia.losses.binary_focal_loss_with_logits,
+            (logits, labels, alpha, gamma),
+            raise_exception=True,
+            fast_mode=True,
         )
 
     def test_same_output(self, device, dtype):
@@ -137,7 +140,7 @@ class TestFocalLoss:
         labels = labels.to(device).long()
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
-        assert gradcheck(kornia.losses.focal_loss, (logits, labels, alpha, gamma), raise_exception=True)
+        assert gradcheck(kornia.losses.focal_loss, (logits, labels, alpha, gamma), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         num_classes = 3
@@ -198,7 +201,9 @@ class TestTverskyLoss:
         labels = labels.to(device).long()
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
-        assert gradcheck(kornia.losses.tversky_loss, (logits, labels, alpha, beta), raise_exception=True)
+        assert gradcheck(
+            kornia.losses.tversky_loss, (logits, labels, alpha, beta), raise_exception=True, fast_mode=True
+        )
 
     def test_jit(self, device, dtype):
         num_classes = 3
@@ -258,7 +263,7 @@ class TestDiceLoss:
         labels = labels.to(device).long()
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
-        assert gradcheck(kornia.losses.dice_loss, (logits, labels), raise_exception=True)
+        assert gradcheck(kornia.losses.dice_loss, (logits, labels), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         num_classes = 3
@@ -315,7 +320,9 @@ class TestDepthSmoothnessLoss:
         depth = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         depth = utils.tensor_to_gradcheck_var(depth)  # to var
         image = utils.tensor_to_gradcheck_var(image)  # to var
-        assert gradcheck(kornia.losses.inverse_depth_smoothness_loss, (depth, image), raise_exception=True)
+        assert gradcheck(
+            kornia.losses.inverse_depth_smoothness_loss, (depth, image), raise_exception=True, fast_mode=True
+        )
 
 
 class TestDivergenceLoss:
@@ -399,7 +406,7 @@ class TestDivergenceLoss:
         # evaluate function gradient
         input = utils.tensor_to_gradcheck_var(input)  # to var
         target = utils.tensor_to_gradcheck_var(target)  # to var
-        assert gradcheck(kornia.losses.kl_div_loss_2d, (input, target), raise_exception=True)
+        assert gradcheck(kornia.losses.kl_div_loss_2d, (input, target), raise_exception=True, fast_mode=True)
 
     def test_gradcheck_js(self, device, dtype):
         input = torch.rand(1, 1, 10, 16, device=device, dtype=dtype)
@@ -408,7 +415,7 @@ class TestDivergenceLoss:
         # evaluate function gradient
         input = utils.tensor_to_gradcheck_var(input)  # to var
         target = utils.tensor_to_gradcheck_var(target)  # to var
-        assert gradcheck(kornia.losses.js_div_loss_2d, (input, target), raise_exception=True)
+        assert gradcheck(kornia.losses.js_div_loss_2d, (input, target), raise_exception=True, fast_mode=True)
 
     def test_jit_kl(self, device, dtype):
         input = torch.full((1, 1, 2, 4), 0.125, dtype=dtype, device=device)
@@ -559,7 +566,7 @@ class TestTotalVariation:
     def test_gradcheck(self, device, dtype):
         image = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         image = utils.tensor_to_gradcheck_var(image)  # to var
-        assert gradcheck(kornia.losses.total_variation, (image,), raise_exception=True)
+        assert gradcheck(kornia.losses.total_variation, (image,), raise_exception=True, fast_mode=True)
 
 
 class TestPSNRLoss:
@@ -619,7 +626,7 @@ class TestPSNRLoss:
         target = torch.rand(2, 3, 3, 2, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)  # to var
         target = utils.tensor_to_gradcheck_var(target)  # to var
-        assert gradcheck(kornia.losses.psnr_loss, (input, target, 1.0), raise_exception=True)
+        assert gradcheck(kornia.losses.psnr_loss, (input, target, 1.0), raise_exception=True, fast_mode=True)
 
 
 class TestLovaszHingeLoss:
@@ -658,7 +665,7 @@ class TestLovaszHingeLoss:
         labels = labels.to(device).long()
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
-        assert gradcheck(kornia.losses.lovasz_hinge_loss, (logits, labels), raise_exception=True)
+        assert gradcheck(kornia.losses.lovasz_hinge_loss, (logits, labels), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         num_classes = 1
@@ -723,7 +730,7 @@ class TestLovaszSoftmaxLoss:
         labels = labels.to(device).long()
 
         logits = utils.tensor_to_gradcheck_var(logits)  # to var
-        assert gradcheck(kornia.losses.lovasz_softmax_loss, (logits, labels), raise_exception=True)
+        assert gradcheck(kornia.losses.lovasz_softmax_loss, (logits, labels), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         num_classes = 6

--- a/test/losses/test_ssim.py
+++ b/test/losses/test_ssim.py
@@ -68,7 +68,9 @@ class TestSSIMLoss:
         img2 = utils.tensor_to_gradcheck_var(img2)  # to var
 
         # TODO: review method since it needs `nondet_tol` in cuda sometimes.
-        assert gradcheck(kornia.losses.ssim_loss, (img1, img2, window_size), raise_exception=True, nondet_tol=1e-8)
+        assert gradcheck(
+            kornia.losses.ssim_loss, (img1, img2, window_size), raise_exception=True, nondet_tol=1e-8, fast_mode=True
+        )
 
 
 class TestMS_SSIMLoss:
@@ -107,7 +109,7 @@ class TestMS_SSIMLoss:
 
         loss = kornia.losses.MS_SSIMLoss().to(device, dtype)
 
-        assert gradcheck(loss, (img1, img2), raise_exception=True, nondet_tol=1e-8)
+        assert gradcheck(loss, (img1, img2), raise_exception=True, nondet_tol=1e-8, fast_mode=True)
 
     def test_jit(self, device, dtype):
         img1 = torch.rand(1, 3, 10, 10, device=device, dtype=dtype)

--- a/test/morphology/test_bottom_hat.py
+++ b/test/morphology/test_bottom_hat.py
@@ -67,7 +67,7 @@ class TestBottomHat:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
-        assert gradcheck(bottom_hat, (input, kernel), raise_exception=True)
+        assert gradcheck(bottom_hat, (input, kernel), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/morphology/test_closing.py
+++ b/test/morphology/test_closing.py
@@ -67,7 +67,7 @@ class TestClosing:
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
-        assert gradcheck(closing, (tensor, kernel), raise_exception=True)
+        assert gradcheck(closing, (tensor, kernel), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/morphology/test_dilation.py
+++ b/test/morphology/test_dilation.py
@@ -91,7 +91,7 @@ class TestDilate:
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
-        assert gradcheck(dilation, (tensor, kernel), raise_exception=True)
+        assert gradcheck(dilation, (tensor, kernel), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/morphology/test_erosion.py
+++ b/test/morphology/test_erosion.py
@@ -90,7 +90,7 @@ class TestErode:
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
-        assert gradcheck(erosion, (tensor, kernel), raise_exception=True)
+        assert gradcheck(erosion, (tensor, kernel), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/morphology/test_gradient.py
+++ b/test/morphology/test_gradient.py
@@ -67,7 +67,7 @@ class TestGradient:
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
-        assert gradcheck(gradient, (tensor, kernel), raise_exception=True)
+        assert gradcheck(gradient, (tensor, kernel), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/morphology/test_opening.py
+++ b/test/morphology/test_opening.py
@@ -67,7 +67,7 @@ class TestOpening:
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
-        assert gradcheck(opening, (tensor, kernel), raise_exception=True)
+        assert gradcheck(opening, (tensor, kernel), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/morphology/test_top_hat.py
+++ b/test/morphology/test_top_hat.py
@@ -67,7 +67,7 @@ class TestTopHat:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
-        assert gradcheck(top_hat, (input, kernel), raise_exception=True)
+        assert gradcheck(top_hat, (input, kernel), raise_exception=True, fast_mode=True)
 
     @pytest.mark.jit
     def test_jit(self, device, dtype):

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -8,7 +8,6 @@ import kornia
 import kornia.testing as utils  # test utils
 from kornia.contrib.face_detection import FaceKeypoint
 from kornia.testing import assert_close
-from packaging import version
 
 
 class TestDiamondSquare:
@@ -141,13 +140,10 @@ class TestConnectedComponents:
         out = kornia.contrib.connected_components(img, num_iterations=10)
         assert_close(out, expected)
 
-    @pytest.mark.skipif(
-        version.parse(torch.__version__) < version.parse("1.9"), reason="Tuple cannot be used with PyTorch < v1.9"
-    )
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.contrib.connected_components, (img,), raise_exception=True)
+        assert gradcheck(kornia.contrib.connected_components, (img,), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
@@ -278,7 +274,7 @@ class TestExtractTensorPatches:
     def test_gradcheck(self, device):
         img = torch.rand(2, 3, 4, 4).to(device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.contrib.extract_tensor_patches, (img, 3), raise_exception=True)
+        assert gradcheck(kornia.contrib.extract_tensor_patches, (img, 3), raise_exception=True, fast_mode=True)
 
 
 class TestCombineTensorPatches:
@@ -369,7 +365,9 @@ class TestCombineTensorPatches:
             torch.arange(16.0, device=device, dtype=dtype).view(1, 1, 4, 4), window_size=(2, 2), stride=(2, 2)
         )
         img = utils.tensor_to_gradcheck_var(patches)  # to var
-        assert gradcheck(kornia.contrib.combine_tensor_patches, (img, (4, 4), (2, 2), (2, 2)), raise_exception=True)
+        assert gradcheck(
+            kornia.contrib.combine_tensor_patches, (img, (4, 4), (2, 2), (2, 2)), raise_exception=True, fast_mode=True
+        )
 
 
 class TestLambdaModule:
@@ -409,7 +407,7 @@ class TestLambdaModule:
         B, C, H, W = 1, 3, 4, 5
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         func = kornia.color.bgr_to_grayscale
-        assert gradcheck(kornia.contrib.Lambda(func), (img,), raise_exception=True)
+        assert gradcheck(kornia.contrib.Lambda(func), (img,), raise_exception=True, fast_mode=True)
 
 
 class TestImageStitcher:
@@ -521,7 +519,7 @@ class TestConvDistanceTransform:
     def test_gradcheck(self, device):
         B, C, H, W = 1, 1, 32, 32
         sample1 = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.contrib.distance_transform, (sample1), raise_exception=True)
+        assert gradcheck(kornia.contrib.distance_transform, (sample1), raise_exception=True, fast_mode=True)
 
     def test_loss_grad(self, device, dtype):
         B, C, H, W = 1, 1, 32, 32
@@ -569,7 +567,7 @@ class TestHistMatch:
         B, C, H, W = 1, 3, 32, 32
         src = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         dst = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(kornia.contrib.histogram_matching, (src, dst), raise_exception=True)
+        assert gradcheck(kornia.contrib.histogram_matching, (src, dst), raise_exception=True, fast_mode=True)
 
 
 class TestFaceDetection:

--- a/test/utils/test_memory.py
+++ b/test/utils/test_memory.py
@@ -29,4 +29,5 @@ class TestBatchedForward:
             (kornia.feature.BlobHessian(), img, device, 2),
             raise_exception=True,
             nondet_tol=1e-4,
+            fast_mode=True,
         )


### PR DESCRIPTION
> fast_mode ([bool](https://docs.python.org/3/library/functions.html#bool), optional) – Fast mode for gradcheck and gradgradcheck is currently only implemented for R to R functions. If none of the inputs and outputs are complex a faster implementation of gradcheck that no longer computes the entire jacobian is run; otherwise, we fall back to the slow implementation. from [docs](https://pytorch.org/docs/stable/generated/torch.autograd.gradcheck.html)

Example running `$ pytest --durations=0 test/augmentation/test_augmentation_3d.py`
before:
```output
0.24s call     test/augmentation/test_augmentation_3d.py::TestCenterCrop3D::test_gradcheck[cpu-float32]
0.08s call     test/augmentation/test_augmentation_3d.py::TestRandomCrop3D::test_gradcheck[cpu-float32]
0.04s call     test/augmentation/test_augmentation_3d.py::TestRandomRotation3D::test_gradcheck[cpu]
0.03s call     test/augmentation/test_augmentation_3d.py::TestRandomEqualize3D::test_gradcheck[cpu-float32]

(129 durations < 0.005s hidden.  Use -vv to show these durations.)
```

Using `fast_mode=True`
```output
0.01s call     test/augmentation/test_augmentation_3d.py::TestRandomCrop3D::test_gradcheck[cpu-float32]

(132 durations < 0.005s hidden.  Use -vv to show these durations.) 
```