### PR TITLE
move deps to `setup.py`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,14 +34,7 @@ project_urls =
 
 [options]
 packages = find:
-install_requires =
-    packaging
-    torch>=1.9.1
 python_requires = >=3.7
-setup_requires =
-    pytest-runner
-tests_require =
-    pytest
 zip_safe = True
 
 [options.packages.find]
@@ -50,37 +43,6 @@ exclude =
     test
     test.*
     examples*
-
-[options.extras_require]
-dev =
-    isort
-    kornia-rs==0.0.8
-    mypy[reports]
-    numpy
-    opencv-python
-    pre-commit>=2.0
-    pydocstyle
-    pytest==7.2.0
-    pytest-cov==4.0.0
-    scipy
-docs =
-    PyYAML>=5.1,<6.1.0
-    furo
-    matplotlib
-    opencv-python
-    sphinx>=4.0
-    sphinx-autodoc-defaultargs
-    sphinx-autodoc-typehints>=1.0
-    sphinx-copybutton>=0.3
-    sphinx-design
-    sphinx-rtd-theme>0.5
-    sphinxcontrib-bibtex
-    sphinxcontrib-gtagjs
-    sphinxcontrib-youtube
-    torch
-    torchvision
-x =
-    accelerate==0.15.0
 
 [options.package_data]
 kornia = py.typed

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
             'PyYAML>=5.1,<6.1.0',
             'furo',
             'matplotlib',
+            'opencv-python',
             'sphinx>=4.0',
             'sphinx-autodoc-defaultargs',
             'sphinx-autodoc-typehints>=1.0',

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,38 @@ if sys.version_info < (3, 7, 0):
 
 from setuptools import setup
 
-setup()
+setup(
+    install_requires=['packaging', 'torch>=1.9.1'],
+    tests_require=['pytest'],
+    setup_requires=['pytest-runner'],
+    extras_require={
+        'dev': [
+            'isort',
+            'kornia-rs==0.0.8',
+            'mypy[reports]',
+            'numpy',
+            'opencv-python',
+            'pre-commit>=2.0',
+            'pydocstyle',
+            'pytest==7.2.0',
+            'pytest-cov==4.0.0',
+            'scipy',
+        ],
+        'docs': [
+            'PyYAML>=5.1,<6.1.0',
+            'furo',
+            'matplotlib',
+            'sphinx>=4.0',
+            'sphinx-autodoc-defaultargs',
+            'sphinx-autodoc-typehints>=1.0',
+            'sphinx-copybutton>=0.3',
+            'sphinx-design',
+            'sphinx-rtd-theme>0.5',
+            'sphinxcontrib-bibtex',
+            'sphinxcontrib-gtagjs',
+            'sphinxcontrib-youtube',
+            'torchvision',
+        ],
+        'x': ['accelerate==0.15.0'],
+    },
+)


### PR DESCRIPTION
GH dependencies graph does not support `.cfg` files -- https://github.com/orgs/community/discussions/6456

This patch try to fix the Kornia [deps graph ](https://github.com/kornia/kornia/network/dependencies)
