### PR TITLE
Run nightly CI just with labeled PR

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -53,7 +53,7 @@ jobs:
 
   tests-nightly:
     if: ${{ github.event.label.name == 'nightly' }}
-    name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.pytorch-dtype }}
+    name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-nightly, ${{ matrix.pytorch-dtype }}
     runs-on: ${{ matrix.os }}-latest
 
     strategy:

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [master]
     types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -3,7 +3,7 @@ name: Run tests on CPU
 on:
   pull_request:
     branches: [master]
-    types: [opened, reopened, synchronize, review_requested, ready_for_review]
+    types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -50,3 +50,30 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }} # to not depend on build via GH API
           flags: cpu,${{ matrix.os }}_py-${{ matrix.python-version }}_pt-${{ matrix.pytorch-version }}_${{ matrix.pytorch-dtype }}
           name: cpu-coverage
+
+  tests-nightly:
+    if: ${{ github.event.label.name == 'nightly' }}
+    name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.pytorch-dtype }}
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['Ubuntu', 'Windows', 'MacOS']
+        python-version: ['3.7', '3.8']
+        pytorch-version: ['nightly']
+        pytorch-dtype: ['float32', 'float64']
+
+    steps:
+      - name: Checkout kornia
+        uses: actions/checkout@v3
+
+      - name: Setting environment on ${{ matrix.os }} with python ${{ matrix.python-version }} and pytorch  ${{ matrix.pytorch-version }}
+        uses: ./.github/actions/env
+        with:
+          python-version: ${{ matrix.python-version }}
+          pytorch-version: ${{ matrix.pytorch-version }}
+
+      - name: Run CPU tests ${{ matrix.pytorch-dtype }}
+        shell: bash -l {0}
+        run: pytest -v --device cpu --dtype ${{ matrix.pytorch-dtype }}

--- a/.github/workflows/scheduled_test_nightly.yml
+++ b/.github/workflows/scheduled_test_nightly.yml
@@ -1,9 +1,6 @@
 name: Tests on CPU (nightly)
 
 on:
-  pull_request:
-    branches: [master]
-    types: [opened, reopened, synchronize, review_requested, ready_for_review]
   push:
     branches: [master]
   schedule:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ English | [简体中文](README_zh-CN.md)
 [![Twitter](https://img.shields.io/twitter/follow/kornia_foss?style=social)](https://twitter.com/kornia_foss)
 
 [![tests-cpu](https://github.com/kornia/kornia/actions/workflows/scheduled_test_cpu.yml/badge.svg?event=schedule&&branch=master)](https://github.com/kornia/kornia/actions/workflows/scheduled_test_cpu.yml)
-[![tests-cpu-nightly](https://github.com/kornia/kornia/actions/workflows/tests_nightly.yml/badge.svg?event=schedule&&branch=master)](https://github.com/kornia/kornia/actions/workflows/tests_nightly.yml)
+[![tests-cpu-nightly](https://github.com/kornia/kornia/actions/workflows/scheduled_test_nightly.yml/badge.svg?event=schedule&&branch=master)](https://github.com/kornia/kornia/actions/workflows/scheduled_test_nightly.yml)
 [![tests-cuda](https://github.com/kornia/kornia/actions/workflows/tests_cuda.yml/badge.svg)](https://github.com/kornia/kornia/actions/workflows/tests_cuda.yml)
 [![codecov](https://codecov.io/gh/kornia/kornia/branch/master/graph/badge.svg?token=FzCb7e0Bso)](https://codecov.io/gh/kornia/kornia)
 [![Documentation Status](https://readthedocs.org/projects/kornia/badge/?version=latest)](https://kornia.readthedocs.io/en/latest/?badge=latest)

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -26,6 +26,7 @@
 [![Twitter](https://img.shields.io/twitter/follow/kornia_foss?style=social)](https://twitter.com/kornia_foss)
 
 [![tests-cpu](https://github.com/kornia/kornia/actions/workflows/tests_cpu.yml/badge.svg)](https://github.com/kornia/kornia/actions/workflows/tests_cpu.yml)
+[![tests-cpu-nightly](https://github.com/kornia/kornia/actions/workflows/scheduled_test_nightly.yml/badge.svg?event=schedule&&branch=master)](https://github.com/kornia/kornia/actions/workflows/scheduled_test_nightly.yml)
 [![tests-cuda](https://github.com/kornia/kornia/actions/workflows/tests_cuda.yml/badge.svg)](https://github.com/kornia/kornia/actions/workflows/tests_cuda.yml)
 [![codecov](https://codecov.io/gh/kornia/kornia/branch/master/graph/badge.svg?token=FzCb7e0Bso)](https://codecov.io/gh/kornia/kornia)
 [![Documentation Status](https://readthedocs.org/projects/kornia/badge/?version=latest)](https://kornia.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
The nightly job will run the tests if the PR have the label `nightly`

(also rename the nightly workflow to match the rest)