### PR TITLE
torch_version_geq -> torch_version_ge according to todo

### DIFF
--- a/kornia/geometry/subpix/spatial_soft_argmax.py
+++ b/kornia/geometry/subpix/spatial_soft_argmax.py
@@ -7,7 +7,7 @@ from kornia.core import Module, Tensor, concatenate, stack, tensor, where, zeros
 from kornia.filters.sobel import spatial_gradient3d
 from kornia.geometry.conversions import normalize_pixel_coordinates, normalize_pixel_coordinates3d
 from kornia.utils import create_meshgrid, create_meshgrid3d
-from kornia.utils._compat import torch_version_geq
+from kornia.utils._compat import torch_version_ge
 from kornia.utils.helpers import safe_solve_with_mask
 
 from .dsnt import spatial_expectation2d, spatial_softmax2d
@@ -609,7 +609,7 @@ def conv_quad_interp3d(input: Tensor, strict_maxima_bonus: float = 10.0, eps: fl
     dxs = 0.25 * A[..., 5]  # normalization to match OpenCV implementation
 
     Hes = stack([dxx, dxy, dxs, dxy, dyy, dys, dxs, dys, dss], -1).view(-1, 3, 3)
-    if not torch_version_geq(1, 10):
+    if not torch_version_ge(1, 10):
         # The following is needed to avoid singular cases
         Hes += torch.rand(Hes[0].size(), device=Hes.device).abs()[None] * eps
 

--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -11,8 +11,7 @@ def torch_version() -> str:
     return torch.__version__.split('+')[0]
 
 
-# TODO: replace by torch_version_ge``
-def torch_version_geq(major, minor) -> bool:
+def torch_version_ge(major, minor) -> bool:
     _version = version.parse(torch_version())
     return _version >= version.parse(f"{major}.{minor}")
 

--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -11,11 +11,6 @@ def torch_version() -> str:
     return torch.__version__.split('+')[0]
 
 
-def torch_version_ge(major, minor) -> bool:
-    _version = version.parse(torch_version())
-    return _version >= version.parse(f"{major}.{minor}")
-
-
 def torch_version_lt(major: int, minor: int, patch: int) -> bool:
     _version = version.parse(torch_version())
     return _version < version.parse(f"{major}.{minor}.{patch}")
@@ -26,9 +21,12 @@ def torch_version_le(major: int, minor: int, patch: int) -> bool:
     return _version <= version.parse(f"{major}.{minor}.{patch}")
 
 
-def torch_version_ge(major: int, minor: int, patch: int) -> bool:
+def torch_version_ge(major: int, minor: int, patch: Optional[int] = None) -> bool:
     _version = version.parse(torch_version())
-    return _version >= version.parse(f"{major}.{minor}.{patch}")
+    if patch is None:
+        return _version >= version.parse(f"{major}.{minor}")
+    else:
+        return _version >= version.parse(f"{major}.{minor}.{patch}")
 
 
 if TYPE_CHECKING:

--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -7,7 +7,7 @@ import torch
 from torch.linalg import inv_ex
 
 from kornia.core import Tensor
-from kornia.utils._compat import torch_version_geq
+from kornia.utils._compat import torch_version_ge
 
 
 def get_cuda_device_if_available(index: int = 0) -> torch.device:
@@ -137,7 +137,7 @@ def _torch_svd_cast(input: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
         dtype = torch.float32
 
     out1, out2, out3H = torch.linalg.svd(input.to(dtype))
-    if torch_version_geq(1, 11):
+    if torch_version_ge(1, 11):
         out3 = out3H.mH
     else:
         out3 = out3H.transpose(-1, -2)
@@ -163,7 +163,7 @@ def _torch_linalg_svdvals(input: Tensor) -> Tensor:
         # TODO: remove this branch when kornia relies on torch >= 1.10
         out: Tensor
     else:
-        if torch_version_geq(1, 10):
+        if torch_version_ge(1, 10):
             out = torch.linalg.svdvals(input.to(dtype))
         else:
             # TODO: remove this branch when kornia relies on torch >= 1.10
@@ -190,7 +190,7 @@ def _torch_solve_cast(A: Tensor, B: Tensor) -> Tensor:
 def safe_solve_with_mask(B: Tensor, A: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
     r"""Helper function, which avoids crashing because of singular matrix input and outputs the mask of valid
     solution."""
-    if not torch_version_geq(1, 10):
+    if not torch_version_ge(1, 10):
         sol = _torch_solve_cast(A, B)
         warnings.warn('PyTorch version < 1.10, solve validness mask maybe not correct', RuntimeWarning)
         return sol, sol, torch.ones(len(A), dtype=torch.bool, device=A.device)
@@ -207,7 +207,7 @@ def safe_solve_with_mask(B: Tensor, A: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
         pivots: Tensor
         info: Tensor
     else:
-        if torch_version_geq(1, 13):
+        if torch_version_ge(1, 13):
             A_LU, pivots, info = torch.linalg.lu_factor_ex(A.to(dtype))
         else:
             # TODO: remove this branch when kornia relies on torch >= 1.13
@@ -223,7 +223,7 @@ def safe_solve_with_mask(B: Tensor, A: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
         # TODO: remove this branch when kornia relies on torch >= 1.13
         X: Tensor
     else:
-        if torch_version_geq(1, 13):
+        if torch_version_ge(1, 13):
             X = torch.linalg.lu_solve(A_LU, pivots, B.to(dtype))
         else:
             # TODO: remove this branch when kornia relies on torch >= 1.13

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -19,7 +19,7 @@ from kornia.augmentation.random_generator import (
     random_mixup_generator,
 )
 from kornia.testing import assert_close
-from kornia.utils._compat import torch_version_geq
+from kornia.utils._compat import torch_version_ge
 
 
 class RandomGeneratorBaseTests:
@@ -131,7 +131,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
 
     def test_random_gen(self, device, dtype):
         # TODO(jian): crashes with pytorch 1.10, cuda and fp64
-        if torch_version_geq(1, 10) and "cuda" in str(device):
+        if torch_version_ge(1, 10) and "cuda" in str(device):
             pytest.skip("AssertionError: Tensor-likes are not close!")
         torch.manual_seed(42)
         batch_size = 8
@@ -179,7 +179,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
 
     def test_random_gen_accumulative_additive_additive(self, device, dtype):
         # TODO(jian): crashes with pytorch 1.10, cuda and fp64
-        if torch_version_geq(1, 10) and "cuda" in str(device):
+        if torch_version_ge(1, 10) and "cuda" in str(device):
             pytest.skip("AssertionError: Tensor-likes are not close!")
         torch.manual_seed(42)
         batch_size = 8
@@ -307,7 +307,7 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
 
     def test_random_gen(self, device, dtype):
         # TODO(jian): crashes with pytorch 1.10, cuda and fp64
-        if torch_version_geq(1, 10) and "cuda" in str(device):
+        if torch_version_ge(1, 10) and "cuda" in str(device):
             pytest.skip("AssertionError: Tensor-likes are not close!")
         torch.manual_seed(42)
         batch_size = 8

--- a/test/feature/test_loftr.py
+++ b/test/feature/test_loftr.py
@@ -8,7 +8,7 @@ import kornia.testing as utils  # test utils
 from kornia.feature import LoFTR
 from kornia.geometry import resize
 from kornia.testing import assert_close
-from kornia.utils._compat import torch_version_geq
+from kornia.utils._compat import torch_version_ge
 
 
 class TestLoFTR:
@@ -20,7 +20,7 @@ class TestLoFTR:
         loftr = LoFTR('indoor').to(device, dtype)
         assert loftr is not None
 
-    @pytest.mark.skipif(torch_version_geq(1, 10), reason="RuntimeError: CUDA out of memory with pytorch>=1.10")
+    @pytest.mark.skipif(torch_version_ge(1, 10), reason="RuntimeError: CUDA out of memory with pytorch>=1.10")
     @pytest.mark.skipif(sys.platform == "win32", reason="this test takes so much memory in the CI with Windows")
     @pytest.mark.parametrize("data", ["loftr_fund"], indirect=True)
     def test_pretrained_indoor(self, device, dtype, data):
@@ -31,7 +31,7 @@ class TestLoFTR:
         assert_close(out['keypoints0'], data_dev["loftr_indoor_tentatives0"])
         assert_close(out['keypoints1'], data_dev["loftr_indoor_tentatives1"])
 
-    @pytest.mark.skipif(torch_version_geq(1, 10), reason="RuntimeError: CUDA out of memory with pytorch>=1.10")
+    @pytest.mark.skipif(torch_version_ge(1, 10), reason="RuntimeError: CUDA out of memory with pytorch>=1.10")
     @pytest.mark.skipif(sys.platform == "win32", reason="this test takes so much memory in the CI with Windows")
     @pytest.mark.parametrize("data", ["loftr_homo"], indirect=True)
     def test_pretrained_outdoor(self, device, dtype, data):

--- a/test/geometry/transform/test_thin_plate_spline.py
+++ b/test/geometry/transform/test_thin_plate_spline.py
@@ -4,7 +4,7 @@ from torch.autograd import gradcheck
 
 import kornia
 from kornia.testing import assert_close
-from kornia.utils._compat import torch_version_geq
+from kornia.utils._compat import torch_version_ge
 
 
 def _sample_points(batch_size, device, dtype=torch.float32):
@@ -154,7 +154,7 @@ class TestWarpImage:
         assert warp.shape == tensor.shape
 
     @pytest.mark.skipif(
-        torch_version_geq(1, 10), reason="for some reason the solver detects singular matrices in pytorch >=1.10."
+        torch_version_ge(1, 10), reason="for some reason the solver detects singular matrices in pytorch >=1.10."
     )
     @pytest.mark.parametrize('batch_size', [1, 3])
     def test_warp(self, batch_size, device, dtype):


### PR DESCRIPTION
#### Changes
Small rename, so all `torch_version_*` checks have the same convention. Before it was `torch_version_geq`, but `torch_version_le`

