### PR TITLE
Fix support for (*, 3, H, W) tensors  in yuv

### DIFF
--- a/kornia/color/yuv.py
+++ b/kornia/color/yuv.py
@@ -68,7 +68,7 @@ def rgb_to_yuv420(image: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
 
     yuvimage = rgb_to_yuv(image)
 
-    return (yuvimage[..., :1, :, :], torch.nn.functional.avg_pool2d(yuvimage[..., 1:3, :, :], (2, 2)))
+    return (yuvimage[..., :1, :, :], yuvimage[..., 1:3, :, :].unfold(-2, 2, 2).unfold(-2, 2, 2).mean((-1, -2)))
 
 
 def rgb_to_yuv422(image: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -99,7 +99,7 @@ def rgb_to_yuv422(image: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
 
     yuvimage = rgb_to_yuv(image)
 
-    return (yuvimage[..., :1, :, :], torch.nn.functional.avg_pool2d(yuvimage[..., 1:3, :, :], (1, 2)))
+    return (yuvimage[..., :1, :, :], yuvimage[..., 1:3, :, :].unfold(-1, 2, 2).mean(-1))
 
 
 def yuv_to_rgb(image: torch.Tensor) -> torch.Tensor:

--- a/test/color/test_yuv.py
+++ b/test/color/test_yuv.py
@@ -72,7 +72,7 @@ class TestRgbToYuv420(BaseTester):
         assert isinstance(kornia.color.rgb_to_yuv420(img)[0], torch.Tensor)
         assert isinstance(kornia.color.rgb_to_yuv420(img)[1], torch.Tensor)
 
-    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2)])
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2), (3, 3, 3, 4, 4)])
     def test_cardinality(self, device, dtype, shape):
         img = torch.ones(shape, device=device, dtype=dtype)
         shapey = list(shape)
@@ -229,7 +229,7 @@ class TestRgbToYuv422(BaseTester):
         assert isinstance(kornia.color.rgb_to_yuv422(img)[0], torch.Tensor)
         assert isinstance(kornia.color.rgb_to_yuv422(img)[1], torch.Tensor)
 
-    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2)])
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2), (3, 3, 3, 4, 4)])
     def test_cardinality(self, device, dtype, shape):
         img = torch.ones(shape, device=device, dtype=dtype)
         shapey = list(shape)


### PR DESCRIPTION
This pull request fixes the support for `(*, 3, H, W)` tensors in `rgb_to_yuv420` and `rgb_to_yuv422`. `F.avg_pool2d` does not support `(*, 3, H, W)` (prev. used), this implementation replaces `F.avg_pool2d` by calling `.unfold` and `.mean` to support an arbitrary number of dimensions. Tests are extended by adding 5D tensors.

Fixes #2072

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

