### PR TITLE
Fix output types of augmentations on autocast regions

### DIFF
--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -39,3 +39,9 @@ Device
 -------
 
 .. autofunction:: get_cuda_device_if_available
+.. autofunction:: map_location_to_cpu
+
+
+Automatic Mixed Precision
+-------------------------
+.. autofunction:: is_autocast_enabled

--- a/kornia/augmentation/_2d/mix/base.py
+++ b/kornia/augmentation/_2d/mix/base.py
@@ -63,7 +63,7 @@ class MixAugmentationBaseV2(_BasicAugmentationBase):
             output = self.apply_non_transform(in_tensor, params, flags)
             output = output.index_put((to_apply,), self.apply_non_transform(applied, params, flags))
         output = _transform_output_shape(output, ori_shape) if self.keepdim else output
-        return output.type(in_tensor.dtype)
+        return output
 
     def transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         to_apply = params['batch_prob']

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -233,14 +233,6 @@ class _AugmentationBase(_BasicAugmentationBase):
         transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Tensor:
-        # Note about the explicit type conversions here:
-        # If this code is run in an autocast-enabled region, the transformation matrix or the output
-        # may be float16 even though the input was float32 (e.g. torch.mm produces float16 output),
-        # see also the documentation on autocasting: https://pytorch.org/docs/stable/amp.html.
-        # It may be unexpected for the user if the output type changes and it can also lead to errors
-        # for the index_put operation below (see also https://github.com/kornia/kornia/issues/1737)
-        # In case the type already matches the input type, the conversions are no-ops
-
         self.validate_tensor(input)
 
         params, flags = self._process_kwargs_to_params_and_flags(

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -319,6 +319,10 @@ class _AugmentationBase(_BasicAugmentationBase):
             applied = self.apply_transform_box(
                 input[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
             )
+            if is_autocast_enabled():
+                output = output.type(input.dtype)
+                applied = applied.type(input.dtype)
+
             output = output.index_put((to_apply,), applied)
         return output
 
@@ -348,6 +352,9 @@ class _AugmentationBase(_BasicAugmentationBase):
             applied = self.apply_transform_keypoint(
                 input[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
             )
+            if is_autocast_enabled():
+                output = output.type(input.dtype)
+                applied = applied.type(input.dtype)
             output = output.index_put((to_apply,), applied)
         return output
 

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -9,6 +9,7 @@ from kornia.augmentation.utils import _adapted_sampling, _transform_output_shape
 from kornia.core import Module, Tensor, tensor
 from kornia.geometry.boxes import Boxes
 from kornia.geometry.keypoints import Keypoints
+from kornia.utils import is_autocast_enabled
 
 TensorWithTransformMat = Union[Tensor, Tuple[Tensor, Tensor]]
 
@@ -259,13 +260,13 @@ class _AugmentationBase(_BasicAugmentationBase):
                 in_tensor[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
             )
 
-            if torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled():
+            if is_autocast_enabled():
                 output = output.type(input.dtype)
                 applied = applied.type(input.dtype)
             output = output.index_put((to_apply,), applied)
         output = _transform_output_shape(output, ori_shape) if self.keepdim else output
 
-        if torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled():
+        if is_autocast_enabled():
             output = output.type(input.dtype)
         return output
 

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -11,7 +11,7 @@ from kornia.constants import DataKey, Resample
 from kornia.core import Module, Tensor
 from kornia.geometry.boxes import Boxes, VideoBoxes
 from kornia.geometry.keypoints import Keypoints, VideoKeypoints
-from kornia.utils import eye_like
+from kornia.utils import eye_like, is_autocast_enabled
 
 __all__ = ["AugmentationSequential"]
 
@@ -141,6 +141,10 @@ class AugmentationSequential(ImageSequential):
 
     _transform_matrix: Optional[Tensor]
     _transform_matrices: List[Tensor] = []
+
+    _boxes_options = {DataKey.BBOX, DataKey.BBOX_XYXY, DataKey.BBOX_XYWH}
+    _keypoints_options = {DataKey.KEYPOINTS}
+    _img_msk_options = {DataKey.INPUT, DataKey.MASK}
 
     def __init__(
         self,
@@ -284,11 +288,11 @@ class AugmentationSequential(ImageSequential):
     def _arguments_preproc(self, *args: DataType, data_keys: List[DataKey]) -> List[DataType]:
         inp: List[DataType] = []
         for arg, dcate in zip(args, data_keys):
-            if DataKey.get(dcate) in [DataKey.INPUT, DataKey.MASK]:
+            if DataKey.get(dcate) in self._img_msk_options:
                 inp.append(arg)
-            elif DataKey.get(dcate) in [DataKey.KEYPOINTS]:
+            elif DataKey.get(dcate) in self._keypoints_options:
                 inp.append(self._preproc_keypoints(arg, dcate))
-            elif DataKey.get(dcate) in [DataKey.BBOX, DataKey.BBOX_XYXY, DataKey.BBOX_XYWH]:
+            elif DataKey.get(dcate) in self._boxes_options:
                 inp.append(self._preproc_boxes(arg, dcate))
             else:
                 raise NotImplementedError(f"input type of {dcate} is not implemented.")
@@ -299,16 +303,23 @@ class AugmentationSequential(ImageSequential):
     ) -> List[DataType]:
         out: List[DataType] = []
         for in_arg, out_arg, dcate in zip(in_args, out_args, data_keys):
-            if DataKey.get(dcate) in [DataKey.INPUT]:
+            if DataKey.get(dcate) in self._img_msk_options:
                 # It is tensor type already.
                 out.append(out_arg)
-            elif DataKey.get(dcate) in [DataKey.MASK]:
-                # TODO: may add the float to integer, etc.
-                out.append(out_arg)
-            elif DataKey.get(dcate) in [DataKey.KEYPOINTS]:
-                out.append(self._postproc_keypoint(in_arg, cast(Keypoints, out_arg), dcate))
-            elif DataKey.get(dcate) in [DataKey.BBOX, DataKey.BBOX_XYXY, DataKey.BBOX_XYWH]:
-                out.append(self._postproc_boxes(in_arg, cast(Boxes, out_arg), dcate))
+                # TODO: may add the float to integer (for masks), etc.
+
+            elif DataKey.get(dcate) in self._keypoints_options:
+                _out = self._postproc_keypoint(in_arg, cast(Keypoints, out_arg), dcate)
+                if is_autocast_enabled():
+                    _out = _out.to(device=in_arg.device, dtype=in_arg.dtype)
+                out.append(_out)
+
+            elif DataKey.get(dcate) in self._boxes_options:
+                _out = self._postproc_boxes(in_arg, cast(Boxes, out_arg), dcate)
+                if is_autocast_enabled():
+                    _out = _out.to(device=in_arg.device, dtype=in_arg.dtype)
+                out.append(_out)
+
             else:
                 raise NotImplementedError(f"input type of {dcate} is not implemented.")
 
@@ -395,6 +406,7 @@ class AugmentationSequential(ImageSequential):
             mode = "xywh"
         else:
             raise ValueError(f"Unsupported mode `{DataKey.get(dcate).name}`.")
+
         # TODO: handle 3d scenarios
         if isinstance(in_arg, (Boxes,)):
             return out_arg

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -309,16 +309,22 @@ class AugmentationSequential(ImageSequential):
                 # TODO: may add the float to integer (for masks), etc.
 
             elif DataKey.get(dcate) in self._keypoints_options:
-                _out = self._postproc_keypoint(in_arg, cast(Keypoints, out_arg), dcate)
-                if is_autocast_enabled():
-                    _out = _out.to(device=in_arg.device, dtype=in_arg.dtype)
-                out.append(_out)
+                _out_k = self._postproc_keypoint(in_arg, cast(Keypoints, out_arg), dcate)
+                if is_autocast_enabled() and isinstance(in_arg, (Tensor, Keypoints)):
+                    if isinstance(_out_k, list):
+                        _out_k = [i.type(in_arg.dtype) for i in _out_k]
+                    else:
+                        _out_k = _out_k.type(in_arg.dtype)
+                out.append(_out_k)
 
             elif DataKey.get(dcate) in self._boxes_options:
-                _out = self._postproc_boxes(in_arg, cast(Boxes, out_arg), dcate)
-                if is_autocast_enabled():
-                    _out = _out.to(device=in_arg.device, dtype=in_arg.dtype)
-                out.append(_out)
+                _out_b = self._postproc_boxes(in_arg, cast(Boxes, out_arg), dcate)
+                if is_autocast_enabled() and isinstance(in_arg, (Tensor, Boxes)):
+                    if isinstance(_out_b, list):
+                        _out_b = [i.type(in_arg.dtype) for i in _out_b]
+                    else:
+                        _out_b = _out_b.type(in_arg.dtype)
+                out.append(_out_b)
 
             else:
                 raise NotImplementedError(f"input type of {dcate} is not implemented.")

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -657,6 +657,10 @@ class Boxes:
         obj._is_batched = self._is_batched
         return obj
 
+    def type(self, dtype: torch.dtype) -> "Boxes":
+        self._data = self._data.type(dtype)
+        return self
+
 
 class VideoBoxes(Boxes):
     temporal_channel_size: int

--- a/kornia/geometry/keypoints.py
+++ b/kornia/geometry/keypoints.py
@@ -1,5 +1,7 @@
 from typing import List, Optional, Tuple, Union, cast
 
+import torch
+
 from kornia.core import Tensor
 from kornia.geometry import transform_points
 
@@ -51,6 +53,16 @@ class Keypoints:
     @property
     def data(self):
         return self._data
+
+    @property
+    def device(self) -> torch.device:
+        """Returns keypoints device."""
+        return self._data.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Returns keypoints dtype."""
+        return self._data.dtype
 
     def index_put(
         self,
@@ -145,6 +157,10 @@ class Keypoints:
 
     def clone(self) -> "Keypoints":
         return Keypoints(self._data.clone(), False)
+
+    def type(self, dtype: torch.dtype) -> "Keypoints":
+        self._data = self._data.type(dtype)
+        return self
 
 
 class VideoKeypoints(Keypoints):

--- a/kornia/utils/__init__.py
+++ b/kornia/utils/__init__.py
@@ -4,6 +4,7 @@ from .grid import create_meshgrid, create_meshgrid3d
 from .helpers import (
     _extract_device_dtype,
     get_cuda_device_if_available,
+    is_autocast_enabled,
     map_location_to_cpu,
     safe_inverse_with_mask,
     safe_solve_with_mask,
@@ -36,4 +37,5 @@ __all__ = [
     "vec_like",
     "torch_meshgrid",
     "map_location_to_cpu",
+    "is_autocast_enabled",
 ]

--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -40,6 +40,7 @@ def map_location_to_cpu(storage: str) -> str:
 
 
 def map_location_to_cpu(storage: Union[str, Tensor], *args: Any, **kwargs: Any) -> Union[str, Tensor]:
+    """Map location of device to CPU, util for loading things from HUB."""
     return storage
 
 
@@ -248,3 +249,28 @@ def safe_inverse_with_mask(A: Tensor) -> Tuple[Tensor, Tensor]:
     inverse, info = inv_ex(A.to(dtype))
     mask = info == 0
     return inverse.to(dtype_original), mask
+
+
+def is_autocast_enabled(both: bool = True) -> bool:
+    """Check if torch autocast is enabled.
+
+    Args:
+        both: if True will consider autocast region for both types of devices
+
+    Returns:
+        Return a Bool,
+        will always return False for a torch without support, otherwise will be: if both is True
+        `torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()`. If both is Flase will return just
+        `torch.is_autocast_enabled()`.
+    """
+    if TYPE_CHECKING:
+        # TODO: remove this branch when kornia relies on torch >= 1.10.2
+        return False
+
+    if not torch_version_ge(1, 10, 2):
+        return False
+
+    if both:
+        return torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()
+
+    return torch.is_autocast_enabled()

--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -263,11 +263,8 @@ def is_autocast_enabled(both: bool = True) -> bool:
         `torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()`. If both is Flase will return just
         `torch.is_autocast_enabled()`.
     """
-    if TYPE_CHECKING:
-        # TODO: remove this branch when kornia relies on torch >= 1.10.2
-        return False
-
-    if not torch_version_ge(1, 10, 2):
+    if not torch_version_ge(1, 10, 2) or TYPE_CHECKING:
+        # TODO: remove `TYPE_CHECKING` statement when kornia relies on torch >= 1.10.2
         return False
 
     if both:

--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -263,8 +263,11 @@ def is_autocast_enabled(both: bool = True) -> bool:
         `torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()`. If both is Flase will return just
         `torch.is_autocast_enabled()`.
     """
-    if not torch_version_ge(1, 10, 2) or TYPE_CHECKING:
-        # TODO: remove `TYPE_CHECKING` statement when kornia relies on torch >= 1.10.2
+    if TYPE_CHECKING:
+        # TODO: remove this branch when kornia relies on torch >= 1.10.2
+        return False
+
+    if not torch_version_ge(1, 10, 2):
         return False
 
     if both:

--- a/kornia/utils/misc.py
+++ b/kornia/utils/misc.py
@@ -23,7 +23,7 @@ def eye_like(n: int, input: torch.Tensor, shared_memory: bool = False) -> torch.
     if len(input.shape) < 1:
         raise AssertionError(input.shape)
 
-    identity = torch.eye(n, device=input.device, dtype=input.dtype)
+    identity = torch.eye(n, device=input.device).type(input.dtype)
     return identity[None].expand(input.shape[0], n, n) if shared_memory else identity[None].repeat(input.shape[0], 1, 1)
 
 

--- a/test/augmentation/test_base.py
+++ b/test/augmentation/test_base.py
@@ -5,9 +5,11 @@ import torch
 from torch.autograd import gradcheck
 
 import kornia.testing as utils  # test utils
-from kornia.augmentation import RandomGaussianBlur
 from kornia.augmentation._2d.base import AugmentationBase2D
 from kornia.augmentation._2d.geometric.affine import RandomAffine
+from kornia.augmentation._2d.intensity.gaussian_blur import RandomGaussianBlur
+from kornia.augmentation._3d.geometric.affine import RandomAffine3D
+from kornia.augmentation._3d.intensity.motion_blur import RandomMotionBlur3D
 from kornia.augmentation.base import _BasicAugmentationBase
 from kornia.testing import assert_close
 
@@ -76,28 +78,6 @@ class TestBasicAugmentationBase:
             output = augmentation(input)
             assert output.shape == expected_output.shape
             assert_close(output, expected_output)
-
-    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
-    def test_autocast(self, batch_prob, device, dtype):
-        if not hasattr(torch, "autocast"):
-            pytest.skip("PyTorch version without autocast support")
-
-        torch.manual_seed(42)
-
-        aug = RandomGaussianBlur((3, 3), (0.1, 3), p=1)
-        x = torch.rand(len(batch_prob), 3, 10, 7, dtype=dtype, device=device)
-
-        # Explicitly set the batch probability to trigger the different conditions in apply_func()
-        params = aug.forward_parameters(x.shape)
-        params["batch_prob"] = torch.tensor(batch_prob, device=params["batch_prob"].device)
-
-        # There is usually only a sigma value for the batch images which get transformed
-        params["sigma"] = params["sigma"][params["batch_prob"]]
-
-        with torch.autocast(device.type):
-            res = aug(x, params)
-
-        assert res.dtype == dtype, "The output dtype should match the input dtype"
 
 
 class TestAugmentationBase2D:
@@ -174,12 +154,77 @@ class TestGeometricAugmentationBase2D:
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
 
+        # Uses some subclass of `GeometricAugmentationBase2D` which perform some op which can mismatch the dtype
+        # Will cover AugmentationBase2D and RigidAffineAugmentationBase2D too
         aug = RandomAffine(0.5, (0.1, 0.5), (0.5, 1.5), 1.2, p=1.0)
         x = torch.rand(len(batch_prob), 5, 10, 7, dtype=dtype, device=device)
 
-        # Explicitly set the batch probability to trigger the different conditions in apply_func()
-        params = aug.forward_parameters(x.shape)
-        params["batch_prob"] = torch.tensor(batch_prob, device=device)
+        to_apply = torch.tensor(batch_prob, device=device)
+        with patch.object(aug, '__batch_prob_generator__', return_value=to_apply):
+            params = aug.forward_parameters(x.shape)
+
+        with torch.autocast(device.type):
+            res = aug(x, params)
+
+        assert res.dtype == dtype, "The output dtype should match the input dtype"
+
+
+class TestIntensityAugmentationBase2D:
+    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    def test_autocast(self, batch_prob, device, dtype):
+        if not hasattr(torch, "autocast"):
+            pytest.skip("PyTorch version without autocast support")
+
+        # Uses some subclass of `IntensityAugmentationBase2D` which perform some op which can mismatch the dtype
+        # Will cover AugmentationBase2D and RigidAffineAugmentationBase2D too
+        aug = RandomGaussianBlur((3, 3), (0.1, 3), p=1)
+        x = torch.rand(len(batch_prob), 5, 10, 7, dtype=dtype, device=device)
+
+        to_apply = torch.tensor(batch_prob, device=device)
+        with patch.object(aug, '__batch_prob_generator__', return_value=to_apply):
+            params = aug.forward_parameters(x.shape)
+
+        with torch.autocast(device.type):
+            res = aug(x, params)
+
+        assert res.dtype == dtype, "The output dtype should match the input dtype"
+
+
+class TestIntensityAugmentationBase3D:
+    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    def test_autocast(self, batch_prob, device, dtype):
+        if not hasattr(torch, "autocast"):
+            pytest.skip("PyTorch version without autocast support")
+
+        # Uses some subclass of `IntensityAugmentationBase3D` which perform some op which can mismatch the dtype
+        # Will cover RigidAffineAugmentationBase3D and AugmentationBase3D too
+        aug = RandomMotionBlur3D(3, 35.0, 0.5, p=1)
+        x = torch.rand(len(batch_prob), 1, 3, 10, 7, dtype=dtype, device=device)
+
+        to_apply = torch.tensor(batch_prob, device=device)
+        with patch.object(aug, '__batch_prob_generator__', return_value=to_apply):
+            params = aug.forward_parameters(x.shape)
+
+        with torch.autocast(device.type):
+            res = aug(x, params)
+
+        assert res.dtype == dtype, "The output dtype should match the input dtype"
+
+
+class TestGeometricAugmentationBase3D:
+    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    def test_autocast(self, batch_prob, device, dtype):
+        if not hasattr(torch, "autocast"):
+            pytest.skip("PyTorch version without autocast support")
+
+        # Uses some subclass of `GeometricAugmentationBase3D` which perform some op which can mismatch the dtype
+        # Will cover RigidAffineAugmentationBase3D and AugmentationBase3D too
+        aug = RandomAffine3D((15.0, 20.0, 20.0), p=1)
+        x = torch.rand(len(batch_prob), 1, 3, 10, 7, dtype=dtype, device=device)
+
+        to_apply = torch.tensor(batch_prob, device=device)
+        with patch.object(aug, '__batch_prob_generator__', return_value=to_apply):
+            params = aug.forward_parameters(x.shape)
 
         with torch.autocast(device.type):
             res = aug(x, params)


### PR DESCRIPTION
#### Changes
Fixes the usage of [autocasting](https://pytorch.org/docs/stable/amp.html#autocasting) with `kornia.augmentation`

Problem related on https://github.com/kornia/kornia/pull/2117#issuecomment-1396876226

Fixes #1737 after #2117

#### Type of change
- [x ] 📚  Documentation update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
  - `utils.is_autocat_enabled`

