### PR TITLE
bug fix for __getitem__ in liegroups and quaternion

### DIFF
--- a/kornia/geometry/liegroup/se2.py
+++ b/kornia/geometry/liegroup/se2.py
@@ -56,7 +56,7 @@ class Se2(Module):
         return f"rotation: {self.r}\ntranslation: {self.t}"
 
     def __getitem__(self, idx) -> 'Se2':
-        return Se2(self._rotation[idx], self._translation[idx][None])
+        return Se2(self._rotation[idx], self._translation[idx])
 
     @overload
     def __mul__(self, right: 'Se2') -> 'Se2':

--- a/kornia/geometry/liegroup/se3.py
+++ b/kornia/geometry/liegroup/se3.py
@@ -57,7 +57,7 @@ class Se3(Module):
         return f"rotation: {self.r}\ntranslation: {self.t}"
 
     def __getitem__(self, idx) -> 'Se3':
-        return Se3(self._r[idx], self._t[idx][None])
+        return Se3(self._r[idx], self._t[idx])
 
     def __mul__(self, right: "Se3") -> "Se3":
         """Compose two Se3 transformations.

--- a/kornia/geometry/liegroup/so2.py
+++ b/kornia/geometry/liegroup/so2.py
@@ -54,7 +54,7 @@ class So2(Module):
         return f"{self.z}"
 
     def __getitem__(self, idx: int) -> 'So2':
-        return So2(self._z[idx][..., None])
+        return So2(self._z[idx])
 
     @overload
     def __mul__(self, right: 'So2') -> 'So2':

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -73,7 +73,7 @@ class Quaternion(Module):
         return f"{self.data}"
 
     def __getitem__(self, idx) -> 'Quaternion':
-        return Quaternion(self.data[idx].reshape(1, -1))
+        return Quaternion(self.data[idx])
 
     def __neg__(self) -> 'Quaternion':
         """Inverts the sign of the quaternion data.

--- a/test/geometry/liegroup/test_se2.py
+++ b/test/geometry/liegroup/test_se2.py
@@ -73,8 +73,8 @@ class TestSe2(BaseTester):
         s = Se2(So2(z), t)
         for i in range(batch_size):
             s1 = s[i]
-            self.assert_close(s1.r.z, z[i][None])
-            self.assert_close(s1.t[0], t[i])
+            self.assert_close(s1.r.z, z[i])
+            self.assert_close(s1.t, t[i])
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_mul(self, device, dtype, batch_size):

--- a/test/geometry/liegroup/test_se3.py
+++ b/test/geometry/liegroup/test_se3.py
@@ -63,8 +63,8 @@ class TestSe3(BaseTester):
         s = Se3(So3(q), t)
         for i in range(batch_size):
             s1 = s[i]
-            self.assert_close(s1.r.q.data[0], q.data[i])
-            self.assert_close(s1.t[0], t[i])
+            self.assert_close(s1.r.q.data, q.data[i])
+            self.assert_close(s1.t, t[i])
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_mul(self, device, dtype, batch_size):

--- a/test/geometry/liegroup/test_so3.py
+++ b/test/geometry/liegroup/test_so3.py
@@ -53,7 +53,7 @@ class TestSo3(BaseTester):
         s = So3(q)
         for i in range(batch_size):
             s1 = s[i]
-            self.assert_close(s1.q.data[0], q.data[i])
+            self.assert_close(s1.q.data, q.data[i])
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_mul(self, device, dtype, batch_size):
@@ -81,9 +81,6 @@ class TestSo3(BaseTester):
         if batch_size is None:
             self.assert_close(s1.q.norm(), ones_vec)
             return
-
-        if batch_size is not None:
-            ones_vec = ones_vec[None]
 
         for i in range(batch_size):
             self.assert_close(s1[i].q.norm(), ones_vec)
@@ -153,9 +150,9 @@ class TestSo3(BaseTester):
             q1 = q[i]
             r1 = r[i, :, :]
             pvec = torch.rand(3, device=device, dtype=dtype)
-            pquat = Quaternion(torch.cat([torch.tensor([0]).to(device, dtype), pvec])[None, :])
+            pquat = Quaternion(torch.cat([torch.tensor([0], device=device, dtype=dtype), pvec]))
             qp_ = q1 * pquat * q1.inv()
-            rp_ = torch.matmul(r1, pvec)[None, :]
+            rp_ = torch.matmul(r1, pvec)
             self.assert_close(rp_, qp_.vec)  # p_ = R*p = q*p*q_inv
             self.assert_close(rp_.norm(), pvec.norm())
 

--- a/test/geometry/test_quaternion.py
+++ b/test/geometry/test_quaternion.py
@@ -195,7 +195,7 @@ class TestQuaternion:
         q = Quaternion.random(batch_size, device, dtype)
         for i in range(batch_size):
             q1 = q[i]
-            self.assert_close(q1.data[0], q.data[i])
+            self.assert_close(q1.data, q.data[i])
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_axis_angle(self, device, dtype, batch_size):


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes batched return of items in __getitem__ over liegroups and quaternion


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
