### PR TITLE
fix doc build - `sphinx-autodoc-typehints==1.21.3`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
             'opencv-python',
             'sphinx>=4.0',
             'sphinx-autodoc-defaultargs',
-            'sphinx-autodoc-typehints>=1.0',
+            'sphinx-autodoc-typehints==1.21.3',  # TODO: verify if works with > 1.24.4
             'sphinx-copybutton>=0.3',
             'sphinx-design',
             'sphinx-rtd-theme>0.5',


### PR DESCRIPTION
The 1.21.4 version is crashing the documentation build

related at https://github.com/kornia/kornia/pull/2154#issuecomment-1397160955


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

