### PR TITLE
bugfix in KORNIA_CHECK_SHAPE

### DIFF
--- a/kornia/geometry/liegroup/so3.py
+++ b/kornia/geometry/liegroup/so3.py
@@ -22,7 +22,7 @@ class So3(Module):
         >>> s = So3(q)
         >>> s.q
         Parameter containing:
-        tensor([1., 0., 0., 0.], requires_grad=True)
+        tensor([[1., 0., 0., 0.]], requires_grad=True)
     """
 
     def __init__(self, q: Quaternion) -> None:
@@ -34,6 +34,7 @@ class So3(Module):
             data: Quaternion with the shape of :math:`(B, 4)`.
 
         Example:
+            >>> import torch
             >>> data = torch.ones((2, 4))
             >>> q = Quaternion(data)
             >>> So3(q)
@@ -86,6 +87,7 @@ class So3(Module):
             v: vector of shape :math:`(B,3)`.
 
         Example:
+            >>> import torch
             >>> v = torch.zeros((2, 3))
             >>> s = So3.identity().exp(v)
             >>> s
@@ -109,6 +111,7 @@ class So3(Module):
         """Converts elements of lie group  to elements of lie algebra.
 
         Example:
+            >>> import torch
             >>> data = torch.ones((2, 4))
             >>> q = Quaternion(data)
             >>> So3(q).log()
@@ -132,6 +135,7 @@ class So3(Module):
             v: vector of shape :math:`(B,3)`.
 
         Example:
+            >>> import torch
             >>> v = torch.ones((1,3))
             >>> m = So3.hat(v)
             >>> m
@@ -160,6 +164,7 @@ class So3(Module):
             omega: 3x3-matrix representing lie algebra.
 
         Example:
+            >>> import torch
             >>> v = torch.ones((1,3))
             >>> omega = So3.hat(v)
             >>> So3.vee(omega)
@@ -180,12 +185,13 @@ class So3(Module):
             2xz-2yw & 2yz+2xw & 1-2x^2-2y^2\end{bmatrix}
 
         Example:
+            >>> import torch
             >>> s = So3.identity()
             >>> m = s.matrix()
             >>> m
-            tensor([[1., 0., 0.],
-                    [0., 1., 0.],
-                    [0., 0., 1.]], grad_fn=<StackBackward0>)
+            tensor([[[1., 0., 0.],
+                     [0., 1., 0.],
+                     [0., 0., 1.]]], grad_fn=<StackBackward0>)
         """
         w = self.q.w[..., None]
         x, y, z = self.q.x[..., None], self.q.y[..., None], self.q.z[..., None]
@@ -211,11 +217,12 @@ class So3(Module):
             matrix: the rotation matrix to convert of shape :math:`(B,3,3)`.
 
         Example:
-            >>> m = torch.eye(3)
+            >>> import torch
+            >>> m = torch.eye(3)[None]
             >>> s = So3.from_matrix(m)
             >>> s
             Parameter containing:
-            tensor([1., 0., 0., 0.], requires_grad=True)
+            tensor([[1., 0., 0., 0.]], requires_grad=True)
         """
         return cls(Quaternion.from_matrix(matrix))
 
@@ -230,7 +237,7 @@ class So3(Module):
             >>> s = So3.identity()
             >>> s
             Parameter containing:
-            tensor([1., 0., 0., 0.], requires_grad=True)
+            tensor([[1., 0., 0., 0.]], requires_grad=True)
 
             >>> s = So3.identity(batch_size=2)
             >>> s
@@ -247,7 +254,7 @@ class So3(Module):
             >>> s = So3.identity()
             >>> s.inverse()
             Parameter containing:
-            tensor([1., -0., -0., -0.], requires_grad=True)
+            tensor([[1., -0., -0., -0.]], requires_grad=True)
         """
         return So3(self.q.conj())
 
@@ -300,8 +307,8 @@ class So3(Module):
         Example:
             >>> s = So3.identity()
             >>> s.adjoint()
-            tensor([[1., 0., 0.],
-                    [0., 1., 0.],
-                    [0., 0., 1.]], grad_fn=<StackBackward0>)
+            tensor([[[1., 0., 0.],
+                     [0., 1., 0.],
+                     [0., 0., 1.]]], grad_fn=<StackBackward0>)
         """
         return self.matrix()

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -60,6 +60,7 @@ class Quaternion(Module):
             data: tensor containing the quaternion data with the sape of :math:`(B, 4)`.
 
         Example:
+            >>> import torch
             >>> data = torch.rand(2, 4)
             >>> q = Quaternion(data)
             >>> q.shape
@@ -81,7 +82,7 @@ class Quaternion(Module):
         Example:
             >>> q = Quaternion.identity()
             >>> -q.data
-            tensor([-1., -0., -0., -0.], grad_fn=<NegBackward0>)
+            tensor([[-1., -0., -0., -0.]], grad_fn=<NegBackward0>)
         """
         return Quaternion(-self.data)
 
@@ -93,11 +94,11 @@ class Quaternion(Module):
 
         Example:
             >>> q1 = Quaternion.identity()
-            >>> q2 = Quaternion(tensor([2., 0., 1., 1.]))
+            >>> q2 = Quaternion(tensor([[2., 0., 1., 1.]]))
             >>> q3 = q1 + q2
             >>> q3.data
             Parameter containing:
-            tensor([3., 0., 1., 1.], requires_grad=True)
+            tensor([[3., 0., 1., 1.]], requires_grad=True)
         """
         KORNIA_CHECK_TYPE(right, Quaternion)
         return Quaternion(self.data + right.data)
@@ -109,12 +110,12 @@ class Quaternion(Module):
             right: the quaternion to subtract.
 
         Example:
-            >>> q1 = Quaternion(tensor([2., 0., 1., 1.]))
+            >>> q1 = Quaternion(tensor([[2., 0., 1., 1.]]))
             >>> q2 = Quaternion.identity()
             >>> q3 = q1 - q2
             >>> q3.data
             Parameter containing:
-            tensor([1., 0., 1., 1.], requires_grad=True)
+            tensor([[1., 0., 1., 1.]], requires_grad=True)
         """
         KORNIA_CHECK_TYPE(right, Quaternion)
         return Quaternion(self.data - right.data)
@@ -143,7 +144,7 @@ class Quaternion(Module):
             t: raised exponent.
 
         Example:
-            >>> q = Quaternion(tensor([1., .5, 0., 0.]))
+            >>> q = Quaternion(tensor([[1., .5, 0., 0.]]))
             >>> q_pow = q**2
         """
         theta = self.polar_angle[..., None]
@@ -224,18 +225,9 @@ class Quaternion(Module):
         Example:
             >>> q = Quaternion.identity()
             >>> q.polar_angle
-            tensor(0., grad_fn=<AcosBackward0>)
+            tensor([0.], grad_fn=<AcosBackward0>)
         """
         return (self.scalar / self.norm()).acos()
-
-    def view(self, *shape) -> "Quaternion":
-        return Quaternion(self.data.view(*shape))
-
-    def repeat(self, *shape) -> "Quaternion":
-        return Quaternion(self.data.repeat(*shape))
-
-    def expand(self, *shape) -> "Quaternion":
-        return Quaternion(self.data.expand(*shape))
 
     def matrix(self) -> Tensor:
         """Convert the quaternion to a rotation matrix of shape :math:`(B, 3, 3)`.
@@ -244,9 +236,9 @@ class Quaternion(Module):
             >>> q = Quaternion.identity()
             >>> m = q.matrix()
             >>> m
-            tensor([[1., 0., 0.],
-                    [0., 1., 0.],
-                    [0., 0., 1.]], grad_fn=<SqueezeBackward1>)
+            tensor([[[1., 0., 0.],
+                     [0., 1., 0.],
+                     [0., 0., 1.]]], grad_fn=<ViewBackward0>)
         """
         return quaternion_to_rotation_matrix(self.data, order=QuaternionCoeffOrder.WXYZ)
 
@@ -258,6 +250,7 @@ class Quaternion(Module):
             matrix: the rotation matrix to convert of shape :math:`(B, 3, 3)`.
 
         Example:
+            >>> import torch
             >>> m = torch.eye(3)[None]
             >>> q = Quaternion.from_matrix(m)
             >>> q.data
@@ -274,6 +267,7 @@ class Quaternion(Module):
             axis_angle: rotation vector of shape :math:`(B, 3)`.
 
         Example:
+            >>> import torch
             >>> axis_angle = torch.tensor([[1., 0., 0.]])
             >>> q = Quaternion.from_axis_angle(axis_angle)
             >>> q.data
@@ -293,7 +287,7 @@ class Quaternion(Module):
             >>> q = Quaternion.identity()
             >>> q.data
             Parameter containing:
-            tensor([1., 0., 0., 0.], requires_grad=True)
+            tensor([[1., 0., 0., 0.]], requires_grad=True)
         """
         data: Tensor = tensor([1.0, 0.0, 0.0, 0.0], device=device, dtype=dtype)
         batch_size = batch_size if batch_size is not None else 1
@@ -314,7 +308,7 @@ class Quaternion(Module):
             >>> q = Quaternion.from_coeffs(1., 0., 0., 0.)
             >>> q.data
             Parameter containing:
-            tensor([1., 0., 0., 0.], requires_grad=True)
+            tensor([[1., 0., 0., 0.]], requires_grad=True)
         """
         return cls(tensor([[w, x, y, z]]))
 
@@ -352,8 +346,9 @@ class Quaternion(Module):
             t: interpolation ratio, range [0-1]
 
         Example:
+            >>> import torch
             >>> q0 = Quaternion.identity()
-            >>> q1 = Quaternion(torch.tensor([1., .5, 0., 0.]))
+            >>> q1 = Quaternion(torch.tensor([[1., .5, 0., 0.]]))
             >>> q2 = q0.slerp(q1, .3)
         """
         KORNIA_CHECK_TYPE(q1, Quaternion)

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -327,7 +327,7 @@ class Quaternion(Module):
             >>> q = Quaternion.random()
             >>> q = Quaternion.random(batch_size=2)
         """
-        rand_shape = (batch_size,) if batch_size is not None else (1, )
+        rand_shape = (batch_size,) if batch_size is not None else (1,)
 
         r1, r2, r3 = rand((3,) + rand_shape, device=device, dtype=dtype)
         q1 = (1.0 - r1).sqrt() * ((2 * pi * r2).sin())

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -228,6 +228,15 @@ class Quaternion(Module):
         """
         return (self.scalar / self.norm()).acos()
 
+    def view(self, *shape) -> "Quaternion":
+        return Quaternion(self.data.view(*shape))
+
+    def repeat(self, *shape) -> "Quaternion":
+        return Quaternion(self.data.repeat(*shape))
+
+    def expand(self, *shape) -> "Quaternion":
+        return Quaternion(self.data.expand(*shape))
+
     def matrix(self) -> Tensor:
         """Convert the quaternion to a rotation matrix of shape :math:`(B, 3, 3)`.
 
@@ -287,8 +296,8 @@ class Quaternion(Module):
             tensor([1., 0., 0., 0.], requires_grad=True)
         """
         data: Tensor = tensor([1.0, 0.0, 0.0, 0.0], device=device, dtype=dtype)
-        if batch_size is not None:
-            data = data.repeat(batch_size, 1)
+        batch_size = batch_size if batch_size is not None else 1
+        data = data.repeat(batch_size, 1)
         return cls(data)
 
     @classmethod
@@ -307,13 +316,13 @@ class Quaternion(Module):
             Parameter containing:
             tensor([1., 0., 0., 0.], requires_grad=True)
         """
-        return cls(tensor([w, x, y, z]))
+        return cls(tensor([[w, x, y, z]]))
 
     # TODO: update signature
     # def random(cls, shape: Optional[List] = None, device = None, dtype = None) -> 'Quaternion':
     @classmethod
     def random(cls, batch_size: Optional[int] = None, device=None, dtype=None) -> 'Quaternion':
-        """Create a random unit quaternion of shape :math:`(B, 4)`.
+        """Create a random unit quaternion of shape :math:`(*, 4)`.
 
         Uniformly distributed across the rotation space as per: http://planning.cs.uiuc.edu/node198.html
 
@@ -324,7 +333,7 @@ class Quaternion(Module):
             >>> q = Quaternion.random()
             >>> q = Quaternion.random(batch_size=2)
         """
-        rand_shape = (batch_size,) if batch_size is not None else ()
+        rand_shape = (batch_size,) if batch_size is not None else (1, )
 
         r1, r2, r3 = rand((3,) + rand_shape, device=device, dtype=dtype)
         q1 = (1.0 - r1).sqrt() * ((2 * pi * r2).sin())

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -306,25 +306,22 @@ def KORNIA_CHECK_SHAPE(x, shape: List[str]) -> None:
     KORNIA_CHECK_IS_TENSOR(x)
 
     if '*' == shape[0]:
-        start_idx: int = 1
         shape_to_check = shape[1:]
         x_shape_to_check = x.shape[-len(shape) + 1:]
     elif '*' == shape[-1]:
-        start_idx = 0
         shape_to_check = shape[:-1]
         x_shape_to_check = x.shape[: len(shape) - 1]
     else:
-        start_idx = 0
         shape_to_check = shape
         x_shape_to_check = x.shape
 
     if len(x_shape_to_check) != len(shape_to_check):
         raise TypeError(f"{x} shape must be [{shape}]. Got {x.shape}")
 
-    for i in range(start_idx, len(x_shape_to_check)):
+    for i in range(len(x_shape_to_check)):
         # The voodoo below is because torchscript does not like
         # that dim can be both int and str
-        dim_: str = shape[i]
+        dim_: str = shape_to_check[i]
         if not dim_.isnumeric():
             continue
         dim = int(dim_)

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -296,10 +296,10 @@ def KORNIA_CHECK_SHAPE(x, shape: List[str]) -> None:
 
     Example:
         >>> x = torch.rand(2, 3, 4, 4)
-        >>> KORNIA_CHECK_SHAPE(x, ["B","C", "H", "W"])  # implicit
+        >>> KORNIA_CHECK_SHAPE(x, ["B", "C", "H", "W"])  # implicit
 
         >>> x = torch.rand(2, 3, 4, 4)
-        >>> KORNIA_CHECK_SHAPE(x, ["2","3", "H", "W"])  # explicit
+        >>> KORNIA_CHECK_SHAPE(x, ["2", "3", "H", "W"])  # explicit
     """
     # Desired shape here is list and not tuple, because torch.jit
     # does not like variable-length tuples
@@ -307,13 +307,19 @@ def KORNIA_CHECK_SHAPE(x, shape: List[str]) -> None:
 
     if '*' == shape[0]:
         start_idx: int = 1
-        x_shape_to_check = x.shape[-len(shape) + 1 :]
+        shape_to_check = shape[1:]
+        x_shape_to_check = x.shape[-len(shape) + 1:]
     elif '*' == shape[-1]:
         start_idx = 0
+        shape_to_check = shape[:-1]
         x_shape_to_check = x.shape[: len(shape) - 1]
     else:
         start_idx = 0
+        shape_to_check = shape
         x_shape_to_check = x.shape
+
+    if len(x_shape_to_check) != len(shape_to_check):
+        raise TypeError(f"{x} shape must be [{shape}]. Got {x.shape}")
 
     for i in range(start_idx, len(x_shape_to_check)):
         # The voodoo below is because torchscript does not like

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -307,7 +307,7 @@ def KORNIA_CHECK_SHAPE(x, shape: List[str]) -> None:
 
     if '*' == shape[0]:
         shape_to_check = shape[1:]
-        x_shape_to_check = x.shape[-len(shape) + 1:]
+        x_shape_to_check = x.shape[-len(shape) + 1 :]
     elif '*' == shape[-1]:
         shape_to_check = shape[:-1]
         x_shape_to_check = x.shape[: len(shape) - 1]

--- a/test/geometry/liegroup/test_se3.py
+++ b/test/geometry/liegroup/test_se3.py
@@ -14,7 +14,7 @@ class TestSe3(BaseTester):
         return Se3(So3(q), t)
 
     def _make_rand_data(self, device, dtype, batch_size, dims):
-        shape = [] if batch_size is None else [batch_size]
+        shape = [1] if batch_size is None else [batch_size]
         return torch.rand(shape + [dims], device=device, dtype=dtype)
 
     def test_smoke(self, device, dtype):
@@ -73,8 +73,8 @@ class TestSe3(BaseTester):
         s1s2 = s1 * s2
         s2s2inv = s2 * s2.inverse()
         zeros_vec = torch.zeros(3, device=device, dtype=dtype)
-        if batch_size is not None:
-            zeros_vec = zeros_vec.repeat(batch_size, 1)
+        batch_size = batch_size if batch_size is not None else 1
+        zeros_vec = zeros_vec.repeat(batch_size, 1)
         so3_expected = So3.identity(batch_size, device, dtype)
         self.assert_close(s1s2.r.q.data, s2.r.q.data)
         self.assert_close(s1s2.t, s2.t)
@@ -98,9 +98,9 @@ class TestSe3(BaseTester):
     def test_exp(self, device, dtype, batch_size):
         omega = torch.zeros(3, device=device, dtype=dtype)
         t = torch.rand(3, device=device, dtype=dtype)
-        if batch_size is not None:
-            omega = omega.repeat(batch_size, 1)
-            t = t.repeat(batch_size, 1)
+        batch_size = batch_size if batch_size is not None else 1
+        omega = omega.repeat(batch_size, 1)
+        t = t.repeat(batch_size, 1)
         s = Se3.exp(torch.cat((t, omega), -1))
         quat_expected = Quaternion.identity(batch_size, device, dtype)
         self.assert_close(s.r.q.data, quat_expected.data)
@@ -112,8 +112,8 @@ class TestSe3(BaseTester):
         t = self._make_rand_data(device, dtype, batch_size, dims=3)
         s = Se3(So3(q), t)
         zero_vec = torch.zeros(3, device=device, dtype=dtype)
-        if batch_size is not None:
-            zero_vec = zero_vec.repeat(batch_size, 1)
+        batch_size = batch_size if batch_size is not None else 1
+        zero_vec = zero_vec.repeat(batch_size, 1)
         self.assert_close(s.log(), torch.cat((t, zero_vec), -1))
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))

--- a/test/geometry/test_quaternion.py
+++ b/test/geometry/test_quaternion.py
@@ -170,7 +170,7 @@ class TestQuaternion:
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_norm_shape(self, device, dtype, batch_size):
         q = Quaternion.random(batch_size, device, dtype)
-        expected_shape = (1, ) if batch_size is None else (batch_size,)
+        expected_shape = (1,) if batch_size is None else (batch_size,)
         self.assert_close(tuple(q.norm().shape), expected_shape)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))

--- a/test/geometry/test_quaternion.py
+++ b/test/geometry/test_quaternion.py
@@ -7,7 +7,7 @@ from kornia.testing import assert_close
 
 class TestQuaternion:
     def _make_rand_data(self, device, dtype, batch_size):
-        shape = [] if batch_size is None else [batch_size]
+        shape = [1] if batch_size is None else [batch_size]
         return torch.rand(shape + [4], device=device, dtype=dtype)
 
     def assert_close(self, actual, expected, rtol=None, atol=None):
@@ -25,9 +25,9 @@ class TestQuaternion:
     def test_smoke(self, device, dtype):
         q = Quaternion.from_coeffs(1.0, 0.0, 0.0, 0.0)
         q = q.to(device, dtype)
-        q_data = torch.tensor([1.0, 0.0, 0.0, 0.0], device=device, dtype=dtype)
+        q_data = torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device, dtype=dtype)
         assert isinstance(q, Quaternion)
-        assert q.shape == (4,)
+        assert q.shape == (1, 4)
         self.assert_close(q.data, q_data)
         self.assert_close(q.q, q_data)
         self.assert_close(q.real, q_data[..., 0])
@@ -170,7 +170,7 @@ class TestQuaternion:
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_norm_shape(self, device, dtype, batch_size):
         q = Quaternion.random(batch_size, device, dtype)
-        expected_shape = () if batch_size is None else (batch_size,)
+        expected_shape = (1, ) if batch_size is None else (batch_size,)
         self.assert_close(tuple(q.norm().shape), expected_shape)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
@@ -211,8 +211,8 @@ class TestQuaternion:
     def test_slerp(self, device, dtype, batch_size):
         for axis in torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]):
             axis = axis.to(device, dtype)
-            if batch_size is not None:
-                axis = axis.repeat(batch_size, 1)
+            batch_size = batch_size if batch_size is not None else 1
+            axis = axis.repeat(batch_size, 1)
             q1 = Quaternion.from_axis_angle(axis * 0)
             q1.to(device, dtype)
             q2 = Quaternion.from_axis_angle(axis * 3.14159)


### PR DESCRIPTION
#### Changes
`KORNIA_CHECK_SHAPE` ignored non numeric dimensions, thus not validating the full required shape.
For example, the following lines passes though they should throw an error:
```
x = torch.rand(1, 1)
KORNIA_CHECK_SHAPE(x, ["B", "1", "H", "W"])
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
