### PR TITLE
Replace `assert_allclose` by `assert_close`

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -716,7 +716,7 @@ def posterize(input: Tensor, bits: Union[int, Tensor]) -> Tensor:
     Example:
         >>> x = torch.rand(1, 6, 3, 3)
         >>> out = posterize(x, bits=8)
-        >>> torch.testing.assert_allclose(x, out)
+        >>> torch.testing.assert_close(x, out)
 
         >>> x = torch.rand(2, 6, 3, 3)
         >>> bits = torch.tensor([4, 2])

--- a/test/augmentation/test_dist_mapper.py
+++ b/test/augmentation/test_dist_mapper.py
@@ -1,9 +1,9 @@
 import torch
 import torch.nn as nn
 from torch.distributions import Normal
-from torch.testing import assert_allclose
 
 from kornia.augmentation.random_generator import DistributionWithMapper
+from kornia.testing import assert_close
 
 
 class TestDistMapper:
@@ -12,4 +12,4 @@ class TestDistMapper:
         dist = DistributionWithMapper(Normal(0.0, 1.0), map_fn=nn.Sigmoid())
         out = dist.rsample((8,))
         exp = torch.tensor([0.8236, 0.4272, 0.1017, 0.6384, 0.2527, 0.1980, 0.5995, 0.6980])
-        assert_allclose(out, exp, rtol=1e-4, atol=1e-4)
+        assert_close(out, exp, rtol=1e-4, atol=1e-4)

--- a/test/geometry/calibration/test_undistort.py
+++ b/test/geometry/calibration/test_undistort.py
@@ -1,9 +1,8 @@
 import pytest
 import torch
-from torch.autograd import gradcheck
 
 from kornia.geometry.calibration.undistort import undistort_image, undistort_points
-from kornia.testing import assert_close
+from kornia.testing import assert_close, gradcheck
 
 
 class TestUndistortPoints:
@@ -232,7 +231,7 @@ class TestUndistortPoints:
         new_K = torch.rand(1, 3, 3, device=device, dtype=torch.float64)
         distCoeff = torch.rand(1, 4, device=device, dtype=torch.float64)
 
-        assert gradcheck(undistort_points, (points, K, distCoeff, new_K), raise_exception=True, fast_mode=True)
+        gradcheck(undistort_points, (points, K, distCoeff, new_K))
 
     def test_jit(self, device, dtype):
         points = torch.rand(1, 1, 2, device=device, dtype=dtype)
@@ -270,7 +269,7 @@ class TestUndistortImage:
 
         imu = undistort_image(im, K, distCoeff)
         assert imu.shape == (3, 2, 3, 5, 5)
-        torch.testing.assert_allclose(imu[0], imu[1])
+        assert_close(imu[0], imu[1])
 
     def test_exception(self, device, dtype):
         with pytest.raises(ValueError):
@@ -341,7 +340,7 @@ class TestUndistortImage:
         K = torch.rand(3, 3, device=device, dtype=torch.float64)
         distCoeff = torch.rand(4, device=device, dtype=torch.float64)
 
-        assert gradcheck(undistort_image, (im, K, distCoeff), raise_exception=True, fast_mode=True)
+        gradcheck(undistort_image, (im, K, distCoeff))
 
     def test_jit(self, device, dtype):
         im = torch.rand(1, 3, 5, 5, device=device, dtype=dtype)

--- a/test/geometry/camera/test_stereo.py
+++ b/test/geometry/camera/test_stereo.py
@@ -1,10 +1,8 @@
-from typing import Type
-
 import pytest
 import torch
-from torch.testing import assert_allclose
 
 from kornia.geometry.camera import StereoCamera
+from kornia.testing import assert_close
 
 
 @pytest.fixture(params=[1, 2, 4])
@@ -139,7 +137,7 @@ class _SmokeTestData:
     """Collection of smoke test data."""
 
     @staticmethod
-    def _create_rectified_camera(params: Type[_TestParams], batch_size, device, dtype, tx_fx=None):
+    def _create_rectified_camera(params, batch_size, device, dtype, tx_fx=None):
         intrinsics = torch.zeros((3, 4), device=device, dtype=dtype)
         intrinsics[..., 0, 0] = params.fx
         intrinsics[..., 1, 1] = params.fy
@@ -202,11 +200,11 @@ class TestStereoCamera:
         left_rectified_camera, right_rectified_camera = _RealTestData._get_real_stereo_camera(batch_size, device, dtype)
 
         stereo_camera = StereoCamera(left_rectified_camera, right_rectified_camera)
-        assert_allclose(stereo_camera.fx, left_rectified_camera[..., 0, 0])
-        assert_allclose(stereo_camera.fy, left_rectified_camera[..., 1, 1])
-        assert_allclose(stereo_camera.cx_left, left_rectified_camera[..., 0, 2])
-        assert_allclose(stereo_camera.cy, left_rectified_camera[..., 1, 2])
-        assert_allclose(stereo_camera.tx, -right_rectified_camera[..., 0, 3] / right_rectified_camera[..., 0, 0])
+        assert_close(stereo_camera.fx, left_rectified_camera[..., 0, 0])
+        assert_close(stereo_camera.fy, left_rectified_camera[..., 1, 1])
+        assert_close(stereo_camera.cx_left, left_rectified_camera[..., 0, 2])
+        assert_close(stereo_camera.cy, left_rectified_camera[..., 1, 2])
+        assert_close(stereo_camera.tx, -right_rectified_camera[..., 0, 3] / right_rectified_camera[..., 0, 0])
 
         assert stereo_camera.Q.shape == (batch_size, 4, 4)
         assert stereo_camera.Q.dtype in (torch.float16, torch.float32, torch.float64)
@@ -238,7 +236,7 @@ class TestStereoCamera:
 
         xyz = stereo_camera.reproject_disparity_to_3D(disparity_tensor)
 
-        assert_allclose(xyz, xyz_gt)
+        assert_close(xyz, xyz_gt)
 
     def test_reproject_disparity_to_3D_simple(self, batch_size, device, dtype):
         """Test reprojecting of disparity to 3D for real data."""

--- a/test/geometry/test_bbox.py
+++ b/test/geometry/test_bbox.py
@@ -1,9 +1,6 @@
 import torch
-from torch.autograd import gradcheck
-from torch.testing import assert_allclose
 
 import kornia
-import kornia.testing as utils
 from kornia.geometry.bbox import (
     infer_bbox_shape,
     infer_bbox_shape3d,
@@ -12,6 +9,7 @@ from kornia.geometry.bbox import (
     validate_bbox,
     validate_bbox3d,
 )
+from kornia.testing import assert_close, gradcheck, tensor_to_gradcheck_var
 
 
 class TestBbox2D:
@@ -45,10 +43,10 @@ class TestBbox2D:
         h, w = infer_bbox_shape(boxes)
         assert (h.unique().item(), w.unique().item()) == (2, 3)
 
-    def test_gradcheck(self, device, dtype):
-        boxes = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
-        boxes = utils.tensor_to_gradcheck_var(boxes)
-        assert gradcheck(infer_bbox_shape, (boxes,), raise_exception=True, fast_mode=True)
+    def test_gradcheck(self, device):
+        boxes = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device)
+        boxes = tensor_to_gradcheck_var(boxes)
+        gradcheck(infer_bbox_shape, (boxes,))
 
     def test_jit(self, device, dtype):
         # Define script
@@ -60,7 +58,7 @@ class TestBbox2D:
         expected = op(boxes)
         actual = op_script(boxes)
         # Compare
-        assert_allclose(actual, expected)
+        assert_close(actual, expected)
 
 
 class TestTransformBoxes2D:
@@ -72,7 +70,7 @@ class TestTransformBoxes2D:
         trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
 
         out = transform_bbox(trans_mat, boxes, restore_coordinates=True)
-        assert_allclose(out, expected, atol=1e-4, rtol=1e-4)
+        assert_close(out, expected, atol=1e-4, rtol=1e-4)
 
     def test_transform_multiple_boxes(self, device, dtype):
         boxes = torch.tensor(
@@ -117,7 +115,7 @@ class TestTransformBoxes2D:
         )
 
         out = transform_bbox(trans_mat, boxes, restore_coordinates=True)
-        assert_allclose(out, expected, atol=1e-4, rtol=1e-4)
+        assert_close(out, expected, atol=1e-4, rtol=1e-4)
 
     def test_transform_boxes_wh(self, device, dtype):
         boxes = torch.tensor(
@@ -145,9 +143,9 @@ class TestTransformBoxes2D:
         trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
 
         out = transform_bbox(trans_mat, boxes, mode='xywh', restore_coordinates=True)
-        assert_allclose(out, expected, atol=1e-4, rtol=1e-4)
+        assert_close(out, expected, atol=1e-4, rtol=1e-4)
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         boxes = torch.tensor(
             [
                 [139.2640, 103.0150, 258.0480, 307.5075],
@@ -156,15 +154,14 @@ class TestTransformBoxes2D:
                 [119.8080, 144.2067, 137.2160, 265.9225],
             ],
             device=device,
-            dtype=dtype,
         )
 
-        trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
+        trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device)
 
-        trans_mat = utils.tensor_to_gradcheck_var(trans_mat)
-        boxes = utils.tensor_to_gradcheck_var(boxes)
+        trans_mat = tensor_to_gradcheck_var(trans_mat)
+        boxes = tensor_to_gradcheck_var(boxes)
 
-        assert gradcheck(transform_bbox, (trans_mat, boxes, "xyxy", True), raise_exception=True, fast_mode=True)
+        gradcheck(transform_bbox, (trans_mat, boxes, "xyxy", True))
 
     def test_jit(self, device, dtype):
         boxes = torch.tensor([[139.2640, 103.0150, 258.0480, 307.5075]], device=device, dtype=dtype)
@@ -172,7 +169,7 @@ class TestTransformBoxes2D:
         args = (boxes, trans_mat)
         op = kornia.geometry.transform_points
         op_jit = torch.jit.script(op)
-        assert_allclose(op(*args), op_jit(*args))
+        assert_close(op(*args), op_jit(*args))
 
 
 class TestBbox3D:
@@ -217,18 +214,28 @@ class TestBbox3D:
         )  # 2x8x3
         d, h, w = infer_bbox_shape3d(boxes)
 
-        assert_allclose(d, torch.tensor([31.0, 61.0], device=device, dtype=dtype))
-        assert_allclose(h, torch.tensor([21.0, 51.0], device=device, dtype=dtype))
-        assert_allclose(w, torch.tensor([11.0, 41.0], device=device, dtype=dtype))
+        assert_close(d, torch.tensor([31.0, 61.0], device=device, dtype=dtype))
+        assert_close(h, torch.tensor([21.0, 51.0], device=device, dtype=dtype))
+        assert_close(w, torch.tensor([11.0, 41.0], device=device, dtype=dtype))
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         boxes = torch.tensor(
-            [[[0, 1, 2], [10, 1, 2], [10, 21, 2], [0, 21, 2], [0, 1, 32], [10, 1, 32], [10, 21, 32], [0, 21, 32]]],
+            [
+                [
+                    [0.0, 1.0, 2.0],
+                    [10, 1, 2],
+                    [10, 21, 2],
+                    [0, 21, 2],
+                    [0, 1, 32],
+                    [10, 1, 32],
+                    [10, 21, 32],
+                    [0, 21, 32],
+                ]
+            ],
             device=device,
-            dtype=dtype,
         )
-        boxes = utils.tensor_to_gradcheck_var(boxes)
-        assert gradcheck(infer_bbox_shape3d, (boxes,), raise_exception=True, fast_mode=True)
+        boxes = tensor_to_gradcheck_var(boxes)
+        gradcheck(infer_bbox_shape3d, (boxes,))
 
     def test_jit(self, device, dtype):
         # Define script
@@ -243,7 +250,7 @@ class TestBbox3D:
 
         actual = op_script(boxes)
         expected = op(boxes)
-        assert_allclose(actual, expected)
+        assert_close(actual, expected)
 
 
 class TestNMS:
@@ -261,4 +268,4 @@ class TestNMS:
         scores = torch.tensor([0.9, 0.8, 0.7, 0.9], device=device, dtype=dtype)
         expected = torch.tensor([0, 3, 1], device=device, dtype=torch.long)
         actual = nms(boxes, scores, iou_threshold=0.8)
-        assert_allclose(actual, expected)
+        assert_close(actual, expected)

--- a/test/geometry/test_boxes.py
+++ b/test/geometry/test_boxes.py
@@ -1,13 +1,10 @@
 from functools import partial
-from typing import Tuple
 
 import pytest
 import torch
-from torch.autograd import gradcheck
-from torch.testing import assert_allclose
 
-import kornia.testing as utils
 from kornia.geometry.boxes import Boxes, Boxes3D
+from kornia.testing import assert_close, gradcheck, tensor_to_gradcheck_var
 
 
 class TestBoxes2D:
@@ -80,7 +77,7 @@ class TestBoxes2D:
         ).all()
 
     @pytest.mark.parametrize('shape', [(1, 4), (1, 1, 4)])
-    def test_from_tensor(self, shape: Tuple[int], device, dtype):
+    def test_from_tensor(self, shape, device, dtype):
         box_xyxy = torch.as_tensor([[1, 2, 3, 4]], device=device, dtype=dtype).view(*shape)
         box_xyxy_plus = torch.as_tensor([[1, 2, 2, 3]], device=device, dtype=dtype).view(*shape)
         box_xywh = torch.as_tensor([[1, 2, 2, 2]], device=device, dtype=dtype).view(*shape)
@@ -98,22 +95,22 @@ class TestBoxes2D:
         boxes_vertices_plus = Boxes.from_tensor(box_vertices_plus, mode='vertices_plus').data
 
         assert boxes_xyxy.shape == expected_box.shape
-        assert_allclose(boxes_xyxy, expected_box)
+        assert_close(boxes_xyxy, expected_box)
 
         assert boxes_xyxy_plus.shape == expected_box.shape
-        assert_allclose(boxes_xyxy_plus, expected_box)
+        assert_close(boxes_xyxy_plus, expected_box)
 
         assert boxes_xywh.shape == expected_box.shape
-        assert_allclose(boxes_xywh, expected_box)
+        assert_close(boxes_xywh, expected_box)
 
         assert box_vertices.shape == expected_box.shape
-        assert_allclose(box_vertices, expected_box)
+        assert_close(box_vertices, expected_box)
 
         assert boxes_vertices_plus.shape == expected_box.shape
-        assert_allclose(boxes_vertices_plus, expected_box)
+        assert_close(boxes_vertices_plus, expected_box)
 
     @pytest.mark.parametrize('shape', [(1, 4), (1, 1, 4)])
-    def test_from_invalid_tensor(self, shape: Tuple[int], device, dtype):
+    def test_from_invalid_tensor(self, shape, device, dtype):
         box_xyxy = torch.as_tensor([[1, 2, -3, 4]], device=device, dtype=dtype).view(*shape)  # Invalid width
         box_xyxy_plus = torch.as_tensor([[1, 2, 0, 3]], device=device, dtype=dtype).view(*shape)  # Invalid height
 
@@ -130,7 +127,7 @@ class TestBoxes2D:
             pass
 
     @pytest.mark.parametrize('shape', [(1, 4), (1, 1, 4)])
-    def test_boxes_to_tensor(self, shape: Tuple[int], device, dtype):
+    def test_boxes_to_tensor(self, shape, device, dtype):
         # quadrilateral with randomized vertices to reflect possible transforms.
         box = Boxes(torch.as_tensor([[[2, 2], [2, 3], [1, 3], [1, 2]]], device=device, dtype=dtype).view(*shape, 2))
 
@@ -151,19 +148,19 @@ class TestBoxes2D:
         boxes_vertices_plus = box.to_tensor(mode='vertices_plus')
 
         assert boxes_xyxy.shape == expected_box_xyxy.shape
-        assert_allclose(boxes_xyxy, expected_box_xyxy)
+        assert_close(boxes_xyxy, expected_box_xyxy)
 
         assert boxes_xyxy_plus.shape == expected_box_xyxy_plus.shape
-        assert_allclose(boxes_xyxy_plus, expected_box_xyxy_plus)
+        assert_close(boxes_xyxy_plus, expected_box_xyxy_plus)
 
         assert boxes_xywh.shape == expected_box_xywh.shape
-        assert_allclose(boxes_xywh, expected_box_xywh)
+        assert_close(boxes_xywh, expected_box_xywh)
 
         assert boxes_vertices.shape == expected_vertices.shape
-        assert_allclose(boxes_vertices, expected_vertices)
+        assert_close(boxes_vertices, expected_vertices)
 
         assert boxes_vertices_plus.shape == expected_vertices_plus.shape
-        assert_allclose(boxes_vertices_plus, expected_vertices_plus)
+        assert_close(boxes_vertices_plus, expected_vertices_plus)
 
     @pytest.mark.parametrize('mode', ['xyxy', 'xyxy_plus', 'xywh', 'vertices', 'vertices_plus'])
     def test_boxes_list_to_tensor_list(self, mode, device, dtype):
@@ -236,16 +233,16 @@ class TestBoxes2D:
         batched_masks = batched_boxes.to_mask(height, width)
 
         assert mask1.shape == expected_mask1.shape
-        assert_allclose(mask1, expected_mask1)
+        assert_close(mask1, expected_mask1)
 
         assert mask2.shape == expected_mask2.shape
-        assert_allclose(mask2, expected_mask2)
+        assert_close(mask2, expected_mask2)
 
         assert two_masks.shape == expected_two_masks.shape
-        assert_allclose(two_masks, expected_two_masks)
+        assert_close(two_masks, expected_two_masks)
 
         assert batched_masks.shape == expected_batched_masks.shape
-        assert_allclose(batched_masks, expected_batched_masks)
+        assert_close(batched_masks, expected_batched_masks)
 
     def test_to(self, device, dtype):
         boxes = Boxes.from_tensor(torch.as_tensor([[1, 2, 3, 4]], device='cpu', dtype=torch.float32))
@@ -256,45 +253,27 @@ class TestBoxes2D:
         assert boxes_moved is boxes  # to is an inplace op.
         assert boxes_moved.data.device == device, boxes_moved.data.dtype == dtype
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         def apply_boxes_method(tensor: torch.Tensor, method: str, **kwargs):
             boxes = Boxes(tensor)
             result = getattr(boxes, method)(**kwargs)
             return result.data if isinstance(result, Boxes) else result
 
-        t_boxes1 = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device, dtype=dtype)
+        t_boxes1 = torch.tensor([[[1.0, 1.0], [3.0, 1.0], [3.0, 2.0], [1.0, 2.0]]], device=device)
 
-        t_boxes1 = utils.tensor_to_gradcheck_var(t_boxes1)
-        t_boxes2 = utils.tensor_to_gradcheck_var(t_boxes1.detach().clone())
-        t_boxes3 = utils.tensor_to_gradcheck_var(t_boxes1.detach().clone())
-        t_boxes4 = utils.tensor_to_gradcheck_var(t_boxes1.detach().clone())
-        t_boxes_xyxy = utils.tensor_to_gradcheck_var(torch.tensor([[1.0, 3.0, 5.0, 6.0]]))
-        t_boxes_xyxy1 = utils.tensor_to_gradcheck_var(t_boxes_xyxy.detach().clone())
+        t_boxes1 = tensor_to_gradcheck_var(t_boxes1)
+        t_boxes2 = tensor_to_gradcheck_var(t_boxes1.detach().clone())
+        t_boxes3 = tensor_to_gradcheck_var(t_boxes1.detach().clone())
+        t_boxes4 = tensor_to_gradcheck_var(t_boxes1.detach().clone())
+        t_boxes_xyxy = tensor_to_gradcheck_var(torch.tensor([[1.0, 3.0, 5.0, 6.0]]))
+        t_boxes_xyxy1 = tensor_to_gradcheck_var(t_boxes_xyxy.detach().clone())
 
-        assert gradcheck(
-            partial(apply_boxes_method, method='to_tensor'), (t_boxes2,), raise_exception=True, fast_mode=True
-        )
-        assert gradcheck(
-            partial(apply_boxes_method, method='to_tensor', mode='xyxy_plus'),
-            (t_boxes3,),
-            raise_exception=True,
-            fast_mode=True,
-        )
-        assert gradcheck(
-            partial(apply_boxes_method, method='to_tensor', mode='vertices_plus'),
-            (t_boxes4,),
-            raise_exception=True,
-            fast_mode=True,
-        )
-        assert gradcheck(
-            partial(apply_boxes_method, method='get_boxes_shape'), (t_boxes1,), raise_exception=True, fast_mode=True
-        )
-        assert gradcheck(
-            lambda x: Boxes.from_tensor(x, mode='xyxy_plus').data, (t_boxes_xyxy,), raise_exception=True, fast_mode=True
-        )
-        assert gradcheck(
-            lambda x: Boxes.from_tensor(x, mode='xywh').data, (t_boxes_xyxy1,), raise_exception=True, fast_mode=True
-        )
+        gradcheck(partial(apply_boxes_method, method='to_tensor'), (t_boxes2,))
+        gradcheck(partial(apply_boxes_method, method='to_tensor', mode='xyxy_plus'), (t_boxes3,))
+        gradcheck(partial(apply_boxes_method, method='to_tensor', mode='vertices_plus'), (t_boxes4,))
+        gradcheck(partial(apply_boxes_method, method='get_boxes_shape'), (t_boxes1,))
+        gradcheck(lambda x: Boxes.from_tensor(x, mode='xyxy_plus').data, (t_boxes_xyxy,))
+        gradcheck(lambda x: Boxes.from_tensor(x, mode='xywh').data, (t_boxes_xyxy1,))
 
 
 class TestTransformBoxes2D:
@@ -309,7 +288,7 @@ class TestTransformBoxes2D:
         trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
 
         transformed_boxes = boxes.transform_boxes(trans_mat)
-        assert_allclose(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
+        assert_close(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
         # inplace check
         assert transformed_boxes is not boxes
 
@@ -324,7 +303,7 @@ class TestTransformBoxes2D:
         trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
 
         transformed_boxes = boxes.transform_boxes_(trans_mat)
-        assert_allclose(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
+        assert_close(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
         # inplace check
         assert transformed_boxes is boxes
 
@@ -375,9 +354,9 @@ class TestTransformBoxes2D:
         expected_boxes = Boxes.from_tensor(expected_boxes_xyxy, validate_boxes=False)
 
         out = boxes.transform_boxes(trans_mat)
-        assert_allclose(out.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
+        assert_close(out.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         # Define boxes in XYXY format for simplicity.
         boxes_xyxy = torch.tensor(
             [
@@ -387,21 +366,20 @@ class TestTransformBoxes2D:
                 [119.8080, 144.2067, 137.2160, 265.9225],
             ],
             device=device,
-            dtype=dtype,
         )
         boxes = Boxes.from_tensor(boxes_xyxy)
 
-        trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
+        trans_mat = torch.tensor([[[-1.0, 0.0, 512.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device)
 
-        trans_mat = utils.tensor_to_gradcheck_var(trans_mat)
-        t_boxes = utils.tensor_to_gradcheck_var(boxes.data)
+        trans_mat = tensor_to_gradcheck_var(trans_mat)
+        t_boxes = tensor_to_gradcheck_var(boxes.data)
 
         def _wrapper_transform_boxes(quadrilaterals, M):
             boxes = Boxes(quadrilaterals)
             boxes = boxes.transform_boxes(M)
             return boxes.data
 
-        assert gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat), raise_exception=True, fast_mode=True)
+        gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat))
 
 
 class TestBbox3D:
@@ -511,7 +489,7 @@ class TestBbox3D:
         )
 
     @pytest.mark.parametrize('shape', [(1, 6), (1, 1, 6)])
-    def test_from_tensor(self, shape: Tuple[int], device, dtype):
+    def test_from_tensor(self, shape, device, dtype):
         box_xyzxyz = torch.as_tensor([[1, 2, 3, 4, 5, 6]], device=device, dtype=dtype).view(*shape)
         box_xyzxyz_plus = torch.as_tensor([[1, 2, 3, 3, 4, 5]], device=device, dtype=dtype).view(*shape)
         box_xyzwhd = torch.as_tensor([[1, 2, 3, 3, 3, 3]], device=device, dtype=dtype).view(*shape)
@@ -527,16 +505,16 @@ class TestBbox3D:
         kornia_xyzwhd = Boxes3D.from_tensor(box_xyzwhd, mode='xyzwhd').data
 
         assert kornia_xyzxyz.shape == expected_box.shape
-        assert_allclose(kornia_xyzxyz, expected_box)
+        assert_close(kornia_xyzxyz, expected_box)
 
         assert kornia_xyzxyz_plus.shape == expected_box.shape
-        assert_allclose(kornia_xyzxyz_plus, expected_box)
+        assert_close(kornia_xyzxyz_plus, expected_box)
 
         assert kornia_xyzwhd.shape == expected_box.shape
-        assert_allclose(kornia_xyzwhd, expected_box)
+        assert_close(kornia_xyzwhd, expected_box)
 
     @pytest.mark.parametrize('shape', [(1, 6), (1, 1, 6)])
-    def test_from_invalid_tensor(self, shape: Tuple[int], device, dtype):
+    def test_from_invalid_tensor(self, shape, device, dtype):
         box_xyzxyz = torch.as_tensor([[1, 2, 3, 4, -5, 6]], device=device, dtype=dtype).view(*shape)
         box_xyzxyz_plus = torch.as_tensor([[1, 2, 3, 0, 6, 4]], device=device, dtype=dtype).view(*shape)
 
@@ -553,7 +531,7 @@ class TestBbox3D:
             pass
 
     @pytest.mark.parametrize('shape', [(1, 6), (1, 1, 6)])
-    def test_boxes_to_tensor(self, shape: Tuple[int], device, dtype):
+    def test_boxes_to_tensor(self, shape, device, dtype):
         # Hexahedron with randomized vertices to reflect possible transforms.
         box = Boxes3D(
             torch.as_tensor(
@@ -584,19 +562,19 @@ class TestBbox3D:
         kornia_vertices_plus = box.to_tensor(mode='vertices_plus')
 
         assert kornia_xyzxyz.shape == expected_box_xyzxyz.shape
-        assert_allclose(kornia_xyzxyz, expected_box_xyzxyz)
+        assert_close(kornia_xyzxyz, expected_box_xyzxyz)
 
         assert kornia_xyzxyz_plus.shape == expected_box_xyzxyz_plus.shape
-        assert_allclose(kornia_xyzxyz_plus, expected_box_xyzxyz_plus)
+        assert_close(kornia_xyzxyz_plus, expected_box_xyzxyz_plus)
 
         assert kornia_xyzwhd.shape == expected_box_xyzwhd.shape
-        assert_allclose(kornia_xyzwhd, expected_box_xyzwhd)
+        assert_close(kornia_xyzwhd, expected_box_xyzwhd)
 
         assert kornia_vertices.shape == expected_vertices.shape
-        assert_allclose(kornia_vertices, expected_vertices)
+        assert_close(kornia_vertices, expected_vertices)
 
         assert kornia_vertices_plus.shape == expected_vertices_plus.shape
-        assert_allclose(kornia_vertices_plus, expected_vertices_plus)
+        assert_close(kornia_vertices_plus, expected_vertices_plus)
 
     def test_bbox_to_mask(self, device, dtype):
         t_box1 = torch.tensor(
@@ -718,16 +696,16 @@ class TestBbox3D:
         batched_masks = batched_boxes.to_mask(depth, height, width)
 
         assert mask1.shape == expected_mask1.shape
-        assert_allclose(mask1, expected_mask1)
+        assert_close(mask1, expected_mask1)
 
         assert mask2.shape == expected_mask2.shape
-        assert_allclose(mask2, expected_mask2)
+        assert_close(mask2, expected_mask2)
 
         assert two_masks.shape == expected_two_masks.shape
-        assert_allclose(two_masks, expected_two_masks)
+        assert_close(two_masks, expected_two_masks)
 
         assert batched_masks.shape == expected_batched_masks.shape
-        assert_allclose(batched_masks, expected_batched_masks)
+        assert_close(batched_masks, expected_batched_masks)
 
     def test_to(self, device, dtype):
         boxes = Boxes3D.from_tensor(torch.as_tensor([[1, 2, 3, 4, 5, 6]], device='cpu', dtype=torch.float32))
@@ -738,7 +716,7 @@ class TestBbox3D:
         assert boxes_moved is boxes  # to is an inplace op.
         assert boxes_moved.data.device == device, boxes_moved.data.dtype == dtype
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         # Uncomment when enabling gradient checks
         # def apply_boxes_method(tensor: torch.Tensor, method: str, **kwargs):
         #     boxes = Boxes3D(tensor)
@@ -746,18 +724,28 @@ class TestBbox3D:
         #     return result.data if isinstance(result, Boxes3D) else result
 
         t_boxes1 = torch.tensor(
-            [[[0, 1, 2], [10, 1, 2], [10, 21, 2], [0, 21, 2], [0, 1, 32], [10, 1, 32], [10, 21, 32], [0, 21, 32]]],
+            [
+                [
+                    [0.0, 1.0, 2.0],
+                    [10, 1, 2],
+                    [10, 21, 2],
+                    [0, 21, 2],
+                    [0, 1, 32],
+                    [10, 1, 32],
+                    [10, 21, 32],
+                    [0, 21, 32],
+                ]
+            ],
             device=device,
-            dtype=dtype,
         )
 
-        t_boxes1 = utils.tensor_to_gradcheck_var(t_boxes1)
+        t_boxes1 = tensor_to_gradcheck_var(t_boxes1)
         # Uncomment when enabling gradient checks
-        # t_boxes2 = utils.tensor_to_gradcheck_var(t_boxes1.detach().clone())
-        # t_boxes3 = utils.tensor_to_gradcheck_var(t_boxes1.detach().clone())
-        # t_boxes4 = utils.tensor_to_gradcheck_var(t_boxes1.detach().clone())
-        t_boxes_xyzxyz = utils.tensor_to_gradcheck_var(torch.tensor([[1.0, 3.0, 8.0, 5.0, 6.0, 12.0]]))
-        t_boxes_xyzxyz1 = utils.tensor_to_gradcheck_var(t_boxes_xyzxyz.detach().clone())
+        # t_boxes2 = tensor_to_gradcheck_var(t_boxes1.detach().clone())
+        # t_boxes3 = tensor_to_gradcheck_var(t_boxes1.detach().clone())
+        # t_boxes4 = tensor_to_gradcheck_var(t_boxes1.detach().clone())
+        t_boxes_xyzxyz = tensor_to_gradcheck_var(torch.tensor([[1.0, 3.0, 8.0, 5.0, 6.0, 12.0]]))
+        t_boxes_xyzxyz1 = tensor_to_gradcheck_var(t_boxes_xyzxyz.detach().clone())
 
         # Gradient checks for Boxes3D.to_tensor (and Boxes3D.get_boxes_shape) are disable since the is a bug
         # in their gradient. See https://github.com/kornia/kornia/issues/1396.
@@ -769,18 +757,8 @@ class TestBbox3D:
         #     partial(apply_boxes_method, method='to_tensor', mode='vertices_plus'), (t_boxes4,), raise_exception=True
         # )
         # assert gradcheck(partial(apply_boxes_method, method='get_boxes_shape'), (t_boxes1,), raise_exception=True)
-        assert gradcheck(
-            lambda x: Boxes3D.from_tensor(x, mode='xyzxyz_plus').data,
-            (t_boxes_xyzxyz,),
-            raise_exception=True,
-            fast_mode=True,
-        )
-        assert gradcheck(
-            lambda x: Boxes3D.from_tensor(x, mode='xyzwhd').data,
-            (t_boxes_xyzxyz1,),
-            raise_exception=True,
-            fast_mode=True,
-        )
+        gradcheck(lambda x: Boxes3D.from_tensor(x, mode='xyzxyz_plus').data, (t_boxes_xyzxyz,))
+        gradcheck(lambda x: Boxes3D.from_tensor(x, mode='xyzwhd').data, (t_boxes_xyzxyz1,))
 
 
 class TestTransformBoxes3D:
@@ -803,7 +781,7 @@ class TestTransformBoxes3D:
         )
 
         transformed_boxes = boxes.transform_boxes(trans_mat)
-        assert_allclose(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
+        assert_close(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
         # inplace check
         assert transformed_boxes is not boxes
 
@@ -826,7 +804,7 @@ class TestTransformBoxes3D:
         )
 
         transformed_boxes = boxes.transform_boxes_(trans_mat)
-        assert_allclose(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
+        assert_close(transformed_boxes.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
         # inplace check
         assert transformed_boxes is boxes
 
@@ -877,9 +855,9 @@ class TestTransformBoxes3D:
         expected_boxes = Boxes3D.from_tensor(expected_boxes_xyzxyz, validate_boxes=False)
 
         out = boxes.transform_boxes(trans_mat)
-        assert_allclose(out.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
+        assert_close(out.data, expected_boxes.data, atol=1e-4, rtol=1e-4)
 
-    def test_gradcheck(self, device, dtype):
+    def test_gradcheck(self, device):
         # Define boxes in XYZXYZ format for simplicity.
         boxes_xyzxyz = torch.tensor(
             [
@@ -889,22 +867,19 @@ class TestTransformBoxes3D:
                 [119.8080, 144.2067, 234.21, 257.0240, 410.1292, 386.14],
             ],
             device=device,
-            dtype=dtype,
         )
         boxes = Boxes3D.from_tensor(boxes_xyzxyz)
 
         trans_mat = torch.tensor(
-            [[[-1.0, 0.0, 0.0, 512.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]],
-            device=device,
-            dtype=dtype,
+            [[[-1.0, 0.0, 0.0, 512.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 2.0, 1.0], [0.0, 0.0, 0.0, 1.0]]], device=device
         )
 
-        trans_mat = utils.tensor_to_gradcheck_var(trans_mat)
-        t_boxes = utils.tensor_to_gradcheck_var(boxes.data)
+        trans_mat = tensor_to_gradcheck_var(trans_mat)
+        t_boxes = tensor_to_gradcheck_var(boxes.data)
 
         def _wrapper_transform_boxes(hexahedrons, M):
             boxes = Boxes3D(hexahedrons)
             boxes = boxes.transform_boxes(M)
             return boxes.data
 
-        assert gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat), raise_exception=True, fast_mode=True)
+        gradcheck(_wrapper_transform_boxes, (t_boxes, trans_mat))

--- a/test/grad_estimator/test_ste.py
+++ b/test/grad_estimator/test_ste.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 import torch.nn.functional as F
-from torch.testing import assert_allclose
+from torch.testing import assert_close
 
 import kornia.augmentation as K
 from kornia.grad_estimator import STEFunction, StraightThroughEstimator
@@ -16,17 +16,17 @@ class TestSTE:
         output = torch.sign(input)
         loss = output.mean()
         loss.backward()
-        assert_allclose(input.grad, torch.tensor([0.0, 0.0, 0.0, 0.0], device=device, dtype=dtype))
+        assert_close(input.grad, torch.tensor([0.0, 0.0, 0.0, 0.0], device=device, dtype=dtype))
 
         out_est = STEFunction.apply(input, output, F.hardtanh)
         loss = out_est.mean()
         loss.backward()
-        assert_allclose(input.grad, torch.tensor([0.2500, 0.2500, 0.2500, 0.2500], device=device, dtype=dtype))
+        assert_close(input.grad, torch.tensor([0.2500, 0.2500, 0.2500, 0.2500], device=device, dtype=dtype))
 
         out_est = STEFunction.apply(input, output, None)
         loss = out_est.mean()
         loss.backward()
-        assert_allclose(input.grad, torch.tensor([0.5000, 0.5000, 0.5000, 0.5000], device=device, dtype=dtype))
+        assert_close(input.grad, torch.tensor([0.5000, 0.5000, 0.5000, 0.5000], device=device, dtype=dtype))
 
     def test_module(self, device, dtype):
         input = torch.randn(1, 1, 4, 4, requires_grad=True, device=device, dtype=dtype)
@@ -48,7 +48,7 @@ class TestSTE:
             device=device,
             dtype=dtype,
         )
-        assert_allclose(input.grad, o)
+        assert_close(input.grad, o)
 
     @pytest.mark.skip("Function.apply is not supported in Torchscript rightnow.")
     def test_jit(self, device, dtype):
@@ -58,7 +58,7 @@ class TestSTE:
         op_script = torch.jit.script(op)
         actual = op_script(inputs)
         expected = op(inputs)
-        assert_allclose(actual, expected)
+        assert_close(actual, expected)
 
     @pytest.mark.skip("Function is not supported to export to onnx rightnow.")
     def test_onnx(self, device, dtype):


### PR DESCRIPTION
- The `torch.testing.assert_allclose` is deprecated in favor of `torch.testing.assert_close`

So this patch updates the `assert_allclose` in favor of `assert_close` from the testing API. Also updates the gradcheck tests using kornia.testing API
#### Type of change
- [x] 🧪 Tests Cases

