### PR TITLE
Move padding_size to device in pad for boxes

### DIFF
--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -293,8 +293,8 @@ class Boxes:
         """
         if not (len(padding_size.shape) == 2 and padding_size.size(1) == 4):
             raise RuntimeError(f"Expected padding_size as (B, 4). Got {padding_size.shape}.")
-        self._data[..., 0] += padding_size[..., None, :1]  # left padding
-        self._data[..., 1] += padding_size[..., None, 2:3]  # top padding
+        self._data[..., 0] += padding_size[..., None, :1].to(device=self._data.device)  # left padding
+        self._data[..., 1] += padding_size[..., None, 2:3].to(device=self._data.device)  # top padding
         return self
 
     def unpad(self, padding_size: Tensor) -> "Boxes":
@@ -305,8 +305,8 @@ class Boxes:
         """
         if not (len(padding_size.shape) == 2 and padding_size.size(1) == 4):
             raise RuntimeError(f"Expected padding_size as (B, 4). Got {padding_size.shape}.")
-        self._data[..., 0] -= padding_size[..., None, :1]  # left padding
-        self._data[..., 1] -= padding_size[..., None, 2:3]  # top padding
+        self._data[..., 0] -= padding_size[..., None, :1].to(device=self._data.device)  # left padding
+        self._data[..., 1] -= padding_size[..., None, 2:3].to(device=self._data.device)  # top padding
         return self
 
     def clamp(


### PR DESCRIPTION
#### Changes
Somehow the padding_size tensor is not on the right device now, so put it there to avoid a mismatch between devices throwing an error.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
