### PR TITLE
move tests workflow to reusable workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,45 @@
+# Kornia GHA
+
+## Actions
+
+### Env
+This GHA action ([.github/actions/env/action.yml](actions/env/action.yml)) is
+responsible for the setup of an environment for kornia in development mode on
+CI.
+
+Use the actions:
+- `conda-incubator/setup-miniconda`
+
+Has the inputs:
+- `python-version`: (string, default: `'3.7'`) the python version desired.
+  - The version should be supported by `setup-miniconda` action.
+- `pytorch-version`: (string, default: `'1.9.1`') the pytorch version desired.
+  - This value will be used to install pytorch using conda from pytorch
+    channel.
+  - If the value passed is `nightly` the nightly version of pytorch with dynamo
+    will be installed from pip.
+
+
+## Reusable workflows
+
+### Tests
+This workflow ([.github/workflows/tests.yml](workflows/tests.yml)) will setup
+an environment using the [env](#Env) action, run the tests using pytest and
+uploading the coverage report to codecov.
+
+Use the actions:
+- `actions/checkout`
+- `.github/actions/env`
+
+Has the inputs:
+- `os`: (string, default: `ubuntu-latest`) the OS name same as supported by [gha](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners).
+- `python-version`: (json list of strings, default: `'["3.7"]'`) a string with
+  format of a json list within strings for each python version desired.
+- `pytorch-version`: (json list of strings, default: `'["1.9.1"]'`) a string
+  with format of a json list within strings for each pytorch version desired.
+- `pytorch-dtype`: (string, default: `float32`) the dtype used to generate
+  the tests with pytest.
+- `continue-on-error`: (boolean, default: `false`) to set the
+  `continue-on-error` behavior on the test step.
+
+A matrix strategy will be adopted from the list of python and pytorch version.

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -12,7 +12,7 @@ on:
       pytorch-version:
         description: "The pytorch version desired."
         required: true
-        default: '1.10.2'
+        default: '1.9.1'
         type: string
 
 runs:

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu', 'Windows', 'MacOS']
+        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
     uses: ./.github/workflows/tests.yml
     with:

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false # TODO: enable it when CI be stable
       matrix:
-        os: ['Ubuntu', 'Windows', 'MacOS']
+        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float16', 'float32', 'float64']
     uses: ./.github/workflows/tests.yml
     with:
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu', 'Windows', 'MacOS']
+        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float16', 'float32', 'float64']
 
     uses: ./.github/workflows/tests.yml

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -27,6 +27,21 @@ jobs:
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       continue-on-error: ${{ contains('float16', matrix.pytorch-dtype) }} # Remove this when float16 stop raising errors
 
+  tests-cpu-old-torch-new-py:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['Ubuntu', 'Windows', 'MacOS']
+        pytorch-dtype: ['float16', 'float32', 'float64']
+
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: '["3.9"]'
+      pytorch-version: '["1.9.1"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}
+      continue-on-error: ${{ contains('float16', matrix.pytorch-dtype) }} # Remove this when float16 stop raising errors
+
   tests-nightly:
     if: ${{ github.event.label.name == 'nightly' }}
     name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-nightly, ${{ matrix.pytorch-dtype }}

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -1,6 +1,8 @@
 name: Run tests on CPU
 
 on:
+  push:
+    branches: [test-me-*]
   pull_request:
     branches: [master]
     types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled]
@@ -12,69 +14,31 @@ concurrency:
 
 jobs:
   tests-cpu:
-    name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.pytorch-dtype }}
-    runs-on: ${{ matrix.os }}-latest
-
     strategy:
       fail-fast: false # TODO: enable it when CI be stable
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.9', '3.10']
-        pytorch-version: ['1.9.1', '1.13.1']
         pytorch-dtype: ['float16', 'float32', 'float64']
-        exclude:
-            - pytorch-version: '1.9.1'
-              python-version: '3.10'
-            - pytorch-version: '1.13.1'
-              python-version: '3.9'
-
-    steps:
-      - name: Checkout kornia
-        uses: actions/checkout@v3
-
-      - name: Setting environment on ${{ matrix.os }} with python ${{ matrix.python-version }} and pytorch  ${{ matrix.pytorch-version }}
-        uses: ./.github/actions/env
-        with:
-          python-version: ${{ matrix.python-version }}
-          pytorch-version: ${{ matrix.pytorch-version }}
-
-      - name: Run CPU tests ${{ matrix.pytorch-dtype }}
-        continue-on-error: ${{ contains('float16', matrix.pytorch-dtype) }}  # Remove this when float16 stop raising errors
-        shell: bash -l {0}
-        run: pytest -v --device cpu --dtype ${{ matrix.pytorch-dtype }} --cov=kornia --cov-report xml ./test
-
-      - if: always()
-        name: Upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          file: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }} # to not depend on build via GH API
-          flags: cpu,${{ matrix.os }}_py-${{ matrix.python-version }}_pt-${{ matrix.pytorch-version }}_${{ matrix.pytorch-dtype }}
-          name: cpu-coverage
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: '["3.7", "3.10"]'
+      pytorch-version: '["1.9.1", "1.13.1"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}
+      continue-on-error: ${{ contains('float16', matrix.pytorch-dtype) }} # Remove this when float16 stop raising errors
 
   tests-nightly:
     if: ${{ github.event.label.name == 'nightly' }}
     name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-nightly, ${{ matrix.pytorch-dtype }}
-    runs-on: ${{ matrix.os }}-latest
 
     strategy:
       fail-fast: false
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.8']
-        pytorch-version: ['nightly']
         pytorch-dtype: ['float32', 'float64']
-
-    steps:
-      - name: Checkout kornia
-        uses: actions/checkout@v3
-
-      - name: Setting environment on ${{ matrix.os }} with python ${{ matrix.python-version }} and pytorch  ${{ matrix.pytorch-version }}
-        uses: ./.github/actions/env
-        with:
-          python-version: ${{ matrix.python-version }}
-          pytorch-version: ${{ matrix.pytorch-version }}
-
-      - name: Run CPU tests ${{ matrix.pytorch-dtype }}
-        shell: bash -l {0}
-        run: pytest -v --device cpu --dtype ${{ matrix.pytorch-dtype }}
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: '["3.7", "3.10"]'
+      pytorch-version: '["nightly"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -38,7 +38,6 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: '["3.9"]'
-      pytorch-version: '["1.9.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       continue-on-error: ${{ contains('float16', matrix.pytorch-dtype) }} # Remove this when float16 stop raising errors
 

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
-        pytorch-dtype: ['float16', 'float32', 'float64']
+        pytorch-dtype: ['float32', 'float64']
 
     uses: ./.github/workflows/tests.yml
     with:

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -2,7 +2,7 @@ name: Tests on CPU (scheduled)
 
 on:
   push:
-    branches: [master]
+    branches: [master, test-me-*]
   schedule:
     - cron: "0 4 * * *"
 
@@ -12,42 +12,15 @@ concurrency:
 
 jobs:
   tests-cpu:
-    name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.pytorch-dtype }}
-    runs-on: ${{ matrix.os }}-latest
-
     strategy:
       fail-fast: false
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        pytorch-version: ['1.9.1', '1.10.2', '1.11.0', '1.12.1', '1.13.1']
         pytorch-dtype: ['float16', 'float32', 'float64']
-        exclude:
-            - pytorch-version: '1.9.1'
-              python-version: '3.10'
-            - pytorch-version: '1.10.2'
-              python-version: '3.10'
 
-    steps:
-      - name: Checkout kornia
-        uses: actions/checkout@v3
-
-      - name: Setting environment on ${{ matrix.os }} with python ${{ matrix.python-version }} and pytorch  ${{ matrix.pytorch-version }}
-        uses: ./.github/actions/env
-        with:
-          python-version: ${{ matrix.python-version }}
-          pytorch-version: ${{ matrix.pytorch-version }}
-
-      - name: Run CPU tests ${{ matrix.pytorch-dtype }}
-        shell: bash -l {0}
-        run: pytest -v --device cpu --dtype ${{ matrix.pytorch-dtype }} --cov=kornia --cov-report xml ./test
-
-
-      - if: always()
-        name: Upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          file: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }} # to not depend on build via GH API
-          flags: cpu,${{ matrix.os }}_py-${{ matrix.python-version }}_pt-${{ matrix.pytorch-version }}_${{ matrix.pytorch-dtype }}
-          name: cpu-coverage
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: '["3.7", "3.8", "3.9", "3.10"]'
+      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu', 'Windows', 'MacOS']
+        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float16', 'float32', 'float64']
 
     uses: ./.github/workflows/tests.yml

--- a/.github/workflows/scheduled_test_cpu_half.yml
+++ b/.github/workflows/scheduled_test_cpu_half.yml
@@ -10,37 +10,14 @@ concurrency:
 
 jobs:
   tests-cpu:
-    name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.pytorch-dtype }}
-    runs-on: ${{ matrix.os }}-latest
-
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.8']
-        pytorch-version: ['1.9.1', '1.10.2', '1.12.1', '1.13.1']
-        pytorch-dtype: ['float16']
+        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
 
-    steps:
-      - name: Checkout kornia
-        uses: actions/checkout@v3
-
-      - name: Setting environment on ${{ matrix.os }} with python ${{ matrix.python-version }} and pytorch  ${{ matrix.pytorch-version }}
-        uses: ./.github/actions/env
-        with:
-          python-version: ${{ matrix.python-version }}
-          pytorch-version: ${{ matrix.pytorch-version }}
-
-      - name: Run CPU tests ${{ matrix.pytorch-dtype }}
-        shell: bash -l {0}
-        run: pytest -v --device cpu --dtype ${{ matrix.pytorch-dtype }} --cov=kornia --cov-report xml ./test
-
-
-      - if: always()
-        name: Upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          file: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }} # to not depend on build via GH API
-          flags: cpu,${{ matrix.os }}_py-${{ matrix.python-version }}_pt-${{ matrix.pytorch-version }}_${{ matrix.pytorch-dtype }}
-          name: cpu-coverage
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: '["3.7", "3.8", "3.9", "3.10"]'
+      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1"]'
+      pytorch-dtype: 'float16'

--- a/.github/workflows/scheduled_test_nightly.yml
+++ b/.github/workflows/scheduled_test_nightly.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu', 'Windows', 'MacOS']
+        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
     uses: ./.github/workflows/tests.yml

--- a/.github/workflows/scheduled_test_nightly.yml
+++ b/.github/workflows/scheduled_test_nightly.yml
@@ -2,7 +2,7 @@ name: Tests on CPU (nightly)
 
 on:
   push:
-    branches: [master]
+    branches: [master, test-me-*]
   schedule:
     - cron: "0 4 * * *"
 
@@ -12,37 +12,15 @@ concurrency:
 
 jobs:
   tests-cpu:
-    name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}, ${{ matrix.pytorch-dtype }}
-    runs-on: ${{ matrix.os }}-latest
-
     strategy:
       fail-fast: false
       matrix:
         os: ['Ubuntu', 'Windows', 'MacOS']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        pytorch-version: ['nightly']
         pytorch-dtype: ['float32', 'float64']
 
-    steps:
-      - name: Checkout kornia
-        uses: actions/checkout@v3
-
-      - name: Setting environment on ${{ matrix.os }} with python ${{ matrix.python-version }} and pytorch  ${{ matrix.pytorch-version }}
-        uses: ./.github/actions/env
-        with:
-          python-version: ${{ matrix.python-version }}
-          pytorch-version: ${{ matrix.pytorch-version }}
-
-      - name: Run CPU tests ${{ matrix.pytorch-dtype }}
-        shell: bash -l {0}
-        run: pytest -v --device cpu --dtype ${{ matrix.pytorch-dtype }} --cov=kornia --cov-report xml ./test
-
-
-      - if: always()
-        name: Upload coverage
-        uses: codecov/codecov-action@v3
-        with:
-          file: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }} # to not depend on build via GH API
-          flags: cpu,${{ matrix.os }}_py-${{ matrix.python-version }}_pt-${{ matrix.pytorch-version }}_${{ matrix.pytorch-dtype }}
-          name: cpu-coverage
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: '["3.7", "3.8", "3.9", "3.10"]'
+      pytorch-version: '["nightly"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}

--- a/.github/workflows/scheduled_test_typing.yml
+++ b/.github/workflows/scheduled_test_typing.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: ['Ubuntu']
         python-version: ['3.7']
-        pytorch-version: ['1.9.1', '1.10.2', '1.12.1', '1.13.1', 'nightly']
+        pytorch-version: ['1.9.1', '1.10.2', '1.11.0', '1.12.1', '1.13.1', 'nightly']
 
     steps:
       - name: Checkout kornia

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,61 @@
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: false
+        type: string
+        default: ubuntu-latest
+      python-version:
+        required: true
+        type: string
+        default: "['3.7']"
+      pytorch-version:
+        required: true
+        type: string
+        default: "['1.9.1']"
+      pytorch-dtype:
+        required: false
+        type: string
+        default: 'float32'
+      continue-on-error:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  tests:
+    name: ${{ inputs.os }} / ${{ inputs.pytorch-dtype }} / python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
+    runs-on: ${{ inputs.os }}
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(inputs.python-version) }}
+        pytorch-version: ${{ fromJSON(inputs.pytorch-version) }}
+        exclude:
+          - pytorch-version: '1.9.1'
+            python-version: '3.10'
+          - pytorch-version: '1.10.2'
+            python-version: '3.10'
+
+    steps:
+    - name: Checkout kornia
+      uses: actions/checkout@v3
+    - name: Setting environment on ${{ inputs.os }} with python ${{ matrix.python-version }} and pytorch ${{ matrix.pytorch-version }}
+      uses: ./.github/actions/env
+      with:
+        python-version: ${{ matrix.python-version }}
+        pytorch-version: ${{ matrix.pytorch-version }}
+
+    - name: Run CPU tests ${{ inputs.pytorch-dtype }}
+      continue-on-error: ${{ inputs.continue-on-error }}
+      shell: bash -l {0}
+      run: pytest -v --device cpu --dtype ${{ inputs.pytorch-dtype }} --cov=kornia --cov-report xml ./test
+
+
+    - if: always()
+      name: Upload coverage
+      uses: codecov/codecov-action@v3
+      with:
+        file: coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }} # to not depend on build via GH API
+        flags: cpu,${{ inputs.os }}_py-${{ matrix.python-version }}_pt-${{ matrix.pytorch-version }}_${{ inputs.pytorch-dtype }}
+        name: cpu-coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,18 +1,18 @@
 on:
   workflow_call:
     inputs:
+      python-version:
+        required: true
+        type: string
+        default: '["3.7"]'
+      pytorch-version:
+        required: true
+        type: string
+        default: '["1.9.1"]'
       os:
         required: false
         type: string
         default: ubuntu-latest
-      python-version:
-        required: true
-        type: string
-        default: "['3.7']"
-      pytorch-version:
-        required: true
-        type: string
-        default: "['1.9.1']"
       pytorch-dtype:
         required: false
         type: string

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   tests:
-    name: ${{ inputs.os }} / ${{ inputs.pytorch-dtype }} / python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
+    name: python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
     runs-on: ${{ inputs.os }}
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,11 +2,11 @@ on:
   workflow_call:
     inputs:
       python-version:
-        required: true
+        required: false
         type: string
         default: '["3.7"]'
       pytorch-version:
-        required: true
+        required: false
         type: string
         default: '["1.9.1"]'
       os:


### PR DESCRIPTION
This moves the test's workflow to be a reusable workflow -- this should save us some lines when doing things like (#2118 and #2128)

Also, give us a better list of the jobs on GitHub actions interface:
![image](https://user-images.githubusercontent.com/20444345/211571402-c3d91052-cc14-4f61-b0ea-e5b0f9894b82.png)
