### PR TITLE
Small refactor on `filters` module: Dropping JIT support

### DIFF
--- a/kornia/augmentation/_2d/intensity/gaussian_blur.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_blur.py
@@ -54,7 +54,7 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
 
     def __init__(
         self,
-        kernel_size: Tuple[int, int],
+        kernel_size: Union[Tuple[int, int], int],
         sigma: Union[Tuple[float, float], Tensor],
         border_type: str = "reflect",
         separable: bool = True,

--- a/kornia/augmentation/_2d/intensity/gaussian_blur.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_blur.py
@@ -1,12 +1,12 @@
 import warnings
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 from torch import Tensor
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.constants import BorderType
-from kornia.filters import gaussian_blur2d_t
+from kornia.filters import gaussian_blur2d
 
 
 class RandomGaussianBlur(IntensityAugmentationBase2D):
@@ -55,7 +55,7 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
     def __init__(
         self,
         kernel_size: Tuple[int, int],
-        sigma: Tuple[float, float],
+        sigma: Union[Tuple[float, float], Tensor],
         border_type: str = "reflect",
         separable: bool = True,
         same_on_batch: bool = False,
@@ -79,7 +79,7 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
         sigma = params["sigma"].to(device=input.device, dtype=input.dtype).unsqueeze(-1).expand(-1, 2)
-        return gaussian_blur2d_t(
+        return gaussian_blur2d(
             input,
             self.flags["kernel_size"],
             sigma,

--- a/kornia/augmentation/random_generator/_2d/gaussian_blur.py
+++ b/kornia/augmentation/random_generator/_2d/gaussian_blur.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -25,7 +25,7 @@ class RandomGaussianBlurGenerator(RandomGeneratorBase):
         ``self.set_rng_device_and_dtype(device="cuda", dtype=torch.float64)``.
     """
 
-    def __init__(self, sigma: Tuple[float, float] = (0.1, 2.0)) -> None:
+    def __init__(self, sigma: Union[Tuple[float, float], Tensor] = (0.1, 2.0)) -> None:
         super().__init__()
         if sigma[1] < sigma[0]:
             raise TypeError(f"sigma_max should be higher than sigma_min: {sigma} passed.")

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
 from .blur import BoxBlur, box_blur
-from .blur_pool import BlurPool2D, MaxBlurPool2D, blur_pool2d, edge_aware_blur_pool2d, max_blur_pool2d
+from .blur_pool import (
+    BlurPool2D,
+    EdgeAwareBlurPool2D,
+    MaxBlurPool2D,
+    blur_pool2d,
+    edge_aware_blur_pool2d,
+    max_blur_pool2d,
+)
 from .canny import Canny, canny
 from .dexined import DexiNed
 from .filter import filter2d, filter2d_separable, filter3d
@@ -78,6 +85,7 @@ __all__ = [
     "BoxBlur",
     "BlurPool2D",
     "MaxBlurPool2D",
+    "EdgeAwareBlurPool2D",
     "MedianBlur",
     "MotionBlur",
     "MotionBlur3D",

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -5,7 +5,7 @@ from .blur_pool import BlurPool2D, MaxBlurPool2D, blur_pool2d, edge_aware_blur_p
 from .canny import Canny, canny
 from .dexined import DexiNed
 from .filter import filter2d, filter2d_separable, filter3d
-from .gaussian import GaussianBlur2d, gaussian_blur2d
+from .gaussian import GaussianBlur2d, gaussian_blur2d, gaussian_blur2d_t
 from .kernels import (
     gaussian,
     get_binary_kernel2d,
@@ -14,8 +14,11 @@ from .kernels import (
     get_gaussian_discrete_kernel1d,
     get_gaussian_erf_kernel1d,
     get_gaussian_kernel1d,
+    get_gaussian_kernel1d_t,
     get_gaussian_kernel2d,
+    get_gaussian_kernel2d_t,
     get_gaussian_kernel3d,
+    get_gaussian_kernel3d_t,
     get_hanning_kernel1d,
     get_hanning_kernel2d,
     get_laplacian_kernel1d,
@@ -82,4 +85,8 @@ __all__ = [
     "spatial_gradient3d",
     "UnsharpMask",
     "DexiNed",
+    "gaussian_blur2d_t",
+    "get_gaussian_kernel1d_t",
+    "get_gaussian_kernel2d_t",
+    "get_gaussian_kernel3d_t",
 ]

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .blur import BoxBlur, box_blur
 from .blur_pool import BlurPool2D, MaxBlurPool2D, blur_pool2d, edge_aware_blur_pool2d, max_blur_pool2d
 from .canny import Canny, canny

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -3,7 +3,7 @@ from .blur_pool import BlurPool2D, MaxBlurPool2D, blur_pool2d, edge_aware_blur_p
 from .canny import Canny, canny
 from .dexined import DexiNed
 from .filter import filter2d, filter2d_separable, filter3d
-from .gaussian import GaussianBlur2d, gaussian_blur2d, gaussian_blur2d_t
+from .gaussian import GaussianBlur2d, gaussian_blur2d
 from .kernels import (
     gaussian,
     get_binary_kernel2d,
@@ -12,11 +12,8 @@ from .kernels import (
     get_gaussian_discrete_kernel1d,
     get_gaussian_erf_kernel1d,
     get_gaussian_kernel1d,
-    get_gaussian_kernel1d_t,
     get_gaussian_kernel2d,
-    get_gaussian_kernel2d_t,
     get_gaussian_kernel3d,
-    get_gaussian_kernel3d_t,
     get_hanning_kernel1d,
     get_hanning_kernel2d,
     get_laplacian_kernel1d,
@@ -38,13 +35,10 @@ __all__ = [
     "get_binary_kernel2d",
     "get_box_kernel2d",
     "get_gaussian_kernel1d",
-    "get_gaussian_kernel1d_t",
     "get_gaussian_discrete_kernel1d",
     "get_gaussian_erf_kernel1d",
     "get_gaussian_kernel2d",
     "get_gaussian_kernel3d",
-    "get_gaussian_kernel2d_t",
-    "get_gaussian_kernel3d_t",
     "get_hanning_kernel1d",
     "get_hanning_kernel2d",
     "get_laplacian_kernel1d",
@@ -56,7 +50,6 @@ __all__ = [
     "get_sobel_kernel2d",
     "get_diff_kernel2d",
     "gaussian_blur2d",
-    "gaussian_blur2d_t",
     "laplacian",
     "laplacian_1d",
     "unsharp_mask",

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 from kornia.core import Module, Tensor
 
@@ -7,7 +7,7 @@ from .kernels import get_box_kernel2d, normalize_kernel2d
 
 
 def box_blur(
-    input: Tensor, kernel_size: Union[Tuple[int, int], int], border_type: str = 'reflect', normalized: bool = True
+    input: Tensor, kernel_size: tuple[int, int] | int, border_type: str = 'reflect', normalized: bool = True
 ) -> Tensor:
     r"""Blur an image using the box filter.
 
@@ -87,7 +87,7 @@ class BoxBlur(Module):
     """
 
     def __init__(
-        self, kernel_size: Union[Tuple[int, int], int], border_type: str = 'reflect', normalized: bool = True
+        self, kernel_size: tuple[int, int] | int, border_type: str = 'reflect', normalized: bool = True
     ) -> None:
         super().__init__()
         self.kernel_size = kernel_size

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -1,15 +1,14 @@
-from typing import Tuple
+from typing import Tuple, Union
 
-import torch
-import torch.nn as nn
+from kornia.core import Module, Tensor
 
 from .filter import filter2d
 from .kernels import get_box_kernel2d, normalize_kernel2d
 
 
 def box_blur(
-    input: torch.Tensor, kernel_size: Tuple[int, int], border_type: str = 'reflect', normalized: bool = True
-) -> torch.Tensor:
+    input: Tensor, kernel_size: Union[Tuple[int, int], int], border_type: str = 'reflect', normalized: bool = True
+) -> Tensor:
     r"""Blur an image using the box filter.
 
     .. image:: _static/img/box_blur.png
@@ -45,13 +44,13 @@ def box_blur(
         >>> output.shape
         torch.Size([2, 4, 5, 7])
     """
-    kernel: torch.Tensor = get_box_kernel2d(kernel_size)
+    kernel = get_box_kernel2d(kernel_size)
     if normalized:
         kernel = normalize_kernel2d(kernel)
     return filter2d(input, kernel, border_type)
 
 
-class BoxBlur(nn.Module):
+class BoxBlur(Module):
     r"""Blur an image using the box filter.
 
     The function smooths an image using the kernel:
@@ -87,11 +86,13 @@ class BoxBlur(nn.Module):
         torch.Size([2, 4, 5, 7])
     """
 
-    def __init__(self, kernel_size: Tuple[int, int], border_type: str = 'reflect', normalized: bool = True) -> None:
+    def __init__(
+        self, kernel_size: Union[Tuple[int, int], int], border_type: str = 'reflect', normalized: bool = True
+    ) -> None:
         super().__init__()
-        self.kernel_size: Tuple[int, int] = kernel_size
-        self.border_type: str = border_type
-        self.normalized: bool = normalized
+        self.kernel_size = kernel_size
+        self.border_type = border_type
+        self.normalized = normalized
 
     def __repr__(self) -> str:
         return (
@@ -107,5 +108,5 @@ class BoxBlur(nn.Module):
             + ')'
         )
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
+    def forward(self, input: Tensor) -> Tensor:
         return box_blur(input, self.kernel_size, self.border_type, self.normalized)

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -44,7 +44,7 @@ def box_blur(
         >>> output.shape
         torch.Size([2, 4, 5, 7])
     """
-    kernel = get_box_kernel2d(kernel_size)
+    kernel = get_box_kernel2d(kernel_size, device=input.device, dtype=input.dtype)
     if normalized:
         kernel = normalize_kernel2d(kernel)
     return filter2d(input, kernel, border_type)

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
@@ -43,7 +43,7 @@ class BlurPool2D(Module):
                   [0.0000, 0.0625, 0.3125]]]])
     """
 
-    def __init__(self, kernel_size: Union[Tuple[int, int], int], stride: int = 2):
+    def __init__(self, kernel_size: tuple[int, int] | int, stride: int = 2):
         super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride
@@ -90,7 +90,7 @@ class MaxBlurPool2D(Module):
     """
 
     def __init__(
-        self, kernel_size: Union[Tuple[int, int], int], stride: int = 2, max_pool_size: int = 2, ceil_mode: bool = False
+        self, kernel_size: tuple[int, int] | int, stride: int = 2, max_pool_size: int = 2, ceil_mode: bool = False
     ):
         super().__init__()
         self.kernel_size = kernel_size
@@ -107,7 +107,7 @@ class MaxBlurPool2D(Module):
         )
 
 
-def blur_pool2d(input: Tensor, kernel_size: Union[Tuple[int, int], int], stride: int = 2):
+def blur_pool2d(input: Tensor, kernel_size: tuple[int, int] | int, stride: int = 2):
     r"""Compute blurs and downsample a given feature map.
 
     .. image:: _static/img/blur_pool2d.png
@@ -154,11 +154,7 @@ def blur_pool2d(input: Tensor, kernel_size: Union[Tuple[int, int], int], stride:
 
 
 def max_blur_pool2d(
-    input: Tensor,
-    kernel_size: Union[Tuple[int, int], int],
-    stride: int = 2,
-    max_pool_size: int = 2,
-    ceil_mode: bool = False,
+    input: Tensor, kernel_size: tuple[int, int] | int, stride: int = 2, max_pool_size: int = 2, ceil_mode: bool = False
 ) -> Tensor:
     r"""Compute pools and blurs and downsample a given feature map.
 
@@ -212,7 +208,7 @@ def _max_blur_pool_by_kernel2d(input: Tensor, kernel: Tensor, stride: int, max_p
 
 def edge_aware_blur_pool2d(
     input: Tensor,
-    kernel_size: Union[Tuple[int, int], int],
+    kernel_size: tuple[int, int] | int,
     edge_threshold: float = 1.25,
     edge_dilation_kernel_size: int = 3,
     epsilon: float = 1e-6,

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import torch
 import torch.nn.functional as F
 
-from kornia.core import Module, Tensor
+from kornia.core import Module, Tensor, as_tensor, pad, tensor
 from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 
 from .kernels import get_pascal_kernel_2d
@@ -47,11 +46,11 @@ class BlurPool2D(Module):
         super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride
-        self.register_buffer('kernel', get_pascal_kernel_2d(kernel_size, norm=True))
+        self.kernel = get_pascal_kernel_2d(kernel_size, norm=True)
 
     def forward(self, input: Tensor) -> Tensor:
         # To align the logic with the whole lib
-        self.kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
+        self.kernel = as_tensor(self.kernel, device=input.device, dtype=input.dtype)
         return _blur_pool_by_kernel2d(input, self.kernel.repeat((input.shape[1], 1, 1, 1)), self.stride)
 
 
@@ -97,11 +96,11 @@ class MaxBlurPool2D(Module):
         self.stride = stride
         self.max_pool_size = max_pool_size
         self.ceil_mode = ceil_mode
-        self.register_buffer('kernel', get_pascal_kernel_2d(kernel_size, norm=True))
+        self.kernel = get_pascal_kernel_2d(kernel_size, norm=True)
 
     def forward(self, input: Tensor) -> Tensor:
         # To align the logic with the whole lib
-        self.kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
+        self.kernel = as_tensor(self.kernel, device=input.device, dtype=input.dtype)
         return _max_blur_pool_by_kernel2d(
             input, self.kernel.repeat((input.size(1), 1, 1, 1)), self.stride, self.max_pool_size, self.ceil_mode
         )
@@ -183,7 +182,7 @@ def max_blur_pool2d(
         tensor([[[[0.5625, 0.3125],
                   [0.3125, 0.8750]]]])
     """
-    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'H', 'W'])
 
     kernel = get_pascal_kernel_2d(kernel_size, norm=True, device=input.device, dtype=input.dtype).repeat(
         (input.shape[1], 1, 1, 1)
@@ -238,14 +237,14 @@ def edge_aware_blur_pool2d(
     KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
     KORNIA_CHECK(edge_threshold > 0.0, f"edge threshold should be positive, but got '{edge_threshold}'")
 
-    input = F.pad(input, (2, 2, 2, 2), mode="reflect")  # pad to avoid artifacts near physical edges
+    input = pad(input, (2, 2, 2, 2), mode="reflect")  # pad to avoid artifacts near physical edges
     blurred_input = blur_pool2d(input, kernel_size=kernel_size, stride=1)  # blurry version of the input
 
     # calculate the edges (add epsilon to avoid taking the log of 0)
-    log_input, log_thresh = torch.log2(input + epsilon), torch.log2(torch.tensor(edge_threshold))
+    log_input, log_thresh = (input + epsilon).log2(), (tensor(edge_threshold)).log2()
     edges_x = log_input[..., :, 4:] - log_input[..., :, :-4]
     edges_y = log_input[..., 4:, :] - log_input[..., :-4, :]
-    edges_x, edges_y = torch.mean(edges_x, dim=-3, keepdim=True), torch.mean(edges_y, dim=-3, keepdim=True)
+    edges_x, edges_y = edges_x.mean(dim=-3, keepdim=True), edges_y.mean(dim=-3, keepdim=True)
     edges_x_mask, edges_y_mask = edges_x.abs() > log_thresh.to(edges_x), edges_y.abs() > log_thresh.to(edges_y)
     edges_xy_mask = (edges_x_mask[..., 2:-2, :] + edges_y_mask[..., :, 2:-2]).type_as(input)
 

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -51,8 +51,8 @@ class BlurPool2D(Module):
 
     def forward(self, input: Tensor) -> Tensor:
         # To align the logic with the whole lib
-        kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
-        return _blur_pool_by_kernel2d(input, kernel.repeat((input.shape[1], 1, 1, 1)), self.stride)
+        self.kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
+        return _blur_pool_by_kernel2d(input, self.kernel.repeat((input.shape[1], 1, 1, 1)), self.stride)
 
 
 class MaxBlurPool2D(Module):
@@ -101,9 +101,9 @@ class MaxBlurPool2D(Module):
 
     def forward(self, input: Tensor) -> Tensor:
         # To align the logic with the whole lib
-        kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
+        self.kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
         return _max_blur_pool_by_kernel2d(
-            input, kernel.repeat((input.size(1), 1, 1, 1)), self.stride, self.max_pool_size, self.ceil_mode
+            input, self.kernel.repeat((input.size(1), 1, 1, 1)), self.stride, self.max_pool_size, self.ceil_mode
         )
 
 
@@ -149,7 +149,9 @@ def blur_pool2d(input: Tensor, kernel_size: tuple[int, int] | int, stride: int =
                   [0.0625, 0.3750, 0.0625],
                   [0.0000, 0.0625, 0.3125]]]])
     """
-    kernel = get_pascal_kernel_2d(kernel_size, norm=True).repeat((input.size(1), 1, 1, 1)).to(input)
+    kernel = get_pascal_kernel_2d(kernel_size, norm=True, device=input.device, dtype=input.dtype).repeat(
+        (input.size(1), 1, 1, 1)
+    )
     return _blur_pool_by_kernel2d(input, kernel, stride)
 
 
@@ -183,7 +185,9 @@ def max_blur_pool2d(
     """
     if not len(input.shape) == 4:
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
-    kernel = get_pascal_kernel_2d(kernel_size, norm=True).repeat((input.shape[1], 1, 1, 1)).to(input)
+    kernel = get_pascal_kernel_2d(kernel_size, norm=True, device=input.device, dtype=input.dtype).repeat(
+        (input.shape[1], 1, 1, 1)
+    )
     return _max_blur_pool_by_kernel2d(input, kernel, stride, max_pool_size, ceil_mode)
 
 

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -43,7 +43,7 @@ class BlurPool2D(Module):
                   [0.0000, 0.0625, 0.3125]]]])
     """
 
-    def __init__(self, kernel_size: int, stride: int = 2):
+    def __init__(self, kernel_size: Union[Tuple[int, int], int], stride: int = 2):
         super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride
@@ -89,7 +89,9 @@ class MaxBlurPool2D(Module):
                   [0.3125, 0.8750]]]])
     """
 
-    def __init__(self, kernel_size: int, stride: int = 2, max_pool_size: int = 2, ceil_mode: bool = False):
+    def __init__(
+        self, kernel_size: Union[Tuple[int, int], int], stride: int = 2, max_pool_size: int = 2, ceil_mode: bool = False
+    ):
         super().__init__()
         self.kernel_size = kernel_size
         self.stride = stride
@@ -105,7 +107,7 @@ class MaxBlurPool2D(Module):
         )
 
 
-def blur_pool2d(input: Tensor, kernel_size: int, stride: int = 2):
+def blur_pool2d(input: Tensor, kernel_size: Union[Tuple[int, int], int], stride: int = 2):
     r"""Compute blurs and downsample a given feature map.
 
     .. image:: _static/img/blur_pool2d.png
@@ -152,7 +154,11 @@ def blur_pool2d(input: Tensor, kernel_size: int, stride: int = 2):
 
 
 def max_blur_pool2d(
-    input: Tensor, kernel_size: int, stride: int = 2, max_pool_size: int = 2, ceil_mode: bool = False
+    input: Tensor,
+    kernel_size: Union[Tuple[int, int], int],
+    stride: int = 2,
+    max_pool_size: int = 2,
+    ceil_mode: bool = False,
 ) -> Tensor:
     r"""Compute pools and blurs and downsample a given feature map.
 
@@ -189,7 +195,7 @@ def _blur_pool_by_kernel2d(input: Tensor, kernel: Tensor, stride: int):
     """Compute blur_pool by a given :math:`CxC_{out}xNxN` kernel."""
     if not (len(kernel.shape) == 4 and kernel.shape[-1] == kernel.shape[-2]):
         raise AssertionError(f"Invalid kernel shape. Expect CxC_outxNxN, Got {kernel.shape}")
-    padding: Tuple[int, int] = _compute_zero_padding((kernel.shape[-2], kernel.shape[-1]))
+    padding = _compute_zero_padding((kernel.shape[-2], kernel.shape[-1]))
     return F.conv2d(input, kernel, padding=padding, stride=stride, groups=input.shape[1])
 
 
@@ -200,13 +206,13 @@ def _max_blur_pool_by_kernel2d(input: Tensor, kernel: Tensor, stride: int, max_p
     # compute local maxima
     input = F.max_pool2d(input, kernel_size=max_pool_size, padding=0, stride=1, ceil_mode=ceil_mode)
     # blur and downsample
-    padding: Tuple[int, int] = _compute_zero_padding((kernel.shape[-2], kernel.shape[-1]))
+    padding = _compute_zero_padding((kernel.shape[-2], kernel.shape[-1]))
     return F.conv2d(input, kernel, padding=padding, stride=stride, groups=input.size(1))
 
 
 def edge_aware_blur_pool2d(
     input: Tensor,
-    kernel_size: int,
+    kernel_size: Union[Tuple[int, int], int],
     edge_threshold: float = 1.25,
     edge_dilation_kernel_size: int = 3,
     epsilon: float = 1e-6,

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 
 from kornia.color import rgb_to_grayscale
 from kornia.core import Module, Tensor
+from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
 
 from .gaussian import gaussian_blur2d
 from .kernels import get_canny_nms_kernel, get_hysteresis_kernel
@@ -52,27 +53,18 @@ def canny(
         >>> edges.shape
         torch.Size([5, 1, 4, 4])
     """
-    if not isinstance(input, Tensor):
-        raise TypeError(f"Input type is not a Tensor. Got {type(input)}")
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'H', 'W'])
+    KORNIA_CHECK(
+        low_threshold <= high_threshold,
+        "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
+        f"{low_threshold}>{high_threshold}",
+    )
+    KORNIA_CHECK(0 < low_threshold < 1, f'Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}')
+    KORNIA_CHECK(0 < high_threshold < 1, f'Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}')
 
-    if not len(input.shape) == 4:
-        raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
-
-    if low_threshold > high_threshold:
-        raise ValueError(
-            "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: {}>{}".format(
-                low_threshold, high_threshold
-            )
-        )
-
-    if low_threshold < 0 and low_threshold > 1:
-        raise ValueError(f"Invalid input threshold. low_threshold should be in range (0,1). Got: {low_threshold}")
-
-    if high_threshold < 0 and high_threshold > 1:
-        raise ValueError(f"Invalid input threshold. high_threshold should be in range (0,1). Got: {high_threshold}")
-
-    device: torch.device = input.device
-    dtype: torch.dtype = input.dtype
+    device = input.device
+    dtype = input.dtype
 
     # To Grayscale
     if input.shape[1] == 3:
@@ -190,19 +182,15 @@ class Canny(Module):
     ) -> None:
         super().__init__()
 
-        if low_threshold > high_threshold:
-            raise ValueError(
-                "Invalid input thresholds. low_threshold should be\
-                             smaller than the high_threshold. Got: {}>{}".format(
-                    low_threshold, high_threshold
-                )
-            )
-
-        if low_threshold < 0 or low_threshold > 1:
-            raise ValueError(f"Invalid input threshold. low_threshold should be in range (0,1). Got: {low_threshold}")
-
-        if high_threshold < 0 or high_threshold > 1:
-            raise ValueError(f"Invalid input threshold. high_threshold should be in range (0,1). Got: {high_threshold}")
+        KORNIA_CHECK(
+            low_threshold <= high_threshold,
+            "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
+            f"{low_threshold}>{high_threshold}",
+        )
+        KORNIA_CHECK(0 < low_threshold < 1, f'Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}')
+        KORNIA_CHECK(
+            0 < high_threshold < 1, f'Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}'
+        )
 
         # Gaussian blur parameters
         self.kernel_size = kernel_size

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -175,7 +175,7 @@ class Canny(Module):
         self,
         low_threshold: float = 0.1,
         high_threshold: float = 0.2,
-        kernel_size: tuple[int, int] = (5, 5),
+        kernel_size: tuple[int, int] | int = (5, 5),
         sigma: tuple[float, float] = (1, 1),
         hysteresis: bool = True,
         eps: float = 1e-6,

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -1,5 +1,5 @@
 import math
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -16,7 +16,7 @@ def canny(
     input: torch.Tensor,
     low_threshold: float = 0.1,
     high_threshold: float = 0.2,
-    kernel_size: Tuple[int, int] = (5, 5),
+    kernel_size: Union[Tuple[int, int], int] = (5, 5),
     sigma: Tuple[float, float] = (1, 1),
     hysteresis: bool = True,
     eps: float = 1e-6,

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -176,7 +176,7 @@ class Canny(Module):
         low_threshold: float = 0.1,
         high_threshold: float = 0.2,
         kernel_size: tuple[int, int] | int = (5, 5),
-        sigma: tuple[float, float] = (1, 1),
+        sigma: tuple[float, float] | Tensor = (1, 1),
         hysteresis: bool = True,
         eps: float = 1e-6,
     ) -> None:

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import math
-from typing import Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -16,11 +17,11 @@ def canny(
     input: torch.Tensor,
     low_threshold: float = 0.1,
     high_threshold: float = 0.2,
-    kernel_size: Union[Tuple[int, int], int] = (5, 5),
-    sigma: Tuple[float, float] = (1, 1),
+    kernel_size: tuple[int, int] | int = (5, 5),
+    sigma: tuple[float, float] = (1, 1),
     hysteresis: bool = True,
     eps: float = 1e-6,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     r"""Find edges of the input image and filters them using the Canny algorithm.
 
     .. image:: _static/img/canny.png
@@ -182,8 +183,8 @@ class Canny(nn.Module):
         self,
         low_threshold: float = 0.1,
         high_threshold: float = 0.2,
-        kernel_size: Tuple[int, int] = (5, 5),
-        sigma: Tuple[float, float] = (1, 1),
+        kernel_size: tuple[int, int] = (5, 5),
+        sigma: tuple[float, float] = (1, 1),
         hysteresis: bool = True,
         eps: float = 1e-6,
     ) -> None:
@@ -227,7 +228,7 @@ class Canny(nn.Module):
             )
         )
 
-    def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         return canny(
             input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
         )

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import math
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 
 from kornia.color import rgb_to_grayscale
+from kornia.core import Module, Tensor
 
 from .gaussian import gaussian_blur2d
 from .kernels import get_canny_nms_kernel, get_hysteresis_kernel
@@ -14,14 +14,14 @@ from .sobel import spatial_gradient
 
 
 def canny(
-    input: torch.Tensor,
+    input: Tensor,
     low_threshold: float = 0.1,
     high_threshold: float = 0.2,
     kernel_size: tuple[int, int] | int = (5, 5),
-    sigma: tuple[float, float] = (1, 1),
+    sigma: tuple[float, float] | Tensor = (1, 1),
     hysteresis: bool = True,
     eps: float = 1e-6,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[Tensor, Tensor]:
     r"""Find edges of the input image and filters them using the Canny algorithm.
 
     .. image:: _static/img/canny.png
@@ -52,8 +52,8 @@ def canny(
         >>> edges.shape
         torch.Size([5, 1, 4, 4])
     """
-    if not isinstance(input, torch.Tensor):
-        raise TypeError(f"Input type is not a torch.Tensor. Got {type(input)}")
+    if not isinstance(input, Tensor):
+        raise TypeError(f"Input type is not a Tensor. Got {type(input)}")
 
     if not len(input.shape) == 4:
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
@@ -79,18 +79,18 @@ def canny(
         input = rgb_to_grayscale(input)
 
     # Gaussian filter
-    blurred: torch.Tensor = gaussian_blur2d(input, kernel_size, sigma)
+    blurred: Tensor = gaussian_blur2d(input, kernel_size, sigma)
 
     # Compute the gradients
-    gradients: torch.Tensor = spatial_gradient(blurred, normalized=False)
+    gradients: Tensor = spatial_gradient(blurred, normalized=False)
 
     # Unpack the edges
-    gx: torch.Tensor = gradients[:, :, 0]
-    gy: torch.Tensor = gradients[:, :, 1]
+    gx: Tensor = gradients[:, :, 0]
+    gy: Tensor = gradients[:, :, 1]
 
     # Compute gradient magnitude and angle
-    magnitude: torch.Tensor = torch.sqrt(gx * gx + gy * gy + eps)
-    angle: torch.Tensor = torch.atan2(gy, gx)
+    magnitude: Tensor = torch.sqrt(gx * gx + gy * gy + eps)
+    angle: Tensor = torch.atan2(gy, gx)
 
     # Radians to Degrees
     angle = 180.0 * angle / math.pi
@@ -99,47 +99,47 @@ def canny(
     angle = torch.round(angle / 45) * 45
 
     # Non-maximal suppression
-    nms_kernels: torch.Tensor = get_canny_nms_kernel(device, dtype)
-    nms_magnitude: torch.Tensor = F.conv2d(magnitude, nms_kernels, padding=nms_kernels.shape[-1] // 2)
+    nms_kernels: Tensor = get_canny_nms_kernel(device, dtype)
+    nms_magnitude: Tensor = F.conv2d(magnitude, nms_kernels, padding=nms_kernels.shape[-1] // 2)
 
     # Get the indices for both directions
-    positive_idx: torch.Tensor = (angle / 45) % 8
+    positive_idx: Tensor = (angle / 45) % 8
     positive_idx = positive_idx.long()
 
-    negative_idx: torch.Tensor = ((angle / 45) + 4) % 8
+    negative_idx: Tensor = ((angle / 45) + 4) % 8
     negative_idx = negative_idx.long()
 
     # Apply the non-maximum suppression to the different directions
-    channel_select_filtered_positive: torch.Tensor = torch.gather(nms_magnitude, 1, positive_idx)
-    channel_select_filtered_negative: torch.Tensor = torch.gather(nms_magnitude, 1, negative_idx)
+    channel_select_filtered_positive: Tensor = torch.gather(nms_magnitude, 1, positive_idx)
+    channel_select_filtered_negative: Tensor = torch.gather(nms_magnitude, 1, negative_idx)
 
-    channel_select_filtered: torch.Tensor = torch.stack(
+    channel_select_filtered: Tensor = torch.stack(
         [channel_select_filtered_positive, channel_select_filtered_negative], 1
     )
 
-    is_max: torch.Tensor = channel_select_filtered.min(dim=1)[0] > 0.0
+    is_max: Tensor = channel_select_filtered.min(dim=1)[0] > 0.0
 
     magnitude = magnitude * is_max
 
     # Threshold
-    edges: torch.Tensor = F.threshold(magnitude, low_threshold, 0.0)
+    edges: Tensor = F.threshold(magnitude, low_threshold, 0.0)
 
-    low: torch.Tensor = magnitude > low_threshold
-    high: torch.Tensor = magnitude > high_threshold
+    low: Tensor = magnitude > low_threshold
+    high: Tensor = magnitude > high_threshold
 
     edges = low * 0.5 + high * 0.5
     edges = edges.to(dtype)
 
     # Hysteresis
     if hysteresis:
-        edges_old: torch.Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
-        hysteresis_kernels: torch.Tensor = get_hysteresis_kernel(device, dtype)
+        edges_old: Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
+        hysteresis_kernels: Tensor = get_hysteresis_kernel(device, dtype)
 
         while ((edges_old - edges).abs() != 0).any():
-            weak: torch.Tensor = (edges == 0.5).float()
-            strong: torch.Tensor = (edges == 1).float()
+            weak: Tensor = (edges == 0.5).float()
+            strong: Tensor = (edges == 1).float()
 
-            hysteresis_magnitude: torch.Tensor = F.conv2d(
+            hysteresis_magnitude: Tensor = F.conv2d(
                 edges, hysteresis_kernels, padding=hysteresis_kernels.shape[-1] // 2
             )
             hysteresis_magnitude = (hysteresis_magnitude == 1).any(1, keepdim=True).to(dtype)
@@ -153,7 +153,7 @@ def canny(
     return magnitude, edges
 
 
-class Canny(nn.Module):
+class Canny(Module):
     r"""Module that finds edges of the input image and filters them using the Canny algorithm.
 
     Args:
@@ -228,7 +228,7 @@ class Canny(nn.Module):
             )
         )
 
-    def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, input: Tensor) -> tuple[Tensor, Tensor]:
         return canny(
             input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
         )

--- a/kornia/filters/dexined.py
+++ b/kornia/filters/dexined.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from kornia.core import Module, Tensor, concatenate
+from kornia.testing import KORNIA_CHECK
 from kornia.utils import map_location_to_cpu
 
 url: str = "http://cmp.felk.cvut.cz/~mishkdmy/models/DexiNed_BIPED_10.pth"
@@ -102,8 +103,7 @@ class UpConvBlock(Module):
         self.constant_features = 16
 
         layers = self.make_deconv_layers(in_features, up_scale)
-        if layers is None:
-            raise Exception("layers cannot be none")
+        KORNIA_CHECK(layers is not None, "layers cannot be none")
         self.features = nn.Sequential(*layers)
 
     def make_deconv_layers(self, in_features: int, up_scale: int) -> list[Module]:

--- a/kornia/filters/dexined.py
+++ b/kornia/filters/dexined.py
@@ -55,7 +55,7 @@ class CoFusion(Module):
         attn = F.softmax(self.conv3(attn), dim=1)
 
         # return ((fusecat * attn).sum(1)).unsqueeze(1)
-        return ((x * attn).sum(1)).unsqueeze(1)
+        return ((x * attn).sum(1))[:, None, ...]
 
 
 class _DenseLayer(nn.Sequential):

--- a/kornia/filters/dexined.py
+++ b/kornia/filters/dexined.py
@@ -1,6 +1,8 @@
 # adapted from: https://github.com/xavysp/DexiNed/blob/d944b70eb6eaf40e22f8467c1e12919aa600d8e4/model.py
+
+from __future__ import annotations
+
 from collections import OrderedDict
-from typing import List
 
 import torch
 import torch.nn as nn
@@ -70,7 +72,7 @@ class _DenseLayer(nn.Sequential):
             )
         )
 
-    def forward(self, x: List[Tensor]) -> List[Tensor]:
+    def forward(self, x: list[Tensor]) -> list[Tensor]:
         x1, x2 = x[0], x[1]
         x3: Tensor = x1
         for mod in self:
@@ -86,7 +88,7 @@ class _DenseBlock(nn.Sequential):
             self.add_module('denselayer%d' % (i + 1), layer)
             input_features = out_features
 
-    def forward(self, x: List[Tensor]) -> List[Tensor]:
+    def forward(self, x: list[Tensor]) -> list[Tensor]:
         x_out = x
         for mod in self:
             x_out = mod(x_out)
@@ -104,8 +106,8 @@ class UpConvBlock(Module):
             raise Exception("layers cannot be none")
         self.features = nn.Sequential(*layers)
 
-    def make_deconv_layers(self, in_features: int, up_scale: int) -> List[Module]:
-        layers: List[Module] = []
+    def make_deconv_layers(self, in_features: int, up_scale: int) -> list[Module]:
+        layers: list[Module] = []
         all_pads = [0, 0, 1, 3, 7]
         for i in range(up_scale):
             kernel_size = 2**up_scale
@@ -120,7 +122,7 @@ class UpConvBlock(Module):
     def compute_out_features(self, idx: int, up_scale: int):
         return 1 if idx == up_scale - 1 else self.constant_features
 
-    def forward(self, x: Tensor, out_shape: List[int]) -> Tensor:
+    def forward(self, x: Tensor, out_shape: list[int]) -> Tensor:
         out = self.features(x)
         if out.shape[-2:] != out_shape:
             out = F.interpolate(out, out_shape, mode='bilinear')
@@ -215,7 +217,7 @@ class DexiNed(Module):
         self.load_state_dict(pretrained_dict, strict=True)
         self.eval()
 
-    def forward(self, x: Tensor) -> List[Tensor]:
+    def forward(self, x: Tensor) -> list[Tensor]:
         # Block 1
         block_1 = self.block_1(x)
         block_1_side = self.side_1(block_1)

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -91,7 +91,7 @@ def filter2d(
 
     # prepare kernel
     b, c, h, w = input.shape
-    tmp_kernel = kernel.unsqueeze(1).to(device=input.device, dtype=input.dtype)
+    tmp_kernel = kernel[:, None, ...].to(device=input.device, dtype=input.dtype)
 
     if normalized:
         tmp_kernel = normalize_kernel2d(tmp_kernel)
@@ -169,8 +169,8 @@ def filter2d_separable(
                   [0., 5., 5., 5., 0.],
                   [0., 0., 0., 0., 0.]]]])
     """
-    out_x = filter2d(input, kernel_x.unsqueeze(-2), border_type, normalized, padding)
-    out = filter2d(out_x, kernel_y.unsqueeze(-1), border_type, normalized, padding)
+    out_x = filter2d(input, kernel_x[..., None, :], border_type, normalized, padding)
+    out = filter2d(out_x, kernel_y[..., None], border_type, normalized, padding)
     return out
 
 
@@ -246,7 +246,7 @@ def filter3d(input: Tensor, kernel: Tensor, border_type: str = 'replicate', norm
 
     # prepare kernel
     b, c, d, h, w = input.shape
-    tmp_kernel = kernel.unsqueeze(1).to(device=input.device, dtype=input.dtype)
+    tmp_kernel = kernel[:, None, ...].to(device=input.device, dtype=input.dtype)
 
     if normalized:
         bk, dk, hk, wk = kernel.shape

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-import torch
 import torch.nn.functional as F
 
+from kornia.core import Tensor, pad
+from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+
 from .kernels import normalize_kernel2d
+
+_VALID_BORDERS = {'constant', 'reflect', 'replicate', 'circular'}
+_VALID_PADDING = {'valid', 'same'}
 
 
 def _compute_padding(kernel_size: list[int]) -> list[int]:
@@ -30,12 +35,8 @@ def _compute_padding(kernel_size: list[int]) -> list[int]:
 
 
 def filter2d(
-    input: torch.Tensor,
-    kernel: torch.Tensor,
-    border_type: str = 'reflect',
-    normalized: bool = False,
-    padding: str = 'same',
-) -> torch.Tensor:
+    input: Tensor, kernel: Tensor, border_type: str = 'reflect', normalized: bool = False, padding: str = 'same'
+) -> Tensor:
     r"""Convolve a tensor with a 2d kernel.
 
     The function applies a given kernel to a tensor. The kernel is applied
@@ -56,7 +57,7 @@ def filter2d(
           2 modes available ``'same'`` or ``'valid'``.
 
     Return:
-        torch.Tensor: the convolved tensor of same size and numbers of channels
+        Tensor: the convolved tensor of same size and numbers of channels
         as the input with shape :math:`(B, C, H, W)`.
 
     Example:
@@ -74,36 +75,23 @@ def filter2d(
                   [0., 5., 5., 5., 0.],
                   [0., 0., 0., 0., 0.]]]])
     """
-    if not isinstance(input, torch.Tensor):
-        raise TypeError(f"Input input is not torch.Tensor. Got {type(input)}")
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'H', 'W'))
+    KORNIA_CHECK_IS_TENSOR(kernel)
+    KORNIA_CHECK_SHAPE(kernel, ('B', 'H', 'W'))
 
-    if not isinstance(kernel, torch.Tensor):
-        raise TypeError(f"Input kernel is not torch.Tensor. Got {type(kernel)}")
-
-    if not isinstance(border_type, str):
-        raise TypeError(f"Input border_type is not string. Got {type(border_type)}")
-
-    if border_type not in ['constant', 'reflect', 'replicate', 'circular']:
-        raise ValueError(
-            f"Invalid border type, we expect 'constant', \
-        'reflect', 'replicate', 'circular'. Got:{border_type}"
-        )
-
-    if not isinstance(padding, str):
-        raise TypeError(f"Input padding is not string. Got {type(padding)}")
-
-    if padding not in ['valid', 'same']:
-        raise ValueError(f"Invalid padding mode, we expect 'valid' or 'same'. Got: {padding}")
-
-    if not len(input.shape) == 4:
-        raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
-
-    if (not len(kernel.shape) == 3) and not ((kernel.shape[0] == 0) or (kernel.shape[0] == input.shape[0])):
-        raise ValueError(f"Invalid kernel shape, we expect 1xHxW or BxHxW. Got: {kernel.shape}")
+    KORNIA_CHECK(
+        str(border_type).lower() in _VALID_BORDERS,
+        f'Invalid border, gotcha {border_type}. Expected one of {_VALID_BORDERS}',
+    )
+    KORNIA_CHECK(
+        str(padding).lower() in _VALID_PADDING,
+        f'Invalid padding mode, gotcha {padding}. Expected one of {_VALID_PADDING}',
+    )
 
     # prepare kernel
     b, c, h, w = input.shape
-    tmp_kernel: torch.Tensor = kernel.unsqueeze(1).to(input)
+    tmp_kernel = kernel.unsqueeze(1).to(device=input.device, dtype=input.dtype)
 
     if normalized:
         tmp_kernel = normalize_kernel2d(tmp_kernel)
@@ -115,15 +103,13 @@ def filter2d(
     # pad the input tensor
     if padding == 'same':
         padding_shape: list[int] = _compute_padding([height, width])
-        input = F.pad(input, padding_shape, mode=border_type)
+        input = pad(input, padding_shape, mode=border_type)
 
     # kernel and input tensor reshape to align element-wise or batch-wise params
     tmp_kernel = tmp_kernel.reshape(-1, 1, height, width)
     input = input.view(-1, tmp_kernel.size(0), input.size(-2), input.size(-1))
 
     # convolve the tensor with the kernel.
-    # NOTE: type(...) to fix getting `torch.bfloat16` type.
-    # TODO: @johnnv1, fix it through the Augmentation Base.
     output = F.conv2d(input, tmp_kernel, groups=tmp_kernel.size(0), padding=0, stride=1).type(input.dtype)
 
     if padding == 'same':
@@ -135,13 +121,13 @@ def filter2d(
 
 
 def filter2d_separable(
-    input: torch.Tensor,
-    kernel_x: torch.Tensor,
-    kernel_y: torch.Tensor,
+    input: Tensor,
+    kernel_x: Tensor,
+    kernel_y: Tensor,
     border_type: str = 'reflect',
     normalized: bool = False,
     padding: str = 'same',
-) -> torch.Tensor:
+) -> Tensor:
     r"""Convolve a tensor with two 1d kernels, in x and y directions.
 
     The function applies a given kernel to a tensor. The kernel is applied
@@ -164,7 +150,7 @@ def filter2d_separable(
           2 modes available ``'same'`` or ``'valid'``.
 
     Return:
-        torch.Tensor: the convolved tensor of same size and numbers of channels
+        Tensor: the convolved tensor of same size and numbers of channels
         as the input with shape :math:`(B, C, H, W)`.
 
     Example:
@@ -188,9 +174,7 @@ def filter2d_separable(
     return out
 
 
-def filter3d(
-    input: torch.Tensor, kernel: torch.Tensor, border_type: str = 'replicate', normalized: bool = False
-) -> torch.Tensor:
+def filter3d(input: Tensor, kernel: Tensor, border_type: str = 'replicate', normalized: bool = False) -> Tensor:
     r"""Convolve a tensor with a 3d kernel.
 
     The function applies a given kernel to a tensor. The kernel is applied
@@ -250,24 +234,19 @@ def filter3d(
                    [0., 5., 5., 5., 0.],
                    [0., 0., 0., 0., 0.]]]]])
     """
-    if not isinstance(input, torch.Tensor):
-        raise TypeError(f"Input border_type is not torch.Tensor. Got {type(input)}")
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'D', 'H', 'W'))
+    KORNIA_CHECK_IS_TENSOR(kernel)
+    KORNIA_CHECK_SHAPE(kernel, ('1', 'D', 'H', 'W'))
 
-    if not isinstance(kernel, torch.Tensor):
-        raise TypeError(f"Input border_type is not torch.Tensor. Got {type(kernel)}")
-
-    if not isinstance(border_type, str):
-        raise TypeError(f"Input border_type is not string. Got {type(kernel)}")
-
-    if not len(input.shape) == 5:
-        raise ValueError(f"Invalid input shape, we expect BxCxDxHxW. Got: {input.shape}")
-
-    if not len(kernel.shape) == 4 and kernel.shape[0] != 1:
-        raise ValueError(f"Invalid kernel shape, we expect 1xDxHxW. Got: {kernel.shape}")
+    KORNIA_CHECK(
+        str(border_type).lower() in _VALID_BORDERS,
+        f'Invalid border, gotcha {border_type}. Expected one of {_VALID_BORDERS}',
+    )
 
     # prepare kernel
     b, c, d, h, w = input.shape
-    tmp_kernel: torch.Tensor = kernel.unsqueeze(1).to(input)
+    tmp_kernel = kernel.unsqueeze(1).to(device=input.device, dtype=input.dtype)
 
     if normalized:
         bk, dk, hk, wk = kernel.shape
@@ -278,7 +257,7 @@ def filter3d(
     # pad the input tensor
     depth, height, width = tmp_kernel.shape[-3:]
     padding_shape: list[int] = _compute_padding([depth, height, width])
-    input_pad: torch.Tensor = F.pad(input, padding_shape, mode=border_type)
+    input_pad = pad(input, padding_shape, mode=border_type)
 
     # kernel and input tensor reshape to align element-wise or batch-wise params
     tmp_kernel = tmp_kernel.reshape(-1, 1, depth, height, width)

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -110,7 +110,7 @@ def filter2d(
     input = input.view(-1, tmp_kernel.size(0), input.size(-2), input.size(-1))
 
     # convolve the tensor with the kernel.
-    output = F.conv2d(input, tmp_kernel, groups=tmp_kernel.size(0), padding=0, stride=1).type(input.dtype)
+    output = F.conv2d(input, tmp_kernel, groups=tmp_kernel.size(0), padding=0, stride=1)
 
     if padding == 'same':
         out = output.view(b, c, h, w)

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from .kernels import normalize_kernel2d
 
 
-def _compute_padding(kernel_size: List[int]) -> List[int]:
+def _compute_padding(kernel_size: list[int]) -> list[int]:
     """Compute padding tuple."""
     # 4 or 6 ints:  (padding_left, padding_right,padding_top,padding_bottom)
     # https://pytorch.org/docs/stable/nn.html#torch.nn.functional.pad
@@ -114,7 +114,7 @@ def filter2d(
 
     # pad the input tensor
     if padding == 'same':
-        padding_shape: List[int] = _compute_padding([height, width])
+        padding_shape: list[int] = _compute_padding([height, width])
         input = F.pad(input, padding_shape, mode=border_type)
 
     # kernel and input tensor reshape to align element-wise or batch-wise params
@@ -277,7 +277,7 @@ def filter3d(
 
     # pad the input tensor
     depth, height, width = tmp_kernel.shape[-3:]
-    padding_shape: List[int] = _compute_padding([depth, height, width])
+    padding_shape: list[int] = _compute_padding([depth, height, width])
     input_pad: torch.Tensor = F.pad(input, padding_shape, mode=border_type)
 
     # kernel and input tensor reshape to align element-wise or batch-wise params

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -76,9 +76,9 @@ def filter2d(
                   [0., 0., 0., 0., 0.]]]])
     """
     KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'H', 'W'])
     KORNIA_CHECK_IS_TENSOR(kernel)
-    KORNIA_CHECK_SHAPE(kernel, ('B', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(kernel, ['B', 'H', 'W'])
 
     KORNIA_CHECK(
         str(border_type).lower() in _VALID_BORDERS,
@@ -235,9 +235,9 @@ def filter3d(input: Tensor, kernel: Tensor, border_type: str = 'replicate', norm
                    [0., 0., 0., 0., 0.]]]]])
     """
     KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'D', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'D', 'H', 'W'])
     KORNIA_CHECK_IS_TENSOR(kernel)
-    KORNIA_CHECK_SHAPE(kernel, ('1', 'D', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(kernel, ['B', 'D', 'H', 'W'])
 
     KORNIA_CHECK(
         str(border_type).lower() in _VALID_BORDERS,

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -53,8 +53,9 @@ def gaussian_blur2d(
 
     if separable:
         ks = _unpack_2d_ks(kernel_size)
-        kernel_x = get_gaussian_kernel1d(ks[1], sigma[:, 1])
-        kernel_y = get_gaussian_kernel1d(ks[0], sigma[:, 0])
+        bs = sigma.shape[0]
+        kernel_x = get_gaussian_kernel1d(ks[1], sigma[:, 1].view(bs, 1))
+        kernel_y = get_gaussian_kernel1d(ks[0], sigma[:, 0].view(bs, 1))
         out = filter2d_separable(input, kernel_x, kernel_y, border_type)
     else:
         kernel = get_gaussian_kernel2d(kernel_size, sigma)

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 from kornia.core import Module, Tensor, as_tensor
 
@@ -8,8 +8,8 @@ from .kernels import _unpack_2d_ks, get_gaussian_kernel1d, get_gaussian_kernel2d
 
 def gaussian_blur2d(
     input: Tensor,
-    kernel_size: Union[Tuple[int, int], int],
-    sigma: Union[Tuple[float, float], Tensor],
+    kernel_size: tuple[int, int] | int,
+    sigma: tuple[float, float] | Tensor,
     border_type: str = 'reflect',
     separable: bool = True,
 ) -> Tensor:
@@ -95,8 +95,8 @@ class GaussianBlur2d(Module):
 
     def __init__(
         self,
-        kernel_size: Union[Tuple[int, int], int],
-        sigma: Union[Tuple[float, float], Tensor],
+        kernel_size: tuple[int, int] | int,
+        sigma: tuple[float, float] | Tensor,
         border_type: str = 'reflect',
         separable: bool = True,
     ) -> None:

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -50,10 +50,12 @@ def gaussian_blur2d(
         >>> output.shape
         torch.Size([2, 4, 5, 5])
     """
+    KORNIA_CHECK_IS_TENSOR(input)
+
     if isinstance(sigma, tuple):
         sigma = as_tensor([sigma], device=input.device, dtype=input.dtype)
     else:
-        KORNIA_CHECK_IS_TENSOR(input)
+        KORNIA_CHECK_IS_TENSOR(sigma)
         sigma = sigma.to(device=input.device, dtype=input.dtype)
 
     if separable:

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from kornia.core import Module, Tensor, as_tensor
+from kornia.core import Module, Tensor, tensor
 from kornia.testing import KORNIA_CHECK_IS_TENSOR
 from kornia.utils import deprecated
 
@@ -53,7 +53,7 @@ def gaussian_blur2d(
     KORNIA_CHECK_IS_TENSOR(input)
 
     if isinstance(sigma, tuple):
-        sigma = as_tensor([sigma], device=input.device, dtype=input.dtype)
+        sigma = tensor([sigma], device=input.device, dtype=input.dtype)
     else:
         KORNIA_CHECK_IS_TENSOR(sigma)
         sigma = sigma.to(device=input.device, dtype=input.dtype)

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
+
 from kornia.core import Module, Tensor, as_tensor
+from kornia.testing import KORNIA_CHECK_IS_TENSOR
+from kornia.utils import deprecated
 
 from .filter import filter2d, filter2d_separable
 from .kernels import _unpack_2d_ks, get_gaussian_kernel1d, get_gaussian_kernel2d
@@ -49,6 +53,7 @@ def gaussian_blur2d(
     if isinstance(sigma, tuple):
         sigma = as_tensor([sigma], device=input.device, dtype=input.dtype)
     else:
+        KORNIA_CHECK_IS_TENSOR(input)
         sigma = sigma.to(device=input.device, dtype=input.dtype)
 
     if separable:
@@ -125,3 +130,8 @@ class GaussianBlur2d(Module):
 
     def forward(self, input: Tensor) -> Tensor:
         return gaussian_blur2d(input, self.kernel_size, self.sigma, self.border_type, self.separable)
+
+
+@deprecated(replace_with='gaussian_blur2d', version='6.9.10')
+def gaussian_blur2d_t(*args: Any, **kwargs: Any) -> Tensor:
+    return gaussian_blur2d(*args, **kwargs)

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -3,12 +3,12 @@ from typing import Tuple, Union
 from kornia.core import Module, Tensor, as_tensor
 
 from .filter import filter2d, filter2d_separable
-from .kernels import get_gaussian_kernel1d, get_gaussian_kernel2d
+from .kernels import _unpack_2d_ks, get_gaussian_kernel1d, get_gaussian_kernel2d
 
 
 def gaussian_blur2d(
     input: Tensor,
-    kernel_size: Tuple[int, int],
+    kernel_size: Union[Tuple[int, int], int],
     sigma: Union[Tuple[float, float], Tensor],
     border_type: str = 'reflect',
     separable: bool = True,
@@ -52,8 +52,9 @@ def gaussian_blur2d(
         sigma = sigma.to(device=input.device, dtype=input.dtype)
 
     if separable:
-        kernel_x = get_gaussian_kernel1d(kernel_size[1], sigma[:, 1])
-        kernel_y = get_gaussian_kernel1d(kernel_size[0], sigma[:, 0])
+        ks = _unpack_2d_ks(kernel_size)
+        kernel_x = get_gaussian_kernel1d(ks[1], sigma[:, 1])
+        kernel_y = get_gaussian_kernel1d(ks[0], sigma[:, 0])
         out = filter2d_separable(input, kernel_x, kernel_y, border_type)
     else:
         kernel = get_gaussian_kernel2d(kernel_size, sigma)
@@ -94,7 +95,7 @@ class GaussianBlur2d(Module):
 
     def __init__(
         self,
-        kernel_size: Tuple[int, int],
+        kernel_size: Union[Tuple[int, int], int],
         sigma: Union[Tuple[float, float], Tensor],
         border_type: str = 'reflect',
         separable: bool = True,

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -8,7 +8,6 @@ import torch
 
 from kornia.core import Device, Tensor, as_tensor, concatenate, stack, tensor, where, zeros, zeros_like
 from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_SHAPE
-from kornia.utils import get_cuda_device_if_available
 
 # TODO: Replace on the functions these alias
 _Device = Optional[Device]
@@ -257,12 +256,12 @@ def get_binary_kernel2d(window_size: tuple[int, int] | int, *, device: _Device =
     return kernel.view(window_range, 1, kx, ky)
 
 
-def get_sobel_kernel_3x3() -> Tensor:
+def get_sobel_kernel_3x3(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     """Utility function that returns a sobel kernel of 3x3."""
-    return tensor([[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]], device=get_cuda_device_if_available())
+    return tensor([[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]], device=device, dtype=dtype)
 
 
-def get_sobel_kernel_5x5_2nd_order() -> Tensor:
+def get_sobel_kernel_5x5_2nd_order(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     """Utility function that returns a 2nd order sobel kernel of 5x5."""
     return tensor(
         [
@@ -272,11 +271,12 @@ def get_sobel_kernel_5x5_2nd_order() -> Tensor:
             [-4.0, 0.0, 8.0, 0.0, -4.0],
             [-1.0, 0.0, 2.0, 0.0, -1.0],
         ],
-        device=get_cuda_device_if_available(),
+        device=device,
+        dtype=dtype,
     )
 
 
-def _get_sobel_kernel_5x5_2nd_order_xy() -> Tensor:
+def _get_sobel_kernel_5x5_2nd_order_xy(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     """Utility function that returns a 2nd order sobel kernel of 5x5."""
     return tensor(
         [
@@ -286,13 +286,14 @@ def _get_sobel_kernel_5x5_2nd_order_xy() -> Tensor:
             [2.0, 4.0, 0.0, -4.0, -2.0],
             [1.0, 2.0, 0.0, -2.0, -1.0],
         ],
-        device=get_cuda_device_if_available(),
+        device=device,
+        dtype=dtype,
     )
 
 
-def get_diff_kernel_3x3() -> Tensor:
+def get_diff_kernel_3x3(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     """Utility function that returns a first order derivative kernel of 3x3."""
-    return tensor([[-0.0, 0.0, 0.0], [-1.0, 0.0, 1.0], [-0.0, 0.0, 0.0]], device=get_cuda_device_if_available())
+    return tensor([[-0.0, 0.0, 0.0], [-1.0, 0.0, 1.0], [-0.0, 0.0, 0.0]], device=device, dtype=dtype)
 
 
 def get_diff_kernel3d(device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
@@ -362,33 +363,33 @@ def get_diff_kernel3d_2nd_order(device: Device | None = None, dtype: torch.dtype
     return kernel.unsqueeze(1)
 
 
-def get_sobel_kernel2d() -> Tensor:
-    kernel_x = get_sobel_kernel_3x3()
+def get_sobel_kernel2d(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+    kernel_x = get_sobel_kernel_3x3(device=device, dtype=dtype)
     kernel_y = kernel_x.transpose(0, 1)
     return stack([kernel_x, kernel_y])
 
 
-def get_diff_kernel2d() -> Tensor:
-    kernel_x = get_diff_kernel_3x3()
+def get_diff_kernel2d(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+    kernel_x = get_diff_kernel_3x3(device=device, dtype=dtype)
     kernel_y = kernel_x.transpose(0, 1)
     return stack([kernel_x, kernel_y])
 
 
-def get_sobel_kernel2d_2nd_order() -> Tensor:
-    gxx = get_sobel_kernel_5x5_2nd_order()
+def get_sobel_kernel2d_2nd_order(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+    gxx = get_sobel_kernel_5x5_2nd_order(device=device, dtype=dtype)
     gyy = gxx.transpose(0, 1)
-    gxy = _get_sobel_kernel_5x5_2nd_order_xy()
+    gxy = _get_sobel_kernel_5x5_2nd_order_xy(device=device, dtype=dtype)
     return stack([gxx, gxy, gyy])
 
 
-def get_diff_kernel2d_2nd_order() -> Tensor:
-    gxx = tensor([[0.0, 0.0, 0.0], [1.0, -2.0, 1.0], [0.0, 0.0, 0.0]], device=get_cuda_device_if_available())
+def get_diff_kernel2d_2nd_order(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+    gxx = tensor([[0.0, 0.0, 0.0], [1.0, -2.0, 1.0], [0.0, 0.0, 0.0]], device=device, dtype=dtype)
     gyy = gxx.transpose(0, 1)
-    gxy = tensor([[-1.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, -1.0]], device=get_cuda_device_if_available())
+    gxy = tensor([[-1.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, -1.0]], device=device, dtype=dtype)
     return stack([gxx, gxy, gyy])
 
 
-def get_spatial_gradient_kernel2d(mode: str, order: int) -> Tensor:
+def get_spatial_gradient_kernel2d(mode: str, order: int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     r"""Function that returns kernel for 1st or 2nd order image gradients, using one of the following operators:
 
     sobel, diff.
@@ -408,19 +409,19 @@ def get_spatial_gradient_kernel2d(mode: str, order: int) -> Tensor:
             )
         )
     if mode == 'sobel' and order == 1:
-        kernel: Tensor = get_sobel_kernel2d()
+        kernel: Tensor = get_sobel_kernel2d(device=device, dtype=dtype)
     elif mode == 'sobel' and order == 2:
-        kernel = get_sobel_kernel2d_2nd_order()
+        kernel = get_sobel_kernel2d_2nd_order(device=device, dtype=dtype)
     elif mode == 'diff' and order == 1:
-        kernel = get_diff_kernel2d()
+        kernel = get_diff_kernel2d(device=device, dtype=dtype)
     elif mode == 'diff' and order == 2:
-        kernel = get_diff_kernel2d_2nd_order()
+        kernel = get_diff_kernel2d_2nd_order(device=device, dtype=dtype)
     else:
         raise NotImplementedError("")
     return kernel
 
 
-def get_spatial_gradient_kernel3d(mode: str, order: int, device=torch.device('cpu'), dtype=torch.float) -> Tensor:
+def get_spatial_gradient_kernel3d(mode: str, order: int, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     r"""Function that returns kernel for 1st or 2nd order scale pyramid gradients, using one of the following
     operators: sobel, diff."""
     if mode not in ['sobel', 'diff']:
@@ -430,9 +431,9 @@ def get_spatial_gradient_kernel3d(mode: str, order: int, device=torch.device('cp
     if mode == 'sobel':
         raise NotImplementedError("Sobel kernel for 3d gradient is not implemented yet")
     if mode == 'diff' and order == 1:
-        kernel = get_diff_kernel3d(device, dtype)
+        kernel = get_diff_kernel3d(device=device, dtype=dtype)
     elif mode == 'diff' and order == 2:
-        kernel = get_diff_kernel3d_2nd_order(device, dtype)
+        kernel = get_diff_kernel3d_2nd_order(device=device, dtype=dtype)
     else:
         raise NotImplementedError("")
     return kernel

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import torch
 
-from kornia.core import Device, Tensor, as_tensor, concatenate, stack, tensor, where, zeros, zeros_like
+from kornia.core import Device, Tensor, concatenate, stack, tensor, where, zeros, zeros_like
 from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
 from kornia.utils import deprecated
 
@@ -76,7 +76,7 @@ def gaussian(
     """
 
     if isinstance(sigma, float):
-        sigma = as_tensor([[sigma]], device=device, dtype=dtype)
+        sigma = tensor([[sigma]], device=device, dtype=dtype)
 
     KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "1"])
@@ -110,7 +110,7 @@ def gaussian_discrete_erf(
         the error function.
     """
     if isinstance(sigma, float):
-        sigma = as_tensor([[sigma]], device=device, dtype=dtype)
+        sigma = tensor([[sigma]], device=device, dtype=dtype)
 
     KORNIA_CHECK_SHAPE(sigma, ["B", "1"])
     batch_size = sigma.shape[0]
@@ -239,7 +239,7 @@ def gaussian_discrete(
         function.
     """
     if isinstance(sigma, float):
-        sigma = as_tensor([[sigma]], device=device, dtype=dtype)
+        sigma = tensor([[sigma]], device=device, dtype=dtype)
 
     KORNIA_CHECK_SHAPE(sigma, ["B", "1"])
 
@@ -257,9 +257,9 @@ def gaussian_discrete(
     return out / out.sum(-1, keepdim=True)
 
 
-def laplacian_1d(window_size: int, *, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
+def laplacian_1d(window_size: int, *, device: Device | None = None, dtype: torch.dtype = torch.float32) -> Tensor:
     """One could also use the Laplacian of Gaussian formula to design the filter."""
-
+    # TODO: add default dtype as None when kornia relies on torch > 1.12
     filter_1d = torch.ones(window_size, device=device, dtype=dtype)
     middle = window_size // 2
     filter_1d[middle] = 1 - window_size
@@ -276,15 +276,18 @@ def get_box_kernel2d(
 
 
 def get_binary_kernel2d(
-    window_size: tuple[int, int] | int, *, device: Device | None = None, dtype: torch.dtype | None = None
+    window_size: tuple[int, int] | int, *, device: Device | None = None, dtype: torch.dtype = torch.float32
 ) -> Tensor:
-    r"""Create a binary kernel to extract the patches.
+    """Create a binary kernel to extract the patches.
 
     If the window size is HxW will create a (H*W)x1xHxW kernel.
     """
+    # TODO: add default dtype as None when kornia relies on torch > 1.12
+
     kx, ky = _unpack_2d_ks(window_size)
 
     window_range = kx * ky
+
     kernel = zeros((window_range, window_range), device=device, dtype=dtype)
     idx = torch.arange(window_range, device=device)
     kernel[idx, idx] += 1.0
@@ -632,7 +635,7 @@ def get_gaussian_kernel2d(
                  [0.0144, 0.0281, 0.0351, 0.0281, 0.0144]]])
     """
     if isinstance(sigma, tuple):
-        sigma = as_tensor([sigma], device=device, dtype=dtype)
+        sigma = tensor([sigma], device=device, dtype=dtype)
 
     KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "2"])
@@ -690,7 +693,7 @@ def get_gaussian_kernel3d(
         torch.Size([1, 3, 7, 5])
     """
     if isinstance(sigma, tuple):
-        sigma = as_tensor([sigma], device=device, dtype=dtype)
+        sigma = tensor([sigma], device=device, dtype=dtype)
 
     KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "3"])
@@ -709,7 +712,7 @@ def get_gaussian_kernel3d(
 
 
 def get_laplacian_kernel1d(
-    kernel_size: int, *, device: Device | None = None, dtype: torch.dtype | None = None
+    kernel_size: int, *, device: Device | None = None, dtype: torch.dtype = torch.float32
 ) -> Tensor:
     r"""Function that returns the coefficients of a 1D Laplacian filter.
 
@@ -730,13 +733,15 @@ def get_laplacian_kernel1d(
         >>> get_laplacian_kernel1d(5)
         tensor([ 1.,  1., -4.,  1.,  1.])
     """
+    # TODO: add default dtype as None when kornia relies on torch > 1.12
+
     _check_kernel_size(kernel_size)
 
     return laplacian_1d(kernel_size, device=device, dtype=dtype)
 
 
 def get_laplacian_kernel2d(
-    kernel_size: tuple[int, int] | int, *, device: Device | None = None, dtype: torch.dtype | None = None
+    kernel_size: tuple[int, int] | int, *, device: Device | None = None, dtype: torch.dtype = torch.float32
 ) -> Tensor:
     r"""Function that returns Gaussian filter matrix coefficients.
 
@@ -763,6 +768,8 @@ def get_laplacian_kernel2d(
                 [  1.,   1.,   1.,   1.,   1.],
                 [  1.,   1.,   1.,   1.,   1.]])
     """
+    # TODO: add default dtype as None when kornia relies on torch > 1.12
+
     kx, ky = _unpack_2d_ks(kernel_size)
     _check_kernel_size((kx, ky))
 
@@ -857,7 +864,7 @@ def get_pascal_kernel_1d(
                 cur[-j - 1] = value
         pre = cur
 
-    out = as_tensor(cur, device=device, dtype=dtype)
+    out = tensor(cur, device=device, dtype=dtype)
 
     if norm:
         out = out / out.sum()

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -7,13 +7,14 @@ from typing import Any
 import torch
 
 from kornia.core import Device, Tensor, as_tensor, concatenate, stack, tensor, where, zeros, zeros_like
-from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
 from kornia.utils import deprecated
 
 
 def _check_kernel_size(kernel_size: tuple[int, ...] | int, min_value: int = 0, allow_even: bool = False):
     if isinstance(kernel_size, int):
         kernel_size = (kernel_size,)
+
     fmt = 'even or odd' if allow_even else 'odd'
     for size in kernel_size:
         KORNIA_CHECK(
@@ -26,7 +27,8 @@ def _unpack_2d_ks(kernel_size: tuple[int, int] | int) -> tuple[int, int]:
     if isinstance(kernel_size, int):
         kx = ky = kernel_size
     else:
-        KORNIA_CHECK(len(kernel_size) == 2, '2D Kernel size should have a length of 2.')
+        KORNIA_CHECK_TYPE(kernel_size, tuple, 'Kernel size should be an integer or a tuple of integer.')
+        KORNIA_CHECK(len(kernel_size) == 2, '2D Kernel size tuple should have a length of 2.')
         kx, ky = kernel_size
 
     kx = int(kx)

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import math
 from math import sqrt
+from typing import Any
 
 import torch
 
 from kornia.core import Device, Tensor, as_tensor, concatenate, stack, tensor, where, zeros, zeros_like
-from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_SHAPE
+from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+from kornia.utils import deprecated
 
 
 def _check_kernel_size(kernel_size: tuple[int, ...] | int, min_value: int = 0, allow_even: bool = False):
@@ -74,6 +76,7 @@ def gaussian(
     if isinstance(sigma, float):
         sigma = as_tensor([[sigma]], device=device, dtype=dtype)
 
+    KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "1"])
     batch_size = sigma.shape[0]
 
@@ -629,6 +632,7 @@ def get_gaussian_kernel2d(
     if isinstance(sigma, tuple):
         sigma = as_tensor([sigma], device=device, dtype=dtype)
 
+    KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "2"])
 
     ksize_x, ksize_y = _unpack_2d_ks(kernel_size)
@@ -686,6 +690,7 @@ def get_gaussian_kernel3d(
     if isinstance(sigma, tuple):
         sigma = as_tensor([sigma], device=device, dtype=dtype)
 
+    KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "3"])
 
     ksize_x, ksize_y, ksize_z = _unpack_3d_ks(kernel_size)
@@ -950,3 +955,18 @@ def get_hanning_kernel2d(
     kernel2d = ky @ kx
 
     return kernel2d
+
+
+@deprecated(replace_with='get_gaussian_kernel1d', version='6.9.10')
+def get_gaussian_kernel1d_t(*args: Any, **kwargs: Any) -> Tensor:
+    return get_gaussian_kernel1d(*args, **kwargs)
+
+
+@deprecated(replace_with='get_gaussian_kernel2d', version='6.9.10')
+def get_gaussian_kernel2d_t(*args: Any, **kwargs: Any) -> Tensor:
+    return get_gaussian_kernel2d(*args, **kwargs)
+
+
+@deprecated(replace_with='get_gaussian_kernel3d', version='6.9.10')
+def get_gaussian_kernel3d_t(*args: Any, **kwargs: Any) -> Tensor:
+    return get_gaussian_kernel3d(*args, **kwargs)

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import math
 from math import sqrt
-from typing import List, Optional, Tuple, Union
+from typing import Optional
 
 import torch
 
@@ -13,7 +15,7 @@ _Device = Optional[Device]
 _Dtype = Optional[torch.dtype]
 
 
-def _unpack_2d_ks(kernel_size: Union[Tuple[int, int], int]) -> Tuple[int, int]:
+def _unpack_2d_ks(kernel_size: tuple[int, int] | int) -> tuple[int, int]:
     if isinstance(kernel_size, int):
         ks = int(kernel_size)
         return (ks, ks)
@@ -30,7 +32,7 @@ def normalize_kernel2d(input: Tensor) -> Tensor:
     return input / (norm.unsqueeze(-1).unsqueeze(-1))
 
 
-def gaussian(window_size: int, sigma: Union[Tensor, float], *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def gaussian(window_size: int, sigma: Tensor | float, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     """Compute the gaussian values based on the window and sigma values.
 
     Args:
@@ -60,7 +62,7 @@ def gaussian(window_size: int, sigma: Union[Tensor, float], *, device: _Device =
 
 
 def gaussian_discrete_erf(
-    window_size: int, sigma: Union[Tensor, float], *, device: _Device = None, dtype: _Dtype = None
+    window_size: int, sigma: Tensor | float, *, device: _Device = None, dtype: _Dtype = None
 ) -> Tensor:
     r"""Discrete Gaussian by interpolating the error function.
 
@@ -190,7 +192,7 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
 
 
 def gaussian_discrete(
-    window_size: int, sigma: Union[Tensor, float], *, device: _Device = None, dtype: _Dtype = None
+    window_size: int, sigma: Tensor | float, *, device: _Device = None, dtype: _Dtype = None
 ) -> Tensor:
     r"""Discrete Gaussian kernel based on the modified Bessel functions.
 
@@ -234,18 +236,14 @@ def laplacian_1d(window_size: int, *, device: _Device = None, dtype: _Dtype = No
     return filter_1d
 
 
-def get_box_kernel2d(
-    kernel_size: Union[Tuple[int, int], int], *, device: _Device = None, dtype: _Dtype = None
-) -> Tensor:
+def get_box_kernel2d(kernel_size: tuple[int, int] | int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     r"""Utility function that returns a box filter."""
     kx, ky = _unpack_2d_ks(kernel_size)
     scale = tensor(1.0, device=device, dtype=dtype) / tensor([kx * ky], device=device, dtype=dtype)
     return scale.expand(1, kx, ky)
 
 
-def get_binary_kernel2d(
-    window_size: Union[Tuple[int, int], int], *, device: _Device = None, dtype: _Dtype = None
-) -> Tensor:
+def get_binary_kernel2d(window_size: tuple[int, int] | int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     r"""Create a binary kernel to extract the patches.
 
     If the window size is HxW will create a (H*W)x1xHxW kernel.
@@ -297,7 +295,7 @@ def get_diff_kernel_3x3() -> Tensor:
     return tensor([[-0.0, 0.0, 0.0], [-1.0, 0.0, 1.0], [-0.0, 0.0, 0.0]], device=get_cuda_device_if_available())
 
 
-def get_diff_kernel3d(device: Optional[Device] = None, dtype: Optional[torch.dtype] = None) -> Tensor:
+def get_diff_kernel3d(device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns a first order derivative kernel of 3x3x3."""
     kernel = tensor(
         [
@@ -323,7 +321,7 @@ def get_diff_kernel3d(device: Optional[Device] = None, dtype: Optional[torch.dty
     return kernel.unsqueeze(1)
 
 
-def get_diff_kernel3d_2nd_order(device: Optional[Device] = None, dtype: Optional[torch.dtype] = None) -> Tensor:
+def get_diff_kernel3d_2nd_order(device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns a first order derivative kernel of 3x3x3."""
     kernel = tensor(
         [
@@ -441,12 +439,7 @@ def get_spatial_gradient_kernel3d(mode: str, order: int, device=torch.device('cp
 
 
 def get_gaussian_kernel1d(
-    kernel_size: int,
-    sigma: Union[float, Tensor],
-    force_even: bool = False,
-    *,
-    device: _Device = None,
-    dtype: _Dtype = None,
+    kernel_size: int, sigma: float | Tensor, force_even: bool = False, *, device: _Device = None, dtype: _Dtype = None
 ) -> Tensor:
     r"""Function that returns Gaussian filter coefficients.
 
@@ -482,12 +475,7 @@ def get_gaussian_kernel1d(
 
 
 def get_gaussian_discrete_kernel1d(
-    kernel_size: int,
-    sigma: Union[float, Tensor],
-    force_even: bool = False,
-    *,
-    device: _Device = None,
-    dtype: _Dtype = None,
+    kernel_size: int, sigma: float | Tensor, force_even: bool = False, *, device: _Device = None, dtype: _Dtype = None
 ) -> Tensor:
     r"""Function that returns Gaussian filter coefficients based on the modified Bessel functions. Adapted from:
     https://github.com/Project-MONAI/MONAI/blob/master/monai/networks/layers/convutils.py.
@@ -523,12 +511,7 @@ def get_gaussian_discrete_kernel1d(
 
 
 def get_gaussian_erf_kernel1d(
-    kernel_size: int,
-    sigma: Union[float, Tensor],
-    force_even: bool = False,
-    *,
-    device: _Device = None,
-    dtype: _Dtype = None,
+    kernel_size: int, sigma: float | Tensor, force_even: bool = False, *, device: _Device = None, dtype: _Dtype = None
 ) -> Tensor:
     r"""Function that returns Gaussian filter coefficients by interpolating the error function, adapted from:
     https://github.com/Project-MONAI/MONAI/blob/master/monai/networks/layers/convutils.py.
@@ -565,8 +548,8 @@ def get_gaussian_erf_kernel1d(
 
 
 def get_gaussian_kernel2d(
-    kernel_size: Union[Tuple[int, int], int],
-    sigma: Union[Tuple[float, float], Tensor],
+    kernel_size: tuple[int, int] | int,
+    sigma: tuple[float, float] | Tensor,
     force_even: bool = False,
     *,
     device: _Device = None,
@@ -625,8 +608,8 @@ def get_gaussian_kernel2d(
 
 
 def get_gaussian_kernel3d(
-    kernel_size: Tuple[int, int, int],
-    sigma: Union[Tuple[float, float, float], Tensor],
+    kernel_size: tuple[int, int, int],
+    sigma: tuple[float, float, float] | Tensor,
     force_even: bool = False,
     *,
     device: _Device = None,
@@ -716,7 +699,7 @@ def get_laplacian_kernel1d(kernel_size: int, *, device: _Device = None, dtype: _
 
 
 def get_laplacian_kernel2d(
-    kernel_size: Union[Tuple[int, int], int], *, device: _Device = None, dtype: _Dtype = None
+    kernel_size: tuple[int, int] | int, *, device: _Device = None, dtype: _Dtype = None
 ) -> Tensor:
     r"""Function that returns Gaussian filter matrix coefficients.
 
@@ -756,7 +739,7 @@ def get_laplacian_kernel2d(
     return kernel
 
 
-def get_pascal_kernel_2d(kernel_size: Union[Tuple[int, int], int], norm: bool = True) -> Tensor:
+def get_pascal_kernel_2d(kernel_size: tuple[int, int] | int, norm: bool = True) -> Tensor:
     """Generate pascal filter kernel by kernel size.
 
     Args:
@@ -815,8 +798,8 @@ def get_pascal_kernel_1d(kernel_size: int, norm: bool = False) -> Tensor:
     >>> get_pascal_kernel_1d(6)
     tensor([ 1.,  5., 10., 10.,  5.,  1.])
     """
-    pre: List[float] = []
-    cur: List[float] = []
+    pre: list[float] = []
+    cur: list[float] = []
     for i in range(kernel_size):
         cur = [1.0] * (i + 1)
 
@@ -901,7 +884,7 @@ def get_hanning_kernel1d(kernel_size: int, device=torch.device('cpu'), dtype=tor
     return x
 
 
-def get_hanning_kernel2d(kernel_size: Tuple[int, int], device=torch.device('cpu'), dtype=torch.float) -> Tensor:
+def get_hanning_kernel2d(kernel_size: tuple[int, int], device=torch.device('cpu'), dtype=torch.float) -> Tensor:
     r"""Returns 2d Hanning kernel, used in signal processing and KCF tracker.
 
     Args:

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -2,16 +2,11 @@ from __future__ import annotations
 
 import math
 from math import sqrt
-from typing import Optional
 
 import torch
 
 from kornia.core import Device, Tensor, as_tensor, concatenate, stack, tensor, where, zeros, zeros_like
 from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_SHAPE
-
-# TODO: Replace on the functions these alias
-_Device = Optional[Device]
-_Dtype = Optional[torch.dtype]
 
 
 def _unpack_2d_ks(kernel_size: tuple[int, int] | int) -> tuple[int, int]:
@@ -31,7 +26,9 @@ def normalize_kernel2d(input: Tensor) -> Tensor:
     return input / (norm.unsqueeze(-1).unsqueeze(-1))
 
 
-def gaussian(window_size: int, sigma: Tensor | float, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def gaussian(
+    window_size: int, sigma: Tensor | float, *, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
     """Compute the gaussian values based on the window and sigma values.
 
     Args:
@@ -61,7 +58,7 @@ def gaussian(window_size: int, sigma: Tensor | float, *, device: _Device = None,
 
 
 def gaussian_discrete_erf(
-    window_size: int, sigma: Tensor | float, *, device: _Device = None, dtype: _Dtype = None
+    window_size: int, sigma: Tensor | float, *, device: Device | None = None, dtype: torch.dtype | None = None
 ) -> Tensor:
     r"""Discrete Gaussian by interpolating the error function.
 
@@ -191,7 +188,7 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
 
 
 def gaussian_discrete(
-    window_size: int, sigma: Tensor | float, *, device: _Device = None, dtype: _Dtype = None
+    window_size: int, sigma: Tensor | float, *, device: Device | None = None, dtype: torch.dtype | None = None
 ) -> Tensor:
     r"""Discrete Gaussian kernel based on the modified Bessel functions.
 
@@ -226,7 +223,7 @@ def gaussian_discrete(
     return out / out.sum(-1, keepdim=True)
 
 
-def laplacian_1d(window_size: int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def laplacian_1d(window_size: int, *, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """One could also use the Laplacian of Gaussian formula to design the filter."""
 
     filter_1d = torch.ones(window_size, device=device, dtype=dtype)
@@ -235,14 +232,18 @@ def laplacian_1d(window_size: int, *, device: _Device = None, dtype: _Dtype = No
     return filter_1d
 
 
-def get_box_kernel2d(kernel_size: tuple[int, int] | int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_box_kernel2d(
+    kernel_size: tuple[int, int] | int, *, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
     r"""Utility function that returns a box filter."""
     kx, ky = _unpack_2d_ks(kernel_size)
     scale = tensor(1.0, device=device, dtype=dtype) / tensor([kx * ky], device=device, dtype=dtype)
     return scale.expand(1, kx, ky)
 
 
-def get_binary_kernel2d(window_size: tuple[int, int] | int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_binary_kernel2d(
+    window_size: tuple[int, int] | int, *, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
     r"""Create a binary kernel to extract the patches.
 
     If the window size is HxW will create a (H*W)x1xHxW kernel.
@@ -256,12 +257,12 @@ def get_binary_kernel2d(window_size: tuple[int, int] | int, *, device: _Device =
     return kernel.view(window_range, 1, kx, ky)
 
 
-def get_sobel_kernel_3x3(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_sobel_kernel_3x3(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns a sobel kernel of 3x3."""
     return tensor([[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]], device=device, dtype=dtype)
 
 
-def get_sobel_kernel_5x5_2nd_order(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_sobel_kernel_5x5_2nd_order(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns a 2nd order sobel kernel of 5x5."""
     return tensor(
         [
@@ -276,7 +277,7 @@ def get_sobel_kernel_5x5_2nd_order(*, device: _Device = None, dtype: _Dtype = No
     )
 
 
-def _get_sobel_kernel_5x5_2nd_order_xy(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def _get_sobel_kernel_5x5_2nd_order_xy(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns a 2nd order sobel kernel of 5x5."""
     return tensor(
         [
@@ -291,7 +292,7 @@ def _get_sobel_kernel_5x5_2nd_order_xy(*, device: _Device = None, dtype: _Dtype 
     )
 
 
-def get_diff_kernel_3x3(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_diff_kernel_3x3(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns a first order derivative kernel of 3x3."""
     return tensor([[-0.0, 0.0, 0.0], [-1.0, 0.0, 1.0], [-0.0, 0.0, 0.0]], device=device, dtype=dtype)
 
@@ -363,33 +364,35 @@ def get_diff_kernel3d_2nd_order(device: Device | None = None, dtype: torch.dtype
     return kernel.unsqueeze(1)
 
 
-def get_sobel_kernel2d(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_sobel_kernel2d(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     kernel_x = get_sobel_kernel_3x3(device=device, dtype=dtype)
     kernel_y = kernel_x.transpose(0, 1)
     return stack([kernel_x, kernel_y])
 
 
-def get_diff_kernel2d(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_diff_kernel2d(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     kernel_x = get_diff_kernel_3x3(device=device, dtype=dtype)
     kernel_y = kernel_x.transpose(0, 1)
     return stack([kernel_x, kernel_y])
 
 
-def get_sobel_kernel2d_2nd_order(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_sobel_kernel2d_2nd_order(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     gxx = get_sobel_kernel_5x5_2nd_order(device=device, dtype=dtype)
     gyy = gxx.transpose(0, 1)
     gxy = _get_sobel_kernel_5x5_2nd_order_xy(device=device, dtype=dtype)
     return stack([gxx, gxy, gyy])
 
 
-def get_diff_kernel2d_2nd_order(*, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_diff_kernel2d_2nd_order(*, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     gxx = tensor([[0.0, 0.0, 0.0], [1.0, -2.0, 1.0], [0.0, 0.0, 0.0]], device=device, dtype=dtype)
     gyy = gxx.transpose(0, 1)
     gxy = tensor([[-1.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, -1.0]], device=device, dtype=dtype)
     return stack([gxx, gxy, gyy])
 
 
-def get_spatial_gradient_kernel2d(mode: str, order: int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_spatial_gradient_kernel2d(
+    mode: str, order: int, *, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
     r"""Function that returns kernel for 1st or 2nd order image gradients, using one of the following operators:
 
     sobel, diff.
@@ -421,7 +424,9 @@ def get_spatial_gradient_kernel2d(mode: str, order: int, *, device: _Device = No
     return kernel
 
 
-def get_spatial_gradient_kernel3d(mode: str, order: int, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_spatial_gradient_kernel3d(
+    mode: str, order: int, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
     r"""Function that returns kernel for 1st or 2nd order scale pyramid gradients, using one of the following
     operators: sobel, diff."""
     if mode not in ['sobel', 'diff']:
@@ -440,7 +445,12 @@ def get_spatial_gradient_kernel3d(mode: str, order: int, device: _Device = None,
 
 
 def get_gaussian_kernel1d(
-    kernel_size: int, sigma: float | Tensor, force_even: bool = False, *, device: _Device = None, dtype: _Dtype = None
+    kernel_size: int,
+    sigma: float | Tensor,
+    force_even: bool = False,
+    *,
+    device: Device | None = None,
+    dtype: torch.dtype | None = None,
 ) -> Tensor:
     r"""Function that returns Gaussian filter coefficients.
 
@@ -476,7 +486,12 @@ def get_gaussian_kernel1d(
 
 
 def get_gaussian_discrete_kernel1d(
-    kernel_size: int, sigma: float | Tensor, force_even: bool = False, *, device: _Device = None, dtype: _Dtype = None
+    kernel_size: int,
+    sigma: float | Tensor,
+    force_even: bool = False,
+    *,
+    device: Device | None = None,
+    dtype: torch.dtype | None = None,
 ) -> Tensor:
     r"""Function that returns Gaussian filter coefficients based on the modified Bessel functions. Adapted from:
     https://github.com/Project-MONAI/MONAI/blob/master/monai/networks/layers/convutils.py.
@@ -512,7 +527,12 @@ def get_gaussian_discrete_kernel1d(
 
 
 def get_gaussian_erf_kernel1d(
-    kernel_size: int, sigma: float | Tensor, force_even: bool = False, *, device: _Device = None, dtype: _Dtype = None
+    kernel_size: int,
+    sigma: float | Tensor,
+    force_even: bool = False,
+    *,
+    device: Device | None = None,
+    dtype: torch.dtype | None = None,
 ) -> Tensor:
     r"""Function that returns Gaussian filter coefficients by interpolating the error function, adapted from:
     https://github.com/Project-MONAI/MONAI/blob/master/monai/networks/layers/convutils.py.
@@ -553,8 +573,8 @@ def get_gaussian_kernel2d(
     sigma: tuple[float, float] | Tensor,
     force_even: bool = False,
     *,
-    device: _Device = None,
-    dtype: _Dtype = None,
+    device: Device | None = None,
+    dtype: torch.dtype | None = None,
 ) -> Tensor:
     r"""Function that returns Gaussian filter matrix coefficients.
 
@@ -613,8 +633,8 @@ def get_gaussian_kernel3d(
     sigma: tuple[float, float, float] | Tensor,
     force_even: bool = False,
     *,
-    device: _Device = None,
-    dtype: _Dtype = None,
+    device: Device | None = None,
+    dtype: torch.dtype | None = None,
 ) -> Tensor:
     r"""Function that returns Gaussian filter matrix coefficients.
 
@@ -673,7 +693,9 @@ def get_gaussian_kernel3d(
     return kernel_3d
 
 
-def get_laplacian_kernel1d(kernel_size: int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+def get_laplacian_kernel1d(
+    kernel_size: int, *, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
     r"""Function that returns the coefficients of a 1D Laplacian filter.
 
     Args:
@@ -700,7 +722,7 @@ def get_laplacian_kernel1d(kernel_size: int, *, device: _Device = None, dtype: _
 
 
 def get_laplacian_kernel2d(
-    kernel_size: tuple[int, int] | int, *, device: _Device = None, dtype: _Dtype = None
+    kernel_size: tuple[int, int] | int, *, device: Device | None = None, dtype: torch.dtype | None = None
 ) -> Tensor:
     r"""Function that returns Gaussian filter matrix coefficients.
 
@@ -740,12 +762,20 @@ def get_laplacian_kernel2d(
     return kernel
 
 
-def get_pascal_kernel_2d(kernel_size: tuple[int, int] | int, norm: bool = True) -> Tensor:
+def get_pascal_kernel_2d(
+    kernel_size: tuple[int, int] | int,
+    norm: bool = True,
+    *,
+    device: Device | None = None,
+    dtype: torch.dtype | None = None,
+) -> Tensor:
     """Generate pascal filter kernel by kernel size.
 
     Args:
         kernel_size: height and width of the kernel.
         norm: if to normalize the kernel or not. Default: True.
+        device: tensor device desired to create the kernel
+        dtype: tensor dtype desired to create the kernel
 
     Returns:
         if kernel_size is an integer the kernel will be shaped as :math:`(kernel_size, kernel_size)`
@@ -766,8 +796,8 @@ def get_pascal_kernel_2d(kernel_size: tuple[int, int] | int, norm: bool = True) 
             [1., 3., 3., 1.]])
     """
     kx, ky = _unpack_2d_ks(kernel_size)
-    ax = get_pascal_kernel_1d(kx)
-    ay = get_pascal_kernel_1d(ky)
+    ax = get_pascal_kernel_1d(kx, device=device, dtype=dtype)
+    ay = get_pascal_kernel_1d(ky, device=device, dtype=dtype)
 
     filt = ax[:, None] * ay[None, :]
     if norm:
@@ -775,12 +805,16 @@ def get_pascal_kernel_2d(kernel_size: tuple[int, int] | int, norm: bool = True) 
     return filt
 
 
-def get_pascal_kernel_1d(kernel_size: int, norm: bool = False) -> Tensor:
+def get_pascal_kernel_1d(
+    kernel_size: int, norm: bool = False, *, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
     """Generate Yang Hui triangle (Pascal's triangle) by a given number.
 
     Args:
         kernel_size: height and width of the kernel.
         norm: if to normalize the kernel or not. Default: False.
+        device: tensor device desired to create the kernel
+        dtype: tensor dtype desired to create the kernel
 
     Returns:
         kernel shaped as :math:`(kernel_size,)`
@@ -811,15 +845,15 @@ def get_pascal_kernel_1d(kernel_size: int, norm: bool = False) -> Tensor:
                 cur[-j - 1] = value
         pre = cur
 
-    out = as_tensor(cur)
+    out = as_tensor(cur, device=device, dtype=dtype)
     if norm:
         out = out / torch.sum(out)
     return out
 
 
-def get_canny_nms_kernel(device=torch.device('cpu'), dtype=torch.float) -> Tensor:
+def get_canny_nms_kernel(device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns 3x3 kernels for the Canny Non-maximal suppression."""
-    kernel: Tensor = tensor(
+    return tensor(
         [
             [[0.0, 0.0, 0.0], [0.0, 1.0, -1.0], [0.0, 0.0, 0.0]],
             [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]],
@@ -832,13 +866,12 @@ def get_canny_nms_kernel(device=torch.device('cpu'), dtype=torch.float) -> Tenso
         ],
         device=device,
         dtype=dtype,
-    )
-    return kernel.unsqueeze(1)
+    ).unsqueeze(1)
 
 
-def get_hysteresis_kernel(device=torch.device('cpu'), dtype=torch.float) -> Tensor:
+def get_hysteresis_kernel(device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     """Utility function that returns the 3x3 kernels for the Canny hysteresis."""
-    kernel: Tensor = tensor(
+    return tensor(
         [
             [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]],
             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
@@ -851,11 +884,10 @@ def get_hysteresis_kernel(device=torch.device('cpu'), dtype=torch.float) -> Tens
         ],
         device=device,
         dtype=dtype,
-    )
-    return kernel.unsqueeze(1)
+    ).unsqueeze(1)
 
 
-def get_hanning_kernel1d(kernel_size: int, device=torch.device('cpu'), dtype=torch.float) -> Tensor:
+def get_hanning_kernel1d(kernel_size: int, device: Device | None = None, dtype: torch.dtype | None = None) -> Tensor:
     r"""Returns Hanning (also known as Hann) kernel, used in signal processing and KCF tracker.
 
     .. math::  w(n) = 0.5 - 0.5cos\\left(\\frac{2\\pi{n}}{M-1}\\right)
@@ -865,6 +897,8 @@ def get_hanning_kernel1d(kernel_size: int, device=torch.device('cpu'), dtype=tor
 
     Args:
         kernel_size: The size the of the kernel. It should be positive.
+        device: tensor device desired to create the kernel
+        dtype: tensor dtype desired to create the kernel
 
     Returns:
         1D tensor with Hanning filter coefficients.
@@ -880,16 +914,20 @@ def get_hanning_kernel1d(kernel_size: int, device=torch.device('cpu'), dtype=tor
     if not isinstance(kernel_size, int) or kernel_size <= 2:
         raise TypeError(f"ksize must be an positive integer > 2. Got {kernel_size}")
 
-    x: Tensor = torch.arange(kernel_size, device=device, dtype=dtype)
+    x = torch.arange(kernel_size, device=device, dtype=dtype)
     x = 0.5 - 0.5 * torch.cos(2.0 * math.pi * x / float(kernel_size - 1))
     return x
 
 
-def get_hanning_kernel2d(kernel_size: tuple[int, int], device=torch.device('cpu'), dtype=torch.float) -> Tensor:
-    r"""Returns 2d Hanning kernel, used in signal processing and KCF tracker.
+def get_hanning_kernel2d(
+    kernel_size: tuple[int, int] | int, device: Device | None = None, dtype: torch.dtype | None = None
+) -> Tensor:
+    """Returns 2d Hanning kernel, used in signal processing and KCF tracker.
 
     Args:
         kernel_size: The size of the kernel for the filter. It should be positive.
+        device: tensor device desired to create the kernel
+        dtype: tensor dtype desired to create the kernel
 
     Returns:
         2D tensor with Hanning filter coefficients.
@@ -898,9 +936,11 @@ def get_hanning_kernel2d(kernel_size: tuple[int, int], device=torch.device('cpu'
     Shape:
         - Output: math:`(\text{kernel_size[0], kernel_size[1]})`
     """
+    kernel_size = _unpack_2d_ks(kernel_size)
     if kernel_size[0] <= 2 or kernel_size[1] <= 2:
         raise TypeError(f"ksize must be an tuple of positive integers > 2. Got {kernel_size}")
-    ky: Tensor = get_hanning_kernel1d(kernel_size[0], device, dtype)[None].T
-    kx: Tensor = get_hanning_kernel1d(kernel_size[1], device, dtype)[None]
+    ky = get_hanning_kernel1d(kernel_size[0], device, dtype)[None].T
+    kx = get_hanning_kernel1d(kernel_size[1], device, dtype)[None]
     kernel2d = ky @ kx
+
     return kernel2d

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -225,11 +225,12 @@ def gaussian_discrete(
     return out / out.sum(-1, keepdim=True)
 
 
-def laplacian_1d(window_size: int) -> Tensor:
-    r"""One could also use the Laplacian of Gaussian formula to design the filter."""
+def laplacian_1d(window_size: int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
+    """One could also use the Laplacian of Gaussian formula to design the filter."""
 
-    filter_1d = torch.ones(window_size)
-    filter_1d[window_size // 2] = 1 - window_size
+    filter_1d = torch.ones(window_size, device=device, dtype=dtype)
+    middle = window_size // 2
+    filter_1d[middle] = 1 - window_size
     return filter_1d
 
 
@@ -685,11 +686,13 @@ def get_gaussian_kernel3d(
     return kernel_3d
 
 
-def get_laplacian_kernel1d(kernel_size: int) -> Tensor:
+def get_laplacian_kernel1d(kernel_size: int, *, device: _Device = None, dtype: _Dtype = None) -> Tensor:
     r"""Function that returns the coefficients of a 1D Laplacian filter.
 
     Args:
         kernel_size: filter size. It should be odd and positive.
+        device: tensor device desired to create the kernel
+        dtype: tensor dtype desired to create the kernel
 
     Returns:
         1D tensor with laplacian filter coefficients.
@@ -705,15 +708,19 @@ def get_laplacian_kernel1d(kernel_size: int) -> Tensor:
     """
     if not isinstance(kernel_size, int) or kernel_size % 2 == 0 or kernel_size <= 0:
         raise TypeError(f"ksize must be an odd positive integer. Got {kernel_size}")
-    window_1d: Tensor = laplacian_1d(kernel_size)
-    return window_1d
+
+    return laplacian_1d(kernel_size, device=device, dtype=dtype)
 
 
-def get_laplacian_kernel2d(kernel_size: Union[Tuple[int, int], int]) -> Tensor:
+def get_laplacian_kernel2d(
+    kernel_size: Union[Tuple[int, int], int], *, device: _Device = None, dtype: _Dtype = None
+) -> Tensor:
     r"""Function that returns Gaussian filter matrix coefficients.
 
     Args:
         kernel_size: filter size should be odd.
+        device: tensor device desired to create the kernel
+        dtype: tensor dtype desired to create the kernel
 
     Returns:
         2D tensor with laplacian filter matrix coefficients.
@@ -738,11 +745,11 @@ def get_laplacian_kernel2d(kernel_size: Union[Tuple[int, int], int]) -> Tensor:
     if (kx % 2 == 0 or kx <= 0) and (ky % 2 == 0 or ky <= 0):
         raise TypeError(f"ksize must be an odd positive integer. Got {kernel_size}")
 
-    kernel = torch.ones((kx, ky), device=get_cuda_device_if_available())
+    kernel = torch.ones((kx, ky), device=device, dtype=dtype)
     mid_x = kx // 2
     mid_y = ky // 2
 
-    kernel[mid_x, mid_y] = 1 - kernel.sum().item()
+    kernel[mid_x, mid_y] = 1 - kernel.sum()
     return kernel
 
 

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -1,6 +1,6 @@
 import math
 from math import sqrt
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 
@@ -198,7 +198,7 @@ def get_diff_kernel_3x3() -> Tensor:
     return tensor([[-0.0, 0.0, 0.0], [-1.0, 0.0, 1.0], [-0.0, 0.0, 0.0]], device=get_cuda_device_if_available())
 
 
-def get_diff_kernel3d(device: Device = None, dtype: torch.dtype = None) -> Tensor:
+def get_diff_kernel3d(device: Optional[Device] = None, dtype: Optional[torch.dtype] = None) -> Tensor:
     """Utility function that returns a first order derivative kernel of 3x3x3."""
     kernel = tensor(
         [
@@ -224,7 +224,7 @@ def get_diff_kernel3d(device: Device = None, dtype: torch.dtype = None) -> Tenso
     return kernel.unsqueeze(1)
 
 
-def get_diff_kernel3d_2nd_order(device: Device = None, dtype: torch.dtype = None) -> Tensor:
+def get_diff_kernel3d_2nd_order(device: Optional[Device] = None, dtype: Optional[torch.dtype] = None) -> Tensor:
     """Utility function that returns a first order derivative kernel of 3x3x3."""
     kernel = tensor(
         [

--- a/kornia/filters/kernels_geometry.py
+++ b/kornia/filters/kernels_geometry.py
@@ -7,7 +7,7 @@ from kornia.geometry.transform import rotate, rotate3d
 from kornia.testing import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 from kornia.utils import _extract_device_dtype
 
-from .kernels import _check_kernel_size, _unpack_2d_ks
+from .kernels import _check_kernel_size, _unpack_2d_ks, _unpack_3d_ks
 
 
 def get_motion_kernel2d(
@@ -43,6 +43,8 @@ def get_motion_kernel2d(
     device, dtype = _extract_device_dtype(
         [angle if isinstance(angle, Tensor) else None, direction if isinstance(direction, Tensor) else None]
     )
+
+    # TODO: add support to kernel_size as tuple or integer
     kernel_tuple = _unpack_2d_ks(kernel_size)
     _check_kernel_size(kernel_size, 2)
 
@@ -136,11 +138,13 @@ def get_motion_kernel3d(
                   [0.0000, 0.0000, 0.0000],
                   [0.0000, 0.0000, 0.0000]]]])
     """
-    _check_kernel_size(kernel_size, 2)
-
     device, dtype = _extract_device_dtype(
         [angle if isinstance(angle, Tensor) else None, direction if isinstance(direction, Tensor) else None]
     )
+
+    # TODO: add support to kernel_size as tuple or integer
+    kernel_tuple = _unpack_3d_ks(kernel_size)
+    _check_kernel_size(kernel_size, 2)
 
     if not isinstance(angle, Tensor):
         angle = tensor([angle], device=device, dtype=dtype)
@@ -161,8 +165,6 @@ def get_motion_kernel3d(
         direction.size(0) == angle.size(0),
         f'direction and angle must have the same batch size. Got {direction.shape} and {angle.shape}.',
     )
-
-    kernel_tuple: tuple[int, int, int] = (kernel_size, kernel_size, kernel_size)
 
     # direction from [-1, 1] to [0, 1] range
     direction = (torch.clamp(direction, -1.0, 1.0) + 1.0) / 2.0

--- a/kornia/filters/kernels_geometry.py
+++ b/kornia/filters/kernels_geometry.py
@@ -81,7 +81,7 @@ def get_motion_kernel2d(
 
     expected_shape = torch.Size([direction.size(0), *kernel_tuple])
     KORNIA_CHECK(kernel.shape == expected_shape, f'Kernel shape should be {expected_shape}. Gotcha {kernel.shape}')
-    kernel = kernel.unsqueeze(1)
+    kernel = kernel[:, None, ...]
 
     # rotate (counterclockwise) kernel by given angle
     kernel = rotate(kernel, angle, mode=mode, align_corners=True)
@@ -176,7 +176,7 @@ def get_motion_kernel3d(
 
     expected_shape = torch.Size([direction.size(0), *kernel_tuple])
     KORNIA_CHECK(kernel.shape == expected_shape, f'Kernel shape should be {expected_shape}. Gotcha {kernel.shape}')
-    kernel = kernel.unsqueeze(1)
+    kernel = kernel[:, None, ...]
 
     # rotate (counterclockwise) kernel by given angle
     kernel = rotate3d(kernel, angle[:, 0], angle[:, 1], angle[:, 2], mode=mode, align_corners=True)

--- a/kornia/filters/kernels_geometry.py
+++ b/kornia/filters/kernels_geometry.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 import torch
 
@@ -8,7 +8,7 @@ from kornia.utils import _extract_device_dtype
 
 
 def get_motion_kernel2d(
-    kernel_size: int, angle: Union[Tensor, float], direction: Union[Tensor, float] = 0.0, mode: str = 'nearest'
+    kernel_size: int, angle: Tensor | float, direction: Tensor | float = 0.0, mode: str = 'nearest'
 ) -> Tensor:
     r"""Return 2D motion blur filter.
 
@@ -65,7 +65,7 @@ def get_motion_kernel2d(
     if direction.size(0) != angle.size(0):
         raise AssertionError(f"direction and angle must have the same length. Got {direction} and {angle}.")
 
-    kernel_tuple: Tuple[int, int] = (kernel_size, kernel_size)
+    kernel_tuple: tuple[int, int] = (kernel_size, kernel_size)
 
     # direction from [-1, 1] to [0, 1] range
     direction = (torch.clamp(direction, -1.0, 1.0) + 1.0) / 2.0
@@ -92,10 +92,7 @@ def get_motion_kernel2d(
 
 
 def get_motion_kernel3d(
-    kernel_size: int,
-    angle: Union[Tensor, Tuple[float, float, float]],
-    direction: Union[Tensor, float] = 0.0,
-    mode: str = 'nearest',
+    kernel_size: int, angle: Tensor | tuple[float, float, float], direction: Tensor | float = 0.0, mode: str = 'nearest'
 ) -> Tensor:
     r"""Return 3D motion blur filter.
 
@@ -168,7 +165,7 @@ def get_motion_kernel3d(
     if direction.size(0) != angle.size(0):
         raise AssertionError(f"direction and angle must have the same length. Got {direction} and {angle}.")
 
-    kernel_tuple: Tuple[int, int, int] = (kernel_size, kernel_size, kernel_size)
+    kernel_tuple: tuple[int, int, int] = (kernel_size, kernel_size, kernel_size)
 
     # direction from [-1, 1] to [0, 1] range
     direction = (torch.clamp(direction, -1.0, 1.0) + 1.0) / 2.0

--- a/kornia/filters/kernels_geometry.py
+++ b/kornia/filters/kernels_geometry.py
@@ -136,7 +136,7 @@ def get_motion_kernel3d(
                   [0.0000, 0.0000, 0.0000],
                   [0.0000, 0.0000, 0.0000]]]])
     """
-    _check_kernel_size(kernel_size, 3)
+    _check_kernel_size(kernel_size, 2)
 
     device, dtype = _extract_device_dtype(
         [angle if isinstance(angle, Tensor) else None, direction if isinstance(direction, Tensor) else None]

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -37,7 +37,7 @@ def laplacian(
         >>> output.shape
         torch.Size([2, 4, 5, 5])
     """
-    kernel = get_laplacian_kernel2d(kernel_size, device=input.device, dtype=input.dtype).unsqueeze(0)
+    kernel = get_laplacian_kernel2d(kernel_size, device=input.device, dtype=input.dtype)[None, ...]
 
     if normalized:
         kernel = normalize_kernel2d(kernel)

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 from kornia.core import Module, Tensor
 
@@ -7,7 +7,7 @@ from .kernels import get_laplacian_kernel2d, normalize_kernel2d
 
 
 def laplacian(
-    input: Tensor, kernel_size: Union[Tuple[int, int], int], border_type: str = 'reflect', normalized: bool = True
+    input: Tensor, kernel_size: tuple[int, int] | int, border_type: str = 'reflect', normalized: bool = True
 ) -> Tensor:
     r"""Create an operator that returns a tensor using a Laplacian filter.
 

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -1,13 +1,14 @@
-import torch
-import torch.nn as nn
+from typing import Tuple, Union
+
+from kornia.core import Module, Tensor
 
 from .filter import filter2d
 from .kernels import get_laplacian_kernel2d, normalize_kernel2d
 
 
 def laplacian(
-    input: torch.Tensor, kernel_size: int, border_type: str = 'reflect', normalized: bool = True
-) -> torch.Tensor:
+    input: Tensor, kernel_size: Union[Tuple[int, int], int], border_type: str = 'reflect', normalized: bool = True
+) -> Tensor:
     r"""Create an operator that returns a tensor using a Laplacian filter.
 
     .. image:: _static/img/laplacian.png
@@ -36,7 +37,7 @@ def laplacian(
         >>> output.shape
         torch.Size([2, 4, 5, 5])
     """
-    kernel: torch.Tensor = torch.unsqueeze(get_laplacian_kernel2d(kernel_size), dim=0)
+    kernel = get_laplacian_kernel2d(kernel_size).unsqueeze(0)
 
     if normalized:
         kernel = normalize_kernel2d(kernel)
@@ -44,7 +45,7 @@ def laplacian(
     return filter2d(input, kernel, border_type)
 
 
-class Laplacian(nn.Module):
+class Laplacian(Module):
     r"""Create an operator that returns a tensor using a Laplacian filter.
 
     The operator smooths the given tensor with a laplacian kernel by convolving
@@ -89,5 +90,5 @@ class Laplacian(nn.Module):
             + ')'
         )
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
+    def forward(self, input: Tensor) -> Tensor:
         return laplacian(input, self.kernel_size, self.border_type, self.normalized)

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -70,9 +70,11 @@ class Laplacian(Module):
         torch.Size([2, 4, 5, 5])
     """
 
-    def __init__(self, kernel_size: int, border_type: str = 'reflect', normalized: bool = True) -> None:
+    def __init__(
+        self, kernel_size: tuple[int, int] | int, border_type: str = 'reflect', normalized: bool = True
+    ) -> None:
         super().__init__()
-        self.kernel_size: int = kernel_size
+        self.kernel_size = kernel_size
         self.border_type: str = border_type
         self.normalized: bool = normalized
 

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -37,7 +37,7 @@ def laplacian(
         >>> output.shape
         torch.Size([2, 4, 5, 5])
     """
-    kernel = get_laplacian_kernel2d(kernel_size).unsqueeze(0)
+    kernel = get_laplacian_kernel2d(kernel_size, device=input.device, dtype=input.dtype).unsqueeze(0)
 
     if normalized:
         kernel = normalize_kernel2d(kernel)

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 import torch.nn.functional as F
 
@@ -7,13 +7,13 @@ from kornia.core import Module, Tensor
 from .kernels import _unpack_2d_ks, get_binary_kernel2d
 
 
-def _compute_zero_padding(kernel_size: Union[Tuple[int, int], int]) -> Tuple[int, int]:
+def _compute_zero_padding(kernel_size: tuple[int, int] | int) -> tuple[int, int]:
     r"""Utility function that computes zero padding tuple."""
     kx, ky = _unpack_2d_ks(kernel_size)
     return (kx - 1) // 2, (ky - 1) // 2
 
 
-def median_blur(input: Tensor, kernel_size: Union[Tuple[int, int], int]) -> Tensor:
+def median_blur(input: Tensor, kernel_size: tuple[int, int] | int) -> Tensor:
     r"""Blur an image using the median filter.
 
     .. image:: _static/img/median_blur.png
@@ -76,9 +76,9 @@ class MedianBlur(Module):
         torch.Size([2, 4, 5, 7])
     """
 
-    def __init__(self, kernel_size: Tuple[int, int]) -> None:
+    def __init__(self, kernel_size: tuple[int, int]) -> None:
         super().__init__()
-        self.kernel_size: Tuple[int, int] = kernel_size
+        self.kernel_size: tuple[int, int] = kernel_size
 
     def forward(self, input: Tensor) -> Tensor:
         return median_blur(input, self.kernel_size)

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -1,19 +1,19 @@
-from typing import List, Tuple
+from typing import Tuple, Union
 
-import torch
-import torch.nn as nn
 import torch.nn.functional as F
 
-from .kernels import get_binary_kernel2d
+from kornia.core import Module, Tensor
+
+from .kernels import _unpack_2d_ks, get_binary_kernel2d
 
 
-def _compute_zero_padding(kernel_size: Tuple[int, int]) -> Tuple[int, int]:
+def _compute_zero_padding(kernel_size: Union[Tuple[int, int], int]) -> Tuple[int, int]:
     r"""Utility function that computes zero padding tuple."""
-    computed: List[int] = [(k - 1) // 2 for k in kernel_size]
-    return computed[0], computed[1]
+    kx, ky = _unpack_2d_ks(kernel_size)
+    return (kx - 1) // 2, (ky - 1) // 2
 
 
-def median_blur(input: torch.Tensor, kernel_size: Tuple[int, int]) -> torch.Tensor:
+def median_blur(input: Tensor, kernel_size: Union[Tuple[int, int], int]) -> Tensor:
     r"""Blur an image using the median filter.
 
     .. image:: _static/img/median_blur.png
@@ -35,29 +35,27 @@ def median_blur(input: torch.Tensor, kernel_size: Tuple[int, int]) -> torch.Tens
         >>> output.shape
         torch.Size([2, 4, 5, 7])
     """
-    if not isinstance(input, torch.Tensor):
-        raise TypeError(f"Input type is not a torch.Tensor. Got {type(input)}")
+    if not isinstance(input, Tensor):
+        raise TypeError(f"Input type is not a Tensor. Got {type(input)}")
 
     if not len(input.shape) == 4:
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
 
-    padding: Tuple[int, int] = _compute_zero_padding(kernel_size)
+    padding = _compute_zero_padding(kernel_size)
 
     # prepare kernel
-    kernel: torch.Tensor = get_binary_kernel2d(kernel_size).to(input)
+    kernel: Tensor = get_binary_kernel2d(kernel_size).to(input)
     b, c, h, w = input.shape
 
     # map the local window to single vector
-    features: torch.Tensor = F.conv2d(input.reshape(b * c, 1, h, w), kernel, padding=padding, stride=1)
+    features: Tensor = F.conv2d(input.reshape(b * c, 1, h, w), kernel, padding=padding, stride=1)
     features = features.view(b, c, -1, h, w)  # BxCx(K_h * K_w)xHxW
 
     # compute the median along the feature axis
-    median: torch.Tensor = torch.median(features, dim=2)[0]
-
-    return median
+    return features.median(dim=2)[0]
 
 
-class MedianBlur(nn.Module):
+class MedianBlur(Module):
     r"""Blur an image using the median filter.
 
     Args:
@@ -82,5 +80,5 @@ class MedianBlur(nn.Module):
         super().__init__()
         self.kernel_size: Tuple[int, int] = kernel_size
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
+    def forward(self, input: Tensor) -> Tensor:
         return median_blur(input, self.kernel_size)

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -74,9 +74,9 @@ class MedianBlur(Module):
         torch.Size([2, 4, 5, 7])
     """
 
-    def __init__(self, kernel_size: tuple[int, int]) -> None:
+    def __init__(self, kernel_size: tuple[int, int] | int) -> None:
         super().__init__()
-        self.kernel_size: tuple[int, int] = kernel_size
+        self.kernel_size = kernel_size
 
     def forward(self, input: Tensor) -> Tensor:
         return median_blur(input, self.kernel_size)

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -44,7 +44,7 @@ def median_blur(input: Tensor, kernel_size: Union[Tuple[int, int], int]) -> Tens
     padding = _compute_zero_padding(kernel_size)
 
     # prepare kernel
-    kernel: Tensor = get_binary_kernel2d(kernel_size).to(input)
+    kernel: Tensor = get_binary_kernel2d(kernel_size, device=input.device, dtype=input.dtype)
     b, c, h, w = input.shape
 
     # map the local window to single vector

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import torch.nn.functional as F
 
 from kornia.core import Module, Tensor
+from kornia.testing import KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
 
 from .kernels import _unpack_2d_ks, get_binary_kernel2d
 
@@ -35,11 +36,8 @@ def median_blur(input: Tensor, kernel_size: tuple[int, int] | int) -> Tensor:
         >>> output.shape
         torch.Size([2, 4, 5, 7])
     """
-    if not isinstance(input, Tensor):
-        raise TypeError(f"Input type is not a Tensor. Got {type(input)}")
-
-    if not len(input.shape) == 4:
-        raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'H', 'W'])
 
     padding = _compute_zero_padding(kernel_size)
 

--- a/kornia/filters/motion.py
+++ b/kornia/filters/motion.py
@@ -100,10 +100,10 @@ class MotionBlur3D(Module):
         if isinstance(angle, float):
             self.angle = (angle, angle, angle)
         elif isinstance(angle, (tuple, list)) and len(angle) == 3:
-            self.angle = tuple(angle)
+            self.angle = (angle[0], angle[1], angle[2])
 
-        self.direction: float = direction
-        self.border_type: str = border_type
+        self.direction = direction
+        self.border_type = border_type
         self.mode = mode
 
     def __repr__(self) -> str:

--- a/kornia/filters/motion.py
+++ b/kornia/filters/motion.py
@@ -1,13 +1,12 @@
 from typing import Tuple, Union
 
-import torch
-import torch.nn as nn
+from kornia.core import Module, Tensor
 
 from .filter import filter2d, filter3d
 from .kernels_geometry import get_motion_kernel2d, get_motion_kernel3d
 
 
-class MotionBlur(nn.Module):
+class MotionBlur(Module):
     r"""Blur 2D images (4D tensor) using the motion filter.
 
     Args:
@@ -46,11 +45,11 @@ class MotionBlur(nn.Module):
             f'angle={self.angle}, direction={self.direction}, border_type={self.border_type})'
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: Tensor):
         return motion_blur(x, self.kernel_size, self.angle, self.direction, self.border_type)
 
 
-class MotionBlur3D(nn.Module):
+class MotionBlur3D(Module):
     r"""Blur 3D volumes (5D tensor) using the motion filter.
 
     Args:
@@ -101,18 +100,18 @@ class MotionBlur3D(nn.Module):
             f'angle={self.angle}, direction={self.direction}, border_type={self.border_type})'
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: Tensor):
         return motion_blur3d(x, self.kernel_size, self.angle, self.direction, self.border_type)
 
 
 def motion_blur(
-    input: torch.Tensor,
+    input: Tensor,
     kernel_size: int,
-    angle: Union[float, torch.Tensor],
-    direction: Union[float, torch.Tensor],
+    angle: Union[float, Tensor],
+    direction: Union[float, Tensor],
     border_type: str = 'constant',
     mode: str = 'nearest',
-) -> torch.Tensor:
+) -> Tensor:
     r"""Perform motion blur on tensor images.
 
     .. image:: _static/img/motion_blur.png
@@ -147,18 +146,18 @@ def motion_blur(
     """
     if border_type not in ["constant", "reflect", "replicate", "circular"]:
         raise AssertionError
-    kernel: torch.Tensor = get_motion_kernel2d(kernel_size, angle, direction, mode)
+    kernel: Tensor = get_motion_kernel2d(kernel_size, angle, direction, mode)
     return filter2d(input, kernel, border_type)
 
 
 def motion_blur3d(
-    input: torch.Tensor,
+    input: Tensor,
     kernel_size: int,
-    angle: Union[Tuple[float, float, float], torch.Tensor],
-    direction: Union[float, torch.Tensor],
+    angle: Union[Tuple[float, float, float], Tensor],
+    direction: Union[float, Tensor],
     border_type: str = 'constant',
     mode: str = 'nearest',
-) -> torch.Tensor:
+) -> Tensor:
     r"""Perform motion blur on 3D volumes (5D tensor).
 
     Args:
@@ -191,5 +190,5 @@ def motion_blur3d(
     """
     if border_type not in ["constant", "reflect", "replicate", "circular"]:
         raise AssertionError
-    kernel: torch.Tensor = get_motion_kernel3d(kernel_size, angle, direction, mode)
+    kernel: Tensor = get_motion_kernel3d(kernel_size, angle, direction, mode)
     return filter3d(input, kernel, border_type)

--- a/kornia/filters/motion.py
+++ b/kornia/filters/motion.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 from kornia.core import Module, Tensor
 
@@ -78,13 +78,13 @@ class MotionBlur3D(Module):
     def __init__(
         self,
         kernel_size: int,
-        angle: Union[float, Tuple[float, float, float]],
+        angle: float | tuple[float, float, float],
         direction: float,
         border_type: str = 'constant',
     ) -> None:
         super().__init__()
         self.kernel_size = kernel_size
-        self.angle: Tuple[float, float, float]
+        self.angle: tuple[float, float, float]
         if isinstance(angle, float):
             self.angle = (angle, angle, angle)
         elif isinstance(angle, (tuple, list)) and len(angle) == 3:
@@ -107,8 +107,8 @@ class MotionBlur3D(Module):
 def motion_blur(
     input: Tensor,
     kernel_size: int,
-    angle: Union[float, Tensor],
-    direction: Union[float, Tensor],
+    angle: float | Tensor,
+    direction: float | Tensor,
     border_type: str = 'constant',
     mode: str = 'nearest',
 ) -> Tensor:
@@ -153,8 +153,8 @@ def motion_blur(
 def motion_blur3d(
     input: Tensor,
     kernel_size: int,
-    angle: Union[Tuple[float, float, float], Tensor],
-    direction: Union[float, Tensor],
+    angle: tuple[float, float, float] | Tensor,
+    direction: float | Tensor,
     border_type: str = 'constant',
     mode: str = 'nearest',
 ) -> Tensor:

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import torch
 import torch.nn.functional as F
 

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -43,7 +43,7 @@ def spatial_gradient(input: Tensor, mode: str = 'sobel', order: int = 1, normali
 
     # prepare kernel
     b, c, h, w = input.shape
-    tmp_kernel = kernel.unsqueeze(1)
+    tmp_kernel = kernel[:, None, ...]
 
     # Pad with "replicate for spatial dims, but with zeros for channel
     spatial_pad = [kernel.size(1) // 2, kernel.size(1) // 2, kernel.size(2) // 2, kernel.size(2) // 2]

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -38,14 +38,13 @@ def spatial_gradient(input: Tensor, mode: str = 'sobel', order: int = 1, normali
     if not len(input.shape) == 4:
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
     # allocate kernel
-    kernel: Tensor = get_spatial_gradient_kernel2d(mode, order)
+    kernel = get_spatial_gradient_kernel2d(mode, order, device=input.device, dtype=input.dtype)
     if normalized:
         kernel = normalize_kernel2d(kernel)
 
     # prepare kernel
     b, c, h, w = input.shape
-    tmp_kernel: Tensor = kernel.to(input).detach()
-    tmp_kernel = tmp_kernel.unsqueeze(1)
+    tmp_kernel = kernel.unsqueeze(1)
 
     # Pad with "replicate for spatial dims, but with zeros for channel
     spatial_pad = [kernel.size(1) // 2, kernel.size(1) // 2, kernel.size(2) // 2, kernel.size(2) // 2]
@@ -95,13 +94,12 @@ def spatial_gradient3d(input: Tensor, mode: str = 'diff', order: int = 1) -> Ten
     else:
         # prepare kernel
         # allocate kernel
-        kernel: Tensor = get_spatial_gradient_kernel3d(mode, order)
+        kernel = get_spatial_gradient_kernel3d(mode, order, device=dev, dtype=dtype)
 
-        tmp_kernel: Tensor = kernel.to(input).detach()
-        tmp_kernel = tmp_kernel.repeat(c, 1, 1, 1, 1)
+        tmp_kernel = kernel.repeat(c, 1, 1, 1, 1)
 
         # convolve input tensor with grad kernel
-        kernel_flip: Tensor = tmp_kernel.flip(-3)
+        kernel_flip = tmp_kernel.flip(-3)
 
         # Pad with "replicate for spatial dims, but with zeros for channel
         spatial_pad = [

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -34,7 +34,7 @@ def spatial_gradient(input: Tensor, mode: str = 'sobel', order: int = 1, normali
         torch.Size([1, 3, 2, 4, 4])
     """
     KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'H', 'W'])
 
     # allocate kernel
     kernel = get_spatial_gradient_kernel2d(mode, order, device=input.device, dtype=input.dtype)
@@ -72,7 +72,7 @@ def spatial_gradient3d(input: Tensor, mode: str = 'diff', order: int = 1) -> Ten
         torch.Size([1, 4, 3, 2, 4, 4])
     """
     KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'D', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'D', 'H', 'W'])
 
     b, c, d, h, w = input.shape
     dev = input.device
@@ -138,7 +138,7 @@ def sobel(input: Tensor, normalized: bool = True, eps: float = 1e-6) -> Tensor:
         torch.Size([1, 3, 4, 4])
     """
     KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'H', 'W'))
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'H', 'W'])
 
     # comput the x/y gradients
     edges: Tensor = spatial_gradient(input, normalized=normalized)

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn.functional as F
 
 from kornia.core import Module, Tensor, pad
+from kornia.testing import KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
 
 from .kernels import get_spatial_gradient_kernel2d, get_spatial_gradient_kernel3d, normalize_kernel2d
 
@@ -32,11 +33,9 @@ def spatial_gradient(input: Tensor, mode: str = 'sobel', order: int = 1, normali
         >>> output.shape
         torch.Size([1, 3, 2, 4, 4])
     """
-    if not isinstance(input, Tensor):
-        raise TypeError(f"Input type is not a Tensor. Got {type(input)}")
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'H', 'W'))
 
-    if not len(input.shape) == 4:
-        raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
     # allocate kernel
     kernel = get_spatial_gradient_kernel2d(mode, order, device=input.device, dtype=input.dtype)
     if normalized:
@@ -72,11 +71,9 @@ def spatial_gradient3d(input: Tensor, mode: str = 'diff', order: int = 1) -> Ten
         >>> output.shape
         torch.Size([1, 4, 3, 2, 4, 4])
     """
-    if not isinstance(input, Tensor):
-        raise TypeError(f"Input type is not a Tensor. Got {type(input)}")
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'D', 'H', 'W'))
 
-    if not len(input.shape) == 5:
-        raise ValueError(f"Invalid input shape, we expect BxCxDxHxW. Got: {input.shape}")
     b, c, d, h, w = input.shape
     dev = input.device
     dtype = input.dtype
@@ -140,11 +137,8 @@ def sobel(input: Tensor, normalized: bool = True, eps: float = 1e-6) -> Tensor:
         >>> output.shape
         torch.Size([1, 3, 4, 4])
     """
-    if not isinstance(input, Tensor):
-        raise TypeError(f"Input type is not a Tensor. Got {type(input)}")
-
-    if not len(input.shape) == 4:
-        raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ('B', 'C', 'H', 'W'))
 
     # comput the x/y gradients
     edges: Tensor = spatial_gradient(input, normalized=normalized)

--- a/kornia/filters/unsharp.py
+++ b/kornia/filters/unsharp.py
@@ -1,14 +1,16 @@
-from typing import Tuple
+from typing import Tuple, Union
 
-import torch
-import torch.nn as nn
+from kornia.core import Module, Tensor
 
 from .gaussian import gaussian_blur2d
 
 
 def unsharp_mask(
-    input: torch.Tensor, kernel_size: Tuple[int, int], sigma: Tuple[float, float], border_type: str = 'reflect'
-) -> torch.Tensor:
+    input: Tensor,
+    kernel_size: Union[Tuple[int, int], int],
+    sigma: Union[Tuple[float, float], Tensor],
+    border_type: str = 'reflect',
+) -> Tensor:
     r"""Create an operator that sharpens a tensor by applying operation out = 2 * image - gaussian_blur2d(image).
 
     .. image:: _static/img/unsharp_mask.png
@@ -30,12 +32,12 @@ def unsharp_mask(
         >>> output.shape
         torch.Size([2, 4, 5, 5])
     """
-    data_blur: torch.Tensor = gaussian_blur2d(input, kernel_size, sigma, border_type)
-    data_sharpened: torch.Tensor = input + (input - data_blur)
+    data_blur: Tensor = gaussian_blur2d(input, kernel_size, sigma, border_type)
+    data_sharpened: Tensor = input + (input - data_blur)
     return data_sharpened
 
 
-class UnsharpMask(nn.Module):
+class UnsharpMask(Module):
     r"""Create an operator that sharpens image with: out = 2 * image - gaussian_blur2d(image).
 
     Args:
@@ -64,11 +66,16 @@ class UnsharpMask(nn.Module):
         torch.Size([2, 4, 5, 5])
     """
 
-    def __init__(self, kernel_size: Tuple[int, int], sigma: Tuple[float, float], border_type: str = 'reflect') -> None:
+    def __init__(
+        self,
+        kernel_size: Union[Tuple[int, int], int],
+        sigma: Union[Tuple[float, float], Tensor],
+        border_type: str = 'reflect',
+    ) -> None:
         super().__init__()
-        self.kernel_size: Tuple[int, int] = kernel_size
-        self.sigma: Tuple[float, float] = sigma
+        self.kernel_size = kernel_size
+        self.sigma = sigma
         self.border_type = border_type
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
+    def forward(self, input: Tensor) -> Tensor:
         return unsharp_mask(input, self.kernel_size, self.sigma, self.border_type)

--- a/kornia/filters/unsharp.py
+++ b/kornia/filters/unsharp.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from __future__ import annotations
 
 from kornia.core import Module, Tensor
 
@@ -6,10 +6,7 @@ from .gaussian import gaussian_blur2d
 
 
 def unsharp_mask(
-    input: Tensor,
-    kernel_size: Union[Tuple[int, int], int],
-    sigma: Union[Tuple[float, float], Tensor],
-    border_type: str = 'reflect',
+    input: Tensor, kernel_size: tuple[int, int] | int, sigma: tuple[float, float] | Tensor, border_type: str = 'reflect'
 ) -> Tensor:
     r"""Create an operator that sharpens a tensor by applying operation out = 2 * image - gaussian_blur2d(image).
 
@@ -67,10 +64,7 @@ class UnsharpMask(Module):
     """
 
     def __init__(
-        self,
-        kernel_size: Union[Tuple[int, int], int],
-        sigma: Union[Tuple[float, float], Tensor],
-        border_type: str = 'reflect',
+        self, kernel_size: tuple[int, int] | int, sigma: tuple[float, float] | Tensor, border_type: str = 'reflect'
     ) -> None:
         super().__init__()
         self.kernel_size = kernel_size

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn.functional as F
 
 from kornia.filters import filter2d
-from kornia.filters.kernels import get_gaussian_kernel2d_t
+from kornia.filters.kernels import get_gaussian_kernel2d
 from kornia.utils import create_meshgrid
 
 __all__ = ["elastic_transform2d"]
@@ -82,8 +82,8 @@ def elastic_transform2d(
         sigma_t = sigma.to(device=device, dtype=dtype)
 
     # Get Gaussian kernel for 'y' and 'x' displacement
-    kernel_x: torch.Tensor = get_gaussian_kernel2d_t(kernel_size, sigma_t[0].expand(2).unsqueeze(0))
-    kernel_y: torch.Tensor = get_gaussian_kernel2d_t(kernel_size, sigma_t[1].expand(2).unsqueeze(0))
+    kernel_x: torch.Tensor = get_gaussian_kernel2d(kernel_size, sigma_t[0].expand(2).unsqueeze(0))
+    kernel_y: torch.Tensor = get_gaussian_kernel2d(kernel_size, sigma_t[1].expand(2).unsqueeze(0))
 
     # Convolve over a random displacement matrix and scale them with 'alpha'
     disp_x: torch.Tensor = noise[:, :1]

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -109,7 +109,8 @@ _DTYPE_PRECISIONS = {
     torch.bfloat16: (7.8e-3, 7.8e-3),
     torch.float16: (9.7e-4, 9.7e-4),
     torch.float32: (1e-4, 1e-5),  # TODO: Update to ~1.2e-7
-    torch.float64: (1e-5, 1e-5),  # TODO: Update to ~2.3e-16
+    # TODO: Update to ~2.3e-16 for fp64
+    torch.float64: (1e-5, 1e-5),  # TODO: BaseTester used (1.3e-6, 1e-5), but it fails for general cases
 }
 
 

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -109,7 +109,7 @@ _DTYPE_PRECISIONS = {
     torch.bfloat16: (7.8e-3, 7.8e-3),
     torch.float16: (9.7e-4, 9.7e-4),
     torch.float32: (1e-4, 1e-5),  # TODO: Update to ~1.2e-7
-    torch.float64: (1e-5, 1e-8),  # TODO: Update to ~2.3e-16
+    torch.float64: (1e-5, 1e-5),  # TODO: Update to ~2.3e-16
 }
 
 

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -128,7 +128,7 @@ class BaseTester(ABC):
 
     # TODO: add @abstractmethod
     def test_dynamo(self, device, dtype, torch_optimizer):
-        pass
+        pass  # TODO: raise NotImplementedError -- now we see a bunch of dynamo tests running by inheritance
 
     @abstractmethod
     def test_gradcheck(self, device):

--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -104,9 +104,16 @@ def create_random_fundamental_matrix(batch_size, std_val=1e-3):
     return H_left.permute(0, 2, 1) @ F_rect @ H_right
 
 
-class BaseTester(ABC):
-    DTYPE_PRECISIONS = {torch.float16: (1e-3, 1e-3), torch.float32: (1.3e-6, 1e-5), torch.float64: (1.3e-6, 1e-5)}
+# {dtype: (rtol, atol)}
+_DTYPE_PRECISIONS = {
+    torch.bfloat16: (7.8e-3, 7.8e-3),
+    torch.float16: (9.7e-4, 9.7e-4),
+    torch.float32: (1e-4, 1e-5),  # TODO: Update to ~1.2e-7
+    torch.float64: (1e-5, 1e-8),  # TODO: Update to ~2.3e-16
+}
 
+
+class BaseTester(ABC):
     @abstractmethod
     def test_smoke(self, device, dtype):
         raise NotImplementedError("Implement a stupid routine.")
@@ -159,8 +166,8 @@ class BaseTester(ABC):
             rtol, atol = 1e-2, 1e-2
 
         if rtol is None and atol is None:
-            actual_rtol, actual_atol = self.DTYPE_PRECISIONS.get(actual.dtype, (0.0, 0.0))
-            expected_rtol, expected_atol = self.DTYPE_PRECISIONS.get(expected.dtype, (0.0, 0.0))
+            actual_rtol, actual_atol = _DTYPE_PRECISIONS.get(actual.dtype, (0.0, 0.0))
+            expected_rtol, expected_atol = _DTYPE_PRECISIONS.get(expected.dtype, (0.0, 0.0))
             rtol, atol = max(actual_rtol, expected_rtol), max(actual_atol, expected_atol)
 
             # halve the tolerance if `low_tolerance` is true
@@ -260,10 +267,6 @@ def _get_precision_by_name(
         return tol_val
 
     return tol_val_default
-
-
-# {dtype: (rtol, atol)}
-_DTYPE_PRECISIONS = {torch.float16: (1e-3, 1e-3), torch.float32: (1e-4, 1e-5), torch.float64: (1e-5, 1e-8)}
 
 
 def _default_tolerances(*inputs: Any) -> Tuple[float, float]:

--- a/kornia/utils/__init__.py
+++ b/kornia/utils/__init__.py
@@ -3,6 +3,7 @@ from .draw import draw_convex_polygon, draw_line, draw_rectangle
 from .grid import create_meshgrid, create_meshgrid3d
 from .helpers import (
     _extract_device_dtype,
+    deprecated,
     get_cuda_device_if_available,
     is_autocast_enabled,
     map_location_to_cpu,
@@ -38,4 +39,5 @@ __all__ = [
     "torch_meshgrid",
     "map_location_to_cpu",
     "is_autocast_enabled",
+    "deprecated",
 ]

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -3390,15 +3390,6 @@ class TestRandomGaussianBlur(BaseTester):
         input = utils.tensor_to_gradcheck_var(input)  # to var
         assert gradcheck(RandomGaussianBlur(kernel_size, sigma, "replicate", p=1.0), (input,), raise_exception=True)
 
-    def test_jit(self, device, dtype):
-        op = kornia.filters.gaussian_blur2d
-        op_script = torch.jit.script(op)
-        func_params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
-        params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
-
-        img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
-        self.assert_close(op(img, *params), op_script(img, *func_params))
-
     def test_module(self, device, dtype):
         func_params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
         params = [(3, 3), (1.5, 1.5)]

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -3391,7 +3391,7 @@ class TestRandomGaussianBlur(BaseTester):
         assert gradcheck(RandomGaussianBlur(kernel_size, sigma, "replicate", p=1.0), (input,), raise_exception=True)
 
     def test_jit(self, device, dtype):
-        op = kornia.filters.gaussian_blur2d_t
+        op = kornia.filters.gaussian_blur2d
         op_script = torch.jit.script(op)
         func_params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
         params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
@@ -3402,7 +3402,7 @@ class TestRandomGaussianBlur(BaseTester):
     def test_module(self, device, dtype):
         func_params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
         params = [(3, 3), (1.5, 1.5)]
-        op = kornia.filters.gaussian_blur2d_t
+        op = kornia.filters.gaussian_blur2d
         op_module = RandomGaussianBlur(*params)
 
         img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)

--- a/test/feature/test_affine_shape_estimator.py
+++ b/test/feature/test_affine_shape_estimator.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from torch.autograd import gradcheck
 
@@ -39,13 +38,6 @@ class TestPatchAffineShapeEstimator:
         patches = torch.rand(batch_size, channels, height, width, device=device)
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         assert gradcheck(ori, (patches,), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
-
-    def test_jit(self, device, dtype):
-        B, C, H, W = 2, 1, 13, 13
-        patches = torch.ones(B, C, H, W, device=device, dtype=dtype)
-        tfeat = PatchAffineShapeEstimator(W).to(patches.device, patches.dtype).eval()
-        tfeat_jit = torch.jit.script(PatchAffineShapeEstimator(W).to(patches.device, patches.dtype).eval())
-        assert_close(tfeat_jit(patches), tfeat(patches))
 
 
 # TODO: add kornia.testing.BaseTester
@@ -111,17 +103,6 @@ class TestLAFAffineShapeEstimator:
             fast_mode=True,
         )
 
-    @pytest.mark.jit
-    @pytest.mark.skip("Failing because of extract patches")
-    def test_jit(self, device, dtype):
-        B, C, H, W = 1, 1, 13, 13
-        inp = torch.zeros(B, C, H, W, device=device)
-        inp[:, :, 15:-15, 9:-9] = 1
-        laf = torch.tensor([[[[20.0, 0.0, 16.0], [0.0, 20.0, 16.0]]]], device=device)
-        tfeat = LAFAffineShapeEstimator(W).to(inp.device, inp.dtype).eval()
-        tfeat_jit = torch.jit.script(LAFAffineShapeEstimator(W).to(inp.device, inp.dtype).eval())
-        assert_close(tfeat_jit(laf, inp), tfeat(laf, inp))
-
 
 # TODO: add kornia.testing.BaseTester
 class TestLAFAffNetShapeEstimator:
@@ -174,13 +155,3 @@ class TestLAFAffNetShapeEstimator:
             nondet_tol=1e-4,
             fast_mode=True,
         )
-
-    @pytest.mark.jit
-    @pytest.mark.skip("Laf type is not a torch.Tensor????")
-    def test_jit(self, device, dtype):
-        B, C, H, W = 1, 1, 32, 32
-        patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
-        laf = torch.tensor([[[[8.0, 0.0, 16.0], [0.0, 8.0, 16.0]]]], device=device)
-        laf_estimator = LAFAffNetShapeEstimator(True).to(device, dtype=patches.dtype).eval()
-        laf_estimator_jit = torch.jit.script(LAFAffNetShapeEstimator(True).to(device, dtype=patches.dtype).eval())
-        assert_close(laf_estimator(laf, patches), laf_estimator_jit(laf, patches))

--- a/test/feature/test_keynet.py
+++ b/test/feature/test_keynet.py
@@ -1,10 +1,8 @@
-import pytest
 import torch
 from torch.autograd import gradcheck
 
 import kornia.testing as utils  # test utils
 from kornia.feature import KeyNet
-from kornia.testing import assert_close
 
 
 class TestKeyNet:
@@ -25,11 +23,3 @@ class TestKeyNet:
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         keynet = KeyNet().to(patches.device, patches.dtype)
         assert gradcheck(keynet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True)
-
-    @pytest.mark.jit
-    def test_jit(self, device, dtype):
-        B, C, H, W = 2, 1, 32, 32
-        patches = torch.ones(B, C, H, W, device=device, dtype=dtype)
-        model = KeyNet(True).to(patches.device, patches.dtype).eval()
-        model_jit = torch.jit.script(KeyNet(True).to(patches.device, patches.dtype).eval())
-        assert_close(model(patches), model_jit(patches))

--- a/test/feature/test_mkd.py
+++ b/test/feature/test_mkd.py
@@ -79,14 +79,6 @@ class TestMKDGradients:
 
         assert gradcheck(grad_describe, (patches), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
-    @pytest.mark.jit
-    def test_jit(self, device, dtype):
-        B, C, H, W = 2, 1, 13, 13
-        patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
-        model = MKDGradients().to(patches.device, patches.dtype).eval()
-        model_jit = torch.jit.script(MKDGradients().to(patches.device, patches.dtype).eval())
-        assert_close(model(patches), model_jit(patches))
-
 
 class TestVonMisesKernel:
     @pytest.mark.parametrize("ps", [5, 13, 25])
@@ -451,13 +443,3 @@ class TestSimpleKD:
             return skd(patches.double())
 
         assert gradcheck(skd_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
-
-    @pytest.mark.jit
-    def test_jit(self, device, dtype):
-        batch_size, channels, ps = 1, 1, 19
-        patches = torch.rand(batch_size, channels, ps, ps).to(device)
-        model = SimpleKD(patch_size=ps, kernel_type='polar', whitening='lw').to(patches.device, patches.dtype).eval()
-        model_jit = torch.jit.script(
-            SimpleKD(patch_size=ps, kernel_type='polar', whitening='lw').to(patches.device, patches.dtype).eval()
-        )
-        assert_close(model(patches), model_jit(patches))

--- a/test/feature/test_responces_local_features.py
+++ b/test/feature/test_responces_local_features.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from torch.autograd import gradcheck
 
@@ -122,18 +121,6 @@ class TestCornerHarris:
             kornia.feature.harris_response, (img, k), raise_exception=True, nondet_tol=1e-4, fast_mode=True
         )
 
-    @pytest.mark.skip(reason="turn off all jit for a while")
-    def test_jit(self, device):
-        @torch.jit.script
-        def op_script(input, k):
-            return kornia.feature.harris_response(input, k)
-
-        k = torch.tensor(0.04)
-        img = torch.rand(2, 3, 4, 5, device=device)
-        actual = op_script(img, k)
-        expected = kornia.feature.harris_response(img, k)
-        assert_close(actual, expected)
-
 
 class TestCornerGFTT:
     def test_shape(self, device):
@@ -245,17 +232,6 @@ class TestCornerGFTT:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.feature.gftt_response, (img), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
-    @pytest.mark.skip(reason="turn off all jit for a while")
-    def test_jit(self, device):
-        @torch.jit.script
-        def op_script(input):
-            return kornia.feature.gftt_response(input)
-
-        img = torch.rand(2, 3, 4, 5, device=device)
-        actual = op_script(img)
-        expected = kornia.feature.gftt_response(img)
-        assert_close(actual, expected)
-
 
 class TestBlobHessian:
     def test_shape(self, device):
@@ -326,17 +302,6 @@ class TestBlobHessian:
         img = torch.rand(batch_size, channels, height, width, device=device)
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.feature.hessian_response, (img), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
-
-    @pytest.mark.jit
-    def test_jit(self, device):
-        @torch.jit.script
-        def op_script(input):
-            return kornia.feature.hessian_response(input)
-
-        img = torch.rand(2, 3, 4, 5, device=device)
-        actual = op_script(img)
-        expected = kornia.feature.hessian_response(img)
-        assert_close(actual, expected)
 
 
 class TestBlobDoGSingle:
@@ -412,14 +377,3 @@ class TestBlobDoGSingle:
         assert gradcheck(
             kornia.feature.dog_response_single, (img), raise_exception=True, nondet_tol=1e-4, fast_mode=True
         )
-
-    @pytest.mark.jit
-    def test_jit(self, device):
-        @torch.jit.script
-        def op_script(input):
-            return kornia.feature.dog_response_single(input)
-
-        img = torch.rand(2, 3, 9, 9, device=device)
-        actual = op_script(img)
-        expected = kornia.feature.dog_response_single(img)
-        assert_close(actual, expected)

--- a/test/filters/test_blur.py
+++ b/test/filters/test_blur.py
@@ -8,11 +8,10 @@ from kornia.testing import BaseTester, tensor_to_gradcheck_var
 class TestBoxBlur(BaseTester):
     @pytest.mark.parametrize('kernel_size', [5, (3, 5)])
     @pytest.mark.parametrize('normalized', [True, False])
-    @pytest.mark.parametrize('border_type', ['constant', 'reflect', 'replicate', 'circular'])
-    def test_smoke(self, kernel_size, normalized, border_type, device, dtype):
+    def test_smoke(self, kernel_size, normalized, device, dtype):
         inpt = torch.rand(1, 1, 10, 10, device=device, dtype=dtype)
 
-        bb = BoxBlur(kernel_size, border_type, normalized)
+        bb = BoxBlur(kernel_size, 'reflect', normalized)
         actual = bb(inpt)
         assert actual.shape == (1, 1, 10, 10)
 

--- a/test/filters/test_blur.py
+++ b/test/filters/test_blur.py
@@ -129,16 +129,6 @@ class TestBoxBlur:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.box_blur, (img, (3, 3)), raise_exception=True)
 
-    def test_jit(self, device, dtype):
-        op = kornia.filters.box_blur
-        op_script = torch.jit.script(op)
-
-        kernel_size = (3, 3)
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        actual = op_script(img, kernel_size)
-        expected = op(img, kernel_size)
-        assert_close(actual, expected)
-
     def test_module(self, device, dtype):
         op = kornia.filters.box_blur
         op_module = kornia.filters.BoxBlur

--- a/test/filters/test_blur.py
+++ b/test/filters/test_blur.py
@@ -1,96 +1,45 @@
+import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
 import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.filters import BoxBlur, box_blur
+from kornia.testing import BaseTester
 
 
-class TestBoxBlur:
-    def test_shape(self, device, dtype):
-        inp = torch.zeros(1, 3, 4, 4, device=device, dtype=dtype)
-        blur = kornia.filters.BoxBlur((3, 3))
-        assert blur(inp).shape == (1, 3, 4, 4)
+class TestBoxBlur(BaseTester):
+    @pytest.mark.parametrize('kernel_size', [5, (3, 5)])
+    @pytest.mark.parametrize('normalized', [True, False])
+    @pytest.mark.parametrize('border_type', ['constant', 'reflect', 'replicate', 'circular'])
+    def test_smoke(self, kernel_size, normalized, border_type, device, dtype):
+        inpt = torch.rand(1, 1, 10, 10, device=device, dtype=dtype)
 
-    def test_shape_batch(self, device, dtype):
-        inp = torch.zeros(2, 6, 4, 4, device=device, dtype=dtype)
-        blur = kornia.filters.BoxBlur((3, 3))
-        assert blur(inp).shape == (2, 6, 4, 4)
+        bb = BoxBlur(kernel_size, border_type, normalized)
+        actual = bb(inpt)
+        assert actual.shape == (1, 1, 10, 10)
 
-    def test_kernel_3x3(self, device, dtype):
-        inp = torch.tensor(
-            [
-                [
-                    [
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [2.0, 2.0, 2.0, 2.0, 2.0],
-                        [2.0, 2.0, 2.0, 2.0, 2.0],
-                    ]
-                ]
-            ],
-            device=device,
-            dtype=dtype,
-        )
+    def test_exception(self):
+        inpt = torch.rand(1, 1, 3, 3)
+        with pytest.raises(TypeError) as errinfo:
+            box_blur(inpt, '1')
+        assert 'Kernel size should be an integer or a tuple of integer.' in str(errinfo)
 
-        kernel_size = (3, 3)
-        actual = kornia.filters.box_blur(inp, kernel_size)
+        with pytest.raises(Exception) as errinfo:
+            box_blur(inpt, (1,))
+        assert '2D Kernel size tuple should have a length of 2.' in str(errinfo)
 
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        assert_close(actual.sum(), torch.tensor(35.0).to(actual), rtol=tol_val, atol=tol_val)
+    @pytest.mark.parametrize('kernel_size', [(3, 3), 5, (5, 7)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_cardinality(self, batch_size, kernel_size, device, dtype):
+        inp = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)
+        blur = BoxBlur(kernel_size)
+        actual = blur(inp)
+        expected = (batch_size, 3, 4, 4)
+        assert actual.shape == expected
 
     # TODO(dmytro): normalized does not make any effect
-    def test_kernel_3x3_nonormalize(self, device, dtype):
-        inp = torch.tensor(
-            [
-                [
-                    [
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [2.0, 2.0, 2.0, 2.0, 2.0],
-                        [2.0, 2.0, 2.0, 2.0, 2.0],
-                    ]
-                ]
-            ],
-            device=device,
-            dtype=dtype,
-        )
-
-        kernel_size = (3, 3)
-        actual = kornia.filters.box_blur(inp, kernel_size, normalized=False)
-
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        assert_close(actual.sum(), torch.tensor(35.0).to(actual), rtol=tol_val, atol=tol_val)
-
-    def test_kernel_5x5(self, device, dtype):
-        inp = torch.tensor(
-            [
-                [
-                    [
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [1.0, 1.0, 1.0, 1.0, 1.0],
-                        [2.0, 2.0, 2.0, 2.0, 2.0],
-                        [2.0, 2.0, 2.0, 2.0, 2.0],
-                    ]
-                ]
-            ],
-            device=device,
-            dtype=dtype,
-        )
-
-        kernel_size = (5, 5)
-        expected = inp.sum((1, 2, 3)) / torch.mul(*kernel_size)
-
-        actual = kornia.filters.box_blur(inp, kernel_size)
-
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        assert_close(actual[:, 0, 2, 2], expected, rtol=tol_val, atol=tol_val)
-
-    def test_kernel_5x5_batch(self, device, dtype):
-        batch_size = 3
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('normalized', [True, False])
+    def test_kernel_3x3(self, batch_size, normalized, device, dtype):
         inp = torch.tensor(
             [
                 [
@@ -107,34 +56,65 @@ class TestBoxBlur:
             dtype=dtype,
         ).repeat(batch_size, 1, 1, 1)
 
+        kernel_size = (3, 3)
+        actual = box_blur(inp, kernel_size, normalized=normalized)
+        expected = torch.tensor(35.0 * batch_size, device=device, dtype=dtype)
+
+        self.assert_close(actual.sum(), expected)
+
+    @pytest.mark.parametrize('batch_size', [None, 1, 3])
+    def test_kernel_5x5(self, batch_size, device, dtype):
+        inp = torch.tensor(
+            [
+                [
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [2.0, 2.0, 2.0, 2.0, 2.0],
+                        [2.0, 2.0, 2.0, 2.0, 2.0],
+                    ]
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        if batch_size:
+            inp = inp.repeat(batch_size, 1, 1, 1)
+
         kernel_size = (5, 5)
+
+        actual = box_blur(inp, kernel_size)
         expected = inp.sum((1, 2, 3)) / torch.mul(*kernel_size)
 
-        actual = kornia.filters.box_blur(inp, kernel_size)
+        self.assert_close(actual[:, 0, 2, 2], expected)
 
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        assert_close(actual[:, 0, 2, 2], expected, rtol=tol_val, atol=tol_val)
-
-    def test_noncontiguous(self, device, dtype):
-        batch_size = 3
-        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
-
-        kernel_size = (3, 3)
-        actual = kornia.filters.box_blur(inp, kernel_size)
-        assert_close(actual, actual)
-
-    def test_gradcheck(self, device, dtype):
+    @pytest.mark.parametrize('kernel_size', [(3, 3), 5, (5, 7)])
+    def test_gradcheck(self, kernel_size, device, dtype):
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.box_blur, (img, (3, 3)), raise_exception=True)
+        fast_mode = 'cpu' in str(device)  # Disable fast mode for GPU
+        self.gradcheck(box_blur, (img, kernel_size), fast_mode=fast_mode)
 
-    def test_module(self, device, dtype):
-        op = kornia.filters.box_blur
-        op_module = kornia.filters.BoxBlur
+    @pytest.mark.parametrize('kernel_size', [(3, 3), 5, (5, 7)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_module(self, kernel_size, batch_size, device, dtype):
+        op = box_blur
+        op_module = BoxBlur
 
-        kernel_size = (3, 3)
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
+        img = torch.rand(batch_size, 3, 4, 5, device=device, dtype=dtype)
         actual = op_module(kernel_size)(img)
         expected = op(img, kernel_size)
-        assert_close(actual, expected)
+
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize('kernel_size', [5, (5, 7)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, kernel_size, device, dtype, torch_optimizer):
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        op = BoxBlur(kernel_size)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))

--- a/test/filters/test_blur_pool.py
+++ b/test/filters/test_blur_pool.py
@@ -1,108 +1,176 @@
 import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.filters import (
+    BlurPool2D,
+    EdgeAwareBlurPool2D,
+    MaxBlurPool2D,
+    blur_pool2d,
+    edge_aware_blur_pool2d,
+    max_blur_pool2d,
+)
+from kornia.testing import BaseTester, tensor_to_gradcheck_var
 
 
-class TestMaxBlurPool:
+class TestMaxBlurPool(BaseTester):
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('ceil_mode', [True, False])
+    def test_smoke(self, kernel_size, ceil_mode, device, dtype):
+        inpt = torch.rand(1, 1, 10, 10, device=device, dtype=dtype)
+        actual = MaxBlurPool2D(kernel_size, ceil_mode=ceil_mode)(inpt)
+
+        assert actual.shape == (1, 1, 5, 5)
+
     @pytest.mark.parametrize("ceil_mode", [True, False])
-    def test_shape(self, ceil_mode, device, dtype):
-        inp = torch.zeros(1, 4, 4, 8, device=device, dtype=dtype)
-        blur = kornia.filters.MaxBlurPool2D(3, ceil_mode=ceil_mode)
-        assert blur(inp).shape == (1, 4, 2, 4)
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_cardinality(self, batch_size, kernel_size, ceil_mode, device, dtype):
+        inpt = torch.zeros(batch_size, 4, 4, 8, device=device, dtype=dtype)
+        blur = MaxBlurPool2D(kernel_size, ceil_mode=ceil_mode)
+        assert blur(inpt).shape == (batch_size, 4, 2, 4)
 
-    @pytest.mark.parametrize("ceil_mode", [True, False])
-    def test_shape_batch(self, ceil_mode, device, dtype):
-        inp = torch.zeros(2, 4, 4, 8, device=device, dtype=dtype)
-        blur = kornia.filters.MaxBlurPool2D(3, ceil_mode=ceil_mode)
-        assert blur(inp).shape == (2, 4, 2, 4)
+    def test_exception(self):
+        inpt = torch.rand(1, 1, 3, 3)
+        with pytest.raises(Exception) as errinfo:
+            MaxBlurPool2D((3, 5))(inpt)
+        assert 'Invalid kernel shape. Expect CxC_outxNxN' in str(errinfo)
 
-    def test_noncontiguous(self, device, dtype):
-        batch_size = 3
-        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
-
-        kernel_size = 3
-        actual = kornia.filters.max_blur_pool2d(inp, kernel_size)
-        assert_close(actual, actual)
-
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 2, 5, 4
-        img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.max_blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
+        img = torch.rand(batch_size, channels, height, width, device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        self.gradcheck(max_blur_pool2d, (img, 3))
 
-    def test_module(self, device, dtype):
-        op = kornia.filters.max_blur_pool2d
-        op_module = kornia.filters.MaxBlurPool2D
+    @pytest.mark.parametrize('kernel_size', [(3, 3), 5])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_module(self, kernel_size, batch_size, device, dtype):
+        op = max_blur_pool2d
+        op_module = MaxBlurPool2D
 
-        kernel_size = 3
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
+        img = torch.rand(batch_size, 3, 4, 5, device=device, dtype=dtype)
         actual = op_module(kernel_size)(img)
         expected = op(img, kernel_size)
-        assert_close(actual, expected)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('ceil_mode', [True, False])
+    def test_dynamo(self, batch_size, kernel_size, ceil_mode, device, dtype, torch_optimizer):
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        op = MaxBlurPool2D(kernel_size, ceil_mode=ceil_mode)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))
 
 
-class TestBlurPool:
-    def test_shape(self, device, dtype):
-        inp = torch.zeros(1, 4, 4, 8, device=device, dtype=dtype)
-        blur = kornia.filters.BlurPool2D(3, stride=1)
-        assert blur(inp).shape == (1, 4, 4, 8)
-        blur = kornia.filters.BlurPool2D(3)
-        assert blur(inp).shape == (1, 4, 2, 4)
+class TestBlurPool(BaseTester):
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('stride', [1, 2])
+    def test_smoke(self, kernel_size, stride, device, dtype):
+        inpt = torch.rand(1, 1, 10, 10, device=device, dtype=dtype)
+        actual = BlurPool2D(kernel_size, stride=stride)(inpt)
+        expected = (1, 1, int(10 / stride), int(10 / stride))
+        assert actual.shape == expected
 
-    def test_shape_batch(self, device, dtype):
-        inp = torch.zeros(2, 4, 4, 8, device=device, dtype=dtype)
-        blur = kornia.filters.BlurPool2D(3, stride=1)
-        assert blur(inp).shape == (2, 4, 4, 8)
-        blur = kornia.filters.BlurPool2D(3)
-        assert blur(inp).shape == (2, 4, 2, 4)
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('stride', [1, 2])
+    def test_cardinality(self, batch_size, kernel_size, stride, device, dtype):
+        inpt = torch.zeros(batch_size, 4, 4, 8, device=device, dtype=dtype)
+        actual = BlurPool2D(kernel_size, stride=stride)(inpt)
+        expected = (batch_size, 4, int(4 / stride), int(8 / stride))
+        assert actual.shape == expected
 
-    def test_noncontiguous(self, device, dtype):
-        batch_size = 3
-        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+    def test_exception(self):
+        inpt = torch.rand(1, 1, 3, 3)
+        with pytest.raises(Exception) as errinfo:
+            BlurPool2D((3, 5))(inpt)
+        assert 'Invalid kernel shape. Expect CxC_(out, None)xNxN' in str(errinfo)
 
-        kernel_size = 3
-        actual = kornia.filters.blur_pool2d(inp, kernel_size)
-        assert_close(actual, actual)
-
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 2, 5, 4
-        img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
+        img = torch.rand(batch_size, channels, height, width, device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        self.gradcheck(blur_pool2d, (img, 3))
 
-    def test_module(self, device, dtype):
-        op = kornia.filters.blur_pool2d
-        op_module = kornia.filters.BlurPool2D
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('stride', [1, 2])
+    def test_module(self, batch_size, kernel_size, stride, device, dtype):
+        op = blur_pool2d
+        op_module = BlurPool2D
 
-        kernel_size = 3
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
+        img = torch.rand(batch_size, 3, 4, 5, device=device, dtype=dtype)
         actual = op_module(kernel_size)(img)
         expected = op(img, kernel_size)
-        assert_close(actual, expected)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('stride', [1, 2])
+    def test_dynamo(self, batch_size, kernel_size, stride, device, dtype, torch_optimizer):
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        op = BlurPool2D(kernel_size, stride=stride)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))
 
 
-class TestEdgeAwareBlurPool:
-    def test_shape(self, device, dtype):
-        inp = torch.zeros(1, 3, 8, 8, device=device, dtype=dtype)
-        blur = kornia.filters.edge_aware_blur_pool2d(inp, kernel_size=3)
+class TestEdgeAwareBlurPool(BaseTester):
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('edge_threshold', [1.25, 2.5])
+    @pytest.mark.parametrize('edge_dilation_kernel_size', [3, 5])
+    def test_smoke(self, kernel_size, batch_size, edge_threshold, edge_dilation_kernel_size, device, dtype):
+        inpt = torch.zeros(batch_size, 3, 8, 8, device=device, dtype=dtype)
+        actual = edge_aware_blur_pool2d(inpt, kernel_size, edge_threshold, edge_dilation_kernel_size)
+        assert actual.shape == inpt.shape
+
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_cardinality(self, kernel_size, batch_size, device, dtype):
+        inp = torch.zeros(batch_size, 3, 8, 8, device=device, dtype=dtype)
+        blur = edge_aware_blur_pool2d(inp, kernel_size=kernel_size)
         assert blur.shape == inp.shape
 
-    def test_shape_batch(self, device, dtype):
-        inp = torch.zeros(2, 3, 8, 8, device=device, dtype=dtype)
-        blur = kornia.filters.edge_aware_blur_pool2d(inp, kernel_size=3)
-        assert blur.shape == inp.shape
+    def test_exception(self):
+        with pytest.raises(Exception) as errinfo:
+            inpt = torch.rand(1, 3, 3)
+            edge_aware_blur_pool2d(inpt, 3)
+        assert "shape must be [[\'B\', \'C\', \'H\', \'W\']]" in str(errinfo)
+        with pytest.raises(Exception) as errinfo:
+            inpt = torch.rand(1, 1, 3, 3)
+            edge_aware_blur_pool2d(inpt, 3, edge_threshold=-1)
+        assert "edge threshold should be positive, but got" in str(errinfo)
 
-    def test_gradcheck(self, device, dtype):
-        img = torch.rand((1, 2, 5, 4), device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.edge_aware_blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_module(self, kernel_size, batch_size, device, dtype):
+        op = edge_aware_blur_pool2d
+        op_module = EdgeAwareBlurPool2D
+
+        img = torch.rand(batch_size, 3, 4, 5, device=device, dtype=dtype)
+        actual = op_module(kernel_size)(img)
+        expected = op(img, kernel_size)
+        self.assert_close(actual, expected)
+
+    def test_gradcheck(self, device):
+        img = torch.rand((1, 2, 5, 4), device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        self.gradcheck(edge_aware_blur_pool2d, (img, 3))
 
     def test_smooth(self, device, dtype):
-        img = torch.ones(1, 1, 5, 5).to(device, dtype)
+        img = torch.ones(1, 1, 5, 5, device=device, dtype=dtype)
         img[0, 0, :, :2] = 0
-        blur = kornia.filters.edge_aware_blur_pool2d(img, kernel_size=3, edge_threshold=32.0)
-        assert_close(img, blur)
+        blur = edge_aware_blur_pool2d(img, kernel_size=3, edge_threshold=32.0)
+        self.assert_close(img, blur)
+
+    @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, kernel_size, device, dtype, torch_optimizer):
+        op = edge_aware_blur_pool2d
+        inpt = torch.rand(batch_size, 3, 4, 5, device=device, dtype=dtype)
+        op = EdgeAwareBlurPool2D(kernel_size)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))

--- a/test/filters/test_blur_pool.py
+++ b/test/filters/test_blur_pool.py
@@ -34,16 +34,6 @@ class TestMaxBlurPool:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.max_blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
 
-    def test_jit(self, device, dtype):
-        op = kornia.filters.max_blur_pool2d
-        op_script = torch.jit.script(op)
-
-        kernel_size = 3
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        actual = op_script(img, kernel_size)
-        expected = op(img, kernel_size)
-        assert_close(actual, expected)
-
     def test_module(self, device, dtype):
         op = kornia.filters.max_blur_pool2d
         op_module = kornia.filters.MaxBlurPool2D
@@ -84,16 +74,6 @@ class TestBlurPool:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
 
-    def test_jit(self, device, dtype):
-        op = kornia.filters.blur_pool2d
-        op_script = torch.jit.script(op)
-
-        kernel_size = 3
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        actual = op_script(img, kernel_size)
-        expected = op(img, kernel_size)
-        assert_close(actual, expected)
-
     def test_module(self, device, dtype):
         op = kornia.filters.blur_pool2d
         op_module = kornia.filters.BlurPool2D
@@ -120,16 +100,6 @@ class TestEdgeAwareBlurPool:
         img = torch.rand((1, 2, 5, 4), device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.edge_aware_blur_pool2d, (img, 3), raise_exception=True, fast_mode=True)
-
-    def test_jit(self, device, dtype):
-        op = kornia.filters.edge_aware_blur_pool2d
-        op_script = torch.jit.script(op)
-
-        kernel_size = 3
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        actual = op_script(img, kernel_size)
-        expected = op(img, kernel_size)
-        assert_close(actual, expected)
 
     def test_smooth(self, device, dtype):
         img = torch.ones(1, 1, 5, 5).to(device, dtype)

--- a/test/filters/test_blur_pool.py
+++ b/test/filters/test_blur_pool.py
@@ -35,6 +35,14 @@ class TestMaxBlurPool(BaseTester):
             MaxBlurPool2D((3, 5))(inpt)
         assert 'Invalid kernel shape. Expect CxC_outxNxN' in str(errinfo)
 
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_noncontiguous(self, batch_size, device, dtype):
+        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+
+        actual = max_blur_pool2d(inp, 3)
+
+        assert actual.is_contiguous()
+
     def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 2, 5, 4
         img = torch.rand(batch_size, channels, height, width, device=device)
@@ -86,6 +94,13 @@ class TestBlurPool(BaseTester):
         with pytest.raises(Exception) as errinfo:
             BlurPool2D((3, 5))(inpt)
         assert 'Invalid kernel shape. Expect CxC_(out, None)xNxN' in str(errinfo)
+
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_noncontiguous(self, batch_size, device, dtype):
+        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+
+        actual = blur_pool2d(inp, 3)
+        assert actual.is_contiguous()
 
     def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 2, 5, 4
@@ -142,6 +157,13 @@ class TestEdgeAwareBlurPool(BaseTester):
             inpt = torch.rand(1, 1, 3, 3)
             edge_aware_blur_pool2d(inpt, 3, edge_threshold=-1)
         assert "edge threshold should be positive, but got" in str(errinfo)
+
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_noncontiguous(self, batch_size, device, dtype):
+        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+
+        actual = edge_aware_blur_pool2d(inp, 3)
+        assert actual.is_contiguous()
 
     @pytest.mark.parametrize('kernel_size', [3, (5, 5)])
     @pytest.mark.parametrize('batch_size', [1, 2])

--- a/test/filters/test_canny.py
+++ b/test/filters/test_canny.py
@@ -269,15 +269,6 @@ class TestCanny:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.canny, img, raise_exception=True, fast_mode=True)
 
-    def test_jit(self, device, dtype):
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.sobel
-        op_script = torch.jit.script(op)
-        expected_magnitude, expected_edges = op(img)
-        actual_magnitude, actual_edges = op_script(img)
-        assert_close(actual_magnitude, expected_magnitude)
-        assert_close(actual_edges, expected_edges)
-
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
         op = kornia.filters.canny

--- a/test/filters/test_canny.py
+++ b/test/filters/test_canny.py
@@ -1,45 +1,65 @@
 import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.filters import Canny, canny
+from kornia.testing import BaseTester, tensor_to_gradcheck_var
 
 
-class TestCanny:
-    def test_shape(self, device, dtype):
-        inp = torch.zeros(1, 3, 4, 4, device=device, dtype=dtype)
-
-        canny = kornia.filters.Canny()
-        magnitude, edges = canny(inp)
-
-        assert magnitude.shape == (1, 1, 4, 4)
-        assert edges.shape == (1, 1, 4, 4)
-
-    def test_shape_batch(self, device, dtype):
-        batch_size = 2
+class TestCanny(BaseTester):
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('kernel_size', [3, (5, 7)])
+    @pytest.mark.parametrize('sigma', [(1.5, 1.0), (2.5, 0.5)])
+    @pytest.mark.parametrize('hysteresis', [False, True])
+    @pytest.mark.parametrize('low_threshold,high_threshold', [(0.1, 0.2), (0.3, 0.5)])
+    def test_smoke(self, batch_size, kernel_size, sigma, hysteresis, low_threshold, high_threshold, device, dtype):
         inp = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)
 
-        canny = kornia.filters.Canny()
-        magnitude, edges = canny(inp)
+        op = Canny(low_threshold, high_threshold, kernel_size, sigma, hysteresis)
+        actual = op(inp)
+        assert len(actual) == 2
+        assert actual[0].shape == (batch_size, 1, 4, 4)
+        assert actual[1].shape == (batch_size, 1, 4, 4)
+
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_cardinality(self, batch_size, device, dtype):
+        inp = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)
+
+        op = Canny()
+        magnitude, edges = op(inp)
 
         assert magnitude.shape == (batch_size, 1, 4, 4)
         assert edges.shape == (batch_size, 1, 4, 4)
 
-    def test_noncontiguous(self, device, dtype):
-        batch_size = 3
-        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+    def test_exception(self, device, dtype):
+        with pytest.raises(Exception) as errinfo:
+            Canny(0.3, 0.2)
+        assert 'low_threshold should be smaller than the high_threshold' in str(errinfo)
 
-        magnitude, edges = kornia.filters.canny(inp)
+        with pytest.raises(Exception) as errinfo:
+            Canny(-2, 0.3)
+        assert 'Invalid low threshold.' in str(errinfo)
 
-        assert inp.is_contiguous() is False
+        with pytest.raises(Exception) as errinfo:
+            Canny(0.1, 3)
+        assert 'Invalid high threshold.' in str(errinfo)
+
+        with pytest.raises(Exception) as errinfo:
+            canny(1)
+        assert 'Not a Tensor type' in str(errinfo)
+
+        inp = torch.zeros(3, 4, 4, device=device, dtype=dtype)
+        with pytest.raises(Exception) as errinfo:
+            canny(inp)
+        assert 'shape must be [[\'B\', \'C\', \'H\', \'W\']]' in str(errinfo)
+
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_noncontiguous(self, batch_size, device, dtype):
+        inp = torch.rand(batch_size, 3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+
+        magnitude, edges = canny(inp)
 
         assert magnitude.is_contiguous()
         assert edges.is_contiguous()
-
-        assert magnitude.shape == (batch_size, 1, 5, 5)
-        assert edges.shape == (batch_size, 1, 5, 5)
 
     def test_magnitude(self, device, dtype):
         inp = torch.tensor(
@@ -90,11 +110,10 @@ class TestCanny:
             dtype=dtype,
         )
 
-        magnitude, edges = kornia.filters.canny(inp)
+        magnitude, edges = canny(inp)
 
-        tol_val: float = utils._get_precision(device, dtype)
-        assert_close(magnitude, expected_magnitude, rtol=tol_val, atol=tol_val)
-        assert_close(edges, expected_edges, rtol=tol_val, atol=tol_val)
+        self.assert_close(magnitude, expected_magnitude, atol=1e-4, rtol=1e-4)
+        self.assert_close(edges, expected_edges, atol=1e-4, rtol=1e-4)
 
     def test_magnitude_hyst(self, device, dtype):
         inp = torch.tensor(
@@ -145,11 +164,10 @@ class TestCanny:
             dtype=dtype,
         )
 
-        magnitude, edges = kornia.filters.canny(inp, hysteresis=True)
+        magnitude, edges = canny(inp, hysteresis=True)
 
-        tol_val: float = utils._get_precision(device, dtype)
-        assert_close(magnitude, expected_magnitude, rtol=tol_val, atol=tol_val)
-        assert_close(edges, expected_edges, rtol=tol_val, atol=tol_val)
+        self.assert_close(magnitude, expected_magnitude, atol=1e-4, rtol=1e-4)
+        self.assert_close(edges, expected_edges, atol=1e-4, rtol=1e-4)
 
     def test_magnitude_hyst_false(self, device, dtype):
         inp = torch.tensor(
@@ -200,11 +218,10 @@ class TestCanny:
             dtype=dtype,
         )
 
-        magnitude, edges = kornia.filters.canny(inp, hysteresis=False)
+        magnitude, edges = canny(inp, hysteresis=False)
 
-        tol_val: float = utils._get_precision(device, dtype)
-        assert_close(magnitude, expected_magnitude, rtol=tol_val, atol=tol_val)
-        assert_close(edges, expected_edges, rtol=tol_val, atol=tol_val)
+        self.assert_close(magnitude, expected_magnitude, atol=1e-4, rtol=1e-4)
+        self.assert_close(edges, expected_edges, atol=1e-4, rtol=1e-4)
 
     def test_magnitude_threshold(self, device, dtype):
         inp = torch.tensor(
@@ -255,25 +272,37 @@ class TestCanny:
             dtype=dtype,
         )
 
-        magnitude, edges = kornia.filters.canny(inp, low_threshold=0.3, high_threshold=0.9)
+        magnitude, edges = canny(inp, low_threshold=0.3, high_threshold=0.9)
 
-        tol_val: float = utils._get_precision(device, dtype)
-        assert_close(magnitude, expected_magnitude, rtol=tol_val, atol=tol_val)
-        assert_close(edges, expected_edges, rtol=tol_val, atol=tol_val)
+        self.assert_close(magnitude, expected_magnitude, atol=1e-4, rtol=1e-4)
+        self.assert_close(edges, expected_edges, atol=1e-4, rtol=1e-4)
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         if "cuda" in str(device):
             pytest.skip("RuntimeError: Backward is not reentrant, i.e., running backward,")
         batch_size, channels, height, width = 1, 1, 3, 4
-        img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.canny, img, raise_exception=True, fast_mode=True)
+        img = torch.rand(batch_size, channels, height, width, device=device)
+        img = tensor_to_gradcheck_var(img)
+        self.gradcheck(canny, img)
 
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.canny
-        op_module = kornia.filters.Canny()
+        op = canny
+        op_module = Canny()
         expected_magnitude, expected_edges = op(img)
         actual_magnitude, actual_edges = op_module(img)
-        assert_close(actual_magnitude, expected_magnitude)
-        assert_close(actual_edges, expected_edges)
+        self.assert_close(actual_magnitude, expected_magnitude)
+        self.assert_close(actual_edges, expected_edges)
+
+    @pytest.mark.parametrize('kernel_size', [5, (5, 7)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, kernel_size, device, dtype, torch_optimizer):
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        op = Canny(kernel_size=kernel_size)
+        op_optimized = torch_optimizer(op)
+
+        expected_magnitude, expected_edges = op(inpt)
+        actual_magnitude, actual_edges = op_optimized(inpt)
+
+        self.assert_close(actual_magnitude, expected_magnitude)
+        self.assert_close(actual_edges, expected_edges)

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -289,17 +289,6 @@ class TestFilter2D:
             kornia.filters.filter2d, (input, kernel), nondet_tol=1e-8, raise_exception=True, fast_mode=True
         )
 
-    @pytest.mark.parametrize("padding", ["same", "valid"])
-    def test_jit(self, padding, device, dtype):
-        op = kornia.filters.filter2d
-        op_script = torch.jit.script(op)
-
-        kernel = torch.rand(1, 3, 3, device=device, dtype=dtype)
-        input = torch.ones(1, 1, 7, 8, device=device, dtype=dtype)
-        expected = op(input, kernel, padding=padding)
-        actual = op_script(input, kernel, padding=padding)
-        assert_close(actual, expected)
-
 
 class TestFilter3D:
     def test_smoke(self, device, dtype):
@@ -617,16 +606,6 @@ class TestFilter3D:
             kornia.filters.filter3d, (input, kernel), nondet_tol=1e-8, raise_exception=True, fast_mode=True
         )
 
-    def test_jit(self, device, dtype):
-        op = kornia.filters.filter3d
-        op_script = torch.jit.script(op)
-
-        kernel = torch.rand(1, 1, 3, 3, device=device, dtype=dtype)
-        input = torch.ones(1, 1, 2, 7, 8, device=device, dtype=dtype)
-        expected = op(input, kernel)
-        actual = op_script(input, kernel)
-        assert_close(actual, expected)
-
 
 class TestDexiNed:
     def test_smoke(self, device, dtype):
@@ -654,10 +633,3 @@ class TestDexiNed:
 
         out = model(img)[-1]
         assert_close(out, expect, atol=3e-4, rtol=3e-4)
-
-    def test_jit(self, device, dtype):
-        op = kornia.filters.DexiNed(pretrained=False).to(device, dtype)
-        op_script = torch.jit.script(op)
-
-        img = torch.rand(1, 3, 64, 64, device=device, dtype=dtype)
-        assert_close(op(img)[-1], op_script(img)[-1])

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -1,40 +1,64 @@
 import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.filters import DexiNed, filter2d, filter2d_separable, filter3d
+from kornia.testing import BaseTester, assert_close, tensor_to_gradcheck_var
 
 
-class TestFilter2D:
+class TestFilter2D(BaseTester):
+    @pytest.mark.parametrize("border_type", ['constant', 'reflect', 'replicate', 'circular'])
+    @pytest.mark.parametrize("normalized", [True, False])
     @pytest.mark.parametrize("padding", ["same", "valid"])
-    def test_smoke(self, padding, device, dtype):
+    def test_smoke(self, border_type, normalized, padding, device, dtype):
         kernel = torch.rand(1, 3, 3, device=device, dtype=dtype)
         _, height, width = kernel.shape
         input = torch.ones(1, 1, 7, 8, device=device, dtype=dtype)
         b, c, h, w = input.shape
-        if padding == 'same':
-            out = kornia.filters.filter2d(input, kernel, padding=padding)
-            assert out.shape == (b, c, h, w)
-        else:
-            out = kornia.filters.filter2d(input, kernel, padding=padding)
-            assert out.shape == (b, c, h - height + 1, w - width + 1)
+
+        actual = filter2d(input, kernel, border_type, normalized, padding)
+        assert isinstance(actual, torch.Tensor)
+        assert actual.shape in {(b, c, h, w), (b, c, h - height + 1, w - width + 1)}
 
     @pytest.mark.parametrize("batch_size", [2, 3, 6, 8])
     @pytest.mark.parametrize("padding", ["same", "valid"])
-    def test_batch(self, batch_size, padding, device, dtype):
+    def test_cardinality(self, batch_size, padding, device, dtype):
         B: int = batch_size
         kernel = torch.rand(1, 3, 3, device=device, dtype=dtype)
         _, height, width = kernel.shape
         input = torch.ones(B, 3, 7, 8, device=device, dtype=dtype)
         b, c, h, w = input.shape
+        out = filter2d(input, kernel, padding=padding)
         if padding == 'same':
-            out = kornia.filters.filter2d(input, kernel, padding=padding)
             assert out.shape == (b, c, h, w)
         else:
-            out = kornia.filters.filter2d(input, kernel, padding=padding)
             assert out.shape == (b, c, h - height + 1, w - width + 1)
+
+    def test_exception(self):
+        k = torch.ones(1, 1, 1)
+        inpt = torch.ones(1, 1, 1, 1)
+        with pytest.raises(TypeError) as errinfo:
+            filter2d(1, k)
+        assert 'Not a Tensor type.' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            filter2d(inpt, 1)
+        assert 'Not a Tensor type.' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            filter2d(torch.ones(1), k)
+        assert 'shape must be [[\'B\', \'C\', \'H\', \'W\']]' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            filter2d(inpt, torch.ones(1))
+        assert 'shape must be [[\'B\', \'H\', \'W\']]' in str(errinfo)
+
+        with pytest.raises(Exception) as errinfo:
+            filter2d(inpt, k, border_type='a')
+        assert 'Invalid border, gotcha a. Ex' in str(errinfo)
+
+        with pytest.raises(Exception) as errinfo:
+            filter2d(inpt, k, padding='a')
+        assert 'Invalid padding mode, gotcha a. Ex' in str(errinfo)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_mean_filter(self, padding, device, dtype):
@@ -54,31 +78,33 @@ class TestFilter2D:
             device=device,
             dtype=dtype,
         )
-        expected_same = torch.tensor(
-            [
+
+        actual = filter2d(input, kernel, padding=padding)
+
+        if padding == 'same':
+            expected_same = torch.tensor(
                 [
                     [
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, 5.0, 5.0, 5.0, 0.0],
-                        [0.0, 5.0, 5.0, 5.0, 0.0],
-                        [0.0, 5.0, 5.0, 5.0, 0.0],
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
+                        [
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 5.0, 5.0, 5.0, 0.0],
+                            [0.0, 5.0, 5.0, 5.0, 0.0],
+                            [0.0, 5.0, 5.0, 5.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                        ]
                     ]
-                ]
-            ],
-            device=device,
-            dtype=dtype,
-        )
+                ],
+                device=device,
+                dtype=dtype,
+            )
 
-        expected_valid = torch.tensor(
-            [[[[5.0, 5.0, 5.0], [5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]]], device=device, dtype=dtype
-        )
-
-        actual = kornia.filters.filter2d(input, kernel, padding=padding)
-        if padding == 'same':
-            assert_close(actual, expected_same)
+            self.assert_close(actual, expected_same)
         else:
-            assert_close(actual, expected_valid)
+            expected_valid = torch.tensor(
+                [[[[5.0, 5.0, 5.0], [5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]]], device=device, dtype=dtype
+            )
+
+            self.assert_close(actual, expected_valid)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_mean_filter_2batch_2ch(self, padding, device, dtype):
@@ -99,35 +125,35 @@ class TestFilter2D:
             dtype=dtype,
         ).expand(2, 2, -1, -1)
 
-        expected_same = torch.tensor(
-            [
+        actual = filter2d(input, kernel, padding=padding)
+
+        if padding == 'same':
+            expected_same = torch.tensor(
                 [
                     [
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, 5.0, 5.0, 5.0, 0.0],
-                        [0.0, 5.0, 5.0, 5.0, 0.0],
-                        [0.0, 5.0, 5.0, 5.0, 0.0],
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
+                        [
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 5.0, 5.0, 5.0, 0.0],
+                            [0.0, 5.0, 5.0, 5.0, 0.0],
+                            [0.0, 5.0, 5.0, 5.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                        ]
                     ]
-                ]
-            ],
-            device=device,
-            dtype=dtype,
-        ).expand(2, 2, -1, -1)
+                ],
+                device=device,
+                dtype=dtype,
+            ).expand(2, 2, -1, -1)
 
-        expected_valid = torch.tensor(
-            [[[[5.0, 5.0, 5.0], [5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]]], device=device, dtype=dtype
-        ).expand(2, 2, -1, -1)
-
-        actual = kornia.filters.filter2d(input, kernel, padding=padding)
-        if padding == 'same':
-            assert_close(actual, expected_same)
+            self.assert_close(actual, expected_same)
         else:
-            assert_close(actual, expected_valid)
+            expected_valid = torch.tensor(
+                [[[[5.0, 5.0, 5.0], [5.0, 5.0, 5.0], [5.0, 5.0, 5.0]]]], device=device, dtype=dtype
+            ).expand(2, 2, -1, -1)
+            self.assert_close(actual, expected_valid)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_normalized_mean_filter(self, padding, device, dtype):
-        kernel = torch.ones(1, 3, 3).to(device)
+        kernel = torch.ones(1, 3, 3, device=device, dtype=dtype)
         input = torch.tensor(
             [
                 [
@@ -145,33 +171,32 @@ class TestFilter2D:
         ).expand(2, 2, -1, -1)
 
         nv: float = 5.0 / 9  # normalization value
-        expected_same = torch.tensor(
-            [
+        actual = filter2d(input, kernel, normalized=True, padding=padding)
+
+        if padding == 'same':
+            expected_same = torch.tensor(
                 [
                     [
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, nv, nv, nv, 0.0],
-                        [0.0, nv, nv, nv, 0.0],
-                        [0.0, nv, nv, nv, 0.0],
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
+                        [
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, nv, nv, nv, 0.0],
+                            [0.0, nv, nv, nv, 0.0],
+                            [0.0, nv, nv, nv, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                        ]
                     ]
-                ]
-            ],
-            device=device,
-            dtype=dtype,
-        ).expand(2, 2, -1, -1)
+                ],
+                device=device,
+                dtype=dtype,
+            ).expand(2, 2, -1, -1)
 
-        expected_valid = torch.tensor(
-            [[[[nv, nv, nv], [nv, nv, nv], [nv, nv, nv]]]], device=device, dtype=dtype
-        ).expand(2, 2, -1, -1)
-
-        actual = kornia.filters.filter2d(input, kernel, normalized=True, padding=padding)
-
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        if padding == 'same':
-            assert_close(actual, expected_same, rtol=tol_val, atol=tol_val)
+            self.assert_close(actual, expected_same)
         else:
-            assert_close(actual, expected_valid, rtol=tol_val, atol=tol_val)
+            expected_valid = torch.tensor(
+                [[[[nv, nv, nv], [nv, nv, nv], [nv, nv, nv]]]], device=device, dtype=dtype
+            ).expand(2, 2, -1, -1)
+
+            self.assert_close(actual, expected_valid)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_even_sized_filter(self, padding, device, dtype):
@@ -192,33 +217,34 @@ class TestFilter2D:
             dtype=dtype,
         )
 
-        expected_same = torch.tensor(
-            [
+        actual = filter2d(input, kernel, padding=padding)
+
+        if padding == 'same':
+            expected_same = torch.tensor(
                 [
                     [
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, 5.0, 5.0, 0.0, 0.0],
-                        [0.0, 5.0, 5.0, 0.0, 0.0],
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, 0.0, 0.0, 0.0, 0.0],
+                        [
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 5.0, 5.0, 0.0, 0.0],
+                            [0.0, 5.0, 5.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0, 0.0],
+                        ]
                     ]
-                ]
-            ],
-            device=device,
-            dtype=dtype,
-        )
+                ],
+                device=device,
+                dtype=dtype,
+            )
 
-        expected_valid = torch.tensor(
-            [[[[0.0, 0.0, 0.0, 0.0], [0.0, 5.0, 5.0, 0.0], [0.0, 5.0, 5.0, 0.0], [0.0, 0.0, 0.0, 0.0]]]],
-            device=device,
-            dtype=dtype,
-        )
-
-        actual = kornia.filters.filter2d(input, kernel, padding=padding)
-        if padding == 'same':
-            assert_close(actual, expected_same)
+            self.assert_close(actual, expected_same)
         else:
-            assert_close(actual, expected_valid)
+            expected_valid = torch.tensor(
+                [[[[0.0, 0.0, 0.0, 0.0], [0.0, 5.0, 5.0, 0.0], [0.0, 5.0, 5.0, 0.0], [0.0, 0.0, 0.0, 0.0]]]],
+                device=device,
+                dtype=dtype,
+            )
+
+            self.assert_close(actual, expected_valid)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_mix_sized_filter_padding_same(self, padding, device, dtype):
@@ -255,8 +281,8 @@ class TestFilter2D:
             dtype=dtype,
         )
 
-        actual = kornia.filters.filter2d(input_, kernel, padding='same', border_type='constant')
-        assert_close(actual, expected_same)
+        actual = filter2d(input_, kernel, padding='same', border_type='constant')
+        self.assert_close(actual, expected_same)
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_noncontiguous(self, padding, device, dtype):
@@ -264,8 +290,8 @@ class TestFilter2D:
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
         kernel = torch.ones(1, 2, 2, device=device, dtype=dtype)
 
-        actual = kornia.filters.filter2d(inp, kernel, padding=padding)
-        assert_close(actual, actual)
+        actual = filter2d(inp, kernel, padding=padding)
+        assert actual.is_contiguous()
 
     @pytest.mark.parametrize("padding", ["same", "valid"])
     def test_separable(self, padding, device, dtype):
@@ -274,34 +300,76 @@ class TestFilter2D:
         kernel_x = torch.ones(1, 3, device=device, dtype=dtype)
         kernel_y = torch.ones(1, 3, device=device, dtype=dtype)
         kernel = kernel_y.t() @ kernel_x
-        out = kornia.filters.filter2d(inp, kernel[None], padding=padding)
-        out_sep = kornia.filters.filter2d_separable(inp, kernel_x, kernel_y, padding=padding)
-        assert_close(out, out_sep)
+        out = filter2d(inp, kernel[None], padding=padding)
+        out_sep = filter2d_separable(inp, kernel_x, kernel_y, padding=padding)
+        self.assert_close(out, out_sep)
 
     def test_gradcheck(self, device):
         kernel = torch.rand(1, 3, 3, device=device)
         input = torch.ones(1, 1, 7, 8, device=device)
 
         # evaluate function gradient
-        input = utils.tensor_to_gradcheck_var(input)  # to var
-        kernel = utils.tensor_to_gradcheck_var(kernel)  # to var
-        assert gradcheck(
-            kornia.filters.filter2d, (input, kernel), nondet_tol=1e-8, raise_exception=True, fast_mode=True
-        )
+        input = tensor_to_gradcheck_var(input)  # to var
+        kernel = tensor_to_gradcheck_var(kernel)  # to var
+        self.gradcheck(filter2d, (input, kernel), nondet_tol=1e-8)
+
+    @pytest.mark.skip(reason='filter2d do not have a module')
+    def test_module(self):
+        ...
+
+    @pytest.mark.parametrize("normalized", [True, False])
+    @pytest.mark.parametrize("padding", ["same", "valid"])
+    def test_dynamo(self, normalized, padding, device, dtype, torch_optimizer):
+        kernel = torch.rand(1, 3, 3, device=device, dtype=dtype)
+        inpt = torch.ones(2, 3, 10, 10, device=device, dtype=dtype)
+        op = filter2d
+        op_optimized = torch_optimizer(op)
+
+        expected = op(inpt, kernel, padding=padding, normalized=normalized)
+        actual = op_optimized(inpt, kernel, padding=padding, normalized=normalized)
+
+        self.assert_close(actual, expected)
 
 
-class TestFilter3D:
-    def test_smoke(self, device, dtype):
-        kernel = torch.rand(1, 3, 3, 3).to(device)
-        input = torch.ones(1, 1, 6, 7, 8).to(device)
-        assert kornia.filters.filter3d(input, kernel).shape == input.shape
+class TestFilter3D(BaseTester):
+    @pytest.mark.parametrize("border_type", ['constant', 'reflect', 'replicate', 'circular'])
+    @pytest.mark.parametrize("normalized", [True, False])
+    def test_smoke(self, border_type, normalized, device, dtype):
+        kernel = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
+        inpt = torch.ones(1, 1, 6, 7, 8, device=device, dtype=dtype)
+        actual = filter3d(inpt, kernel, border_type, normalized)
+
+        assert isinstance(actual, torch.Tensor)
+        assert actual.shape == inpt.shape
 
     @pytest.mark.parametrize("batch_size", [2, 3, 6, 8])
-    def test_batch(self, batch_size, device, dtype):
-        B: int = batch_size
+    def test_cardinality(self, batch_size, device, dtype):
         kernel = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
-        input = torch.ones(B, 3, 6, 7, 8, device=device, dtype=dtype)
-        assert kornia.filters.filter3d(input, kernel).shape == input.shape
+        inpt = torch.ones(batch_size, 3, 6, 7, 8, device=device, dtype=dtype)
+        assert filter3d(inpt, kernel).shape == inpt.shape
+
+    def test_exception(self):
+        k = torch.ones(1, 1, 1, 1)
+        inpt = torch.ones(1, 1, 1, 1, 1)
+        with pytest.raises(TypeError) as errinfo:
+            filter3d(1, k)
+        assert 'Not a Tensor type.' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            filter3d(inpt, 1)
+        assert 'Not a Tensor type.' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            filter3d(torch.ones(1), k)
+        assert 'shape must be [[\'B\', \'C\', \'D\', \'H\', \'W\']]' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            filter3d(inpt, torch.ones(1))
+        assert 'shape must be [[\'B\', \'D\', \'H\', \'W\']]' in str(errinfo)
+
+        with pytest.raises(Exception) as errinfo:
+            filter3d(inpt, k, border_type='a')
+        assert 'Invalid border, gotcha a. Ex' in str(errinfo)
 
     def test_mean_filter(self, device, dtype):
         kernel = torch.ones(1, 3, 3, 3, device=device, dtype=dtype)
@@ -369,8 +437,8 @@ class TestFilter3D:
             dtype=dtype,
         )
 
-        actual = kornia.filters.filter3d(input, kernel)
-        assert_close(actual, expected)
+        actual = filter3d(input, kernel)
+        self.assert_close(actual, expected)
 
     def test_mean_filter_2batch_2ch(self, device, dtype):
         kernel = torch.ones(1, 3, 3, 3, device=device, dtype=dtype)
@@ -440,8 +508,8 @@ class TestFilter3D:
         )
         expected = expected.expand(2, 2, -1, -1, -1)
 
-        actual = kornia.filters.filter3d(input, kernel)
-        assert_close(actual, expected)
+        actual = filter3d(input, kernel)
+        self.assert_close(actual, expected)
 
     def test_normalized_mean_filter(self, device, dtype):
         kernel = torch.ones(1, 3, 3, 3, device=device, dtype=dtype)
@@ -512,10 +580,9 @@ class TestFilter3D:
         )
         expected = expected.expand(2, 2, -1, -1, -1)
 
-        actual = kornia.filters.filter3d(input, kernel, normalized=True)
+        actual = filter3d(input, kernel, normalized=True)
 
-        tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
-        assert_close(actual, expected, rtol=tol_val, atol=tol_val)
+        self.assert_close(actual, expected)
 
     def test_even_sized_filter(self, device, dtype):
         kernel = torch.ones(1, 2, 2, 2, device=device, dtype=dtype)
@@ -583,41 +650,54 @@ class TestFilter3D:
             dtype=dtype,
         )
 
-        actual = kornia.filters.filter3d(input, kernel)
-        assert_close(actual, expected)
+        actual = filter3d(input, kernel)
+        self.assert_close(actual, expected)
 
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
         inp = torch.rand(3, 5, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1, -1)
         kernel = torch.ones(1, 2, 2, 2, device=device, dtype=dtype)
 
-        actual = kornia.filters.filter3d(inp, kernel)
-        expected = actual
-        assert_close(actual, expected)
+        actual = filter3d(inp, kernel)
+        assert actual.is_contiguous()
 
     def test_gradcheck(self, device):
         kernel = torch.rand(1, 3, 3, 3, device=device)
         input = torch.ones(1, 1, 6, 7, 8, device=device)
 
         # evaluate function gradient
-        input = utils.tensor_to_gradcheck_var(input)  # to var
-        kernel = utils.tensor_to_gradcheck_var(kernel)  # to var
-        assert gradcheck(
-            kornia.filters.filter3d, (input, kernel), nondet_tol=1e-8, raise_exception=True, fast_mode=True
-        )
+        input = tensor_to_gradcheck_var(input)  # to var
+        kernel = tensor_to_gradcheck_var(kernel)  # to var
+        self.gradcheck(filter3d, (input, kernel), nondet_tol=1e-8)
+
+    @pytest.mark.skip(reason='filter3d do not have a module')
+    def test_module(self):
+        ...
+
+    @pytest.mark.parametrize("normalized", [True, False])
+    def test_dynamo(self, normalized, device, dtype, torch_optimizer):
+        kernel = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
+        inpt = torch.ones(2, 3, 4, 10, 10, device=device, dtype=dtype)
+        op = filter3d
+        op_optimized = torch_optimizer(op)
+
+        expected = op(inpt, kernel, normalized=normalized)
+        actual = op_optimized(inpt, kernel, normalized=normalized)
+
+        self.assert_close(actual, expected)
 
 
 class TestDexiNed:
     def test_smoke(self, device, dtype):
-        img = torch.rand(2, 3, 64, 64, device=device, dtype=dtype)
-        net = kornia.filters.DexiNed(pretrained=False).to(device, dtype)
+        img = torch.rand(2, 3, 32, 32, device=device, dtype=dtype)
+        net = DexiNed(pretrained=False).to(device, dtype)
         out = net(img)
         assert len(out) == 7
-        assert out[-1].shape == (2, 1, 64, 64)
+        assert out[-1].shape == (2, 1, 32, 32)
 
     @pytest.mark.parametrize("data", ["dexined"], indirect=True)
     def test_inference(self, device, dtype, data):
-        model = kornia.filters.DexiNed(pretrained=False)
+        model = DexiNed(pretrained=False)
         model.load_state_dict(data, strict=True)
         model = model.to(device, dtype)
         model.eval()
@@ -633,3 +713,15 @@ class TestDexiNed:
 
         out = model(img)[-1]
         assert_close(out, expect, atol=3e-4, rtol=3e-4)
+
+    @pytest.mark.skip(reason='DexiNed do not compile with dynamo.')
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        # TODO: update the dexined to be possible to use with dynamo
+        inpt = torch.rand(2, 3, 32, 32, device=device, dtype=dtype)
+        op = DexiNed(pretrained=True).to(device, dtype)
+        op_optimized = torch_optimizer(op)
+
+        expected = op(inpt)
+        actual = op_optimized(inpt)
+
+        assert_close(actual, expected)

--- a/test/filters/test_filters.py
+++ b/test/filters/test_filters.py
@@ -3,6 +3,7 @@ import torch
 
 from kornia.filters import DexiNed, filter2d, filter2d_separable, filter3d
 from kornia.testing import BaseTester, assert_close, tensor_to_gradcheck_var
+from kornia.utils._compat import torch_version_le
 
 
 class TestFilter2D(BaseTester):
@@ -335,6 +336,9 @@ class TestFilter3D(BaseTester):
     @pytest.mark.parametrize("border_type", ['constant', 'reflect', 'replicate', 'circular'])
     @pytest.mark.parametrize("normalized", [True, False])
     def test_smoke(self, border_type, normalized, device, dtype):
+        if torch_version_le(1, 9, 1) and border_type == 'reflect':
+            pytest.skip(reason='Reflect border is not implemented for 3D on torch < 1.9.1')
+
         kernel = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
         inpt = torch.ones(1, 1, 6, 7, 8, device=device, dtype=dtype)
         actual = filter3d(inpt, kernel, border_type, normalized)

--- a/test/filters/test_gaussian.py
+++ b/test/filters/test_gaussian.py
@@ -4,13 +4,18 @@ from torch.autograd import gradcheck
 
 import kornia
 import kornia.testing as utils  # test utils
-from kornia.filters.kernels import get_gaussian_kernel1d, get_gaussian_kernel2d, get_gaussian_kernel3d
+from kornia.filters.kernels import (
+    get_gaussian_erf_kernel1d,
+    get_gaussian_kernel1d,
+    get_gaussian_kernel2d,
+    get_gaussian_kernel3d,
+)
 from kornia.testing import assert_close
 
 
 @pytest.mark.parametrize("window_size", [5, 11])
 @pytest.mark.parametrize("sigma", [1.5, 5.0])
-def test_get_gaussian_kernel_float(window_size, sigma, device, dtype):
+def test_get_gaussian_kernel1d_float(window_size, sigma, device, dtype):
     actual = get_gaussian_kernel1d(window_size, sigma, device=device, dtype=dtype)
     expected = torch.ones(1, device=device, dtype=dtype)
 
@@ -20,7 +25,7 @@ def test_get_gaussian_kernel_float(window_size, sigma, device, dtype):
 
 @pytest.mark.parametrize("window_size", [5, 11])
 @pytest.mark.parametrize("sigma", [[[1.5]], [[1.5], [5.0]], [[1.5], [5.0]]])
-def test_get_gaussian_kernel_tensor(window_size, sigma, device, dtype):
+def test_get_gaussian_kernel1d_tensor(window_size, sigma, device, dtype):
     sigma = torch.tensor(sigma, device=device, dtype=dtype)
     bs = sigma.shape[0]
 
@@ -83,6 +88,32 @@ def test_get_gaussian_kernel3d_tensor(ksize_x, ksize_y, ksize_z, sigma, device, 
 
     assert actual.shape == (bs, ksize_x, ksize_y, ksize_z)
     assert_close(actual.sum(), expected.sum())
+
+
+@pytest.mark.parametrize("window_size", [5, 11])
+@pytest.mark.parametrize("sigma", [1.5, 5.0])
+def test_get_discrete_gaussian_erf_kernel1d_float(window_size, sigma, device, dtype):
+    actual = get_gaussian_erf_kernel1d(window_size, sigma, device=device, dtype=dtype)
+    expected = torch.ones(1, device=device, dtype=dtype)
+
+    assert actual.shape == (1, window_size)
+    assert_close(actual.sum(), expected.sum())
+
+
+@pytest.mark.parametrize("window_size", [5, 11])
+@pytest.mark.parametrize("sigma", [[[1.5]], [[1.5], [5.0]], [[1.5], [5.0]]])
+def test_get_discrete_gaussian_erf_kernel1d_tensor(window_size, sigma, device, dtype):
+    sigma = torch.tensor(sigma, device=device, dtype=dtype)
+    bs = sigma.shape[0]
+
+    actual = get_gaussian_erf_kernel1d(window_size, sigma)
+    expected = torch.ones(bs, device=device, dtype=dtype)
+
+    assert actual.shape == (bs, window_size)
+    assert_close(actual.sum(), expected.sum())
+
+
+# -----------------------------------------------------
 
 
 @pytest.mark.parametrize("window_size", [5, 11])

--- a/test/filters/test_gaussian.py
+++ b/test/filters/test_gaussian.py
@@ -165,18 +165,17 @@ class TestGaussianBlur2d(BaseTester):
     @pytest.mark.parametrize("shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
     @pytest.mark.parametrize("kernel_size", [3, (5, 5), (5, 7)])
     @pytest.mark.parametrize("separable", [False, True])
-    @pytest.mark.parametrize("border_type", ['constant', 'reflect', 'replicate', 'circular'])
-    def test_smoke(self, shape, kernel_size, separable, border_type, device, dtype):
+    def test_smoke(self, shape, kernel_size, separable, device, dtype):
         B, C, H, W = shape
         inpt = torch.rand(B, C, H, W, device=device, dtype=dtype)
         sigma_tensor = torch.rand(B, 2, device=device, dtype=dtype)
 
-        actual_A = gaussian_blur2d(inpt, kernel_size, sigma_tensor, border_type, separable)
+        actual_A = gaussian_blur2d(inpt, kernel_size, sigma_tensor, 'reflect', separable)
         assert isinstance(actual_A, torch.Tensor)
         assert actual_A.shape == shape
 
         sigma = tuple(sigma_tensor[0, ...].cpu().numpy().tolist())
-        actual_B = gaussian_blur2d(inpt, kernel_size, sigma, border_type, separable)
+        actual_B = gaussian_blur2d(inpt, kernel_size, sigma, 'reflect', separable)
         assert isinstance(actual_B, torch.Tensor)
         assert actual_B.shape == shape
 

--- a/test/filters/test_hanning.py
+++ b/test/filters/test_hanning.py
@@ -1,13 +1,13 @@
 import pytest
 import torch
 
-import kornia
+from kornia.filters import get_hanning_kernel1d, get_hanning_kernel2d
 from kornia.testing import assert_close
 
 
 @pytest.mark.parametrize("window_size", [5, 11])
 def test_get_hanning_kernel(window_size, device, dtype):
-    kernel = kornia.filters.get_hanning_kernel1d(window_size, dtype=dtype, device=device)
+    kernel = get_hanning_kernel1d(window_size, dtype=dtype, device=device)
     assert kernel.shape == (window_size,)
     assert kernel.max().item() == pytest.approx(1.0)
 
@@ -15,20 +15,20 @@ def test_get_hanning_kernel(window_size, device, dtype):
 @pytest.mark.parametrize("ksize_x", [5, 11])
 @pytest.mark.parametrize("ksize_y", [3, 7])
 def test_get_hanning_kernel2d(ksize_x, ksize_y, device, dtype):
-    kernel = kornia.filters.get_hanning_kernel2d((ksize_x, ksize_y), dtype=dtype, device=device)
+    kernel = get_hanning_kernel2d((ksize_x, ksize_y), dtype=dtype, device=device)
     assert kernel.shape == (ksize_x, ksize_y)
     assert kernel.max().item() == pytest.approx(1.0)
 
 
 def test_get_hanning_kernel1d_5(device, dtype):
-    kernel = kornia.filters.get_hanning_kernel1d(5, dtype=dtype, device=device)
+    kernel = get_hanning_kernel1d(5, dtype=dtype, device=device)
     expected = torch.tensor([0, 0.5, 1.0, 0.5, 0], dtype=dtype, device=device)
     assert kernel.shape == (5,)
     assert_close(kernel, expected)
 
 
 def test_get_hanning_kernel2d_3x4(device, dtype):
-    kernel = kornia.filters.get_hanning_kernel2d((3, 4), dtype=dtype, device=device)
+    kernel = get_hanning_kernel2d((3, 4), dtype=dtype, device=device)
     expected = torch.tensor(
         [[0.0, 0.00, 0.00, 0.0], [0.0, 0.75, 0.75, 0.0], [0.0, 0.00, 0.00, 0.0]], dtype=dtype, device=device
     )

--- a/test/filters/test_laplacian.py
+++ b/test/filters/test_laplacian.py
@@ -17,7 +17,7 @@ def test_get_laplacian_kernel1d(window_size, device, dtype):
     assert_close(actual.sum(), expected.sum())
 
 
-@pytest.mark.parametrize("window_size", [5, 11, (7, 8)])
+@pytest.mark.parametrize("window_size", [5, 11, (3, 3)])
 def test_get_laplacian_kernel2d(window_size, device, dtype):
     actual = get_laplacian_kernel2d(window_size, device=device, dtype=dtype)
     expected = torch.zeros(1, device=device, dtype=dtype)

--- a/test/filters/test_laplacian.py
+++ b/test/filters/test_laplacian.py
@@ -51,11 +51,10 @@ def test_get_laplacian_kernel2d_exact(device, dtype):
 class TestLaplacian(BaseTester):
     @pytest.mark.parametrize("shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
     @pytest.mark.parametrize("kernel_size", [5, (11, 7), (3, 3)])
-    @pytest.mark.parametrize('border_type', ['constant', 'reflect', 'replicate', 'circular'])
     @pytest.mark.parametrize("normalized", [True, False])
-    def test_smoke(self, shape, kernel_size, border_type, normalized, device, dtype):
+    def test_smoke(self, shape, kernel_size, normalized, device, dtype):
         inpt = torch.rand(shape, device=device, dtype=dtype)
-        actual = laplacian(inpt, kernel_size, border_type, normalized)
+        actual = laplacian(inpt, kernel_size, 'reflect', normalized)
         assert isinstance(actual, torch.Tensor)
         assert actual.shape == shape
 

--- a/test/filters/test_laplacian.py
+++ b/test/filters/test_laplacian.py
@@ -28,7 +28,8 @@ def test_get_laplacian_kernel2d(window_size):
             [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
             [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
-        ]
+        ],
+        device=kernel.device,
     )
     assert_close(expected, kernel)
 
@@ -59,14 +60,6 @@ class TestLaplacian:
         input = torch.rand(batch_shape, device=device, dtype=dtype)
         input = utils.tensor_to_gradcheck_var(input)
         assert gradcheck(kornia.filters.laplacian, (input, kernel_size), raise_exception=True, fast_mode=True)
-
-    def test_jit(self, device, dtype):
-        op = kornia.filters.laplacian
-        op_script = torch.jit.script(op)
-        params = [3]
-
-        img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
-        assert_close(op(img, *params), op_script(img, *params))
 
     def test_module(self, device, dtype):
         params = [3]

--- a/test/filters/test_median.py
+++ b/test/filters/test_median.py
@@ -1,19 +1,31 @@
+import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.filters import MedianBlur, median_blur
+from kornia.testing import BaseTester, tensor_to_gradcheck_var
 
 
-class TestMedianBlur:
-    def test_shape(self, device, dtype):
+class TestMedianBlur(BaseTester):
+    def test_smoke(self, device, dtype):
         inp = torch.zeros(1, 3, 4, 4, device=device, dtype=dtype)
-        assert kornia.filters.median_blur(inp, (3, 3)).shape == (1, 3, 4, 4)
+        actual = median_blur(inp, 3)
+        assert isinstance(actual, torch.Tensor)
 
-    def test_shape_batch(self, device, dtype):
-        inp = torch.zeros(2, 6, 4, 4, device=device, dtype=dtype)
-        assert kornia.filters.median_blur(inp, (3, 3)).shape == (2, 6, 4, 4)
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('kernel_size', [3, (5, 7)])
+    def test_cardinality(self, batch_size, kernel_size, device, dtype):
+        inp = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)
+        actual = median_blur(inp, kernel_size)
+        assert actual.shape == (batch_size, 3, 4, 4)
+
+    def test_exception(self, device, dtype):
+        with pytest.raises(TypeError) as errinfo:
+            median_blur(1, 1)
+        assert 'Not a Tensor type.' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            median_blur(torch.ones(1, 1, device=device, dtype=dtype), 1)
+        assert 'shape must be [[\'B\', \'C\', \'H\', \'W\']].' in str(errinfo)
 
     def test_kernel_3x3(self, device, dtype):
         inp = torch.tensor(
@@ -38,29 +50,38 @@ class TestMedianBlur:
         ).repeat(2, 1, 1, 1)
 
         kernel_size = (3, 3)
-        actual = kornia.filters.median_blur(inp, kernel_size)
-        assert_close(actual[0, 0, 2, 2], torch.tensor(3.0, device=device, dtype=dtype))
-        assert_close(actual[0, 1, 1, 1], torch.tensor(14.0, device=device, dtype=dtype))
+        actual = median_blur(inp, kernel_size)
+        self.assert_close(actual[0, 0, 2, 2], torch.tensor(3.0, device=device, dtype=dtype))
+        self.assert_close(actual[0, 1, 1, 1], torch.tensor(14.0, device=device, dtype=dtype))
 
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
 
         kernel_size = (3, 3)
-        actual = kornia.filters.median_blur(inp, kernel_size)
-        assert_close(actual, actual)
+        actual = median_blur(inp, kernel_size)
+        assert actual.is_contiguous()
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 2, 5, 4
-        img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.median_blur, (img, (5, 3)), raise_exception=True, fast_mode=True)
+        img = torch.rand(batch_size, channels, height, width, device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        self.gradcheck(median_blur, (img, (5, 3)))
 
     def test_module(self, device, dtype):
         kernel_size = (3, 5)
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.median_blur
-        op_module = kornia.filters.MedianBlur((3, 5))
+        op = median_blur
+        op_module = MedianBlur((3, 5))
         actual = op_module(img)
         expected = op(img, kernel_size)
-        assert_close(actual, expected)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize('kernel_size', [5, (5, 7)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, kernel_size, device, dtype, torch_optimizer):
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        op = MedianBlur(kernel_size)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))

--- a/test/filters/test_median.py
+++ b/test/filters/test_median.py
@@ -39,8 +39,8 @@ class TestMedianBlur:
 
         kernel_size = (3, 3)
         actual = kornia.filters.median_blur(inp, kernel_size)
-        assert_close(actual[0, 0, 2, 2], torch.tensor(3.0).to(actual))
-        assert_close(actual[0, 1, 1, 1], torch.tensor(14.0).to(actual))
+        assert_close(actual[0, 0, 2, 2], torch.tensor(3.0, device=device, dtype=dtype))
+        assert_close(actual[0, 1, 1, 1], torch.tensor(14.0, device=device, dtype=dtype))
 
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
@@ -55,15 +55,6 @@ class TestMedianBlur:
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.median_blur, (img, (5, 3)), raise_exception=True, fast_mode=True)
-
-    def test_jit(self, device, dtype):
-        kernel_size = (3, 5)
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.median_blur
-        op_script = torch.jit.script(op)
-        actual = op_script(img, kernel_size)
-        expected = op(img, kernel_size)
-        assert_close(actual, expected)
 
     def test_module(self, device, dtype):
         kernel_size = (3, 5)

--- a/test/filters/test_motion.py
+++ b/test/filters/test_motion.py
@@ -1,37 +1,68 @@
 import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
-
-
-@pytest.mark.parametrize("batch_size", [0, 1, 5])
-@pytest.mark.parametrize("ksize", [3, 11])
-@pytest.mark.parametrize("angle", [0.0, 360.0])
-@pytest.mark.parametrize("direction", [-1.0, 1.0])
-def test_get_motion_kernel2d(batch_size, ksize, angle, direction):
-    if batch_size != 0:
-        angle = torch.tensor([angle] * batch_size)
-        direction = torch.tensor([direction] * batch_size)
-    else:
-        batch_size = 1
-    kernel = kornia.filters.kernels_geometry.get_motion_kernel2d(ksize, angle, direction)
-    assert kernel.shape == (batch_size, ksize, ksize)
-    assert kernel.sum().item() == pytest.approx(batch_size)
+from kornia.filters import (
+    MotionBlur,
+    MotionBlur3D,
+    get_motion_kernel2d,
+    get_motion_kernel3d,
+    motion_blur,
+    motion_blur3d,
+)
+from kornia.testing import BaseTester, tensor_to_gradcheck_var
 
 
-class TestMotionBlur:
-    @pytest.mark.parametrize("batch_shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
-    def test_motion_blur(self, batch_shape, device, dtype):
+class TestMotionBlur(BaseTester):
+    @pytest.mark.parametrize("shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
+    @pytest.mark.parametrize("kernel_size", [3, 5])
+    @pytest.mark.parametrize("angle", [36.0, 200.0])
+    @pytest.mark.parametrize("direction", [-0.9, 0.0, 0.9])
+    @pytest.mark.parametrize("mode", ['bilinear', 'nearest'])
+    @pytest.mark.parametrize("params_as_tensor", [True, False])
+    def test_smoke(self, shape, kernel_size, angle, direction, mode, params_as_tensor, device, dtype):
+        B, C, H, W = shape
+        inpt = torch.rand(shape, device=device, dtype=dtype)
+
+        if params_as_tensor is True:
+            angle = torch.tensor([angle], device=device, dtype=dtype).repeat(B)
+            direction = torch.tensor([direction], device=device, dtype=dtype).repeat(B)
+        actual = motion_blur(inpt, kernel_size, angle, direction, 'constant', mode)
+
+        assert isinstance(actual, torch.Tensor)
+        assert actual.shape == shape
+
+    @pytest.mark.parametrize("shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
+    def test_cardinality(self, shape, device, dtype):
         ksize = 5
         angle = 200.0
         direction = 0.3
 
-        input = torch.rand(batch_shape, device=device, dtype=dtype)
-        motion = kornia.filters.MotionBlur(ksize, angle, direction)
-        assert motion(input).shape == batch_shape
+        input = torch.rand(shape, device=device, dtype=dtype)
+        motion = MotionBlur(ksize, angle, direction)
+        assert motion(input).shape == shape
+
+    @pytest.mark.skip(reason='nothing to test')
+    def test_exception(self):
+        ...
+
+    @pytest.mark.parametrize("batch_size", [1, 3])
+    @pytest.mark.parametrize("ksize", [3, 11])
+    @pytest.mark.parametrize("angle", [0.0, 360.0])
+    @pytest.mark.parametrize("direction", [-1.0, 1.0])
+    @pytest.mark.parametrize("params_as_tensor", [True, False])
+    def test_get_motion_kernel2d(self, batch_size, ksize, angle, direction, params_as_tensor, device, dtype):
+        if params_as_tensor is True:
+            angle = torch.tensor([angle], device=device, dtype=dtype).repeat(batch_size)
+            direction = torch.tensor([direction], device=device, dtype=dtype).repeat(batch_size)
+        else:
+            batch_size = 1
+            device = None
+            dtype = None
+
+        actual = get_motion_kernel2d(ksize, angle, direction)
+        expected = torch.ones(1, device=device, dtype=dtype) * batch_size
+        assert actual.shape == (batch_size, ksize, ksize)
+        self.assert_close(actual.sum(), expected.sum())
 
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
@@ -40,21 +71,124 @@ class TestMotionBlur:
         kernel_size = 3
         angle = 200.0
         direction = 0.3
-        actual = kornia.filters.motion_blur(inp, kernel_size, angle, direction)
-        assert_close(actual, actual)
+        actual = motion_blur(inp, kernel_size, angle, direction)
+        assert actual.is_contiguous()
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         batch_shape = (1, 3, 4, 5)
         ksize = 9
         angle = 34.0
         direction = -0.2
 
-        input = torch.rand(batch_shape, device=device, dtype=dtype)
-        input = utils.tensor_to_gradcheck_var(input)
-        assert gradcheck(
-            kornia.filters.motion_blur,
-            (input, ksize, angle, direction, "replicate"),
-            nondet_tol=1e-8,
-            raise_exception=True,
-            fast_mode=True,
-        )
+        input = torch.rand(batch_shape, device=device)
+        input = tensor_to_gradcheck_var(input)
+        self.gradcheck(motion_blur, (input, ksize, angle, direction, "replicate"), nondet_tol=1e-8)
+
+    def test_module(self, device, dtype):
+        params = [3, 20.0, 0.5]
+        op = motion_blur
+        op_module = MotionBlur(*params)
+        img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
+
+        self.assert_close(op(img, *params), op_module(img))
+
+    @pytest.mark.skip(reason='After the op be optimized the results are not the same')
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, device, dtype, torch_optimizer):
+        # TODO: FIX op
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        op = MotionBlur(3, 36.0, 0.5)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))
+
+
+class TestMotionBlur3D(BaseTester):
+    @pytest.mark.parametrize("shape", [(1, 4, 3, 8, 15), (2, 2, 3, 11, 7)])
+    @pytest.mark.parametrize("kernel_size", [3, 5])
+    @pytest.mark.parametrize("angle", [(36.0, 15.0, 200.0), (200.0, 10.0, 150.0)])
+    @pytest.mark.parametrize("direction", [-0.9, 0.0, 0.9])
+    @pytest.mark.parametrize("mode", ['bilinear', 'nearest'])
+    @pytest.mark.parametrize("params_as_tensor", [True, False])
+    def test_smoke(self, shape, kernel_size, angle, direction, mode, params_as_tensor, device, dtype):
+        B, C, D, H, W = shape
+        inpt = torch.rand(shape, device=device, dtype=dtype)
+
+        if params_as_tensor is True:
+            angle = torch.tensor([angle], device=device, dtype=dtype).expand(B, 3)
+            direction = torch.tensor([direction], device=device, dtype=dtype).repeat(B)
+        actual = motion_blur3d(inpt, kernel_size, angle, direction, 'constant', mode)
+
+        assert isinstance(actual, torch.Tensor)
+        assert actual.shape == shape
+
+    @pytest.mark.parametrize("shape", [(1, 4, 1, 8, 15), (2, 3, 1, 11, 7)])
+    def test_cardinality(self, shape, device, dtype):
+        ksize = 5
+        angle = (200.0, 15.0, 120.0)
+        direction = 0.3
+
+        input = torch.rand(shape, device=device, dtype=dtype)
+        motion = MotionBlur3D(ksize, angle, direction)
+        assert motion(input).shape == shape
+
+    @pytest.mark.skip(reason='nothing to test')
+    def test_exception(self):
+        ...
+
+    @pytest.mark.parametrize("batch_size", [1, 3])
+    @pytest.mark.parametrize("ksize", [3, 11])
+    @pytest.mark.parametrize("angle", [(0.0, 360.0, 150.0)])
+    @pytest.mark.parametrize("direction", [-1.0, 1.0])
+    @pytest.mark.parametrize("params_as_tensor", [True, False])
+    def test_get_motion_kernel3d(self, batch_size, ksize, angle, direction, params_as_tensor, device, dtype):
+        if params_as_tensor is True:
+            angle = torch.tensor([angle], device=device, dtype=dtype).repeat(batch_size, 1)
+            direction = torch.tensor([direction], device=device, dtype=dtype).repeat(batch_size)
+        else:
+            batch_size = 1
+            device = None
+            dtype = None
+
+        actual = get_motion_kernel3d(ksize, angle, direction)
+        expected = torch.ones(1, device=device, dtype=dtype) * batch_size
+        assert actual.shape == (batch_size, ksize, ksize, ksize)
+        self.assert_close(actual.sum(), expected.sum())
+
+    def test_noncontiguous(self, device, dtype):
+        batch_size = 3
+        inp = torch.rand(3, 1, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1, -1)
+
+        kernel_size = 3
+        angle = (0.0, 360.0, 150.0)
+        direction = 0.3
+        actual = motion_blur3d(inp, kernel_size, angle, direction)
+        assert actual.is_contiguous()
+
+    def test_gradcheck(self, device):
+        batch_shape = (1, 3, 1, 4, 5)
+        ksize = 9
+        angle = (0.0, 360.0, 150.0)
+        direction = -0.2
+
+        input = torch.rand(batch_shape, device=device)
+        input = tensor_to_gradcheck_var(input)
+        self.gradcheck(motion_blur3d, (input, ksize, angle, direction, "replicate"), nondet_tol=1e-8)
+
+    def test_module(self, device, dtype):
+        params = [3, (0.0, 360.0, 150.0), 0.5]
+        op = motion_blur3d
+        op_module = MotionBlur3D(*params)
+        img = torch.ones(1, 3, 1, 5, 5, device=device, dtype=dtype)
+
+        self.assert_close(op(img, *params), op_module(img))
+
+    @pytest.mark.skip(reason='After the op be optimized the results are not the same')
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, device, dtype, torch_optimizer):
+        # TODO: Fix the operation to works after dynamo optimize
+        inpt = torch.ones(batch_size, 3, 1, 10, 10, device=device, dtype=dtype)
+        op = MotionBlur3D(3, (0.0, 360.0, 150.0), 0.5)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))

--- a/test/filters/test_motion.py
+++ b/test/filters/test_motion.py
@@ -58,15 +58,3 @@ class TestMotionBlur:
             raise_exception=True,
             fast_mode=True,
         )
-
-    @pytest.mark.skip("angle can be Union")
-    def test_jit(self, device, dtype):
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        ksize = 5
-        angle = 65.0
-        direction = 0.1
-        op = kornia.filters.motion_blur
-        op_script = torch.jit.script(op)
-        actual = op_script(img, ksize, angle, direction)
-        expected = op(img, ksize, angle, direction)
-        assert_close(actual, expected)

--- a/test/filters/test_sobel.py
+++ b/test/filters/test_sobel.py
@@ -362,15 +362,6 @@ class TestSpatialGradient3d:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.spatial_gradient3d, (img,), raise_exception=True)
 
-    @pytest.mark.skip("issue with device in kernel generation")
-    def test_jit(self, device, dtype):
-        img = torch.rand(2, 3, 1, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.spatial_gradient3d
-        op_script = torch.jit.script(op)
-        expected = op(img)
-        actual = op_script(img)
-        assert_close(actual, expected)
-
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 1, 4, 5, device=device, dtype=dtype)
         op = kornia.filters.spatial_gradient3d
@@ -453,15 +444,6 @@ class TestSobel:
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.sobel, (img, True), raise_exception=True, fast_mode=True)
-
-    @pytest.mark.skip(reason="`kornia.utils.get_cuda_device_if_available` is not jittable")
-    def test_jit(self, device, dtype):
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.sobel
-        op_script = torch.jit.script(op)
-        expected = op(img)
-        actual = op_script(img)
-        assert_close(actual, expected)
 
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)

--- a/test/filters/test_sobel.py
+++ b/test/filters/test_sobel.py
@@ -1,22 +1,33 @@
 import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.filters import Sobel, SpatialGradient, SpatialGradient3d, sobel, spatial_gradient, spatial_gradient3d
+from kornia.testing import BaseTester, tensor_to_gradcheck_var
 
 
-class TestSpatialGradient:
-    def test_shape(self, device, dtype):
-        inp = torch.zeros(1, 3, 4, 4, device=device, dtype=dtype)
-        sobel = kornia.filters.SpatialGradient()
-        assert sobel(inp).shape == (1, 3, 2, 4, 4)
+class TestSpatialGradient(BaseTester):
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('mode', ['sobel', 'diff'])
+    @pytest.mark.parametrize('order', [1, 2])
+    @pytest.mark.parametrize('normalized', [True, False])
+    def test_smoke(self, batch_size, mode, order, normalized, device, dtype):
+        inpt = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)
+        actual = SpatialGradient(mode, order, normalized)(inpt)
+        assert isinstance(actual, torch.Tensor)
 
-    def test_shape_batch(self, device, dtype):
-        inp = torch.zeros(2, 6, 4, 4, device=device, dtype=dtype)
-        sobel = kornia.filters.SpatialGradient()
-        assert sobel(inp).shape == (2, 6, 2, 4, 4)
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_cardinality(self, batch_size, device, dtype):
+        inp = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)
+        assert SpatialGradient()(inp).shape == (batch_size, 3, 2, 4, 4)
+
+    def test_exception(self):
+        with pytest.raises(TypeError) as errinfo:
+            spatial_gradient(1)
+        assert 'Not a Tensor type' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            spatial_gradient(torch.zeros(1))
+        assert 'shape must be [[\'B\', \'C\', \'H\', \'W\']]' in str(errinfo)
 
     def test_edges(self, device, dtype):
         inp = torch.tensor(
@@ -60,8 +71,8 @@ class TestSpatialGradient:
             dtype=dtype,
         )
 
-        edges = kornia.filters.spatial_gradient(inp, normalized=False)
-        assert_close(edges, expected)
+        edges = spatial_gradient(inp, normalized=False)
+        self.assert_close(edges, expected)
 
     def test_edges_norm(self, device, dtype):
         inp = torch.tensor(
@@ -108,8 +119,8 @@ class TestSpatialGradient:
             / 8.0
         )
 
-        edges = kornia.filters.spatial_gradient(inp, normalized=True)
-        assert_close(edges, expected)
+        edges = spatial_gradient(inp, normalized=True)
+        self.assert_close(edges, expected)
 
     def test_edges_sep(self, device, dtype):
         inp = torch.tensor(
@@ -153,8 +164,8 @@ class TestSpatialGradient:
             dtype=dtype,
         )
 
-        edges = kornia.filters.spatial_gradient(inp, 'diff', normalized=False)
-        assert_close(edges, expected)
+        edges = spatial_gradient(inp, 'diff', normalized=False)
+        self.assert_close(edges, expected)
 
     def test_edges_sep_norm(self, device, dtype):
         inp = torch.tensor(
@@ -201,46 +212,71 @@ class TestSpatialGradient:
             / 2.0
         )
 
-        edges = kornia.filters.spatial_gradient(inp, 'diff', normalized=True)
-        assert_close(edges, expected)
+        edges = spatial_gradient(inp, 'diff', normalized=True)
+        self.assert_close(edges, expected)
 
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
 
-        actual = kornia.filters.spatial_gradient(inp)
+        actual = spatial_gradient(inp)
 
         assert inp.is_contiguous() is False
         assert actual.is_contiguous()
         assert actual.shape == (3, 3, 2, 5, 5)
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 1, 3, 4
-        img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.spatial_gradient, (img,), raise_exception=True, fast_mode=True)
+        img = torch.rand(batch_size, channels, height, width, device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        self.gradcheck(spatial_gradient, (img,))
 
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.spatial_gradient
-        op_module = kornia.filters.SpatialGradient()
+        op = spatial_gradient
+        op_module = SpatialGradient()
         expected = op(img)
         actual = op_module(img)
-        assert_close(actual, expected)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize('mode', ['sobel', 'diff'])
+    @pytest.mark.parametrize('order', [1, 2])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, order, mode, device, dtype, torch_optimizer):
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        if order == 1 and dtype == torch.float64:
+            # TODO: FIX order 1 spatial gradient with fp64 on dynamo
+            pytest.xfail(reason='Order 1 on spatial gradient may be wrong computed for float64 on dynamo')
+        op = SpatialGradient(mode, order)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))
 
 
-class TestSpatialGradient3d:
-    def test_shape(self, device, dtype):
-        inp = torch.zeros(1, 2, 4, 5, 6, device=device, dtype=dtype)
-        sobel = kornia.filters.SpatialGradient3d()
-        assert sobel(inp).shape == (1, 2, 3, 4, 5, 6)
+class TestSpatialGradient3d(BaseTester):
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('mode', ['diff'])  # TODO: add support to 'sobel'
+    @pytest.mark.parametrize('order', [1, 2])
+    def test_smoke(self, batch_size, mode, order, device, dtype):
+        inpt = torch.ones(batch_size, 3, 2, 7, 4, device=device, dtype=dtype)
+        actual = SpatialGradient3d(mode, order)(inpt)
+        assert isinstance(actual, torch.Tensor)
 
-    def test_shape_batch(self, device, dtype):
-        inp = torch.zeros(7, 2, 4, 5, 6, device=device, dtype=dtype)
-        sobel = kornia.filters.SpatialGradient3d()
-        assert sobel(inp).shape == (7, 2, 3, 4, 5, 6)
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_cardinality(self, batch_size, device, dtype):
+        inp = torch.zeros(batch_size, 2, 4, 5, 6, device=device, dtype=dtype)
+        sobel = SpatialGradient3d()
+        assert sobel(inp).shape == (batch_size, 2, 3, 4, 5, 6)
 
-    @pytest.mark.skip("fix due to bug in kernel_flip")
+    def test_exception(self):
+        with pytest.raises(TypeError) as errinfo:
+            spatial_gradient3d(1)
+        assert 'Not a Tensor type' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            spatial_gradient3d(torch.zeros(1))
+        assert 'shape must be [[\'B\', \'C\', \'D\', \'H\', \'W\']]' in str(errinfo)
+
     def test_edges(self, device, dtype):
         inp = torch.tensor(
             [
@@ -354,33 +390,56 @@ class TestSpatialGradient3d:
             dtype=dtype,
         )
 
-        edges = kornia.filters.spatial_gradient3d(inp)
-        assert_close(edges, expected)
+        edges = spatial_gradient3d(inp)
+        self.assert_close(edges, expected)
 
-    def test_gradcheck(self, device, dtype):
-        img = torch.rand(1, 1, 1, 3, 4, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.spatial_gradient3d, (img,), raise_exception=True)
+    def test_gradcheck(self, device):
+        img = torch.rand(1, 1, 1, 3, 4, device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        fast_mode = 'cpu' in str(device)  # disable fast mode on gpu
+        self.gradcheck(spatial_gradient3d, (img,), fast_mode=fast_mode)
 
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 1, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.spatial_gradient3d
-        op_module = kornia.filters.SpatialGradient3d()
+        op = spatial_gradient3d
+        op_module = SpatialGradient3d()
         expected = op(img)
         actual = op_module(img)
-        assert_close(actual, expected)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize('mode', ['diff'])
+    @pytest.mark.parametrize('order', [1, 2])
+    def test_dynamo(self, mode, order, device, dtype, torch_optimizer):
+        inpt = torch.ones(1, 3, 1, 10, 10, device=device, dtype=dtype)
+        op = SpatialGradient3d(mode, order)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))
 
 
-class TestSobel:
-    def test_shape(self, device, dtype):
-        inp = torch.zeros(1, 3, 4, 4, device=device, dtype=dtype)
-        sobel = kornia.filters.Sobel()
-        assert sobel(inp).shape == (1, 3, 4, 4)
+class TestSobel(BaseTester):
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    @pytest.mark.parametrize('normalized', [True, False])
+    def test_smoke(self, batch_size, normalized, device, dtype):
+        inp = torch.zeros(batch_size, 3, 4, 7, device=device, dtype=dtype)
+        actual = Sobel()(inp)
 
-    def test_shape_batch(self, device, dtype):
-        inp = torch.zeros(3, 2, 4, 4, device=device, dtype=dtype)
-        sobel = kornia.filters.Sobel()
-        assert sobel(inp).shape == (3, 2, 4, 4)
+        assert isinstance(actual, torch.Tensor)
+        assert actual.shape == (batch_size, 3, 4, 7)
+
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_cardinality(self, batch_size, device, dtype):
+        inp = torch.zeros(batch_size, 3, 4, 7, device=device, dtype=dtype)
+        assert Sobel()(inp).shape == (batch_size, 3, 4, 7)
+
+    def test_exception(self):
+        with pytest.raises(TypeError) as errinfo:
+            sobel(1)
+        assert 'Not a Tensor type' in str(errinfo)
+
+        with pytest.raises(TypeError) as errinfo:
+            sobel(torch.zeros(1))
+        assert 'shape must be [[\'B\', \'C\', \'H\', \'W\']]' in str(errinfo)
 
     def test_magnitude(self, device, dtype):
         inp = torch.tensor(
@@ -415,40 +474,42 @@ class TestSobel:
             dtype=dtype,
         )
 
-        edges = kornia.filters.sobel(inp, normalized=False, eps=0.0)
-        assert_close(edges, expected)
+        edges = sobel(inp, normalized=False, eps=0.0)
+        self.assert_close(edges, expected)
 
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
 
-        sobel = kornia.filters.Sobel()
-        actual = sobel(inp)
+        op = Sobel()
+        actual = op(inp)
 
         assert inp.is_contiguous() is False
         assert actual.is_contiguous()
         assert actual.shape == (3, 3, 5, 5)
 
-    def test_gradcheck_unnorm(self, device, dtype):
-        if "cuda" in str(device):
-            pytest.skip("RuntimeError: Backward is not reentrant, i.e., running backward,")
+    @pytest.mark.parametrize('normalized', [True, False])
+    def test_gradcheck(self, normalized, device):
         batch_size, channels, height, width = 1, 1, 3, 4
-        img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.sobel, (img, False), raise_exception=True, fast_mode=True)
-
-    def test_gradcheck(self, device, dtype):
-        if "cuda" in str(device):
-            pytest.skip("RuntimeError: Backward is not reentrant, i.e., running backward,")
-        batch_size, channels, height, width = 1, 1, 3, 4
-        img = torch.rand(batch_size, channels, height, width, device=device, dtype=dtype)
-        img = utils.tensor_to_gradcheck_var(img)  # to var
-        assert gradcheck(kornia.filters.sobel, (img, True), raise_exception=True, fast_mode=True)
+        img = torch.rand(batch_size, channels, height, width, device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        self.gradcheck(sobel, (img, normalized))
 
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.sobel
-        op_module = kornia.filters.Sobel()
+        op = sobel
+        op_module = Sobel()
         expected = op(img)
         actual = op_module(img)
-        assert_close(actual, expected)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_dynamo(self, batch_size, device, dtype, torch_optimizer):
+        if dtype == torch.float64:
+            # TODO: investigate sobel for float64 with dynamo
+            pytest.xfail(reason='The sobel results can be different after dynamo on fp64')
+        inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        op = Sobel()
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))

--- a/test/filters/test_sobel.py
+++ b/test/filters/test_sobel.py
@@ -220,14 +220,6 @@ class TestSpatialGradient:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.spatial_gradient, (img,), raise_exception=True, fast_mode=True)
 
-    def test_jit(self, device, dtype):
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.filters.spatial_gradient
-        op_script = torch.jit.script(op)
-        actual = op_script(img)
-        expected = op(img)
-        assert_close(actual, expected)
-
     def test_module(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
         op = kornia.filters.spatial_gradient
@@ -462,6 +454,7 @@ class TestSobel:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.filters.sobel, (img, True), raise_exception=True, fast_mode=True)
 
+    @pytest.mark.skip(reason="`kornia.utils.get_cuda_device_if_available` is not jittable")
     def test_jit(self, device, dtype):
         img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
         op = kornia.filters.sobel

--- a/test/filters/test_unsharp_mask.py
+++ b/test/filters/test_unsharp_mask.py
@@ -39,14 +39,6 @@ class Testunsharp:
             kornia.filters.unsharp_mask, (input, kernel_size, sigma, "replicate"), raise_exception=True, fast_mode=True
         )
 
-    def test_jit(self, device, dtype):
-        op = kornia.filters.unsharp_mask
-        op_script = torch.jit.script(op)
-        params = [(3, 3), (1.5, 1.5)]
-
-        img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
-        assert_close(op(img, *params), op_script(img, *params))
-
     def test_module(self, device, dtype):
         params = [(3, 3), (1.5, 1.5)]
         op = kornia.filters.unsharp_mask

--- a/test/filters/test_unsharp_mask.py
+++ b/test/filters/test_unsharp_mask.py
@@ -1,21 +1,36 @@
 import pytest
 import torch
-from torch.autograd import gradcheck
 
-import kornia
-import kornia.testing as utils  # test utils
-from kornia.testing import assert_close
+from kornia.filters import UnsharpMask, unsharp_mask
+from kornia.testing import BaseTester, tensor_to_gradcheck_var
 
 
-class Testunsharp:
-    @pytest.mark.parametrize("batch_shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
-    def test_cardinality(self, batch_shape, device, dtype):
+class Testunsharp(BaseTester):
+    @pytest.mark.parametrize("shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
+    @pytest.mark.parametrize("kernel_size", [3, (5, 3)])
+    @pytest.mark.parametrize("sigma", [(3.0, 1.0), (0.5, -0.1)])
+    @pytest.mark.parametrize("params_as_tensor", [True, False])
+    def test_smoke(self, shape, kernel_size, sigma, params_as_tensor, device, dtype):
+        if params_as_tensor is True:
+            sigma = torch.tensor([sigma], device=device, dtype=dtype).repeat(shape[0], 1)
+
+        inpt = torch.ones(shape, device=device, dtype=dtype)
+        actual = unsharp_mask(inpt, kernel_size, sigma, 'replicate')
+        assert isinstance(actual, torch.Tensor)
+        assert actual.shape == shape
+
+    @pytest.mark.parametrize("shape", [(1, 4, 8, 15), (2, 3, 11, 7)])
+    def test_cardinality(self, shape, device, dtype):
         kernel_size = (5, 7)
         sigma = (1.5, 2.1)
 
-        input = torch.rand(batch_shape, device=device, dtype=dtype)
-        actual = kornia.filters.unsharp_mask(input, kernel_size, sigma, "replicate")
-        assert actual.shape == batch_shape
+        inpt = torch.ones(shape, device=device, dtype=dtype)
+        actual = unsharp_mask(inpt, kernel_size, sigma, "replicate")
+        assert actual.shape == shape
+
+    @pytest.mark.skip(reason='nothing to test')
+    def test_exception(self):
+        ...
 
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
@@ -23,26 +38,36 @@ class Testunsharp:
 
         kernel_size = (3, 3)
         sigma = (1.5, 2.1)
-        actual = kornia.filters.unsharp_mask(input, kernel_size, sigma, "replicate")
-        assert_close(actual, actual)
+        actual = unsharp_mask(input, kernel_size, sigma, "replicate")
+        assert actual.is_contiguous()
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         # test parameters
-        batch_shape = (1, 3, 5, 5)
+        shape = (1, 3, 5, 5)
         kernel_size = (3, 3)
         sigma = (1.5, 2.1)
 
         # evaluate function gradient
-        input = torch.rand(batch_shape, device=device, dtype=dtype)
-        input = utils.tensor_to_gradcheck_var(input)  # to var
-        assert gradcheck(
-            kornia.filters.unsharp_mask, (input, kernel_size, sigma, "replicate"), raise_exception=True, fast_mode=True
-        )
+        inpt = torch.rand(shape, device=device)
+        inpt = tensor_to_gradcheck_var(inpt)  # to var
+        self.gradcheck(unsharp_mask, (inpt, kernel_size, sigma, "replicate"))
 
     def test_module(self, device, dtype):
         params = [(3, 3), (1.5, 1.5)]
-        op = kornia.filters.unsharp_mask
-        op_module = kornia.filters.UnsharpMask(*params)
+        op = unsharp_mask
+        op_module = UnsharpMask(*params)
 
         img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
-        assert_close(op(img, *params), op_module(img))
+        self.assert_close(op(img, *params), op_module(img))
+
+    @pytest.mark.parametrize("sigma", [(3.0, 1.0), (0.5, -0.1)])
+    @pytest.mark.parametrize("params_as_tensor", [True, False])
+    def test_dynamo(self, sigma, params_as_tensor, device, dtype, torch_optimizer):
+        if params_as_tensor is True:
+            sigma = torch.tensor([sigma], device=device, dtype=dtype)
+
+        inpt = torch.ones(1, 3, 10, 10, device=device, dtype=dtype)
+        op = UnsharpMask(3, sigma)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))

--- a/test/geometry/transform/test_elastic_transform.py
+++ b/test/geometry/transform/test_elastic_transform.py
@@ -2,7 +2,6 @@ import pytest
 import torch
 from torch.autograd import gradcheck
 
-import kornia
 from kornia.geometry.transform import elastic_transform2d
 from kornia.testing import assert_close
 
@@ -77,12 +76,3 @@ class TestElasticTransform:
         image = torch.rand(1, 1, 3, 3, device=device, dtype=torch.float64, requires_grad=requires_grad)
         noise = torch.rand(1, 2, 3, 3, device=device, dtype=torch.float64, requires_grad=not requires_grad)
         assert gradcheck(elastic_transform2d, (image, noise), raise_exception=True, fast_mode=True)
-
-    def test_jit(self, device, dtype):
-        image = torch.rand(1, 4, 5, 5, device=device, dtype=dtype)
-        noise = torch.rand(1, 2, 5, 5, device=device, dtype=dtype)
-
-        op = kornia.geometry.transform.elastic_transform2d
-        op_jit = torch.jit.script(op)
-
-        assert_close(op(image, noise), op_jit(image, noise))

--- a/test/geometry/transform/test_pyramid.py
+++ b/test/geometry/transform/test_pyramid.py
@@ -23,12 +23,6 @@ class TestPyrUp:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.geometry.pyrup, (img,), nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
-    def test_jit(self, device, dtype):
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.geometry.pyrup
-        op_jit = torch.jit.script(op)
-        assert_close(op(img), op_jit(img))
-
 
 class TestPyrDown:
     def test_shape(self, device, dtype):
@@ -57,12 +51,6 @@ class TestPyrDown:
         img = torch.rand(1, 2, 5, 4, device=device, dtype=dtype)
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.geometry.pyrdown, (img,), nondet_tol=1e-8, raise_exception=True, fast_mode=True)
-
-    def test_jit(self, device, dtype):
-        img = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
-        op = kornia.geometry.pyrdown
-        op_jit = torch.jit.script(op)
-        assert_close(op(img), op_jit(img))
 
 
 class TestScalePyramid:

--- a/test/losses/test_ssim.py
+++ b/test/losses/test_ssim.py
@@ -35,17 +35,6 @@ class TestSSIMLoss:
         tol_val: float = utils._get_precision_by_name(device, 'xla', 1e-1, 1e-4)
         assert_close(loss.item(), 0.0, rtol=tol_val, atol=tol_val)
 
-    def test_jit(self, device, dtype):
-        img1 = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
-        img2 = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
-
-        args = (img1, img2, 5, 1.0, 1e-6, 'mean')
-
-        op = kornia.losses.ssim_loss
-        op_script = torch.jit.script(op)
-
-        assert_close(op(*args), op_script(*args))
-
     def test_module(self, device, dtype):
         img1 = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
         img2 = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
@@ -160,17 +149,6 @@ class TestSSIM3DLoss(BaseTester):
             expected = (torch.ones_like(img1, device=device, dtype=dtype) * 0.9999).sum()
 
         self.assert_close(actual, expected)
-
-    def test_jit(self, device, dtype):
-        img1 = torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype)
-        img2 = torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype)
-
-        args = (img1, img2, 5, 1.0, 1e-6, 'mean')
-
-        op = kornia.losses.ssim3d_loss
-        op_script = torch.jit.script(op)
-
-        self.assert_close(op(*args), op_script(*args))
 
     def test_module(self, device, dtype):
         img1 = torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype)

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -352,12 +352,3 @@ class TestSSIM3d(BaseTester):
         img = tensor_to_gradcheck_var(img)
 
         assert self.gradcheck(op, (img, img, 3), nondet_tol=1e-8)
-
-    @pytest.mark.jit
-    def test_jit(self, device, dtype):
-        img = torch.rand(1, 1, 3, 3, 3, device=device, dtype=dtype)
-
-        op = kornia.metrics.ssim3d
-        op_jit = torch.jit.script(op)
-
-        assert_close(op(img, img, 3), op_jit(img, img, 3))


### PR DESCRIPTION
#### Changes

- Add support to kernel size as integer or tuple for 2d and 3d kernels - fixes #1109
  - The `motion` filters didn't receive this change, because they would have to change the whole implementation of the kernel
- Add support to use float (or sequence of floats)  or Tensor - e.g for sigma (on gaussian kernels), 
- Improve the gaussian kernels to be batched - for sigmas as Tensor (will match the `B`)
    - Gaussian
    - Discrete Gaussian (via bessel function)
    - Discrete ERF Gaussian (via error function)
- Add device and dtype as parameters for kernels creation
- Add `from __future__ import annotations` to have typing as py 3.10
- Depreciated the kernel creation for sigmas as tensor, e.g `get_gaussian_kernel1d_t` -- before this patch, to be able to support jit, we have duplicated functions for have support for sigmas as tensors and float.  -- all functions with suffix `_t` from filters.kernels are depreciated in favor of the functions with the same name but without this suffix
- Update the tests for all filters 
  - Add `BaseTester` on the class tests
  - Add dynamo tests
  - Remove JIT tests: With these changes, we now don't support anymore JIT on `filters` module -- in favor of using dynamo in the future versions of torch.
    - The inside modules of Kornia which use `filters` also will not support JIT anymore. e.g `affine_shape_estimator`, `keynet, `test_elastic_transform`, and some others.


#### Type of change
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Drop support for JIT on `filters` module, and modules with dep on it
- [x] 🔬 New feature (non-breaking change which adds functionality)
  - added support for creating batched kernels
- [x] 📝 This change requires a documentation update
