### PR TITLE
update config tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -94,7 +94,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(autouse=True)
-def add_np(doctest_namespace):
+def add_doctest_deps(doctest_namespace):
     doctest_namespace["np"] = numpy
     doctest_namespace["torch"] = torch
     doctest_namespace["kornia"] = kornia

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,6 +103,7 @@ markers =
     jit: mark a test as torchscript test
     grad: mark a test as gradcheck test
     nn: mark a test as module test
+testpaths = test
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
- ~move the conftest to the test directory~ -- can't be done because doctest needs the deps injection
- add `testpath` on pytest config to allow run pytest without pass the tests path
