### PR TITLE
Drop some ci job

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -5,7 +5,7 @@ on:
     branches: [test-me-*]
   pull_request:
     branches: [master]
-    types: [opened, reopened, synchronize, review_requested, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
 
 concurrency:
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false # TODO: enable it when CI be stable
       matrix:
         os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
-        pytorch-dtype: ['float16', 'float32', 'float64']
+        pytorch-dtype: ['float32', 'float64']
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
@@ -32,14 +32,13 @@ jobs:
       fail-fast: false
       matrix:
         os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
-        pytorch-dtype: ['float16', 'float32', 'float64']
+        pytorch-dtype: ['float32', 'float64']
 
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
       python-version: '["3.9"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
-      continue-on-error: ${{ contains('float16', matrix.pytorch-dtype) }} # Remove this when float16 stop raising errors
 
   tests-nightly:
     if:  contains(github.event.pull_request.labels.*.name, 'nightly')
@@ -53,6 +52,17 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
-      python-version: '["3.7", "3.10"]'
+      python-version: '["3.10"]'
       pytorch-version: '["nightly"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
+
+  tests-cpu-half:
+    strategy:
+      fail-fast: false # TODO: enable it when CI be stable
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: 'Ubuntu-latest'
+      python-version: '["3.10"]'
+      pytorch-version: '["1.13.1"]'
+      pytorch-dtype: 'float16'
+      continue-on-error: true

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -25,7 +25,6 @@ jobs:
       python-version: '["3.7", "3.10"]'
       pytorch-version: '["1.9.1", "1.13.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
-      continue-on-error: ${{ contains('float16', matrix.pytorch-dtype) }} # Remove this when float16 stop raising errors
 
   tests-cpu-old-torch-new-py:
     strategy:
@@ -56,13 +55,13 @@ jobs:
       pytorch-version: '["nightly"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
-  tests-cpu-half:
-    strategy:
-      fail-fast: false # TODO: enable it when CI be stable
-    uses: ./.github/workflows/tests.yml
-    with:
-      os: 'Ubuntu-latest'
-      python-version: '["3.10"]'
-      pytorch-version: '["1.13.1"]'
-      pytorch-dtype: 'float16'
-      continue-on-error: true
+  # tests-cpu-half:
+  #   strategy:
+  #     fail-fast: false # TODO: enable it when CI be stable
+  #   uses: ./.github/workflows/tests.yml
+  #   with:
+  #     os: 'Ubuntu-latest'
+  #     python-version: '["3.10"]'
+  #     pytorch-version: '["1.13.1"]'
+  #     pytorch-dtype: 'float16'
+  #     continue-on-error: true

--- a/.github/workflows/pr_test_typing.yml
+++ b/.github/workflows/pr_test_typing.yml
@@ -2,8 +2,8 @@ name: Run typing tests
 
 on:
   pull_request:
-    branches: [master]
-    types: [opened, reopened, synchronize, review_requested, ready_for_review]
+    branches: [master, test-me-*]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -11,16 +11,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests-cpu:
+  tests-cpu-ubuntu:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
     uses: ./.github/workflows/tests.yml
     with:
-      os: ${{ matrix.os }}
+      os: 'Ubuntu-latest'
       python-version: '["3.7", "3.8", "3.9", "3.10"]'
       pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}
+
+  tests-cpu-windows:
+    strategy:
+      fail-fast: true
+      matrix:
+        pytorch-dtype: ['float32', 'float64']
+
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: 'Windows-latest'
+      python-version: '["3.10"]'
+      pytorch-version: '["1.9.1", "1.13.1"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}
+
+  tests-cpu-mac:
+    strategy:
+      fail-fast: true
+      matrix:
+        pytorch-dtype: ['float32', 'float64']
+
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: 'MacOS-latest'
+      python-version: '["3.10"]'
+      pytorch-version: '[ "1.13.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}

--- a/.github/workflows/scheduled_test_cpu_half.yml
+++ b/.github/workflows/scheduled_test_cpu_half.yml
@@ -1,6 +1,8 @@
 name: Tests on CPU (float16)
 
 on:
+  push:
+    branches: [test-me-*]
   schedule:
     - cron: "0 4 * * *"
 
@@ -13,11 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        os: ['Ubuntu-latest'] #, 'Windows-latest', 'MacOS-latest']
 
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
-      python-version: '["3.7", "3.8", "3.9", "3.10"]'
-      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1"]'
+      python-version: '["3.7", , "3.10"]' # "3.8", "3.9"
+      pytorch-version:  '["1.13.1"]' # '["1.9.1", "1.10.2", "1.11.0", "1.12.1",]'
       pytorch-dtype: 'float16'

--- a/.github/workflows/scheduled_test_cpu_half.yml
+++ b/.github/workflows/scheduled_test_cpu_half.yml
@@ -3,8 +3,8 @@ name: Tests on CPU (float16)
 on:
   push:
     branches: [test-me-*]
-  schedule:
-    - cron: "0 4 * * *"
+#  schedule:
+#    - cron: "0 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/scheduled_test_nightly.yml
+++ b/.github/workflows/scheduled_test_nightly.yml
@@ -2,7 +2,7 @@ name: Tests on CPU (nightly)
 
 on:
   push:
-    branches: [master, test-me-*]
+    branches: [test-me-*]
   schedule:
     - cron: "0 4 * * *"
 
@@ -15,12 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        os: ['Ubuntu-latest'] #, 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
-      python-version: '["3.7", "3.8", "3.9", "3.10"]'
+      python-version: '["3.7", "3.10"]' # "3.8", "3.9",
       pytorch-version: '["nightly"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}

--- a/.github/workflows/scheduled_test_typing.yml
+++ b/.github/workflows/scheduled_test_typing.yml
@@ -1,8 +1,9 @@
-name: (scheduled) Run typing tests
+name: Run typing tests (scheduled)
 
 on:
   push:
-    branches: [master]
+    branches: [master, test-me-*]
+
   schedule:
     - cron: "0 4 * * *"
 


### PR DESCRIPTION
This patch aims to lower the time consumption of GitHub actions -- as describe on [gha actions docs](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes):

> Jobs that run on Windows and macOS runners that GitHub hosts consume minutes at 2 and 10 times the rate that jobs on Linux runners consume. 

So here I dropped some tests on windows and macOS 