### PR TITLE
DataKey: add 'image' as alias of 'input'

### DIFF
--- a/kornia/augmentation/_2d/mix/base.py
+++ b/kornia/augmentation/_2d/mix/base.py
@@ -24,7 +24,7 @@ class MixAugmentationBaseV2(_BasicAugmentationBase):
         keepdim: whether to keep the output shape the same as input ``True`` or broadcast it
           to the batch form ``False``.
         data_keys: the input type sequential for applying augmentations.
-            Accepts "input", "mask", "bbox", "bbox_xyxy", "bbox_xywh", "keypoints".
+            Accepts "input", "image", "mask", "bbox", "bbox_xyxy", "bbox_xywh", "keypoints".
     """
 
     def __init__(

--- a/kornia/augmentation/_2d/mix/jigsaw.py
+++ b/kornia/augmentation/_2d/mix/jigsaw.py
@@ -24,7 +24,7 @@ class RandomJigsaw(MixAugmentationBaseV2):
         ensure_perm: to ensure the nonidentical patch permutation generation against
             the original one.
         data_keys: the input type sequential for applying augmentations.
-            Accepts "input", "mask", "bbox", "bbox_xyxy", "bbox_xywh", "keypoints".
+            Accepts "input", "image", "mask", "bbox", "bbox_xyxy", "bbox_xywh", "keypoints".
         p: probability of applying the transformation for the whole batch.
         same_on_batch: apply the same transformation across the batch.
         keepdim: whether to keep the output shape the same as input ``True`` or broadcast it

--- a/kornia/augmentation/_2d/mix/mosaic.py
+++ b/kornia/augmentation/_2d/mix/mosaic.py
@@ -35,7 +35,7 @@ class RandomMosaic(MixAugmentationBaseV2):
             each output will mix 4 images in a 2x2 grid.
         min_bbox_size: minimum area of bounding boxes. Default to 0.
         data_keys: the input type sequential for applying augmentations.
-            Accepts "input", "mask", "bbox", "bbox_xyxy", "bbox_xywh", "keypoints".
+            Accepts "input", "image", "mask", "bbox", "bbox_xyxy", "bbox_xywh", "keypoints".
         p: probability of applying the transformation for the whole batch.
         keepdim: whether to keep the output shape the same as input ``True`` or broadcast it
             to the batch form ``False``.

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -24,8 +24,8 @@ class AugmentationSequential(ImageSequential):
     Args:
         *args: a list of kornia augmentation modules.
 
-        data_keys: the input type sequential for applying augmentations. Accepts "input", "image", "mask", "bbox", "bbox_xyxy",
-                   "bbox_xywh", "keypoints".
+        data_keys: the input type sequential for applying augmentations. Accepts "input", "image", "mask",
+                   "bbox", "bbox_xyxy", "bbox_xywh", "keypoints".
 
         same_on_batch: apply the same transformation across the batch. If None, it will not overwrite the function-wise
                        settings.

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -24,7 +24,7 @@ class AugmentationSequential(ImageSequential):
     Args:
         *args: a list of kornia augmentation modules.
 
-        data_keys: the input type sequential for applying augmentations. Accepts "input", "mask", "bbox", "bbox_xyxy",
+        data_keys: the input type sequential for applying augmentations. Accepts "input", "image", "mask", "bbox", "bbox_xyxy",
                    "bbox_xywh", "keypoints".
 
         same_on_batch: apply the same transformation across the batch. If None, it will not overwrite the function-wise
@@ -52,7 +52,7 @@ class AugmentationSequential(ImageSequential):
                     strategies.
 
     .. note::
-        Mix augmentations (e.g. RandomMixUp, RandomCutMix) can only be working with "input" data key.
+        Mix augmentations (e.g. RandomMixUp, RandomCutMix) can only be working with "input"/"image" data key.
         It is not clear how to deal with the conversions of masks, bounding boxes and keypoints.
 
     .. note::

--- a/kornia/constants.py
+++ b/kornia/constants.py
@@ -123,6 +123,7 @@ class DType(Enum, metaclass=_KORNIA_EnumMeta):
 
 # TODO: (low-priority) add INPUT3D, MASK3D, BBOX3D, LAFs etc.
 class DataKey(Enum, metaclass=_KORNIA_EnumMeta):
+    IMAGE = 0
     INPUT = 0
     MASK = 1
     BBOX = 2

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -219,7 +219,7 @@ class TestSequential:
 
 class TestAugmentationSequential:
     @pytest.mark.parametrize(
-        'data_keys', ["input", ["mask", "input"], ["input", "bbox_yxyx"], [0, 10], [BorderType.REFLECT]]
+        'data_keys', ["input", "image", ["mask", "input"], ["input", "bbox_yxyx"], [0, 10], [BorderType.REFLECT]]
     )
     @pytest.mark.parametrize("augmentation_list", [K.ColorJiggle(0.1, 0.1, 0.1, 0.1, p=1.0)])
     def test_exception(self, augmentation_list, data_keys, device, dtype):
@@ -292,7 +292,7 @@ class TestAugmentationSequential:
         )
 
         aug_hor = K.AugmentationSequential(
-            K.RandomHorizontalFlip(p=1.0), data_keys=["input", "bbox"], same_on_batch=False
+            K.RandomHorizontalFlip(p=1.0), data_keys=["image", "bbox"], same_on_batch=False
         )
 
         out_ver = aug_ver(inp.clone(), bbox.clone())
@@ -371,7 +371,7 @@ class TestAugmentationSequential:
     def test_random_erasing(self, device, dtype):
         fill_value = 0.5
         input = torch.randn(3, 3, 100, 100, device=device, dtype=dtype)
-        aug = K.AugmentationSequential(K.RandomErasing(p=1.0, value=fill_value), data_keys=["input", "mask"])
+        aug = K.AugmentationSequential(K.RandomErasing(p=1.0, value=fill_value), data_keys=["image", "mask"])
 
         reproducibility_test((input, input), aug)
 


### PR DESCRIPTION
#### Changes

This PR makes "image" an alias of "input" in the `data_keys` argument to `AugmentationSequential`.

What's wrong with "input"? There are several issues:

* "input" is not very specific, and in no way implies a B x C x H x W "image"
* We may want to add "video" or other input keys someday
* [input](https://docs.python.org/3/library/functions.html#input) is a builtin function and should be avoided for variable names

Okay, but what's the real reason?

* In #2119, I'm trying to add support for dicts as input so that `data_keys` is not necessary. In [TorchGeo](https://github.com/microsoft/torchgeo), we're already using "image" as our key. Trying to avoid changing this to "input" in hundreds of places.

#### Type of change

- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?

I'll update the documentation and tests soon, just wanted to get feedback on whether or not there is interest in this before doing so. Hopefully there are no places in the codebase that hardcode things to use "input" instead of using the enum.

@isaaccorley @calebrob6