### PR TITLE
add trans, trans_x, trans_y + minor changes se2

### DIFF
--- a/kornia/geometry/liegroup/se2.py
+++ b/kornia/geometry/liegroup/se2.py
@@ -2,10 +2,10 @@
 # https://github.com/strasdat/Sophus/blob/master/sympy/sophus/se2.py
 from typing import Optional, Tuple, overload
 
-from kornia.core import Module, Parameter, Tensor, concatenate, pad, rand, stack, tensor, where
+from kornia.core import Module, Parameter, Tensor, concatenate, pad, rand, stack, tensor, where, zeros_like
 from kornia.geometry.liegroup._utils import check_se2_omega_shape, check_se2_r_t_shape, check_v_shape
 from kornia.geometry.liegroup.so2 import So2
-from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_TYPE
+from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_SAME_DEVICES, KORNIA_CHECK_TYPE
 
 
 class Se2(Module):
@@ -32,8 +32,8 @@ class Se2(Module):
         Internally represented by a complex number `z` and a translation 2-vector.
 
         Args:
-            r: So2 group encompassing a rotation.
-            t: translation vector with the shape of :math:`(B, 2)`.
+            rotation: So2 group encompassing a rotation.
+            translation: translation vector with the shape of :math:`(B, 2)`.
 
         Example:
             >>> so2 = So2.identity(1)
@@ -280,6 +280,40 @@ class Se2(Module):
             KORNIA_CHECK(batch_size >= 1, msg="batch_size must be positive")
             shape = (batch_size, 2)
         return cls(r, rand(shape, device=device, dtype=dtype))
+
+    @classmethod
+    def trans(cls, x: Tensor, y: Tensor) -> "Se2":
+        """Construct a translation only Se2 instance.
+
+        Args:
+            x: the x-axis translation.
+            y: the y-axis translation.
+        """
+        KORNIA_CHECK(x.shape == y.shape)
+        KORNIA_CHECK_SAME_DEVICES([x, y])
+        batch_size = x.shape[0] if len(x.shape) > 0 else None
+        rotation = So2.identity(batch_size, x.device, x.dtype)
+        return cls(rotation, stack((x, y), -1))
+
+    @classmethod
+    def trans_x(cls, x: Tensor) -> "Se2":
+        """Construct a x-axis translation.
+
+        Args:
+            x: the x-axis translation.
+        """
+        zs = zeros_like(x)
+        return cls.trans(x, zs)
+
+    @classmethod
+    def trans_y(cls, y: Tensor) -> "Se2":
+        """Construct a y-axis translation.
+
+        Args:
+            y: the y-axis translation.
+        """
+        zs = zeros_like(y)
+        return cls.trans(zs, y)
 
     def adjoint(self) -> Tensor:
         """Returns the adjoint matrix of shape :math:`(B, 3, 3)`.

--- a/test/geometry/liegroup/test_se2.py
+++ b/test/geometry/liegroup/test_se2.py
@@ -177,6 +177,30 @@ class TestSe2(BaseTester):
         self.assert_close(se2_in_se2.t, i.t)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_trans(self, device, dtype, batch_size):
+        trans = self._make_rand_data(device, dtype, (batch_size, 2))
+        x, y = trans[..., 0], trans[..., 1]
+        se2 = Se2.trans(x, y)
+        self.assert_close(se2.t, trans)
+        self.assert_close(se2.so2.matrix(), So2.identity(batch_size, device, dtype).matrix())
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_trans_x(self, device, dtype, batch_size):
+        x = self._make_rand_data(device, dtype, (batch_size, 1)).squeeze(-1)
+        zs = torch.zeros_like(x)
+        se2 = Se2.trans_x(x)
+        self.assert_close(se2.t, torch.stack((x, zs), -1))
+        self.assert_close(se2.so2.matrix(), So2.identity(batch_size, device, dtype).matrix())
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_trans_y(self, device, dtype, batch_size):
+        y = self._make_rand_data(device, dtype, (batch_size, 1)).squeeze(-1)
+        zs = torch.zeros_like(y)
+        se2 = Se2.trans_y(y)
+        self.assert_close(se2.t, torch.stack((zs, y), -1))
+        self.assert_close(se2.so2.matrix(), So2.identity(batch_size, device, dtype).matrix())
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_adjoint(self, device, dtype, batch_size):
         x = Se2.random(batch_size)
         y = Se2.random(batch_size)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

I think with this PR, (So3,se3) and (Se2,So2) pretty much will have the same num of features. (rot_x and rot_y for so2 can be done with exp i think). Hence good for the 0.6.9 release . Can aim for jacobians in the next one. 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
