### PR TITLE
Replace pad call with explicit cat of 1's

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -201,7 +201,8 @@ def convert_points_to_homogeneous(points: Tensor) -> Tensor:
     if len(points.shape) < 2:
         raise ValueError(f"Input must be at least a 2D tensor. Got {points.shape}")
 
-    return pad(points, [0, 1], "constant", 1.0)
+    ones = torch.ones_like(points[..., 0].unsqueeze(-1), device=points.device, dtype=points.dtype)
+    return torch.cat([points, ones], dim=-1)
 
 
 def _convert_affinematrix_to_homography_impl(A: Tensor) -> Tensor:


### PR DESCRIPTION
#### Changes
I ran into the issue that the "1.0" passed as a float to a pad function errors out when trying to use mps with apple silicon because float64 is not supported. I couldn't find a different format to pass to pad that it would accept. This change fixed it for me and shouldn't ruin any other machines, but it's not the most efficient approach.
This could be a problem elsewhere, but I don't have time at the moment to look for other spots. This is in a function that appends a 1 to all points in a tensor for re-projection to 3D.



#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
