### PR TITLE
Remove py 3.7 for nightly CI

### DIFF
--- a/.github/workflows/scheduled_test_nightly.yml
+++ b/.github/workflows/scheduled_test_nightly.yml
@@ -21,6 +21,6 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
-      python-version: '["3.7", "3.10"]' # "3.8", "3.9",
+      python-version: '["3.10"]' # "3.8", "3.9",
       pytorch-version: '["nightly"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}


### PR DESCRIPTION
- Deprecation of CUDA 11.6 and Python 3.7 Support (**pytorch 2.0**) - from https://pytorch.org/blog/deprecation-cuda-python-support/