### PR TITLE
Improve losses tests, add `TestSSIM3d`, and `BaseTester.gradcheck`

### DIFF
--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -11,6 +11,10 @@ Reconstruction
 .. autofunction:: psnr_loss
 .. autofunction:: total_variation
 .. autofunction:: inverse_depth_smoothness_loss
+.. autofunction:: charbonnier_loss
+.. autofunction:: welsch_loss
+.. autofunction:: cauchy_loss
+.. autofunction:: geman_mcclure_loss
 
 .. autoclass:: SSIMLoss
 .. autoclass:: SSIM3DLoss
@@ -18,6 +22,10 @@ Reconstruction
 .. autoclass:: TotalVariation
 .. autoclass:: PSNRLoss
 .. autoclass:: InverseDepthSmoothnessLoss
+.. autoclass:: CharbonnierLoss
+.. autoclass:: WelschLoss
+.. autoclass:: CauchyLoss
+.. autoclass:: GemanMcclureLoss
 
 Semantic Segmentation
 ---------------------

--- a/kornia/losses/cauchy.py
+++ b/kornia/losses/cauchy.py
@@ -14,8 +14,8 @@ def cauchy_loss(img1: Tensor, img2: Tensor, reduction: str = "none") -> Tensor:
         \text{WL}(x, y) = log(\frac{1}{2} (x - y)^{2} + 1)
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf
@@ -72,8 +72,8 @@ class CauchyLoss(Module):
         \text{WL}(x, y) = log(\frac{1}{2} (x - y)^{2} + 1)
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf

--- a/kornia/losses/charbonnier.py
+++ b/kornia/losses/charbonnier.py
@@ -14,8 +14,8 @@ def charbonnier_loss(img1: Tensor, img2: Tensor, reduction: str = "none") -> Ten
         \text{WL}(x, y) = \sqrt{(x - y)^{2} + 1} - 1
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf
@@ -78,8 +78,8 @@ class CharbonnierLoss(Module):
         \text{WL}(x, y) = \sqrt{(x - y)^{2} + 1} - 1
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf

--- a/kornia/losses/geman_mcclure.py
+++ b/kornia/losses/geman_mcclure.py
@@ -14,8 +14,8 @@ def geman_mcclure_loss(img1: Tensor, img2: Tensor, reduction: str = "none") -> T
         \text{WL}(x, y) = \frac{2 (x - y)^{2}}{(x - y)^{2} + 4}
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf
@@ -72,8 +72,8 @@ class GemanMcclureLoss(Module):
         \text{WL}(x, y) = \frac{2 (x - y)^{2}}{(x - y)^{2} + 4}
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf

--- a/kornia/losses/welsch.py
+++ b/kornia/losses/welsch.py
@@ -14,8 +14,8 @@ def welsch_loss(img1: Tensor, img2: Tensor, reduction: str = "none") -> Tensor:
         \text{WL}(x, y) = 1 - exp(-\frac{1}{2} (x - y)^{2})
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf
@@ -73,8 +73,8 @@ class WelschLoss(Module):
         \text{WL}(x, y) = 1 - exp(-\frac{1}{2} (x - y)^{2})
 
     Where:
-       - :math:`x` expects to be the prediction.
-       - :math:`z` expects to be the target to be regressed to.
+       - :math:`x` is the prediction.
+       - :math:`y` is the target to be regressed to.
 
     Reference:
         [1] https://arxiv.org/pdf/1701.03077.pdf

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -4,9 +4,10 @@ import math
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from itertools import product
-from typing import Any, Dict, List, Optional, Sequence, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypeVar, Union, cast
 
 import torch
+from torch.autograd import gradcheck
 from torch.testing import assert_close as _assert_close
 from typing_extensions import TypeGuard
 
@@ -167,6 +168,17 @@ class BaseTester(ABC):
             atol = math.sqrt(atol) if low_tolerance else atol
 
         return assert_close(actual, expected, rtol=rtol, atol=atol)
+
+    @staticmethod
+    def gradcheck(
+        func: Callable[..., Union[torch.Tensor, Sequence[torch.Tensor]]],
+        inputs: Union[torch.Tensor, Sequence[torch.Tensor]],
+        *,
+        raise_exception: bool = True,
+        fast_mode: bool = True,
+        **kwargs: Dict[str, Any],
+    ) -> bool:
+        return gradcheck(func, inputs, raise_exception=raise_exception, fast_mode=fast_mode, **kwargs)
 
 
 def generate_two_view_random_scene(

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -176,7 +176,7 @@ class BaseTester(ABC):
         *,
         raise_exception: bool = True,
         fast_mode: bool = True,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> bool:
         return gradcheck(func, inputs, raise_exception=raise_exception, fast_mode=fast_mode, **kwargs)
 

--- a/test/losses/test_losses.py
+++ b/test/losses/test_losses.py
@@ -5,8 +5,7 @@ import torch
 from torch.autograd import gradcheck
 
 import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.testing import BaseTester, assert_close, tensor_to_gradcheck_var
 from kornia.utils import torch_meshgrid
 
 
@@ -81,7 +80,7 @@ class TestBinaryFocalLossWithLogits:
         labels = torch.rand(2, 1, 3, 2)
         labels = labels.to(device, dtype).long()
 
-        logits = utils.tensor_to_gradcheck_var(logits)  # to var
+        logits = tensor_to_gradcheck_var(logits)  # to var
         assert gradcheck(
             kornia.losses.binary_focal_loss_with_logits,
             (logits, labels, alpha, gamma),
@@ -148,7 +147,7 @@ class TestFocalLoss:
         labels = torch.rand(2, 3, 2) * num_classes
         labels = labels.to(device).long()
 
-        logits = utils.tensor_to_gradcheck_var(logits)  # to var
+        logits = tensor_to_gradcheck_var(logits)  # to var
         assert gradcheck(kornia.losses.focal_loss, (logits, labels, alpha, gamma), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
@@ -209,7 +208,7 @@ class TestTverskyLoss:
         labels = torch.rand(2, 3, 2) * num_classes
         labels = labels.to(device).long()
 
-        logits = utils.tensor_to_gradcheck_var(logits)  # to var
+        logits = tensor_to_gradcheck_var(logits)  # to var
         assert gradcheck(
             kornia.losses.tversky_loss, (logits, labels, alpha, beta), raise_exception=True, fast_mode=True
         )
@@ -271,7 +270,7 @@ class TestDiceLoss:
         labels = torch.rand(2, 3, 2) * num_classes
         labels = labels.to(device).long()
 
-        logits = utils.tensor_to_gradcheck_var(logits)  # to var
+        logits = tensor_to_gradcheck_var(logits)  # to var
         assert gradcheck(kornia.losses.dice_loss, (logits, labels), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
@@ -327,8 +326,8 @@ class TestDepthSmoothnessLoss:
     def test_gradcheck(self, device, dtype):
         image = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         depth = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
-        depth = utils.tensor_to_gradcheck_var(depth)  # to var
-        image = utils.tensor_to_gradcheck_var(image)  # to var
+        depth = tensor_to_gradcheck_var(depth)  # to var
+        image = tensor_to_gradcheck_var(image)  # to var
         assert gradcheck(
             kornia.losses.inverse_depth_smoothness_loss, (depth, image), raise_exception=True, fast_mode=True
         )
@@ -413,8 +412,8 @@ class TestDivergenceLoss:
         target = torch.rand(1, 1, 10, 16, device=device, dtype=dtype)
 
         # evaluate function gradient
-        input = utils.tensor_to_gradcheck_var(input)  # to var
-        target = utils.tensor_to_gradcheck_var(target)  # to var
+        input = tensor_to_gradcheck_var(input)  # to var
+        target = tensor_to_gradcheck_var(target)  # to var
         assert gradcheck(kornia.losses.kl_div_loss_2d, (input, target), raise_exception=True, fast_mode=True)
 
     def test_gradcheck_js(self, device, dtype):
@@ -422,8 +421,8 @@ class TestDivergenceLoss:
         target = torch.rand(1, 1, 10, 16, device=device, dtype=dtype)
 
         # evaluate function gradient
-        input = utils.tensor_to_gradcheck_var(input)  # to var
-        target = utils.tensor_to_gradcheck_var(target)  # to var
+        input = tensor_to_gradcheck_var(input)  # to var
+        target = tensor_to_gradcheck_var(target)  # to var
         assert gradcheck(kornia.losses.js_div_loss_2d, (input, target), raise_exception=True, fast_mode=True)
 
     def test_jit_kl(self, device, dtype):
@@ -574,7 +573,7 @@ class TestTotalVariation:
 
     def test_gradcheck(self, device, dtype):
         image = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
-        image = utils.tensor_to_gradcheck_var(image)  # to var
+        image = tensor_to_gradcheck_var(image)  # to var
         assert gradcheck(kornia.losses.total_variation, (image,), raise_exception=True, fast_mode=True)
 
 
@@ -633,8 +632,8 @@ class TestPSNRLoss:
     def test_gradcheck(self, device, dtype):
         input = torch.rand(2, 3, 3, 2, device=device, dtype=dtype)
         target = torch.rand(2, 3, 3, 2, device=device, dtype=dtype)
-        input = utils.tensor_to_gradcheck_var(input)  # to var
-        target = utils.tensor_to_gradcheck_var(target)  # to var
+        input = tensor_to_gradcheck_var(input)  # to var
+        target = tensor_to_gradcheck_var(target)  # to var
         assert gradcheck(kornia.losses.psnr_loss, (input, target, 1.0), raise_exception=True, fast_mode=True)
 
 
@@ -673,7 +672,7 @@ class TestLovaszHingeLoss:
         labels = torch.rand(2, 3, 2) * num_classes
         labels = labels.to(device).long()
 
-        logits = utils.tensor_to_gradcheck_var(logits)  # to var
+        logits = tensor_to_gradcheck_var(logits)  # to var
         assert gradcheck(kornia.losses.lovasz_hinge_loss, (logits, labels), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
@@ -738,7 +737,7 @@ class TestLovaszSoftmaxLoss:
         labels = torch.rand(2, 3, 2) * num_classes
         labels = labels.to(device).long()
 
-        logits = utils.tensor_to_gradcheck_var(logits)  # to var
+        logits = tensor_to_gradcheck_var(logits)  # to var
         assert gradcheck(kornia.losses.lovasz_softmax_loss, (logits, labels), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
@@ -764,60 +763,94 @@ class TestLovaszSoftmaxLoss:
         assert_close(op(logits, labels), op_module(logits, labels))
 
 
-class TestWelschLoss:
+class TestWelschLoss(BaseTester):
     def test_smoke(self, device, dtype):
         img1 = torch.rand(2, 3, 2, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 2)
-        img2 = img2.to(device).long()
+        img2 = torch.rand(2, 3, 2, device=device, dtype=dtype)
 
         criterion = kornia.losses.WelschLoss()
+
         assert criterion(img1, img2) is not None
 
-    def test_gradcheck(self, device, dtype):
-        img1 = torch.rand(2, 3, 64, 12, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 64, 12)
-        img2 = img2.to(device).long()
+    @pytest.mark.parametrize("shape", [(1, 3, 5, 5), (2, 5, 5)])
+    def test_cardinality(self, shape, device, dtype):
+        img = torch.rand(shape, device=device, dtype=dtype)
 
-        img1 = utils.tensor_to_gradcheck_var(img1)  # to var
-        assert gradcheck(kornia.losses.welsch_loss, (img1, img2), raise_exception=True, fast_mode=True)
+        actual = kornia.losses.WelschLoss(reduction='none')(img, img)
+        assert actual.shape == shape
+
+        actual = kornia.losses.WelschLoss(reduction='mean')(img, img)
+        assert actual.shape == ()
+
+    def test_gradcheck(self, device):
+        img1 = torch.rand(2, 3, 3, 3, device=device)
+        img2 = torch.rand(2, 3, 3, 3, device=device)
+
+        img1 = tensor_to_gradcheck_var(img1)  # to var
+        assert self.gradcheck(kornia.losses.welsch_loss, (img1, img2))
 
     def test_jit(self, device, dtype):
-        img1 = torch.rand(2, 3, 64, 1904, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 64, 1904)
-        img2 = img2.to(device).long()
+        img1 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
+        img2 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
 
         op = kornia.losses.welsch_loss
         op_script = torch.jit.script(op)
 
-        assert_close(op(img1, img2), op_script(img1, img2))
+        self.assert_close(op(img1, img2), op_script(img1, img2))
 
     def test_module(self, device, dtype):
-        img1 = torch.rand(2, 3, 32, 1904, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 32, 1904)
-        img2 = img2.to(device).long()
+        img1 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
+        img2 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
 
         op = kornia.losses.welsch_loss
         op_module = kornia.losses.WelschLoss()
 
-        assert_close(op(img1, img2), op_module(img1, img2))
+        self.assert_close(op(img1, img2), op_module(img1, img2))
 
-    def test_perfect_prediction(self, device, dtype):
-        img1 = torch.ones(100, device=device, dtype=dtype)
-        img2 = torch.ones(100, device=device, dtype=torch.int64)
+    @pytest.mark.parametrize("reduction", ["mean", "sum"])
+    @pytest.mark.parametrize("shape", [(1, 2, 9, 9), (2, 4, 3, 6)])
+    def test_perfect_prediction(self, device, dtype, reduction, shape):
+        # Sanity test
+        img = torch.rand(shape, device=device, dtype=dtype)
+        actual = kornia.losses.welsch_loss(img, img, reduction=reduction)
+        expected = torch.tensor(0.0, device=device, dtype=dtype)
+        self.assert_close(actual, expected)
 
-        criterion = kornia.losses.WelschLoss()
-        loss = criterion(img1, img2)
-        assert_close(loss, torch.zeros_like(loss), rtol=1e-3, atol=1e-3)
+        # Check loss computation
+        img1 = torch.ones(shape, device=device, dtype=dtype)
+        img2 = torch.zeros(shape, device=device, dtype=dtype)
 
-    def test_shape(self, device, dtype):
-        criterion = kornia.losses.WelschLoss()
-        with pytest.raises(Exception):
-            criterion(torch.rand(2, 3, 3, 2), torch.rand(2, 3, 3))
+        actual = kornia.losses.welsch_loss(img1, img2, reduction=reduction)
 
-    def test_reduction(self, device, dtype):
-        criterion = kornia.losses.WelschLoss(reduction="test")
-        with pytest.raises(Exception):
-            criterion(torch.rand(3, 3), torch.rand(3, 3))
+        if reduction == 'mean':
+            expected = torch.tensor(0.39346934028, device=device, dtype=dtype)
+        elif reduction == 'sum':
+            expected = (torch.ones_like(img1, device=device, dtype=dtype) * 0.39346934028).sum()
+
+        self.assert_close(actual, expected)
+
+    def test_exception(self, device, dtype):
+        img = torch.rand(3, 3, 3, device=device, dtype=dtype)
+
+        # wrong reduction
+        with pytest.raises(Exception) as execinfo:
+            kornia.losses.welsch_loss(img, img, reduction='test')
+        assert 'Given type of reduction is not supported. Got: test' in str(execinfo)
+
+        # Check if both are tensors
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.welsch_loss(1.0, img)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.welsch_loss(img, 1.0)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        # Check if same shape
+        img_b = torch.rand(1, 1, 3, 3, 4, device=device, dtype=dtype)
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.welsch_loss(img, img_b, 3)
+        assert 'Not same shape for tensors. Got:' in str(errinfo)
 
 
 class TestCauchyLoss:
@@ -834,7 +867,7 @@ class TestCauchyLoss:
         img2 = torch.rand(2, 3, 64, 12)
         img2 = img2.to(device).long()
 
-        img1 = utils.tensor_to_gradcheck_var(img1)  # to var
+        img1 = tensor_to_gradcheck_var(img1)  # to var
         assert gradcheck(kornia.losses.cauchy_loss, (img1, img2), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
@@ -890,7 +923,7 @@ class TestGemanMcclureLossLoss:
         img2 = torch.rand(2, 3, 64, 12)
         img2 = img2.to(device).long()
 
-        img1 = utils.tensor_to_gradcheck_var(img1)  # to var
+        img1 = tensor_to_gradcheck_var(img1)  # to var
         assert gradcheck(kornia.losses.geman_mcclure_loss, (img1, img2), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):
@@ -946,7 +979,7 @@ class TestCharbonnierLoss:
         img2 = torch.rand(2, 3, 64, 12)
         img2 = img2.to(device).long()
 
-        img1 = utils.tensor_to_gradcheck_var(img1)  # to var
+        img1 = tensor_to_gradcheck_var(img1)  # to var
         assert gradcheck(kornia.losses.charbonnier_loss, (img1, img2), raise_exception=True, fast_mode=True)
 
     def test_jit(self, device, dtype):

--- a/test/losses/test_losses.py
+++ b/test/losses/test_losses.py
@@ -946,71 +946,99 @@ class TestCauchyLoss(BaseTester):
 
         self.assert_close(actual, expected)
 
-    def test_shape(self, device, dtype):
-        criterion = kornia.losses.CauchyLoss()
-        with pytest.raises(Exception):
-            criterion(torch.rand(2, 3, 3, 2), torch.rand(2, 3, 3))
 
-    def test_reduction(self, device, dtype):
-        criterion = kornia.losses.CauchyLoss(reduction="test")
-        with pytest.raises(Exception):
-            criterion(torch.rand(2, 2), torch.rand(2, 2))
+class TestGemanMcclureLossLoss(BaseTester):
+    @pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+    @pytest.mark.parametrize("shape", [(1, 2, 9, 9), (2, 4, 3, 6)])
+    def test_smoke(self, device, dtype, reduction, shape):
+        img1 = torch.rand(shape, device=device, dtype=dtype)
+        img2 = torch.rand(shape, device=device, dtype=dtype)
 
+        assert kornia.losses.geman_mcclure_loss(img1, img2, reduction) is not None
 
-class TestGemanMcclureLossLoss:
-    def test_smoke(self, device, dtype):
-        img1 = torch.rand(2, 3, 2, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 2)
-        img2 = img2.to(device).long()
+    def test_exception(self, device, dtype):
+        img = torch.rand(3, 3, 3, device=device, dtype=dtype)
 
-        criterion = kornia.losses.GemanMcclureLoss()
-        assert criterion(img1, img2) is not None
+        # wrong reduction
+        with pytest.raises(Exception) as execinfo:
+            kornia.losses.geman_mcclure_loss(img, img, reduction='test')
+        assert 'Given type of reduction is not supported. Got: test' in str(execinfo)
 
-    def test_gradcheck(self, device, dtype):
-        img1 = torch.rand(2, 3, 64, 12, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 64, 12)
-        img2 = img2.to(device).long()
+        # Check if both are tensors
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.geman_mcclure_loss(1.0, img)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.geman_mcclure_loss(img, 1.0)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        # Check if same shape
+        img_b = torch.rand(1, 1, 3, 3, 4, device=device, dtype=dtype)
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.geman_mcclure_loss(img, img_b, 3)
+        assert 'Not same shape for tensors. Got:' in str(errinfo)
+
+    @pytest.mark.parametrize("shape", [(1, 3, 5, 5), (2, 5, 5)])
+    def test_cardinality(self, shape, device, dtype):
+        img = torch.rand(shape, device=device, dtype=dtype)
+
+        actual = kornia.losses.geman_mcclure_loss(img, img, reduction='none')
+        assert actual.shape == shape
+
+        actual = kornia.losses.geman_mcclure_loss(img, img, reduction='sum')
+        assert actual.shape == ()
+
+        actual = kornia.losses.geman_mcclure_loss(img, img, reduction='mean')
+        assert actual.shape == ()
+
+    def test_gradcheck(self, device):
+        img1 = torch.rand(2, 3, 3, 3, device=device)
+        img2 = torch.rand(2, 3, 3, 3, device=device)
 
         img1 = tensor_to_gradcheck_var(img1)  # to var
-        assert gradcheck(kornia.losses.geman_mcclure_loss, (img1, img2), raise_exception=True, fast_mode=True)
+        img2 = tensor_to_gradcheck_var(img2)  # to var
+        self.gradcheck(kornia.losses.geman_mcclure_loss, (img1, img2))
 
     def test_jit(self, device, dtype):
-        img1 = torch.rand(2, 3, 64, 1904, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 64, 1904)
-        img2 = img2.to(device).long()
+        img1 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
+        img2 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
 
         op = kornia.losses.geman_mcclure_loss
         op_script = torch.jit.script(op)
 
-        assert_close(op(img1, img2), op_script(img1, img2))
+        self.assert_close(op(img1, img2), op_script(img1, img2))
 
     def test_module(self, device, dtype):
-        img1 = torch.rand(2, 3, 32, 1904, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 32, 1904)
-        img2 = img2.to(device).long()
+        img1 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
+        img2 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
 
         op = kornia.losses.geman_mcclure_loss
         op_module = kornia.losses.GemanMcclureLoss()
 
-        assert_close(op(img1, img2), op_module(img1, img2))
+        self.assert_close(op(img1, img2), op_module(img1, img2))
 
-    def test_perfect_prediction(self, device, dtype):
-        img1 = torch.ones(100, device=device, dtype=dtype)
-        img2 = torch.ones(100, device=device, dtype=torch.int64)
+    @pytest.mark.parametrize("reduction", ["mean", "sum"])
+    @pytest.mark.parametrize("shape", [(1, 2, 9, 9), (2, 4, 3, 6)])
+    def test_perfect_prediction(self, device, dtype, reduction, shape):
+        # Sanity test
+        img = torch.rand(shape, device=device, dtype=dtype)
+        actual = kornia.losses.geman_mcclure_loss(img, img, reduction=reduction)
+        expected = torch.tensor(0.0, device=device, dtype=dtype)
+        self.assert_close(actual, expected)
 
-        criterion = kornia.losses.GemanMcclureLoss()
-        loss = criterion(img1, img2)
-        assert_close(loss, torch.zeros_like(loss), rtol=1e-3, atol=1e-3)
+        # Check loss computation
+        img1 = torch.ones(shape, device=device, dtype=dtype)
+        img2 = torch.zeros(shape, device=device, dtype=dtype)
 
-    def test_shape(self, device, dtype):
-        criterion = kornia.losses.GemanMcclureLoss()
-        with pytest.raises(Exception):
-            criterion(torch.rand(2, 3, 3, 2), torch.rand(2, 3, 3))
+        actual = kornia.losses.geman_mcclure_loss(img1, img2, reduction=reduction)
 
-    def test_reduction(self, device, dtype):
-        criterion = kornia.losses.GemanMcclureLoss(reduction="test")
-        with pytest.raises(Exception):
-            criterion(torch.rand(4, 4), torch.rand(4, 4))
+        if reduction == 'mean':
+            expected = torch.tensor(0.4, device=device, dtype=dtype)
+        elif reduction == 'sum':
+            expected = (torch.ones_like(img1, device=device, dtype=dtype) * 0.4).sum()
+
+        self.assert_close(actual, expected)
 
 
 class TestCharbonnierLoss:

--- a/test/losses/test_losses.py
+++ b/test/losses/test_losses.py
@@ -853,50 +853,98 @@ class TestWelschLoss(BaseTester):
         assert 'Not same shape for tensors. Got:' in str(errinfo)
 
 
-class TestCauchyLoss:
-    def test_smoke(self, device, dtype):
-        img1 = torch.rand(2, 3, 2, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 2)
-        img2 = img2.to(device).long()
+class TestCauchyLoss(BaseTester):
+    @pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+    @pytest.mark.parametrize("shape", [(1, 2, 9, 9), (2, 4, 3, 6)])
+    def test_smoke(self, device, dtype, reduction, shape):
+        img1 = torch.rand(shape, device=device, dtype=dtype)
+        img2 = torch.rand(shape, device=device, dtype=dtype)
 
-        criterion = kornia.losses.CauchyLoss()
-        assert criterion(img1, img2) is not None
+        assert kornia.losses.cauchy_loss(img1, img2, reduction) is not None
 
-    def test_gradcheck(self, device, dtype):
-        img1 = torch.rand(2, 3, 64, 12, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 64, 12)
-        img2 = img2.to(device).long()
+    def test_exception(self, device, dtype):
+        img = torch.rand(3, 3, 3, device=device, dtype=dtype)
+
+        # wrong reduction
+        with pytest.raises(Exception) as execinfo:
+            kornia.losses.cauchy_loss(img, img, reduction='test')
+        assert 'Given type of reduction is not supported. Got: test' in str(execinfo)
+
+        # Check if both are tensors
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.cauchy_loss(1.0, img)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.cauchy_loss(img, 1.0)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        # Check if same shape
+        img_b = torch.rand(1, 1, 3, 3, 4, device=device, dtype=dtype)
+        with pytest.raises(TypeError) as errinfo:
+            kornia.losses.cauchy_loss(img, img_b, 3)
+        assert 'Not same shape for tensors. Got:' in str(errinfo)
+
+    @pytest.mark.parametrize("shape", [(1, 3, 5, 5), (2, 5, 5)])
+    def test_cardinality(self, shape, device, dtype):
+        img = torch.rand(shape, device=device, dtype=dtype)
+
+        actual = kornia.losses.cauchy_loss(img, img, reduction='none')
+        assert actual.shape == shape
+
+        actual = kornia.losses.cauchy_loss(img, img, reduction='sum')
+        assert actual.shape == ()
+
+        actual = kornia.losses.cauchy_loss(img, img, reduction='mean')
+        assert actual.shape == ()
+
+    def test_gradcheck(self, device):
+        img1 = torch.rand(2, 3, 3, 3, device=device)
+        img2 = torch.rand(2, 3, 3, 3, device=device)
 
         img1 = tensor_to_gradcheck_var(img1)  # to var
-        assert gradcheck(kornia.losses.cauchy_loss, (img1, img2), raise_exception=True, fast_mode=True)
+        img2 = tensor_to_gradcheck_var(img2)  # to var
+        self.gradcheck(kornia.losses.cauchy_loss, (img1, img2))
 
     def test_jit(self, device, dtype):
-        img1 = torch.rand(2, 3, 64, 1904, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 64, 1904)
-        img2 = img2.to(device).long()
+        img1 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
+        img2 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
 
         op = kornia.losses.cauchy_loss
         op_script = torch.jit.script(op)
 
-        assert_close(op(img1, img2), op_script(img1, img2))
+        self.assert_close(op(img1, img2), op_script(img1, img2))
 
     def test_module(self, device, dtype):
-        img1 = torch.rand(2, 3, 32, 1904, device=device, dtype=dtype)
-        img2 = torch.rand(2, 3, 32, 1904)
-        img2 = img2.to(device).long()
+        img1 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
+        img2 = torch.rand(2, 3, 3, 3, device=device, dtype=dtype)
 
         op = kornia.losses.cauchy_loss
         op_module = kornia.losses.CauchyLoss()
 
-        assert_close(op(img1, img2), op_module(img1, img2))
+        self.assert_close(op(img1, img2), op_module(img1, img2))
 
-    def test_perfect_prediction(self, device, dtype):
-        img1 = torch.ones(100, device=device, dtype=dtype)
-        img2 = torch.ones(100, device=device, dtype=torch.int64)
+    @pytest.mark.parametrize("reduction", ["mean", "sum"])
+    @pytest.mark.parametrize("shape", [(1, 2, 9, 9), (2, 4, 3, 6)])
+    def test_perfect_prediction(self, device, dtype, reduction, shape):
+        # Sanity test
+        img = torch.rand(shape, device=device, dtype=dtype)
+        actual = kornia.losses.cauchy_loss(img, img, reduction=reduction)
+        expected = torch.tensor(0.0, device=device, dtype=dtype)
+        self.assert_close(actual, expected)
 
-        criterion = kornia.losses.CauchyLoss()
-        loss = criterion(img1, img2)
-        assert_close(loss, torch.zeros_like(loss), rtol=1e-3, atol=1e-3)
+        # Check loss computation
+        img1 = torch.ones(shape, device=device, dtype=dtype)
+        img2 = torch.zeros(shape, device=device, dtype=dtype)
+
+        actual = kornia.losses.cauchy_loss(img1, img2, reduction=reduction)
+
+        if reduction == 'mean':
+            expected = torch.tensor(0.40546512603759766, device=device, dtype=dtype)
+        elif reduction == 'sum':
+            expected = (torch.ones_like(img1, device=device, dtype=dtype) * 0.40546512603759766).sum()
+
+        self.assert_close(actual, expected)
 
     def test_shape(self, device, dtype):
         criterion = kornia.losses.CauchyLoss()

--- a/test/losses/test_ssim.py
+++ b/test/losses/test_ssim.py
@@ -126,7 +126,7 @@ class TestMS_SSIMLoss:
 class TestSSIM3DLoss(BaseTester):
     def test_smoke(self, device, dtype):
         # input data
-        img1 = torch.rand(1, 1, 2, 4, 4, device=device, dtype=dtype)
+        img1 = torch.rand(1, 1, 2, 4, 3, device=device, dtype=dtype)
         img2 = torch.rand(1, 1, 2, 4, 4, device=device, dtype=dtype)
 
         ssim1 = kornia.losses.ssim3d_loss(img1, img1, window_size=3, reduction="none")

--- a/test/losses/test_ssim.py
+++ b/test/losses/test_ssim.py
@@ -4,7 +4,7 @@ from torch.autograd import gradcheck
 
 import kornia
 import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.testing import BaseTester, assert_close
 
 
 class TestSSIMLoss:
@@ -123,33 +123,43 @@ class TestMS_SSIMLoss:
         assert_close(op(*args), op_script(*args))
 
 
-class TestSSIM3DLoss:
-    def test_ssim_equal_none(self, device, dtype):
+class TestSSIM3DLoss(BaseTester):
+    def test_smoke(self, device, dtype):
         # input data
-        img1 = torch.rand(1, 1, 10, 16, 16, device=device, dtype=dtype)
-        img2 = torch.rand(1, 1, 10, 16, 16, device=device, dtype=dtype)
+        img1 = torch.rand(1, 1, 2, 4, 4, device=device, dtype=dtype)
+        img2 = torch.rand(1, 1, 2, 4, 4, device=device, dtype=dtype)
 
-        ssim1 = kornia.losses.ssim3d_loss(img1, img1, window_size=5, reduction="none")
-        ssim2 = kornia.losses.ssim3d_loss(img2, img2, window_size=5, reduction="none")
+        ssim1 = kornia.losses.ssim3d_loss(img1, img1, window_size=3, reduction="none")
+        ssim2 = kornia.losses.ssim3d_loss(img2, img2, window_size=3, reduction="none")
 
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        assert_close(ssim1, torch.zeros_like(img1), rtol=tol_val, atol=tol_val)
-        assert_close(ssim2, torch.zeros_like(img2), rtol=tol_val, atol=tol_val)
+        self.assert_close(ssim1, torch.zeros_like(img1))
+        self.assert_close(ssim2, torch.zeros_like(img2))
 
     @pytest.mark.parametrize("window_size", [5, 11])
     @pytest.mark.parametrize("reduction_type", ["mean", "sum"])
-    @pytest.mark.parametrize("batch_shape", [(1, 1, 10, 16, 16), (2, 4, 8, 15, 20)])
-    def test_ssim(self, device, dtype, batch_shape, window_size, reduction_type):
+    @pytest.mark.parametrize("shape", [(1, 1, 2, 16, 16), (2, 4, 2, 15, 20)])
+    def test_ssim(self, device, dtype, shape, window_size, reduction_type):
         if device.type == 'xla':
             pytest.skip("test highly unstable with tpu")
 
-        # input data
-        img = torch.rand(batch_shape, device=device, dtype=dtype)
+        # Sanity test
+        img = torch.rand(shape, device=device, dtype=dtype)
+        actual = kornia.losses.ssim3d_loss(img, img, window_size, reduction=reduction_type)
+        expected = torch.tensor(0.0, device=device, dtype=dtype)
+        self.assert_close(actual, expected)
 
-        loss = kornia.losses.ssim3d_loss(img, img, window_size, reduction=reduction_type)
+        # Check loss computation
+        img1 = torch.ones(shape, device=device, dtype=dtype)
+        img2 = torch.zeros(shape, device=device, dtype=dtype)
 
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        assert_close(loss.item(), 0.0, rtol=tol_val, atol=tol_val)
+        actual = kornia.losses.ssim3d_loss(img1, img2, window_size, reduction=reduction_type)
+
+        if reduction_type == 'mean':
+            expected = torch.tensor(0.9999, device=device, dtype=dtype)
+        elif reduction_type == 'sum':
+            expected = (torch.ones_like(img1, device=device, dtype=dtype) * 0.9999).sum()
+
+        self.assert_close(actual, expected)
 
     def test_jit(self, device, dtype):
         img1 = torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype)
@@ -160,7 +170,7 @@ class TestSSIM3DLoss:
         op = kornia.losses.ssim3d_loss
         op_script = torch.jit.script(op)
 
-        assert_close(op(*args), op_script(*args))
+        self.assert_close(op(*args), op_script(*args))
 
     def test_module(self, device, dtype):
         img1 = torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype)
@@ -171,19 +181,30 @@ class TestSSIM3DLoss:
         op = kornia.losses.ssim3d_loss
         op_module = kornia.losses.SSIM3DLoss(*args[2:])
 
-        assert_close(op(*args), op_module(*args[:2]))
+        self.assert_close(op(*args), op_module(*args[:2]))
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         # input data
-        window_size = 3
-        img1 = torch.rand(1, 1, 5, 4, 3, device=device, dtype=dtype)
-        img2 = torch.rand(1, 1, 5, 4, 3, device=device, dtype=dtype)
+        img = torch.rand(1, 1, 5, 4, 3, device=device)
 
         # evaluate function gradient
-        img1 = utils.tensor_to_gradcheck_var(img1)  # to var
-        img2 = utils.tensor_to_gradcheck_var(img2)  # to var
+        img = utils.tensor_to_gradcheck_var(img)  # to var
 
         # TODO: review method since it needs `nondet_tol` in cuda sometimes.
         assert gradcheck(
-            kornia.losses.ssim3d_loss, (img1, img2, window_size), raise_exception=True, nondet_tol=1e-8, fast_mode=True
+            kornia.losses.ssim3d_loss, (img, img, 3), raise_exception=True, nondet_tol=1e-8, fast_mode=True
         )
+
+    @pytest.mark.parametrize("shape", [(1, 2, 3, 5, 5), (2, 4, 2, 5, 5)])
+    def test_cardinality(self, shape, device, dtype):
+        img = torch.rand(shape, device=device, dtype=dtype)
+
+        actual = kornia.losses.SSIM3DLoss(5, reduction='none')(img, img)
+        assert actual.shape == shape
+
+        actual = kornia.losses.SSIM3DLoss(5)(img, img)
+        assert actual.shape == ()
+
+    @pytest.mark.skip('loss have no exception case')
+    def test_exception(self):
+        pass

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 import kornia
-from kornia.testing import assert_close
+from kornia.testing import BaseTester, assert_close, tensor_to_gradcheck_var
 
 
 class TestMeanIoU:
@@ -220,3 +220,144 @@ class TestMeanAveragePrecision:
 
         with pytest.raises(AssertionError):
             _ = kornia.metrics.mean_average_precision(boxes[0], [labels], [scores], [gt_boxes], [gt_labels], 2)
+
+
+class TestSSIM3d(BaseTester):
+    @pytest.mark.parametrize(
+        "shape,padding,window_size,max_value",
+        [
+            ((1, 1, 3, 3, 3), 'same', 5, 1.0),
+            ((1, 1, 3, 3, 3), 'same', 3, 2.0),
+            ((1, 1, 3, 3, 3), 'same', 3, 0.5),
+            ((1, 1, 3, 3, 3), 'valid', 3, 1.0),
+            ((2, 4, 3, 3, 3), 'same', 3, 1.0),
+        ],
+    )
+    def test_smoke(self, shape, padding, window_size, max_value, device, dtype):
+        img_a = (torch.ones(shape, device=device, dtype=dtype) * max_value).clamp(0.0, max_value)
+        img_b = torch.zeros(shape, device=device, dtype=dtype)
+
+        actual = kornia.metrics.ssim3d(img_a, img_b, window_size, max_value, padding=padding)
+        expected = torch.ones_like(actual, device=device, dtype=dtype)
+
+        self.assert_close(actual, expected * 0.0001)
+
+        actual = kornia.metrics.ssim3d(img_a, img_a, window_size, max_value, padding=padding)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize(
+        "shape,padding,window_size,expected",
+        [
+            ((1, 1, 2, 2, 3), 'same', 3, (1, 1, 2, 2, 3)),
+            ((1, 1, 3, 3, 3), 'same', 5, (1, 1, 3, 3, 3)),
+            ((1, 1, 3, 3, 3), 'valid', 3, (1, 1, 1, 1, 1)),
+            ((2, 4, 3, 3, 3), 'same', 3, (2, 4, 3, 3, 3)),
+        ],
+    )
+    def test_cardinality(self, shape, padding, window_size, expected, device, dtype):
+        img = torch.rand(shape, device=device, dtype=dtype)
+
+        actual = kornia.metrics.ssim3d(img, img, window_size, padding=padding)
+
+        assert actual.shape == expected
+
+    def test_exception(self, device, dtype):
+        img = torch.rand(1, 1, 3, 3, 3, device=device, dtype=dtype)
+
+        # Check if both are tensors
+        with pytest.raises(TypeError) as errinfo:
+            kornia.metrics.ssim3d(1.0, img, 3)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            kornia.metrics.ssim3d(img, 1.0, 3)
+        assert 'Not a Tensor type. Got:' in str(errinfo)
+
+        # Check both shapes
+        img_wrong_shape = torch.rand(3, 3, device=device, dtype=dtype)
+        with pytest.raises(TypeError) as errinfo:
+            kornia.metrics.ssim3d(img, img_wrong_shape, 3)
+        assert 'shape must be [' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            kornia.metrics.ssim3d(img_wrong_shape, img, 3)
+        assert 'shape must be [' in str(errinfo)
+
+        # Check if same shape
+        img_b = torch.rand(1, 1, 3, 3, 4, device=device, dtype=dtype)
+        with pytest.raises(Exception) as errinfo:
+            kornia.metrics.ssim3d(img, img_b, 3)
+        assert 'img1 and img2 shapes must be the same. Got:' in str(errinfo)
+
+    def test_unit(self, device, dtype):
+        img_a = torch.tensor(
+            [
+                [
+                    [
+                        [[0.7, 1.0, 0.5], [1.0, 0.3, 1.0], [0.2, 1.0, 0.1]],
+                        [[0.2, 1.0, 0.1], [1.0, 0.3, 1.0], [0.7, 1.0, 0.5]],
+                        [[1.0, 0.3, 1.0], [0.7, 1.0, 0.5], [0.2, 1.0, 0.1]],
+                    ]
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        img_b = torch.ones(1, 1, 3, 3, 3, device=device, dtype=dtype) * 0.5
+
+        actual = kornia.metrics.ssim3d(img_a, img_b, 3, padding='same')
+
+        expected = torch.tensor(
+            [
+                [
+                    [
+                        [[0.0093, 0.0080, 0.0075], [0.0075, 0.0068, 0.0063], [0.0067, 0.0060, 0.0056]],
+                        [[0.0077, 0.0070, 0.0065], [0.0077, 0.0069, 0.0064], [0.0075, 0.0066, 0.0062]],
+                        [[0.0075, 0.0069, 0.0064], [0.0078, 0.0070, 0.0065], [0.0077, 0.0067, 0.0064]],
+                    ]
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        self.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize(
+        "shape,padding,window_size,max_value",
+        [
+            ((1, 1, 3, 3, 3), 'same', 5, 1.0),
+            ((1, 1, 3, 3, 3), 'same', 3, 2.0),
+            ((1, 1, 3, 3, 3), 'same', 3, 0.5),
+            ((1, 1, 3, 3, 3), 'valid', 3, 1.0),
+        ],
+    )
+    def test_module(self, shape, padding, window_size, max_value, device, dtype):
+        img_a = torch.rand(shape, device=device, dtype=dtype).clamp(0.0, max_value)
+        img_b = torch.rand(shape, device=device, dtype=dtype).clamp(0.0, max_value)
+
+        ops = kornia.metrics.ssim3d
+        mod = kornia.metrics.SSIM3D(window_size, max_value, padding=padding)
+
+        ops_out = ops(img_a, img_b, window_size, max_value, padding=padding)
+        mod_out = mod(img_a, img_b)
+
+        self.assert_close(ops_out, mod_out)
+
+    def test_gradcheck(self, device):
+        img = torch.rand(1, 1, 3, 3, 3, device=device)
+
+        op = kornia.metrics.ssim3d
+        img = tensor_to_gradcheck_var(img)
+
+        assert self.gradcheck(op, (img, img, 3), nondet_tol=1e-8)
+
+    @pytest.mark.jit
+    def test_jit(self, device, dtype):
+        img = torch.rand(1, 1, 3, 3, 3, device=device, dtype=dtype)
+
+        op = kornia.metrics.ssim3d
+        op_jit = torch.jit.script(op)
+
+        assert_close(op(img, img, 3), op_jit(img, img, 3))


### PR DESCRIPTION
#### Changes
Fixes #2136 


#### Type of change
- [x] 📚  Documentation Update
  - add to docs the losses: `Welsch`, `Cauchy`, `GemanMcclureLoss` and `Charbonnier`
- [x] 🧪 Tests Cases
   - Improve some losses tests
   - add missing test for `kornia.metrics.SSIM3D`
- [x] 🔬 New feature (non-breaking change which adds functionality)
  -  add gradcheck method to `BaseTester`