### PR TITLE
Update `nightly` labeled condition

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -53,7 +53,7 @@ jobs:
           name: cpu-coverage
 
   tests-nightly:
-    if: ${{ github.event.label.name == 'nightly' }}
+    if:  contains(github.event.pull_request.labels.*.name, 'nightly')
     name: ${{ matrix.os }} - python-${{ matrix.python-version }}, torch-nightly, ${{ matrix.pytorch-dtype }}
     runs-on: ${{ matrix.os }}-latest
 


### PR DESCRIPTION
This should fix this little problem https://github.com/kornia/kornia/pull/2133#discussion_r1069621012 -- this statement is more generic, and having more than one label should not be a problem to trigger the nightly CI

I play around here https://github.com/johnnv1/kornia/pull/6, and it seems to be fine, after having the nightly label, when the CI is retriggered it runs again