### PR TITLE
Fix numerical stability for binary focal loss

### DIFF
--- a/kornia/losses/focal.py
+++ b/kornia/losses/focal.py
@@ -212,9 +212,12 @@ def binary_focal_loss_with_logits(
     probs_pos = input.sigmoid()
     probs_neg = (-input).sigmoid()
 
+    log_probs_pos = nn.functional.logsigmoid(input)
+    log_probs_neg = nn.functional.logsigmoid(-input)
+
     loss_tmp = (
-        -alpha * pos_weight * probs_neg.pow(gamma) * target * probs_pos.log()
-        - (1 - alpha) * probs_pos.pow(gamma) * (1.0 - target) * probs_neg.log()
+        -alpha * pos_weight * probs_neg.pow(gamma) * target * log_probs_pos
+        - (1 - alpha) * probs_pos.pow(gamma) * (1.0 - target) * log_probs_neg
     )
 
     if reduction == 'none':

--- a/test/losses/test_losses.py
+++ b/test/losses/test_losses.py
@@ -100,14 +100,12 @@ class TestBinaryFocalLossWithLogits:
         ) == kornia.losses.BinaryFocalLossWithLogits(**kwargs)(logits, labels)
 
     def test_numeric_stability(self, device, dtype):
-        logits = torch.tensor([[100., -100]], dtype=dtype, device=device)
-        labels = torch.tensor([[1., 0.]], dtype=dtype, device=device)
-        expected = torch.tensor([[0., 0.]], dtype=dtype, device=device)
+        logits = torch.tensor([[100.0, -100]], dtype=dtype, device=device)
+        labels = torch.tensor([[1.0, 0.0]], dtype=dtype, device=device)
+        expected = torch.tensor([[0.0, 0.0]], dtype=dtype, device=device)
 
         kwargs = {"alpha": 0.25, "gamma": 2.0, "reduction": 'none'}
-        actual = kornia.losses.binary_focal_loss_with_logits(
-            logits, labels, **kwargs
-        )
+        actual = kornia.losses.binary_focal_loss_with_logits(logits, labels, **kwargs)
         assert_close(actual, expected, atol=1e-3, rtol=1e-3)
 
 

--- a/test/losses/test_losses.py
+++ b/test/losses/test_losses.py
@@ -99,6 +99,17 @@ class TestBinaryFocalLossWithLogits:
             logits, labels, **kwargs
         ) == kornia.losses.BinaryFocalLossWithLogits(**kwargs)(logits, labels)
 
+    def test_numeric_stability(self, device, dtype):
+        logits = torch.tensor([[100., -100]], dtype=dtype, device=device)
+        labels = torch.tensor([[1., 0.]], dtype=dtype, device=device)
+        expected = torch.tensor([[0., 0.]], dtype=dtype, device=device)
+
+        kwargs = {"alpha": 0.25, "gamma": 2.0, "reduction": 'none'}
+        actual = kornia.losses.binary_focal_loss_with_logits(
+            logits, labels, **kwargs
+        )
+        assert_close(actual, expected, atol=1e-3, rtol=1e-3)
+
 
 class TestFocalLoss:
     def test_smoke_none(self, device, dtype):


### PR DESCRIPTION
#### Changes
Adds numerical stability test for focal loss.
Loss is expected to be 0:
- when logit is a large positive value and label is 1
- when logit is a large negative value and label is 0

Current master does not pass test (focal loss is numerically unstable), because `log(sigmoid(x))` is used. PR simply replaces `log(sigmoid(x))` with `torch.nn.functional.logsigmoid`, which seems to be quite stable.
PR passes the test.


Fixes https://github.com/kornia/kornia/issues/2115

#### Type of change
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~ Irrelevant, only minor and trivial changes
- [ ] ~I have made corresponding changes to the documentation~ Irrelevant, docs changes are not needed
- [x] My changes generate no new warnings
- [ ] ~Did you update CHANGELOG in case of a major change?~ Irrelevant
