### PR TITLE
Skip `x` tests for `torch=1.12.1` and `accelerate` not available

### DIFF
--- a/test/x/test_detection.py
+++ b/test/x/test_detection.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from torch.utils.data import Dataset
 
 from kornia.x import Configuration, ObjectDetectionTrainer
+from kornia.x.trainer import Accelerator
 
 
 class DummyDatasetDetection(Dataset):
@@ -57,6 +58,9 @@ def configuration():
 
 
 class TestObjectDetectionTrainer:
+    @pytest.mark.skipif(
+        torch.__version__ == '1.12.1' and Accelerator is None, reason='accelerate lib problem with torch 1.12.1'
+    )
     @pytest.mark.parametrize("loss_computed_by_model", [True, False])
     def test_fit(self, model, dataloader, criterion, optimizer, scheduler, configuration, loss_computed_by_model):
         trainer = ObjectDetectionTrainer(
@@ -72,6 +76,9 @@ class TestObjectDetectionTrainer:
         )
         trainer.fit()
 
+    @pytest.mark.skipif(
+        torch.__version__ == '1.12.1' and Accelerator is None, reason='accelerate lib problem with torch 1.12.1'
+    )
     def test_exception(self, model, dataloader, criterion, optimizer, scheduler, configuration):
         with pytest.raises(ValueError):
             ObjectDetectionTrainer(

--- a/test/x/test_image_classification.py
+++ b/test/x/test_image_classification.py
@@ -5,6 +5,7 @@ from torch.utils.data import Dataset
 
 from kornia.contrib import ClassificationHead, VisionTransformer
 from kornia.x import Configuration, ImageClassifierTrainer
+from kornia.x.trainer import Accelerator
 
 
 class DummyDatasetClassification(Dataset):
@@ -49,10 +50,16 @@ def configuration():
 
 
 class TestImageClassifierTrainer:
+    @pytest.mark.skipif(
+        torch.__version__ == '1.12.1' and Accelerator is None, reason='accelerate lib problem with torch 1.12.1'
+    )
     def test_fit(self, model, dataloader, criterion, optimizer, scheduler, configuration):
         trainer = ImageClassifierTrainer(model, dataloader, dataloader, criterion, optimizer, scheduler, configuration)
         trainer.fit()
 
+    @pytest.mark.skipif(
+        torch.__version__ == '1.12.1' and Accelerator is None, reason='accelerate lib problem with torch 1.12.1'
+    )
     def test_exception(self, model, dataloader, criterion, optimizer, scheduler, configuration):
         with pytest.raises(ValueError):
             ImageClassifierTrainer(

--- a/test/x/test_segmentation.py
+++ b/test/x/test_segmentation.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from torch.utils.data import Dataset
 
 from kornia.x import Configuration, SemanticSegmentationTrainer
+from kornia.x.trainer import Accelerator
 
 
 class DummyDatasetSegmentation(Dataset):
@@ -48,12 +49,18 @@ def configuration():
 
 
 class TestsemanticSegmentationTrainer:
+    @pytest.mark.skipif(
+        torch.__version__ == '1.12.1' and Accelerator is None, reason='accelerate lib problem with torch 1.12.1'
+    )
     def test_fit(self, model, dataloader, criterion, optimizer, scheduler, configuration):
         trainer = SemanticSegmentationTrainer(
             model, dataloader, dataloader, criterion, optimizer, scheduler, configuration
         )
         trainer.fit()
 
+    @pytest.mark.skipif(
+        torch.__version__ == '1.12.1' and Accelerator is None, reason='accelerate lib problem with torch 1.12.1'
+    )
     def test_exception(self, model, dataloader, criterion, optimizer, scheduler, configuration):
         with pytest.raises(ValueError):
             SemanticSegmentationTrainer(


### PR DESCRIPTION
Currently, the tests CI [is failing at master](https://github.com/kornia/kornia/actions/runs/4002736948/jobs/6870235907#step:4:9930) because some problem with setting `accelerate` with torch 1.12.1

So, I added to skip these tests when accelerate is not available and is specifically using torch 1.12.1.

First we had this problem here: https://github.com/kornia/kornia/pull/2038#discussion_r1038096647