### PR TITLE
[Feat/aug] Move transform_matrix to augmentation param

### DIFF
--- a/kornia/augmentation/_2d/base.py
+++ b/kornia/augmentation/_2d/base.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from torch import float16, float32, float64, Size
+from torch import Size, float16, float32, float64
 
 from kornia.augmentation.base import _AugmentationBase
 from kornia.augmentation.utils import _transform_input, _validate_input_dtype
@@ -82,29 +82,19 @@ class RigidAffineAugmentationBase2D(AugmentationBase2D):
 
         return trans_matrix * batch_prob.round() + self.identity_matrix(in_tensor) * (1 - batch_prob.round())
 
-    def inverse_inputs(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def inverse_inputs(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         raise NotImplementedError
 
-    def inverse_masks(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def inverse_masks(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         raise NotImplementedError
 
-    def inverse_boxes(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def inverse_boxes(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         raise NotImplementedError
 
-    def inverse_keypoints(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Keypoints:
+    def inverse_keypoints(self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Keypoints:
         raise NotImplementedError
 
-    def inverse_classes(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def inverse_classes(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         raise NotImplementedError
 
     def forward_parameters(self, batch_shape: Size) -> Dict[str, Tensor]:
@@ -118,7 +108,7 @@ class RigidAffineAugmentationBase2D(AugmentationBase2D):
         input: Tensor,
         params: Optional[Dict[str, Tensor]] = None,
         flags: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ) -> Tensor:
         """Perform forward operations.
 

--- a/kornia/augmentation/_2d/base.py
+++ b/kornia/augmentation/_2d/base.py
@@ -7,7 +7,7 @@ from kornia.augmentation.utils import _transform_input, _validate_input_dtype
 from kornia.core import Tensor
 from kornia.geometry.boxes import Boxes
 from kornia.geometry.keypoints import Keypoints
-from kornia.utils import eye_like, is_autocast_enabled
+from kornia.utils import eye_like
 
 
 class AugmentationBase2D(_AugmentationBase):
@@ -142,6 +142,6 @@ class RigidAffineAugmentationBase2D(AugmentationBase2D):
 
         params, flags = self._process_kwargs_to_params_and_flags(params, flags, **kwargs)
 
-        output = self.transform_inputs(in_tensor, params, flags, transform=params["transform_matrix"])
+        output = self.transform_inputs(in_tensor, params, flags)
 
         return self.transform_output_tensor(output, input_shape) if self.keepdim else output

--- a/kornia/augmentation/_2d/geometric/affine.py
+++ b/kornia/augmentation/_2d/geometric/affine.py
@@ -40,7 +40,7 @@ class RandomAffine(GeometricAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -122,7 +122,14 @@ class RandomAffine(GeometricAugmentationBase2D):
         self,
         input: Tensor,
         flags: Dict[str, Any],
-        transform: Tensor,
+        transform: Optional[Tensor] = None,
         size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
-        return self.apply_transform(input, params=self._params, flags=flags)
+        return warp_affine(
+            input,
+            transform[:, :2, :],
+            (size[0], size[1]),
+            flags["resample"].name.lower(),
+            align_corners=flags["align_corners"],
+            padding_mode=flags["padding_mode"].name.lower(),
+        )

--- a/kornia/augmentation/_2d/geometric/affine.py
+++ b/kornia/augmentation/_2d/geometric/affine.py
@@ -105,7 +105,7 @@ class RandomAffine(GeometricAugmentationBase2D):
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, _, height, width = input.shape
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return warp_affine(
             input,
@@ -117,15 +117,14 @@ class RandomAffine(GeometricAugmentationBase2D):
         )
 
     def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        size = params['forward_input_shape'].numpy().tolist()
-        size = (size[-2], size[-1])
+        _, _, height, width = input.shape
 
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
 
         return warp_affine(
             input,
             transform[:, :2, :],
-            (size[0], size[1]),
+            (height, width),
             flags["resample"].name.lower(),
             align_corners=flags["align_corners"],
             padding_mode=flags["padding_mode"].name.lower(),

--- a/kornia/augmentation/_2d/geometric/affine.py
+++ b/kornia/augmentation/_2d/geometric/affine.py
@@ -104,11 +104,10 @@ class RandomAffine(GeometricAugmentationBase2D):
         )
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         _, _, height, width = input.shape
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
+        transform = params["transform_matrix"]
 
         return warp_affine(
             input,
@@ -123,14 +122,7 @@ class RandomAffine(GeometricAugmentationBase2D):
         self,
         input: Tensor,
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
+        transform: Tensor,
         size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
-        return self.apply_transform(
-            input,
-            params=self._params,
-            transform=as_tensor(transform, device=input.device, dtype=input.dtype),
-            flags=flags,
-        )
+        return self.apply_transform(input, params=self._params, flags=flags)

--- a/kornia/augmentation/_2d/geometric/affine.py
+++ b/kornia/augmentation/_2d/geometric/affine.py
@@ -103,9 +103,7 @@ class RandomAffine(GeometricAugmentationBase2D):
             deg2rad(as_tensor(params["shear_y"], device=input.device, dtype=input.dtype)),
         )
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, _, height, width = input.shape
         transform = params["transform_matrix"]
 
@@ -118,13 +116,12 @@ class RandomAffine(GeometricAugmentationBase2D):
             padding_mode=flags["padding_mode"].name.lower(),
         )
 
-    def inverse_transform(
-        self,
-        input: Tensor,
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
-    ) -> Tensor:
+    def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        size = params['forward_input_shape'].numpy().tolist()
+        size = (size[-2], size[-1])
+
+        transform = params["transform_matrix_inv"]
+
         return warp_affine(
             input,
             transform[:, :2, :],

--- a/kornia/augmentation/_2d/geometric/base.py
+++ b/kornia/augmentation/_2d/geometric/base.py
@@ -53,6 +53,21 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             transform = params["transform_matrix"]
         return as_tensor(transform, device=input.device, dtype=input.dtype)
 
+    def get_inverse_transformation_matrix(
+        self, input: Tensor, params: Dict[str, Tensor], flags: Optional[Dict[str, Any]] = None
+    ) -> Tensor:
+        """Obtain inversed transformation matrices.
+
+        Return the current transformation matrix if existed. Generate a new one, otherwise.
+        """
+        flags = self.flags if flags is None else flags
+        if "transform_matrix_inv" in params:
+            transform = params["transform_matrix_inv"]
+        else:
+            params = self.inverse_parameters(params)
+            transform = params["transform_matrix_inv"]
+        return as_tensor(transform, device=input.device, dtype=input.dtype)
+
     def apply_non_transform_mask(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:

--- a/kornia/augmentation/_2d/geometric/base.py
+++ b/kornia/augmentation/_2d/geometric/base.py
@@ -25,7 +25,7 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         self,
         input: Tensor,
         flags: Dict[str, Any],
-        transform: Tensor,
+        transform: Optional[Tensor] = None,
         size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
         """By default, the exact transformation as ``apply_transform`` will be used."""

--- a/kornia/augmentation/_2d/geometric/base.py
+++ b/kornia/augmentation/_2d/geometric/base.py
@@ -68,15 +68,11 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             transform = params["transform_matrix_inv"]
         return as_tensor(transform, device=input.device, dtype=input.dtype)
 
-    def apply_non_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process masks corresponding to the inputs that are no transformation applied."""
         return input
 
-    def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process masks corresponding to the inputs that are transformed.
 
         Note:
@@ -91,15 +87,11 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             flags["resample"] = resample_method
         return output
 
-    def apply_non_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def apply_non_transform_box(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         """Process boxes corresponding to the inputs that are no transformation applied."""
         return input
 
-    def apply_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def apply_transform_box(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         """Process boxes corresponding to the inputs that are transformed."""
         transform = params["transform_matrix"]
         input = self.apply_non_transform_box(input, params, flags)
@@ -111,29 +103,21 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         """Process keypoints corresponding to the inputs that are no transformation applied."""
         return input
 
-    def apply_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Keypoints:
+    def apply_transform_keypoint(self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Keypoints:
         """Process keypoints corresponding to the inputs that are transformed."""
         transform = params["transform_matrix"]
         input = self.apply_non_transform_keypoint(input, params, flags)
         return input.transform_keypoints_(transform)
 
-    def apply_non_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process class tags corresponding to the inputs that are no transformation applied."""
         return input
 
-    def apply_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process class tags corresponding to the inputs that are transformed."""
         return input
 
-    def inverse_inputs(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
-    ) -> Tensor:
+    def inverse_inputs(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Tensor:
         in_tensor = self.transform_tensor(input)
         batch_prob = params['batch_prob'][:, None, None, None]
 
@@ -151,9 +135,7 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             return inversed
         return inversed * batch_prob.round() + input * (1 - batch_prob.round())
 
-    def inverse_masks(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
-    ) -> Tensor:
+    def inverse_masks(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Tensor:
         resample_method: Optional[Resample] = None
         if "resample" in flags:
             resample_method = flags["resample"]
@@ -163,9 +145,7 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             flags["resample"] = resample_method
         return output
 
-    def inverse_boxes(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
-    ) -> Boxes:
+    def inverse_boxes(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Boxes:
         batch_prob = params['batch_prob'][:, None, None]
 
         params, flags = self._process_kwargs_to_params_and_flags(
@@ -182,7 +162,7 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         return input.transform_boxes(transform) * batch_prob.round() + input * (1 - batch_prob.round())
 
     def inverse_keypoints(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs
     ) -> Keypoints:
         """Inverse the transformation on keypoints.
 
@@ -207,9 +187,7 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             return input.transform_keypoints(transform)
         return input.transform_keypoints(transform) * batch_prob.round() + input * (1 - batch_prob.round())
 
-    def inverse_classes(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
-    ) -> Tensor:
+    def inverse_classes(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Tensor:
         return input
 
     def inverse(self, input: Tensor, params: Optional[Dict[str, Tensor]] = None, **kwargs) -> Tensor:

--- a/kornia/augmentation/_2d/geometric/base.py
+++ b/kornia/augmentation/_2d/geometric/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 from kornia.augmentation._2d.base import RigidAffineAugmentationBase2D
 from kornia.constants import Resample
@@ -21,19 +21,20 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
           to the batch form ``False``.
     """
 
-    def inverse_transform(
-        self,
-        input: Tensor,
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
-    ) -> Tensor:
+    def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """By default, the exact transformation as ``apply_transform`` will be used."""
         raise NotImplementedError
 
-    def compute_inverse_transformation(self, transform: Tensor):
+    def compute_inverse_transformation(self, transform: Tensor) -> Tensor:
         """Compute the inverse transform of given transformation matrices."""
         return _torch_inverse_cast(transform)
+
+    def inverse_parameters(self, params: Dict[str, Tensor]) -> Dict[str, Tensor]:
+        """Update the value for `transform_matrix_inv` key."""
+        transform = params["transform_matrix"]
+        transform = self.compute_inverse_transformation(transform)
+        params.update({"transform_matrix_inv": transform})
+        return params
 
     def get_transformation_matrix(
         self, input: Tensor, params: Optional[Dict[str, Tensor]] = None, flags: Optional[Dict[str, Any]] = None
@@ -47,11 +48,9 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             transform = params["transform_matrix"]
         elif params is not None:
             transform = self.generate_transformation_matrix(input, params, flags)
-        elif self.transform_matrix is None:
-            params = self.forward_parameters(input.shape)
-            transform = self.generate_transformation_matrix(input, params, flags)
         else:
-            transform = self.transform_matrix
+            params = self.forward_parameters(input.shape)
+            transform = params["transform_matrix"]
         return as_tensor(transform, device=input.device, dtype=input.dtype)
 
     def apply_non_transform_mask(
@@ -118,11 +117,7 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         return input
 
     def inverse_inputs(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
     ) -> Tensor:
         in_tensor = self.transform_tensor(input)
         batch_prob = params['batch_prob'][:, None, None, None]
@@ -131,24 +126,18 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             self._params if params is None else params, flags, **kwargs
         )
 
-        size = None
-        if "forward_input_shape" in params:
-            # Majorly for cropping functions
-            size = params['forward_input_shape'].numpy().tolist()
-            size = (size[-2], size[-1])
+        if "transform_matrix_inv" not in params:
+            params = self.inverse_parameters(params)
 
-        transform = params["transform_matrix_inv"]
+        inversed = self.inverse_transform(in_tensor, params=params, flags=flags)
 
-        inversed = self.inverse_transform(in_tensor, flags=flags, transform=transform, size=size)
-
+        # No need to permute according to batch_prob
+        if self._param_generator is not None and self._param_generator.has_fit_batch_prob:
+            return inversed
         return inversed * batch_prob.round() + input * (1 - batch_prob.round())
 
     def inverse_masks(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
     ) -> Tensor:
         resample_method: Optional[Resample] = None
         if "resample" in flags:
@@ -160,11 +149,7 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         return output
 
     def inverse_boxes(
-        self,
-        input: Boxes,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
+        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
     ) -> Boxes:
         batch_prob = params['batch_prob'][:, None, None]
 
@@ -172,16 +157,17 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             self._params if params is None else params, flags, **kwargs
         )
 
+        if "transform_matrix_inv" not in params:
+            params = self.inverse_parameters(params)
         transform = params["transform_matrix_inv"]
 
+        # No need to permute according to batch_prob
+        if self._param_generator is not None and self._param_generator.has_fit_batch_prob:
+            return input.transform_boxes(transform)
         return input.transform_boxes(transform) * batch_prob.round() + input * (1 - batch_prob.round())
 
     def inverse_keypoints(
-        self,
-        input: Keypoints,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
     ) -> Keypoints:
         """Inverse the transformation on keypoints.
 
@@ -197,16 +183,17 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             self._params if params is None else params, flags, **kwargs
         )
 
+        if "transform_matrix_inv" not in params:
+            params = self.inverse_parameters(params)
         transform = params["transform_matrix_inv"]
 
+        # No need to permute according to batch_prob
+        if self._param_generator is not None and self._param_generator.has_fit_batch_prob:
+            return input.transform_keypoints(transform)
         return input.transform_keypoints(transform) * batch_prob.round() + input * (1 - batch_prob.round())
 
     def inverse_classes(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
     ) -> Tensor:
         return input
 
@@ -228,13 +215,6 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
 
         if params is None:
             params = self._params
-
-        if "transform_matrix_inv" in params:
-            transform = params["transform_matrix_inv"]
-        else:
-            transform = self.get_transformation_matrix(in_tensor, params=params, flags=flags)
-            transform = self.compute_inverse_transformation(transform)
-            params.update({"transform_matrix_inv": transform})
 
         output = self.inverse_inputs(in_tensor, params, flags)
 

--- a/kornia/augmentation/_2d/geometric/center_crop.py
+++ b/kornia/augmentation/_2d/geometric/center_crop.py
@@ -2,10 +2,10 @@ from typing import Any, Dict, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
-from kornia.core import Tensor
 from kornia.constants import Resample
-from kornia.geometry.transform import crop_by_indices, crop_by_transform_mat, get_perspective_transform
+from kornia.core import Tensor
 from kornia.geometry.bbox import infer_bbox_shape
+from kornia.geometry.transform import crop_by_indices, crop_by_transform_mat, get_perspective_transform
 
 
 class CenterCrop(GeometricAugmentationBase2D):
@@ -110,7 +110,8 @@ class CenterCrop(GeometricAugmentationBase2D):
             if not (len(height) == len(width) == 1):
                 raise RuntimeError(f"Invalid dst boxes with multiple height {height} and width {width}.")
             return crop_by_indices(
-                input, params["src"].to(device=input.device), (height.long().item(), width.long().item()))
+                input, params["src"].to(device=input.device), (height.long().item(), width.long().item())
+            )
         raise NotImplementedError(f"Not supported type: {flags['cropping_mode']}.")
 
     def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:

--- a/kornia/augmentation/_2d/geometric/center_crop.py
+++ b/kornia/augmentation/_2d/geometric/center_crop.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
-from torch import Tensor
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
+from kornia.core import Tensor
 from kornia.constants import Resample
 from kornia.geometry.transform import crop_by_indices, crop_by_transform_mat, get_perspective_transform
 
@@ -29,7 +29,7 @@ class CenterCrop(GeometricAugmentationBase2D):
                        differentiability.
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, out_h, out_w)`
 
     .. note::
@@ -94,15 +94,16 @@ class CenterCrop(GeometricAugmentationBase2D):
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         if flags["cropping_mode"] in ("resample", "slice"):
-            transform: Tensor = get_perspective_transform(params["src"].to(input), params["dst"].to(input))
+            transform = get_perspective_transform(params["src"].to(input), params["dst"].to(input))
             transform = transform.expand(input.shape[0], -1, -1)
             return transform
         raise NotImplementedError(f"Not supported type: {flags['cropping_mode']}.")
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         if flags["cropping_mode"] == "resample":  # uses bilinear interpolation to crop
+            transform = params["transform_matrix"]
             if not isinstance(transform, Tensor):
                 raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
 

--- a/kornia/augmentation/_2d/geometric/crop.py
+++ b/kornia/augmentation/_2d/geometric/crop.py
@@ -151,9 +151,7 @@ class RandomCrop(GeometricAugmentationBase2D):
             return transform
         raise NotImplementedError(f"Not supported type: {flags['cropping_mode']}.")
 
-    def apply_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Keypoints:
+    def apply_transform_keypoint(self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Keypoints:
         """Process keypoints corresponding to the inputs that are no transformation applied."""
         # For pad the keypoints properly.
         padding_size = params["padding_size"].to(device=input.device)
@@ -224,9 +222,7 @@ class RandomCrop(GeometricAugmentationBase2D):
             align_corners=flags["align_corners"],
         )
 
-    def inverse_inputs(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
-    ) -> Tensor:
+    def inverse_inputs(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Tensor:
         if flags["cropping_mode"] != "resample":
             raise NotImplementedError(
                 f"`inverse` is only applicable for resample cropping mode. Got {flags['cropping_mode']}."
@@ -238,9 +234,7 @@ class RandomCrop(GeometricAugmentationBase2D):
         padding_size = [-padding_size[0], -padding_size[1], -padding_size[2], -padding_size[3]]
         return self.precrop_padding(out, padding_size)
 
-    def inverse_boxes(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs,
-    ) -> Boxes:
+    def inverse_boxes(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Boxes:
         if flags["cropping_mode"] != "resample":
             raise NotImplementedError(
                 f"`inverse` is only applicable for resample cropping mode. Got {flags['cropping_mode']}."

--- a/kornia/augmentation/_2d/geometric/crop.py
+++ b/kornia/augmentation/_2d/geometric/crop.py
@@ -175,7 +175,7 @@ class RandomCrop(GeometricAugmentationBase2D):
 
         flags = self.flags if flags is None else flags
         if flags["cropping_mode"] == "resample":  # uses bilinear interpolation to crop
-            transform = params["transform_matrix"]
+            transform = self.get_transformation_matrix(input, params=params, flags=flags)
             # Fit the arg to F.pad
             if flags['padding_mode'] == "constant":
                 padding_mode = "zeros"
@@ -205,7 +205,7 @@ class RandomCrop(GeometricAugmentationBase2D):
             )
         size = params['forward_input_shape'].numpy().tolist()
         size = (size[-2], size[-1])
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
         # Fit the arg to F.pad
         if flags['padding_mode'] == "constant":
             padding_mode = "zeros"

--- a/kornia/augmentation/_2d/geometric/crop.py
+++ b/kornia/augmentation/_2d/geometric/crop.py
@@ -152,25 +152,25 @@ class RandomCrop(GeometricAugmentationBase2D):
         raise NotImplementedError(f"Not supported type: {flags['cropping_mode']}.")
 
     def apply_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Keypoints:
         """Process keypoints corresponding to the inputs that are no transformation applied."""
         # For pad the keypoints properly.
         padding_size = params["padding_size"].to(device=input.device)
         input = input.pad(padding_size)
-        return super().apply_transform_keypoint(input=input, params=params, flags=flags, transform=transform)
+        return super().apply_transform_keypoint(input=input, params=params, flags=flags)
 
     def apply_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Boxes:
         """Process keypoints corresponding to the inputs that are no transformation applied."""
         # For pad the boxes properly.
         padding_size = params["padding_size"]
         input = input.pad(padding_size)
-        return super().apply_transform_box(input=input, params=params, flags=flags, transform=transform)
+        return super().apply_transform_box(input=input, params=params, flags=flags)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         padding_size: Optional[List[int]] = None
         if "padding_size" in params and isinstance(params["padding_size"], Tensor):
@@ -179,8 +179,7 @@ class RandomCrop(GeometricAugmentationBase2D):
 
         flags = self.flags if flags is None else flags
         if flags["cropping_mode"] == "resample":  # uses bilinear interpolation to crop
-            if not isinstance(transform, Tensor):
-                raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
+            transform = params["transform_matrix"]
             # Fit the arg to F.pad
             if flags['padding_mode'] == "constant":
                 padding_mode = "zeros"
@@ -241,14 +240,13 @@ class RandomCrop(GeometricAugmentationBase2D):
         input: Tensor,
         params: Dict[str, Tensor],
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Tensor:
         if flags["cropping_mode"] != "resample":
             raise NotImplementedError(
                 f"`inverse` is only applicable for resample cropping mode. Got {flags['cropping_mode']}."
             )
-        out = super().inverse_inputs(input, params, flags, transform, **kwargs)
+        out = super().inverse_inputs(input, params, flags, **kwargs)
         if not params["batch_prob"].all():
             return out
         padding_size = params["padding_size"].unique(dim=0).cpu().squeeze().numpy().tolist()
@@ -278,14 +276,13 @@ class RandomCrop(GeometricAugmentationBase2D):
         input: Keypoints,
         params: Dict[str, Tensor],
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Keypoints:
         if flags["cropping_mode"] != "resample":
             raise NotImplementedError(
                 f"`inverse` is only applicable for resample cropping mode. Got {flags['cropping_mode']}."
             )
-        output = super().inverse_keypoints(input, params, flags, transform, **kwargs)
+        output = super().inverse_keypoints(input, params, flags, **kwargs)
         if not params["batch_prob"].all():
             return output
 

--- a/kornia/augmentation/_2d/geometric/elastic_transform.py
+++ b/kornia/augmentation/_2d/geometric/elastic_transform.py
@@ -78,9 +78,7 @@ class RandomElasticTransform(AugmentationBase2D):
             noise = torch.rand(B, 2, H, W, device=self.device, dtype=self.dtype)
         return dict(noise=noise * 2 - 1)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return elastic_transform2d(
             input,
             params["noise"].to(input),
@@ -92,21 +90,15 @@ class RandomElasticTransform(AugmentationBase2D):
             flags["padding_mode"],
         )
 
-    def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process masks corresponding to the inputs that are transformed."""
         return self.apply_transform(input, params=params, flags=flags)
 
-    def apply_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def apply_transform_box(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         """Process masks corresponding to the inputs that are transformed."""
         # We assume that boxes may not be affected too much by the deformation.
         return input
 
-    def apply_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process class tags corresponding to the inputs that are transformed."""
         return input

--- a/kornia/augmentation/_2d/geometric/elastic_transform.py
+++ b/kornia/augmentation/_2d/geometric/elastic_transform.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -79,7 +79,7 @@ class RandomElasticTransform(AugmentationBase2D):
         return dict(noise=noise * 2 - 1)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return elastic_transform2d(
             input,
@@ -93,20 +93,20 @@ class RandomElasticTransform(AugmentationBase2D):
         )
 
     def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         """Process masks corresponding to the inputs that are transformed."""
-        return self.apply_transform(input, params=params, flags=flags, transform=transform)
+        return self.apply_transform(input, params=params, flags=flags)
 
     def apply_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Boxes:
         """Process masks corresponding to the inputs that are transformed."""
         # We assume that boxes may not be affected too much by the deformation.
         return input
 
     def apply_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         """Process class tags corresponding to the inputs that are transformed."""
         return input

--- a/kornia/augmentation/_2d/geometric/fisheye.py
+++ b/kornia/augmentation/_2d/geometric/fisheye.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.base import AugmentationBase2D
@@ -65,7 +65,7 @@ class RandomFisheye(AugmentationBase2D):
             raise ValueError(f"Tensor must be of shape (2,). Got: {data.shape}.")
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         # create the initial sampling fields
         B, _, H, W = input.shape

--- a/kornia/augmentation/_2d/geometric/fisheye.py
+++ b/kornia/augmentation/_2d/geometric/fisheye.py
@@ -76,6 +76,6 @@ class RandomFisheye(AugmentationBase2D):
         gamma = params["gamma"].view(B, 1, 1).to(input)
         # compute and apply the distances respect to the camera optical center
         distance = ((center_x - field_x) ** 2 + (center_y - field_y) ** 2) ** 0.5
-        field_x = field_x + field_x * distance ** gamma  # BxHxw
-        field_y = field_y + field_y * distance ** gamma  # BxHxW
+        field_x = field_x + field_x * distance**gamma  # BxHxw
+        field_y = field_y + field_y * distance**gamma  # BxHxW
         return remap(input, field_x, field_y, normalized_coordinates=True, align_corners=True)

--- a/kornia/augmentation/_2d/geometric/fisheye.py
+++ b/kornia/augmentation/_2d/geometric/fisheye.py
@@ -64,9 +64,7 @@ class RandomFisheye(AugmentationBase2D):
         if len(data.shape) != 1 and data.shape[0] != 2:
             raise ValueError(f"Tensor must be of shape (2,). Got: {data.shape}.")
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         # create the initial sampling fields
         B, _, H, W = input.shape
         grid = create_meshgrid(H, W, normalized_coordinates=True)
@@ -78,6 +76,6 @@ class RandomFisheye(AugmentationBase2D):
         gamma = params["gamma"].view(B, 1, 1).to(input)
         # compute and apply the distances respect to the camera optical center
         distance = ((center_x - field_x) ** 2 + (center_y - field_y) ** 2) ** 0.5
-        field_x = field_x + field_x * distance**gamma  # BxHxw
-        field_y = field_y + field_y * distance**gamma  # BxHxW
+        field_x = field_x + field_x * distance ** gamma  # BxHxw
+        field_y = field_y + field_y * distance ** gamma  # BxHxW
         return remap(input, field_x, field_y, normalized_coordinates=True, align_corners=True)

--- a/kornia/augmentation/_2d/geometric/horizontal_flip.py
+++ b/kornia/augmentation/_2d/geometric/horizontal_flip.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict
 
 from torch import Tensor
 
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
-from kornia.core import as_tensor, tensor
+from kornia.core import tensor
 from kornia.geometry.transform import hflip
 
 
@@ -59,23 +59,8 @@ class RandomHorizontalFlip(GeometricAugmentationBase2D):
 
         return flip_mat.expand(input.shape[0], 3, 3)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return hflip(input)
 
-    def inverse_transform(
-        self,
-        input: Tensor,
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
-        return self.apply_transform(
-            input,
-            params=self._params,
-            transform=as_tensor(transform, device=input.device, dtype=input.dtype),
-            flags=flags,
-        )
+    def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        return hflip(input)

--- a/kornia/augmentation/_2d/geometric/horizontal_flip.py
+++ b/kornia/augmentation/_2d/geometric/horizontal_flip.py
@@ -25,7 +25,7 @@ class RandomHorizontalFlip(GeometricAugmentationBase2D):
                  to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -60,7 +60,7 @@ class RandomHorizontalFlip(GeometricAugmentationBase2D):
         return flip_mat.expand(input.shape[0], 3, 3)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return hflip(input)
 

--- a/kornia/augmentation/_2d/geometric/pad.py
+++ b/kornia/augmentation/_2d/geometric/pad.py
@@ -1,12 +1,12 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import torch
 from torch import Tensor
 
-from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
+from kornia.augmentation._2d.base import AugmentationBase2D
 
 
-class PadTo(GeometricAugmentationBase2D):
+class PadTo(AugmentationBase2D):
     r"""Pad the given sample to a specific size. Always occurs (p=1.0).
 
     .. image:: _static/img/PadTo.png
@@ -51,14 +51,7 @@ class PadTo(GeometricAugmentationBase2D):
         super().__init__(p=1.0, same_on_batch=True, p_batch=1.0, keepdim=keepdim)
         self.flags = dict(size=size, pad_mode=pad_mode, pad_value=pad_value)
 
-    # TODO: It is incorrect to return identity
-    # TODO: Having a resampled version with ``warp_affine``
-    def compute_transformation(self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        return self.identity_matrix(image)
-
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, _, height, width = input.shape
         height_pad: int = flags["size"][0] - height
         width_pad: int = flags["size"][1] - width
@@ -66,13 +59,8 @@ class PadTo(GeometricAugmentationBase2D):
             input, [0, width_pad, 0, height_pad], mode=flags["pad_mode"], value=flags["pad_value"]
         )
 
-    def inverse_transform(
-        self,
-        input: Tensor,
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
-    ) -> Tensor:
-        if size is None:
-            raise RuntimeError("`size` has to be a tuple. Got None.")
+    def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        size = params['forward_input_shape'].numpy().tolist()
+        size = (size[-2], size[-1])
+
         return input[..., : size[0], : size[1]]

--- a/kornia/augmentation/_2d/geometric/pad.py
+++ b/kornia/augmentation/_2d/geometric/pad.py
@@ -21,7 +21,7 @@ class PadTo(GeometricAugmentationBase2D):
                  to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -57,7 +57,7 @@ class PadTo(GeometricAugmentationBase2D):
         return self.identity_matrix(image)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         _, _, height, width = input.shape
         height_pad: int = flags["size"][0] - height

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
@@ -26,7 +26,7 @@ class RandomPerspective(GeometricAugmentationBase2D):
             Preserves area on average. See https://arxiv.org/abs/2104.03308 for further details.
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -87,15 +87,15 @@ class RandomPerspective(GeometricAugmentationBase2D):
     def inverse_transform(
         self,
         input: Tensor,
+        params: Dict[str, Tensor],
         flags: Dict[str, Any],
         transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
         if not isinstance(transform, Tensor):
             raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
         return self.apply_transform(
             input,
-            params=self._params,
+            params=params,
             transform=as_tensor(transform, device=input.device, dtype=input.dtype),
             flags=flags,
         )

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -75,7 +75,7 @@ class RandomPerspective(GeometricAugmentationBase2D):
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, _, height, width = input.shape
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return warp_perspective(
             input, transform, (height, width), mode=flags["resample"].name.lower(), align_corners=flags["align_corners"]
@@ -85,7 +85,7 @@ class RandomPerspective(GeometricAugmentationBase2D):
         size = params['forward_input_shape'].numpy().tolist()
         size = (size[-2], size[-1])
 
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
         return warp_perspective(
             input, transform, (size[0], size[1]), mode=flags["resample"].name.lower(),
             align_corners=flags["align_corners"]

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -87,6 +87,9 @@ class RandomPerspective(GeometricAugmentationBase2D):
 
         transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
         return warp_perspective(
-            input, transform, (size[0], size[1]), mode=flags["resample"].name.lower(),
-            align_corners=flags["align_corners"]
+            input,
+            transform,
+            (size[0], size[1]),
+            mode=flags["resample"].name.lower(),
+            align_corners=flags["align_corners"],
         )

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import torch
 
@@ -50,7 +50,7 @@ class Resize(GeometricAugmentationBase2D):
         return transform
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         B, C, _, _ = input.shape
         out_size = tuple(params["output_size"][0].tolist())
@@ -72,19 +72,11 @@ class Resize(GeometricAugmentationBase2D):
             )
         return out
 
-    def inverse_transform(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-    ) -> Tensor:
+    def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        size = params['forward_input_shape'].numpy().tolist()
+        size = (size[-2], size[-1])
 
-        forward_input_shape = params['forward_input_shape'].numpy().tolist()
-        size: Tuple[int, int] = (forward_input_shape[-2], forward_input_shape[-1])
-
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
+        transform = params["transform_matrix_inv"]
 
         return crop_by_transform_mat(
             input, transform[:, :2, :], size, flags["resample"].name.lower(), "zeros", flags["align_corners"]

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -53,7 +53,7 @@ class Resize(GeometricAugmentationBase2D):
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         B, C, _, _ = input.shape
-        out_size = tuple(params["output_size"][0].tolist())
+        out_size = tuple(params["output_size"].long()[0].tolist())
         out = torch.empty(B, C, *out_size, device=input.device, dtype=input.dtype)
 
         for i in range(B):
@@ -76,7 +76,7 @@ class Resize(GeometricAugmentationBase2D):
         size = params['forward_input_shape'].numpy().tolist()
         size = (size[-2], size[-1])
 
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
 
         return crop_by_transform_mat(
             input, transform[:, :2, :], size, flags["resample"].name.lower(), "zeros", flags["align_corners"]

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -49,9 +49,7 @@ class Resize(GeometricAugmentationBase2D):
         transform = transform.expand(input.shape[0], -1, -1)
         return transform
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         B, C, _, _ = input.shape
         out_size = tuple(params["output_size"].long()[0].tolist())
         out = torch.empty(B, C, *out_size, device=input.device, dtype=input.dtype)

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -75,12 +75,13 @@ class Resize(GeometricAugmentationBase2D):
     def inverse_transform(
         self,
         input: Tensor,
+        params: Dict[str, Tensor],
         flags: Dict[str, Any],
         transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
-        if not isinstance(size, tuple):
-            raise TypeError(f'Expected the size be a tuple. Gotcha {type(size)}')
+
+        forward_input_shape = params['forward_input_shape'].numpy().tolist()
+        size: Tuple[int, int] = (forward_input_shape[-2], forward_input_shape[-1])
 
         if not isinstance(transform, Tensor):
             raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')

--- a/kornia/augmentation/_2d/geometric/resized_crop.py
+++ b/kornia/augmentation/_2d/geometric/resized_crop.py
@@ -117,19 +117,20 @@ class RandomResizedCrop(GeometricAugmentationBase2D):
     def inverse_transform(
         self,
         input: Tensor,
+        params: Dict[str, Tensor],
         flags: Dict[str, Any],
         transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
         if flags["cropping_mode"] != "resample":
             raise NotImplementedError(
                 f"`inverse` is only applicable for resample cropping mode. Got {flags['cropping_mode']}."
             )
-        if not isinstance(size, tuple):
-            raise TypeError(f'Expected the size be a tuple. Gotcha {type(size)}')
 
         if not isinstance(transform, Tensor):
             raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
+
+        forward_input_shape = params['forward_input_shape'].numpy().tolist()
+        size: Tuple[int, int] = (forward_input_shape[-2], forward_input_shape[-1])
 
         return crop_by_transform_mat(
             input,

--- a/kornia/augmentation/_2d/geometric/resized_crop.py
+++ b/kornia/augmentation/_2d/geometric/resized_crop.py
@@ -84,9 +84,7 @@ class RandomResizedCrop(GeometricAugmentationBase2D):
             return transform
         raise NotImplementedError(f"Not supported type: {flags['cropping_mode']}.")
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         if flags["cropping_mode"] == "resample":  # uses bilinear interpolation to crop
             transform = self.get_transformation_matrix(input, params=params, flags=flags)
 

--- a/kornia/augmentation/_2d/geometric/resized_crop.py
+++ b/kornia/augmentation/_2d/geometric/resized_crop.py
@@ -88,7 +88,7 @@ class RandomResizedCrop(GeometricAugmentationBase2D):
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         if flags["cropping_mode"] == "resample":  # uses bilinear interpolation to crop
-            transform = params["transform_matrix"]
+            transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
             return crop_by_transform_mat(
                 input,
@@ -116,7 +116,7 @@ class RandomResizedCrop(GeometricAugmentationBase2D):
 
         size = params['forward_input_shape'].numpy().tolist()
         size = (size[-2], size[-1])
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
 
         return crop_by_transform_mat(
             input,

--- a/kornia/augmentation/_2d/geometric/rotation.py
+++ b/kornia/augmentation/_2d/geometric/rotation.py
@@ -98,15 +98,15 @@ class RandomRotation(GeometricAugmentationBase2D):
     def inverse_transform(
         self,
         input: Tensor,
+        params: Dict[str, Tensor],
         flags: Dict[str, Any],
         transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
     ) -> Tensor:
         if not isinstance(transform, Tensor):
             raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
         return self.apply_transform(
             input,
-            params=self._params,
+            params=params,
             transform=as_tensor(transform, device=input.device, dtype=input.dtype),
             flags=flags,
         )

--- a/kornia/augmentation/_2d/geometric/rotation.py
+++ b/kornia/augmentation/_2d/geometric/rotation.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
 from kornia.constants import Resample
-from kornia.core import Tensor, as_tensor
+from kornia.core import Tensor
 from kornia.geometry.transform import affine
 from kornia.geometry.transform.affwarp import _compute_rotation_matrix, _compute_tensor_center
 from kornia.utils.misc import eye_like
@@ -25,7 +25,7 @@ class RandomRotation(GeometricAugmentationBase2D):
                  to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -87,26 +87,10 @@ class RandomRotation(GeometricAugmentationBase2D):
 
         return trans_mat
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
-
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        transform = params["transform_matrix"]
         return affine(input, transform[..., :2, :3], flags["resample"].name.lower(), "zeros", flags["align_corners"])
 
-    def inverse_transform(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
-        return self.apply_transform(
-            input,
-            params=params,
-            transform=as_tensor(transform, device=input.device, dtype=input.dtype),
-            flags=flags,
-        )
+    def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        transform = params["transform_matrix_inv"]
+        return affine(input, transform[..., :2, :3], flags["resample"].name.lower(), "zeros", flags["align_corners"])

--- a/kornia/augmentation/_2d/geometric/rotation.py
+++ b/kornia/augmentation/_2d/geometric/rotation.py
@@ -88,9 +88,9 @@ class RandomRotation(GeometricAugmentationBase2D):
         return trans_mat
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
         return affine(input, transform[..., :2, :3], flags["resample"].name.lower(), "zeros", flags["align_corners"])
 
     def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
         return affine(input, transform[..., :2, :3], flags["resample"].name.lower(), "zeros", flags["align_corners"])

--- a/kornia/augmentation/_2d/geometric/shear.py
+++ b/kornia/augmentation/_2d/geometric/shear.py
@@ -82,7 +82,7 @@ class RandomShear(GeometricAugmentationBase2D):
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, _, height, width = input.shape
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return warp_affine(
             input,
@@ -97,7 +97,7 @@ class RandomShear(GeometricAugmentationBase2D):
         size = params['forward_input_shape'].numpy().tolist()
         size = (size[-2], size[-1])
 
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
         return warp_affine(
             input,
             transform[:, :2, :],

--- a/kornia/augmentation/_2d/geometric/thin_plate_spline.py
+++ b/kornia/augmentation/_2d/geometric/thin_plate_spline.py
@@ -55,9 +55,7 @@ class RandomThinPlateSpline(AugmentationBase2D):
         dst = src + self.dist.rsample(src.shape)
         return dict(src=src, dst=dst)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         src = params["src"].to(input)
         dst = params["dst"].to(input)
         # NOTE: warp_image_tps need to use inverse parameters

--- a/kornia/augmentation/_2d/geometric/thin_plate_spline.py
+++ b/kornia/augmentation/_2d/geometric/thin_plate_spline.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
 
@@ -56,7 +56,7 @@ class RandomThinPlateSpline(AugmentationBase2D):
         return dict(src=src, dst=dst)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         src = params["src"].to(input)
         dst = params["dst"].to(input)

--- a/kornia/augmentation/_2d/geometric/translate.py
+++ b/kornia/augmentation/_2d/geometric/translate.py
@@ -78,7 +78,7 @@ class RandomTranslate(GeometricAugmentationBase2D):
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, _, height, width = input.shape
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return warp_affine(
             input,
@@ -92,7 +92,7 @@ class RandomTranslate(GeometricAugmentationBase2D):
     def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         size = params['forward_input_shape'].numpy().tolist()
         size = (size[-2], size[-1])
-        transform = params["transform_matrix_inv"]
+        transform = self.get_inverse_transformation_matrix(input, params=params, flags=flags)
 
         return warp_affine(
             input,

--- a/kornia/augmentation/_2d/geometric/vertical_flip.py
+++ b/kornia/augmentation/_2d/geometric/vertical_flip.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict
 
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
-from kornia.core import Tensor, as_tensor, tensor
+from kornia.core import Tensor, tensor
 from kornia.geometry.transform import vflip
 
 
@@ -17,7 +17,7 @@ class RandomVerticalFlip(GeometricAugmentationBase2D):
                         to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -51,23 +51,8 @@ class RandomVerticalFlip(GeometricAugmentationBase2D):
 
         return flip_mat.expand(input.shape[0], 3, 3)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return vflip(input)
 
-    def inverse_transform(
-        self,
-        input: Tensor,
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-        size: Optional[Tuple[int, int]] = None,
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the `transform` be a Tensor. Got {type(transform)}.')
-        return self.apply_transform(
-            input,
-            params=self._params,
-            transform=as_tensor(transform, device=input.device, dtype=input.dtype),
-            flags=flags,
-        )
+    def inverse_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        return vflip(input)

--- a/kornia/augmentation/_2d/intensity/base.py
+++ b/kornia/augmentation/_2d/intensity/base.py
@@ -23,30 +23,20 @@ class IntensityAugmentationBase2D(RigidAffineAugmentationBase2D):
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return self.identity_matrix(input)
 
-    def apply_non_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         # For the images where batch_prob == False.
         return input
 
-    def apply_non_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return input
 
-    def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return input
 
-    def apply_non_transform_boxes(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def apply_non_transform_boxes(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         return input
 
-    def apply_transform_boxes(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def apply_transform_boxes(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         return input
 
     def apply_non_transform_keypoint(
@@ -54,17 +44,11 @@ class IntensityAugmentationBase2D(RigidAffineAugmentationBase2D):
     ) -> Keypoints:
         return input
 
-    def apply_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Keypoints:
+    def apply_transform_keypoint(self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Keypoints:
         return input
 
-    def apply_non_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return input
 
-    def apply_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return input

--- a/kornia/augmentation/_2d/intensity/base.py
+++ b/kornia/augmentation/_2d/intensity/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from torch import Tensor
 
@@ -24,47 +24,47 @@ class IntensityAugmentationBase2D(RigidAffineAugmentationBase2D):
         return self.identity_matrix(input)
 
     def apply_non_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         # For the images where batch_prob == False.
         return input
 
     def apply_non_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return input
 
     def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return input
 
     def apply_non_transform_boxes(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Boxes:
         return input
 
     def apply_transform_boxes(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Boxes:
         return input
 
     def apply_non_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Keypoints:
         return input
 
     def apply_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Keypoints:
         return input
 
     def apply_non_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return input
 
     def apply_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return input

--- a/kornia/augmentation/_2d/intensity/box_blur.py
+++ b/kornia/augmentation/_2d/intensity/box_blur.py
@@ -48,7 +48,5 @@ class RandomBoxBlur(IntensityAugmentationBase2D):
         super().__init__(p=p, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim)
         self.flags = dict(kernel_size=kernel_size, border_type=border_type, normalized=normalized)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return box_blur(input, flags["kernel_size"], flags["border_type"], flags["normalized"])

--- a/kornia/augmentation/_2d/intensity/box_blur.py
+++ b/kornia/augmentation/_2d/intensity/box_blur.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from torch import Tensor
 
@@ -49,6 +49,6 @@ class RandomBoxBlur(IntensityAugmentationBase2D):
         self.flags = dict(kernel_size=kernel_size, border_type=border_type, normalized=normalized)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return box_blur(input, flags["kernel_size"], flags["border_type"], flags["normalized"])

--- a/kornia/augmentation/_2d/intensity/brightness.py
+++ b/kornia/augmentation/_2d/intensity/brightness.py
@@ -68,8 +68,6 @@ class RandomBrightness(IntensityAugmentationBase2D):
 
         self.clip_output = clip_output
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         brightness_factor = params["brightness_factor"].to(input)
         return adjust_brightness(input, brightness_factor - 1, self.clip_output)

--- a/kornia/augmentation/_2d/intensity/brightness.py
+++ b/kornia/augmentation/_2d/intensity/brightness.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -23,7 +23,7 @@ class RandomBrightness(IntensityAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -69,7 +69,7 @@ class RandomBrightness(IntensityAugmentationBase2D):
         self.clip_output = clip_output
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         brightness_factor = params["brightness_factor"].to(input)
         return adjust_brightness(input, brightness_factor - 1, self.clip_output)

--- a/kornia/augmentation/_2d/intensity/channel_shuffle.py
+++ b/kornia/augmentation/_2d/intensity/channel_shuffle.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
 from torch import Tensor
@@ -43,7 +43,7 @@ class RandomChannelShuffle(IntensityAugmentationBase2D):
         return dict(channels=channels)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         out = torch.empty_like(input)
         for i in range(out.shape[0]):

--- a/kornia/augmentation/_2d/intensity/channel_shuffle.py
+++ b/kornia/augmentation/_2d/intensity/channel_shuffle.py
@@ -42,9 +42,7 @@ class RandomChannelShuffle(IntensityAugmentationBase2D):
         channels = torch.rand(B, C).argsort(dim=1)
         return dict(channels=channels)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         out = torch.empty_like(input)
         for i in range(out.shape[0]):
             out[i] = input[i, params["channels"][i]]

--- a/kornia/augmentation/_2d/intensity/color_jiggle.py
+++ b/kornia/augmentation/_2d/intensity/color_jiggle.py
@@ -71,9 +71,7 @@ class ColorJiggle(IntensityAugmentationBase2D):
         self.hue = hue
         self._param_generator = rg.ColorJiggleGenerator(brightness, contrast, saturation, hue)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         transforms = [
             lambda img: adjust_brightness(img, params["brightness_factor"] - 1),
             lambda img: adjust_contrast(img, params["contrast_factor"]),

--- a/kornia/augmentation/_2d/intensity/color_jiggle.py
+++ b/kornia/augmentation/_2d/intensity/color_jiggle.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -22,7 +22,7 @@ class ColorJiggle(IntensityAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -72,7 +72,7 @@ class ColorJiggle(IntensityAugmentationBase2D):
         self._param_generator = rg.ColorJiggleGenerator(brightness, contrast, saturation, hue)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         transforms = [
             lambda img: adjust_brightness(img, params["brightness_factor"] - 1),

--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -84,9 +84,7 @@ class ColorJitter(IntensityAugmentationBase2D):
         self.hue = hue
         self._param_generator = rg.ColorJitterGenerator(brightness, contrast, saturation, hue)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         transforms = [
             lambda img: adjust_brightness_accumulative(img, params["brightness_factor"]),
             lambda img: adjust_contrast_with_mean_subtraction(img, params["contrast_factor"]),

--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -32,7 +32,7 @@ class ColorJitter(IntensityAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -85,7 +85,7 @@ class ColorJitter(IntensityAugmentationBase2D):
         self._param_generator = rg.ColorJitterGenerator(brightness, contrast, saturation, hue)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         transforms = [
             lambda img: adjust_brightness_accumulative(img, params["brightness_factor"]),

--- a/kornia/augmentation/_2d/intensity/contrast.py
+++ b/kornia/augmentation/_2d/intensity/contrast.py
@@ -67,8 +67,6 @@ class RandomContrast(IntensityAugmentationBase2D):
 
         self.clip_output = clip_output
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         contrast_factor = params["contrast_factor"].to(input)
         return adjust_contrast(input, contrast_factor, self.clip_output)

--- a/kornia/augmentation/_2d/intensity/contrast.py
+++ b/kornia/augmentation/_2d/intensity/contrast.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -22,7 +22,7 @@ class RandomContrast(IntensityAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -68,7 +68,7 @@ class RandomContrast(IntensityAugmentationBase2D):
         self.clip_output = clip_output
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         contrast_factor = params["contrast_factor"].to(input)
         return adjust_contrast(input, contrast_factor, self.clip_output)

--- a/kornia/augmentation/_2d/intensity/denormalize.py
+++ b/kornia/augmentation/_2d/intensity/denormalize.py
@@ -60,7 +60,5 @@ class Denormalize(IntensityAugmentationBase2D):
 
         self.flags = dict(mean=mean, std=std)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return denormalize(input, flags["mean"], flags["std"])

--- a/kornia/augmentation/_2d/intensity/denormalize.py
+++ b/kornia/augmentation/_2d/intensity/denormalize.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -61,6 +61,6 @@ class Denormalize(IntensityAugmentationBase2D):
         self.flags = dict(mean=mean, std=std)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return denormalize(input, flags["mean"], flags["std"])

--- a/kornia/augmentation/_2d/intensity/equalize.py
+++ b/kornia/augmentation/_2d/intensity/equalize.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from torch import Tensor
 
@@ -18,7 +18,7 @@ class RandomEqualize(IntensityAugmentationBase2D):
                  to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -46,6 +46,6 @@ class RandomEqualize(IntensityAugmentationBase2D):
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return equalize(input)

--- a/kornia/augmentation/_2d/intensity/equalize.py
+++ b/kornia/augmentation/_2d/intensity/equalize.py
@@ -45,7 +45,5 @@ class RandomEqualize(IntensityAugmentationBase2D):
     def __init__(self, same_on_batch: bool = False, p: float = 0.5, keepdim: bool = False) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return equalize(input)

--- a/kornia/augmentation/_2d/intensity/erasing.py
+++ b/kornia/augmentation/_2d/intensity/erasing.py
@@ -67,9 +67,7 @@ class RandomErasing(IntensityAugmentationBase2D):
         self.value = value
         self._param_generator = rg.RectangleEraseGenerator(scale, ratio, value)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, c, h, w = input.size()
         values = params["values"].unsqueeze(-1).unsqueeze(-1).unsqueeze(-1).repeat(1, *input.shape[1:]).to(input)
 
@@ -79,9 +77,7 @@ class RandomErasing(IntensityAugmentationBase2D):
         transformed = where(mask == 1.0, values, input)
         return transformed
 
-    def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         _, c, h, w = input.size()
 
         values = params["values"][..., None, None, None].repeat(1, *input.shape[1:]).to(input)

--- a/kornia/augmentation/_2d/intensity/erasing.py
+++ b/kornia/augmentation/_2d/intensity/erasing.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -28,7 +28,7 @@ class RandomErasing(IntensityAugmentationBase2D):
                         to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     Note:
@@ -68,7 +68,7 @@ class RandomErasing(IntensityAugmentationBase2D):
         self._param_generator = rg.RectangleEraseGenerator(scale, ratio, value)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         _, c, h, w = input.size()
         values = params["values"].unsqueeze(-1).unsqueeze(-1).unsqueeze(-1).repeat(1, *input.shape[1:]).to(input)
@@ -80,7 +80,7 @@ class RandomErasing(IntensityAugmentationBase2D):
         return transformed
 
     def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         _, c, h, w = input.size()
 

--- a/kornia/augmentation/_2d/intensity/gamma.py
+++ b/kornia/augmentation/_2d/intensity/gamma.py
@@ -64,9 +64,7 @@ class RandomGamma(IntensityAugmentationBase2D):
             (gamma, "gamma_factor", None, None), (gain, "gain_factor", None, None)
         )
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         gamma_factor = params["gamma_factor"].to(input)
         gain_factor = params["gain_factor"].to(input)
         return adjust_gamma(input, gamma_factor, gain_factor)

--- a/kornia/augmentation/_2d/intensity/gamma.py
+++ b/kornia/augmentation/_2d/intensity/gamma.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -21,7 +21,7 @@ class RandomGamma(IntensityAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -65,7 +65,7 @@ class RandomGamma(IntensityAugmentationBase2D):
         )
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         gamma_factor = params["gamma_factor"].to(input)
         gain_factor = params["gain_factor"].to(input)

--- a/kornia/augmentation/_2d/intensity/gaussian_blur.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_blur.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 from torch import Tensor
 
@@ -28,7 +28,7 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         silence_instantiation_warning: if True, silence the warning at instantiation.
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -76,7 +76,7 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         self._param_generator = rg.RandomGaussianBlurGenerator(sigma)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         sigma = params["sigma"].to(device=input.device, dtype=input.dtype).unsqueeze(-1).expand(-1, 2)
         return gaussian_blur2d(

--- a/kornia/augmentation/_2d/intensity/gaussian_blur.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_blur.py
@@ -75,9 +75,7 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         self.flags = dict(kernel_size=kernel_size, separable=separable, border_type=BorderType.get(border_type))
         self._param_generator = rg.RandomGaussianBlurGenerator(sigma)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         sigma = params["sigma"].to(device=input.device, dtype=input.dtype).unsqueeze(-1).expand(-1, 2)
         return gaussian_blur2d(
             input,

--- a/kornia/augmentation/_2d/intensity/gaussian_noise.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_noise.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
 from torch import Tensor
@@ -51,7 +51,7 @@ class RandomGaussianNoise(IntensityAugmentationBase2D):
         return {}
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         if "gaussian_noise" in params:
             gaussian_noise = params["gaussian_noise"]

--- a/kornia/augmentation/_2d/intensity/gaussian_noise.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_noise.py
@@ -50,9 +50,7 @@ class RandomGaussianNoise(IntensityAugmentationBase2D):
     def generate_parameters(self, shape: torch.Size) -> Dict[str, Tensor]:
         return {}
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         if "gaussian_noise" in params:
             gaussian_noise = params["gaussian_noise"]
         else:

--- a/kornia/augmentation/_2d/intensity/grayscale.py
+++ b/kornia/augmentation/_2d/intensity/grayscale.py
@@ -54,9 +54,7 @@ class RandomGrayscale(IntensityAugmentationBase2D):
     def __init__(self, same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         # Make sure it returns (*, 3, H, W)
         grayscale = torch.ones_like(input)
         grayscale[:] = rgb_to_grayscale(input)

--- a/kornia/augmentation/_2d/intensity/grayscale.py
+++ b/kornia/augmentation/_2d/intensity/grayscale.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
 from torch import Tensor
@@ -21,7 +21,7 @@ class RandomGrayscale(IntensityAugmentationBase2D):
                         to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -55,7 +55,7 @@ class RandomGrayscale(IntensityAugmentationBase2D):
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         # Make sure it returns (*, 3, H, W)
         grayscale = torch.ones_like(input)

--- a/kornia/augmentation/_2d/intensity/hue.py
+++ b/kornia/augmentation/_2d/intensity/hue.py
@@ -60,8 +60,6 @@ class RandomHue(IntensityAugmentationBase2D):
         self.hue: Tensor = _range_bound(hue, 'hue', bounds=(-0.5, 0.5))
         self._param_generator = rg.PlainUniformGenerator((self.hue, "hue_factor", None, None))
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         hue_factor = params["hue_factor"].to(input)
         return adjust_hue(input, hue_factor * 2 * pi)

--- a/kornia/augmentation/_2d/intensity/hue.py
+++ b/kornia/augmentation/_2d/intensity/hue.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -22,7 +22,7 @@ class RandomHue(IntensityAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -61,7 +61,7 @@ class RandomHue(IntensityAugmentationBase2D):
         self._param_generator = rg.PlainUniformGenerator((self.hue, "hue_factor", None, None))
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         hue_factor = params["hue_factor"].to(input)
         return adjust_hue(input, hue_factor * 2 * pi)

--- a/kornia/augmentation/_2d/intensity/invert.py
+++ b/kornia/augmentation/_2d/intensity/invert.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import torch
 from torch import Tensor
@@ -51,6 +51,6 @@ class RandomInvert(IntensityAugmentationBase2D):
         self.flags = dict(max_val=max_val)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return invert(input, torch.as_tensor(flags["max_val"], device=input.device, dtype=input.dtype))

--- a/kornia/augmentation/_2d/intensity/invert.py
+++ b/kornia/augmentation/_2d/intensity/invert.py
@@ -50,7 +50,5 @@ class RandomInvert(IntensityAugmentationBase2D):
         super().__init__(p=p, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim)
         self.flags = dict(max_val=max_val)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return invert(input, torch.as_tensor(flags["max_val"], device=input.device, dtype=input.dtype))

--- a/kornia/augmentation/_2d/intensity/motion_blur.py
+++ b/kornia/augmentation/_2d/intensity/motion_blur.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Tuple, Union, cast
 
 import torch
 
@@ -34,7 +34,7 @@ class RandomMotionBlur(IntensityAugmentationBase2D):
                  to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     Note:
@@ -86,7 +86,7 @@ class RandomMotionBlur(IntensityAugmentationBase2D):
         return params
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         # sample a kernel size
         kernel_size_list: List[int] = params["ksize_factor"].tolist()

--- a/kornia/augmentation/_2d/intensity/motion_blur.py
+++ b/kornia/augmentation/_2d/intensity/motion_blur.py
@@ -85,9 +85,7 @@ class RandomMotionBlur(IntensityAugmentationBase2D):
         params["idx"] = tensor([0]) if batch_shape[0] == 0 else torch.randint(batch_shape[0], (1,))
         return params
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         # sample a kernel size
         kernel_size_list: List[int] = params["ksize_factor"].tolist()
 

--- a/kornia/augmentation/_2d/intensity/normalize.py
+++ b/kornia/augmentation/_2d/intensity/normalize.py
@@ -59,7 +59,5 @@ class Normalize(IntensityAugmentationBase2D):
 
         self.flags = dict(mean=mean, std=std)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return normalize(input, flags["mean"], flags["std"])

--- a/kornia/augmentation/_2d/intensity/normalize.py
+++ b/kornia/augmentation/_2d/intensity/normalize.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -60,6 +60,6 @@ class Normalize(IntensityAugmentationBase2D):
         self.flags = dict(mean=mean, std=std)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return normalize(input, flags["mean"], flags["std"])

--- a/kornia/augmentation/_2d/intensity/planckian_jitter.py
+++ b/kornia/augmentation/_2d/intensity/planckian_jitter.py
@@ -170,7 +170,7 @@ class RandomPlanckianJitter(IntensityAugmentationBase2D):
         self._param_generator = rg.PlanckianJitterGenerator([_param_min, _param_max])
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         list_idx = params['idx'].tolist()
 

--- a/kornia/augmentation/_2d/intensity/planckian_jitter.py
+++ b/kornia/augmentation/_2d/intensity/planckian_jitter.py
@@ -2,77 +2,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
-from kornia.core import Tensor, stack, tensor
-from kornia.utils import get_cuda_device_if_available
-
-
-def get_planckian_coeffs(mode: str) -> Tensor:
-    default_device = get_cuda_device_if_available()
-    if mode.lower() == 'blackbody':
-        coefs = tensor(
-            [
-                [0.6743, 0.4029, 0.0013],
-                [0.6281, 0.4241, 0.1665],
-                [0.5919, 0.4372, 0.2513],
-                [0.5623, 0.4457, 0.3154],
-                [0.5376, 0.4515, 0.3672],
-                [0.5163, 0.4555, 0.4103],
-                [0.4979, 0.4584, 0.4468],
-                [0.4816, 0.4604, 0.4782],
-                [0.4672, 0.4619, 0.5053],
-                [0.4542, 0.4630, 0.5289],
-                [0.4426, 0.4638, 0.5497],
-                [0.4320, 0.4644, 0.5681],
-                [0.4223, 0.4648, 0.5844],
-                [0.4135, 0.4651, 0.5990],
-                [0.4054, 0.4653, 0.6121],
-                [0.3980, 0.4654, 0.6239],
-                [0.3911, 0.4655, 0.6346],
-                [0.3847, 0.4656, 0.6444],
-                [0.3787, 0.4656, 0.6532],
-                [0.3732, 0.4656, 0.6613],
-                [0.3680, 0.4655, 0.6688],
-                [0.3632, 0.4655, 0.6756],
-                [0.3586, 0.4655, 0.6820],
-                [0.3544, 0.4654, 0.6878],
-                [0.3503, 0.4653, 0.6933],
-            ],
-            device=default_device,
-        )
-
-    elif mode.upper() == 'CIED':
-        coefs = tensor(
-            [
-                [0.5829, 0.4421, 0.2288],
-                [0.5510, 0.4514, 0.2948],
-                [0.5246, 0.4576, 0.3488],
-                [0.5021, 0.4618, 0.3941],
-                [0.4826, 0.4646, 0.4325],
-                [0.4654, 0.4667, 0.4654],
-                [0.4502, 0.4681, 0.4938],
-                [0.4364, 0.4692, 0.5186],
-                [0.4240, 0.4700, 0.5403],
-                [0.4127, 0.4705, 0.5594],
-                [0.4023, 0.4709, 0.5763],
-                [0.3928, 0.4713, 0.5914],
-                [0.3839, 0.4715, 0.6049],
-                [0.3757, 0.4716, 0.6171],
-                [0.3681, 0.4717, 0.6281],
-                [0.3609, 0.4718, 0.6380],
-                [0.3543, 0.4719, 0.6472],
-                [0.3480, 0.4719, 0.6555],
-                [0.3421, 0.4719, 0.6631],
-                [0.3365, 0.4719, 0.6702],
-                [0.3313, 0.4719, 0.6766],
-                [0.3263, 0.4719, 0.6826],
-                [0.3217, 0.4719, 0.6882],
-            ],
-            device=default_device,
-        )
-    else:
-        raise RuntimeError(f'Unexpected mode. Gotcha {mode}')
-
-    return stack((coefs[:, 0] / coefs[:, 1], coefs[:, 2] / coefs[:, 1]), 1)
+from kornia.core import Tensor, stack
 
 
 class RandomPlanckianJitter(IntensityAugmentationBase2D):
@@ -154,29 +84,13 @@ class RandomPlanckianJitter(IntensityAugmentationBase2D):
     ) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
 
-        if isinstance(select_from, int):
-            select_from = [select_from]
-
-        _pl = get_planckian_coeffs(mode)
-        if select_from is not None:
-            self.pl = _pl[select_from]
-        else:
-            self.pl = _pl
-
-        # the range of the sampling parameters
-        _param_min: float = 0.0
-        _param_max: float = float(self.pl.shape[0])
-
-        self._param_generator = rg.PlanckianJitterGenerator([_param_min, _param_max])
+        self._param_generator = rg.PlanckianJitterGenerator(mode=mode, select_from=select_from)
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
-        list_idx = params['idx'].tolist()
 
-        self.pl = self.pl.to(device=input.device)
-
-        coeffs = self.pl[list_idx]
+        coeffs = params["coeffs"]
 
         r_w = coeffs[:, 0][..., None, None]
         b_w = coeffs[:, 1][..., None, None]

--- a/kornia/augmentation/_2d/intensity/planckian_jitter.py
+++ b/kornia/augmentation/_2d/intensity/planckian_jitter.py
@@ -86,10 +86,7 @@ class RandomPlanckianJitter(IntensityAugmentationBase2D):
 
         self._param_generator = rg.PlanckianJitterGenerator(mode=mode, select_from=select_from)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
-
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         coeffs = params["coeffs"]
 
         r_w = coeffs[:, 0][..., None, None]

--- a/kornia/augmentation/_2d/intensity/plasma.py
+++ b/kornia/augmentation/_2d/intensity/plasma.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -48,7 +48,7 @@ class RandomPlasmaBrightness(IntensityAugmentationBase2D):
         )
 
     def apply_transform(
-        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         B, C, H, W = image.shape
         roughness = params["roughness"].to(image)
@@ -96,7 +96,7 @@ class RandomPlasmaContrast(IntensityAugmentationBase2D):
         self._param_generator = rg.PlainUniformGenerator((roughness, "roughness", None, None))
 
     def apply_transform(
-        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         B, C, H, W = image.shape
         roughness = params["roughness"].to(image)
@@ -150,7 +150,7 @@ class RandomPlasmaShadow(IntensityAugmentationBase2D):
         )
 
     def apply_transform(
-        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         B, _, H, W = image.shape
         roughness = params["roughness"].to(image)

--- a/kornia/augmentation/_2d/intensity/plasma.py
+++ b/kornia/augmentation/_2d/intensity/plasma.py
@@ -47,9 +47,7 @@ class RandomPlasmaBrightness(IntensityAugmentationBase2D):
             (roughness, "roughness", None, None), (intensity, "intensity", None, None)
         )
 
-    def apply_transform(
-        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         B, C, H, W = image.shape
         roughness = params["roughness"].to(image)
         intensity = params["intensity"].to(image).view(-1, 1, 1, 1)
@@ -95,9 +93,7 @@ class RandomPlasmaContrast(IntensityAugmentationBase2D):
         super().__init__(p=p, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim)
         self._param_generator = rg.PlainUniformGenerator((roughness, "roughness", None, None))
 
-    def apply_transform(
-        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         B, C, H, W = image.shape
         roughness = params["roughness"].to(image)
         contrast_map = 4 * diamond_square((B, C, H, W), roughness, device=image.device, dtype=image.dtype)
@@ -149,9 +145,7 @@ class RandomPlasmaShadow(IntensityAugmentationBase2D):
             (shade_quantity, "shade_quantity", None, None),
         )
 
-    def apply_transform(
-        self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, image: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         B, _, H, W = image.shape
         roughness = params["roughness"].to(image)
         shade_intensity = params["shade_intensity"].to(image).view(-1, 1, 1, 1)

--- a/kornia/augmentation/_2d/intensity/posterize.py
+++ b/kornia/augmentation/_2d/intensity/posterize.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -21,7 +21,7 @@ class RandomPosterize(IntensityAugmentationBase2D):
                  to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -57,6 +57,6 @@ class RandomPosterize(IntensityAugmentationBase2D):
         self._param_generator = rg.PosterizeGenerator(bits)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return posterize(input, params["bits_factor"].to(input.device))

--- a/kornia/augmentation/_2d/intensity/posterize.py
+++ b/kornia/augmentation/_2d/intensity/posterize.py
@@ -56,7 +56,5 @@ class RandomPosterize(IntensityAugmentationBase2D):
         # TODO: the generator should receive the device
         self._param_generator = rg.PosterizeGenerator(bits)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return posterize(input, params["bits_factor"].to(input.device))

--- a/kornia/augmentation/_2d/intensity/random_rgb_shift.py
+++ b/kornia/augmentation/_2d/intensity/random_rgb_shift.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -90,6 +90,6 @@ class RandomRGBShift(IntensityAugmentationBase2D):
         )
 
     def apply_transform(
-        self, inp: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, inp: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         return shift_rgb(inp, params['r_shift'], params['g_shift'], params['b_shift'])

--- a/kornia/augmentation/_2d/intensity/random_rgb_shift.py
+++ b/kornia/augmentation/_2d/intensity/random_rgb_shift.py
@@ -89,7 +89,5 @@ class RandomRGBShift(IntensityAugmentationBase2D):
             (b_shift_limit, "b_shift", 0, (-b_shift_limit, b_shift_limit)),
         )
 
-    def apply_transform(
-        self, inp: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, inp: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return shift_rgb(inp, params['r_shift'], params['g_shift'], params['b_shift'])

--- a/kornia/augmentation/_2d/intensity/saturation.py
+++ b/kornia/augmentation/_2d/intensity/saturation.py
@@ -63,8 +63,6 @@ class RandomSaturation(IntensityAugmentationBase2D):
         self.saturation: Tensor = _range_bound(saturation, 'saturation', center=1.0)
         self._param_generator = rg.PlainUniformGenerator((self.saturation, "saturation_factor", None, None))
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         saturation_factor = params["saturation_factor"].to(input)
         return adjust_saturation(input, saturation_factor)

--- a/kornia/augmentation/_2d/intensity/saturation.py
+++ b/kornia/augmentation/_2d/intensity/saturation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -21,7 +21,7 @@ class RandomSaturation(IntensityAugmentationBase2D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -64,7 +64,7 @@ class RandomSaturation(IntensityAugmentationBase2D):
         self._param_generator = rg.PlainUniformGenerator((self.saturation, "saturation_factor", None, None))
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         saturation_factor = params["saturation_factor"].to(input)
         return adjust_saturation(input, saturation_factor)

--- a/kornia/augmentation/_2d/intensity/sharpness.py
+++ b/kornia/augmentation/_2d/intensity/sharpness.py
@@ -53,8 +53,6 @@ class RandomSharpness(IntensityAugmentationBase2D):
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
         self._param_generator = rg.PlainUniformGenerator((sharpness, "sharpness", 0.0, (0, float("inf"))))
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         factor = params["sharpness"]
         return sharpness(input, factor)

--- a/kornia/augmentation/_2d/intensity/sharpness.py
+++ b/kornia/augmentation/_2d/intensity/sharpness.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
@@ -54,7 +54,7 @@ class RandomSharpness(IntensityAugmentationBase2D):
         self._param_generator = rg.PlainUniformGenerator((sharpness, "sharpness", 0.0, (0, float("inf"))))
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         factor = params["sharpness"]
         return sharpness(input, factor)

--- a/kornia/augmentation/_2d/intensity/solarize.py
+++ b/kornia/augmentation/_2d/intensity/solarize.py
@@ -24,7 +24,7 @@ class RandomSolarize(IntensityAugmentationBase2D):
                  to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
+        - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
 
     .. note::
@@ -62,7 +62,7 @@ class RandomSolarize(IntensityAugmentationBase2D):
         )
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         thresholds = params["thresholds"]
         additions: Optional[Tensor]

--- a/kornia/augmentation/_2d/intensity/solarize.py
+++ b/kornia/augmentation/_2d/intensity/solarize.py
@@ -61,9 +61,7 @@ class RandomSolarize(IntensityAugmentationBase2D):
             (thresholds, "thresholds", 0.5, (0.0, 1.0)), (additions, "additions", 0.0, (-0.5, 0.5))
         )
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         thresholds = params["thresholds"]
         additions: Optional[Tensor]
         if "additions" in params:

--- a/kornia/augmentation/_3d/base.py
+++ b/kornia/augmentation/_3d/base.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict, Optional
 
-from torch import float16, float32, float64
+from torch import Size, float16, float32, float64
 
 import kornia
 from kornia.augmentation.base import _AugmentationBase
 from kornia.augmentation.utils import _transform_input3d, _validate_input_dtype
-from kornia.core import Tensor
+from kornia.core import Tensor, zeros
 from kornia.geometry.boxes import Boxes3D
 from kornia.geometry.keypoints import Keypoints3D
 
@@ -20,6 +20,9 @@ class AugmentationBase3D(_AugmentationBase):
           probabilities batch-wise.
         same_on_batch: apply the same transformation across the batch.
     """
+
+    def _expand_batch_prob(self, batch_prob: Tensor) -> Tensor:
+        return batch_prob[:, None, None, None, None]
 
     def validate_tensor(self, input: Tensor) -> None:
         """Check if the input tensor is formatted as expected."""
@@ -52,31 +55,30 @@ class RigidAffineAugmentationBase3D(AugmentationBase3D):
         keepdim: whether to keep the output shape the same as input ``True`` or broadcast it to the batch
           form ``False``.
     """
-
-    _transform_matrix: Optional[Tensor]
-
     @property
     def transform_matrix(self) -> Optional[Tensor]:
-        return self._transform_matrix
+        if self._params is not None and "transform_matrix" in self._params:
+            return self._params["transform_matrix"]
+        return None
 
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         raise NotImplementedError
 
+    def forward_parameters(self, batch_shape: Size) -> Dict[str, Tensor]:
+        params = super().forward_parameters(batch_shape)
+        transform_matrix = self.generate_transformation_matrix(zeros(batch_shape), params, self.flags)
+        params.update({"transform_matrix": transform_matrix})
+        return params
+
     def generate_transformation_matrix(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Generate transformation matrices with the given input and param settings."""
-        batch_prob = params['batch_prob']
-        to_apply = batch_prob > 0.5  # NOTE: in case of Relaxed Distributions.
+        batch_prob = params['batch_prob'][:, None, None]
+
         in_tensor = self.transform_tensor(input)
-        if not to_apply.any():
-            trans_matrix = self.identity_matrix(in_tensor)
-        elif to_apply.all():
-            trans_matrix = self.compute_transformation(in_tensor, params=params, flags=flags)
-        else:
-            trans_matrix = self.identity_matrix(in_tensor)
-            trans_matrix = trans_matrix.index_put(
-                (to_apply,), self.compute_transformation(in_tensor[to_apply], params=params, flags=flags)
-            )
-        return trans_matrix
+
+        trans_matrix = self.compute_transformation(in_tensor, params=params, flags=flags)
+
+        return trans_matrix * batch_prob.round() + self.identity_matrix(in_tensor) * (1 - batch_prob.round())
 
     def inverse_inputs(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
@@ -109,8 +111,6 @@ class RigidAffineAugmentationBase3D(AugmentationBase3D):
         if flags is None:
             flags = self.flags
 
-        trans_matrix = self.generate_transformation_matrix(in_tensor, params, flags)
-        output = self.transform_inputs(in_tensor, params, flags, trans_matrix)
-        self._transform_matrix = trans_matrix
+        output = self.transform_inputs(in_tensor, params, flags)
 
         return output

--- a/kornia/augmentation/_3d/base.py
+++ b/kornia/augmentation/_3d/base.py
@@ -55,6 +55,7 @@ class RigidAffineAugmentationBase3D(AugmentationBase3D):
         keepdim: whether to keep the output shape the same as input ``True`` or broadcast it to the batch
           form ``False``.
     """
+
     @property
     def transform_matrix(self) -> Optional[Tensor]:
         if self._params is not None and "transform_matrix" in self._params:

--- a/kornia/augmentation/_3d/geometric/affine.py
+++ b/kornia/augmentation/_3d/geometric/affine.py
@@ -143,7 +143,7 @@ class RandomAffine3D(GeometricAugmentationBase3D):
         size = params['forward_input_shape'].numpy().tolist()
         size = (size[-2], size[-1])
 
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return warp_affine3d(
             input,

--- a/kornia/augmentation/_3d/geometric/affine.py
+++ b/kornia/augmentation/_3d/geometric/affine.py
@@ -139,11 +139,11 @@ class RandomAffine3D(GeometricAugmentationBase3D):
         ).to(input)
         return transform
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        size = params['forward_input_shape'].numpy().tolist()
+        size = (size[-2], size[-1])
+
+        transform = params["transform_matrix"]
 
         return warp_affine3d(
             input,

--- a/kornia/augmentation/_3d/geometric/base.py
+++ b/kornia/augmentation/_3d/geometric/base.py
@@ -5,7 +5,6 @@ from kornia.core import Tensor, as_tensor
 
 
 class GeometricAugmentationBase3D(RigidAffineAugmentationBase3D):
-
     def get_transformation_matrix(
         self, input: Tensor, params: Optional[Dict[str, Tensor]] = None, flags: Optional[Dict[str, Any]] = None
     ) -> Tensor:

--- a/kornia/augmentation/_3d/geometric/base.py
+++ b/kornia/augmentation/_3d/geometric/base.py
@@ -1,5 +1,24 @@
+from typing import Any, Dict, Optional
+
 from kornia.augmentation._3d.base import RigidAffineAugmentationBase3D
+from kornia.core import Tensor, as_tensor
 
 
 class GeometricAugmentationBase3D(RigidAffineAugmentationBase3D):
-    pass
+
+    def get_transformation_matrix(
+        self, input: Tensor, params: Optional[Dict[str, Tensor]] = None, flags: Optional[Dict[str, Any]] = None
+    ) -> Tensor:
+        """Obtain transformation matrices.
+
+        Return the current transformation matrix if existed. Generate a new one, otherwise.
+        """
+        flags = self.flags if flags is None else flags
+        if params is not None and "transform_matrix" in params:
+            transform = params["transform_matrix"]
+        elif params is not None:
+            transform = self.generate_transformation_matrix(input, params, flags)
+        else:
+            params = self.forward_parameters(input.shape)
+            transform = params["transform_matrix"]
+        return as_tensor(transform, device=input.device, dtype=input.dtype)

--- a/kornia/augmentation/_3d/geometric/center_crop.py
+++ b/kornia/augmentation/_3d/geometric/center_crop.py
@@ -84,7 +84,7 @@ class CenterCrop3D(GeometricAugmentationBase3D):
         return transform
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
         return crop_by_transform_mat3d(
             input, transform, self.size, mode=flags["resample"].name.lower(), align_corners=flags["align_corners"]
         )

--- a/kornia/augmentation/_3d/geometric/crop.py
+++ b/kornia/augmentation/_3d/geometric/crop.py
@@ -121,11 +121,8 @@ class RandomCrop3D(GeometricAugmentationBase3D):
         transform = transform.expand(input.shape[0], -1, -1)
         return transform
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        transform = params["transform_matrix"]
 
         return crop_by_transform_mat3d(
             input, transform, flags["size"], mode=flags["resample"].name.lower(), align_corners=flags["align_corners"]

--- a/kornia/augmentation/_3d/geometric/crop.py
+++ b/kornia/augmentation/_3d/geometric/crop.py
@@ -122,7 +122,7 @@ class RandomCrop3D(GeometricAugmentationBase3D):
         return transform
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return crop_by_transform_mat3d(
             input, transform, flags["size"], mode=flags["resample"].name.lower(), align_corners=flags["align_corners"]

--- a/kornia/augmentation/_3d/geometric/depthical_flip.py
+++ b/kornia/augmentation/_3d/geometric/depthical_flip.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
-from torch import Tensor
 
 from kornia.augmentation._3d.geometric.base import GeometricAugmentationBase3D
+from kornia.core import Tensor
 
 
 class RandomDepthicalFlip3D(GeometricAugmentationBase3D):
@@ -22,13 +22,11 @@ class RandomDepthicalFlip3D(GeometricAugmentationBase3D):
           to the batch form ``False``.
 
     Shape:
-        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`, Optional: :math:`(B, 4, 4)`
+        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`
         - Output: :math:`(B, C, D, H, W)`
 
     Note:
         Input tensor must be float and normalized into [0, 1] for the best differentiability support.
-        Additionally, this function accepts another transformation tensor (:math:`(B, 4, 4)`), then the
-        applied transformation will be merged int to the input transformation tensor and returned.
 
     Examples:
         >>> import torch
@@ -67,7 +65,5 @@ class RandomDepthicalFlip3D(GeometricAugmentationBase3D):
         )
         return flip_mat.expand(input.shape[0], 4, 4)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return torch.flip(input, [-3])

--- a/kornia/augmentation/_3d/geometric/horizontal_flip.py
+++ b/kornia/augmentation/_3d/geometric/horizontal_flip.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
-from torch import Tensor
 
 from kornia.augmentation._3d.geometric.base import GeometricAugmentationBase3D
+from kornia.core import Tensor
 
 
 class RandomHorizontalFlip3D(GeometricAugmentationBase3D):
@@ -16,13 +16,11 @@ class RandomHorizontalFlip3D(GeometricAugmentationBase3D):
           to the batch form ``False``.
 
     Shape:
-        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`, Optional: :math:`(B, 4, 4)`
+        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`
         - Output: :math:`(B, C, D, H, W)`
 
     Note:
         Input tensor must be float and normalized into [0, 1] for the best differentiability support.
-        Additionally, this function accepts another transformation tensor (:math:`(B, 4, 4)`), then the
-        applied transformation will be merged int to the input transformation tensor and returned.
 
     Examples:
         >>> import torch
@@ -61,7 +59,5 @@ class RandomHorizontalFlip3D(GeometricAugmentationBase3D):
         )
         return flip_mat.expand(input.shape[0], 4, 4)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return torch.flip(input, [-1])

--- a/kornia/augmentation/_3d/geometric/perspective.py
+++ b/kornia/augmentation/_3d/geometric/perspective.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._3d.geometric.base import GeometricAugmentationBase3D
@@ -20,13 +20,11 @@ class RandomPerspective3D(GeometricAugmentationBase3D):
           to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`, Optional: :math:`(B, 4, 4)`
+        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`
         - Output: :math:`(B, C, D, H, W)`
 
     Note:
         Input tensor must be float and normalized into [0, 1] for the best differentiability support.
-        Additionally, this function accepts another transformation tensor (:math:`(B, 4, 4)`), then the
-        applied transformation will be merged int to the input transformation tensor and returned.
 
     Examples:
         >>> import torch
@@ -79,11 +77,8 @@ class RandomPerspective3D(GeometricAugmentationBase3D):
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return get_perspective_transform3d(params["start_points"], params["end_points"]).to(input)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        transform = params["transform_matrix"]
 
         return warp_perspective3d(
             input,

--- a/kornia/augmentation/_3d/geometric/perspective.py
+++ b/kornia/augmentation/_3d/geometric/perspective.py
@@ -78,7 +78,7 @@ class RandomPerspective3D(GeometricAugmentationBase3D):
         return get_perspective_transform3d(params["start_points"], params["end_points"]).to(input)
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return warp_perspective3d(
             input,

--- a/kornia/augmentation/_3d/geometric/rotation.py
+++ b/kornia/augmentation/_3d/geometric/rotation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import kornia
 from kornia.augmentation import random_generator as rg
@@ -34,13 +34,11 @@ class RandomRotation3D(GeometricAugmentationBase3D):
           to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`, Optional: :math:`(B, 4, 4)`
+        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`
         - Output: :math:`(B, C, D, H, W)`
 
     Note:
         Input tensor must be float and normalized into [0, 1] for the best differentiability support.
-        Additionally, this function accepts another transformation tensor (:math:`(B, 4, 4)`), then the
-        applied transformation will be merged int to the input transformation tensor and returned.
 
     Examples:
         >>> import torch
@@ -104,10 +102,7 @@ class RandomRotation3D(GeometricAugmentationBase3D):
 
         return trans_mat
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
-        if not isinstance(transform, Tensor):
-            raise TypeError(f'Expected the transform to be a Tensor. Gotcha {type(transform)}')
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        transform = params["transform_matrix"]
 
         return affine3d(input, transform[..., :3, :4], flags["resample"].name.lower(), "zeros", flags["align_corners"])

--- a/kornia/augmentation/_3d/geometric/rotation.py
+++ b/kornia/augmentation/_3d/geometric/rotation.py
@@ -103,6 +103,6 @@ class RandomRotation3D(GeometricAugmentationBase3D):
         return trans_mat
 
     def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
-        transform = params["transform_matrix"]
+        transform = self.get_transformation_matrix(input, params=params, flags=flags)
 
         return affine3d(input, transform[..., :3, :4], flags["resample"].name.lower(), "zeros", flags["align_corners"])

--- a/kornia/augmentation/_3d/geometric/vertical_flip.py
+++ b/kornia/augmentation/_3d/geometric/vertical_flip.py
@@ -22,13 +22,11 @@ class RandomVerticalFlip3D(GeometricAugmentationBase3D):
           to the batch form ``False``.
 
     Shape:
-        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`, Optional: :math:`(B, 4, 4)`
+        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`
         - Output: :math:`(B, C, D, H, W)`
 
     Note:
         Input tensor must be float and normalized into [0, 1] for the best differentiability support.
-        Additionally, this function accepts another transformation tensor (:math:`(B, 4, 4)`), then the
-        applied transformation will be merged int to the input transformation tensor and returned.
 
     Examples:
         >>> import torch
@@ -67,7 +65,5 @@ class RandomVerticalFlip3D(GeometricAugmentationBase3D):
         )
         return flip_mat.expand(input.shape[0], 4, 4)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return torch.flip(input, [-2])

--- a/kornia/augmentation/_3d/geometric/vertical_flip.py
+++ b/kornia/augmentation/_3d/geometric/vertical_flip.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import torch
 from torch import Tensor

--- a/kornia/augmentation/_3d/intensity/equalize.py
+++ b/kornia/augmentation/_3d/intensity/equalize.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, Optional
-
-from torch import Tensor
+from typing import Any, Dict
 
 from kornia.augmentation._3d.intensity.base import IntensityAugmentationBase3D
+from kornia.core import Tensor
 from kornia.enhance import equalize3d
 
 
@@ -11,18 +10,16 @@ class RandomEqualize3D(IntensityAugmentationBase3D):
 
     Args:
         p: probability of the image being equalized.
-        same_on_batch): apply the same transformation across the batch.
+        same_on_batch: apply the same transformation across the batch.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
           to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`, Optional: :math:`(B, 4, 4)`
+        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`
         - Output: :math:`(B, C, D, H, W)`
 
     Note:
         Input tensor must be float and normalized into [0, 1] for the best differentiability support.
-        Additionally, this function accepts another transformation tensor (:math:`(B, 4, 4)`), then the
-        applied transformation will be merged int to the input transformation tensor and returned.
 
     Examples:
         >>> import torch
@@ -55,7 +52,5 @@ class RandomEqualize3D(IntensityAugmentationBase3D):
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return self.identity_matrix(input)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return equalize3d(input)

--- a/kornia/augmentation/_3d/intensity/motion_blur.py
+++ b/kornia/augmentation/_3d/intensity/motion_blur.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._3d.intensity.base import IntensityAugmentationBase3D
@@ -35,13 +35,11 @@ class RandomMotionBlur3D(IntensityAugmentationBase3D):
         keepdim: whether to keep the output shape the same as input (True) or broadcast it to the batch form (False).
 
     Shape:
-        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`, Optional: :math:`(B, 4, 4)`
+        - Input: :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`
         - Output: :math:`(B, C, D, H, W)`
 
     Note:
         Input tensor must be float and normalized into [0, 1] for the best differentiability support.
-        Additionally, this function accepts another transformation tensor (:math:`(B, 4, 4)`), then the
-        applied transformation will be merged int to the input transformation tensor and returned.
 
     Examples:
         >>> import torch
@@ -97,9 +95,7 @@ class RandomMotionBlur3D(IntensityAugmentationBase3D):
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return self.identity_matrix(input)
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         kernel_size = int(params["ksize_factor"].unique().item())
         angle = params["angle_factor"]
         direction = params["direction_factor"]

--- a/kornia/augmentation/auto/operations/policy.py
+++ b/kornia/augmentation/auto/operations/policy.py
@@ -64,10 +64,10 @@ class PolicySequential(ImageSequentialBase):
                 if recompute:
                     flags = override_parameters(module.op.flags, extra_args, in_place=False)
                     mat = module.op.generate_transformation_matrix(input, param.data, flags)
-                elif module.op._transform_matrix is not None:
-                    mat = as_tensor(module.op._transform_matrix, device=input.device, dtype=input.dtype)
+                elif module.op.transform_matrix is not None:
+                    mat = as_tensor(module.op.transform_matrix, device=input.device, dtype=input.dtype)
                 else:
-                    raise RuntimeError(f"{module}.op._transform_matrix is None while `recompute=False`.")
+                    raise RuntimeError(f"{module}.op.transform_matrix is None while `recompute=False`.")
                 res_mat = mat @ res_mat
                 input = module.op.transform_output_tensor(input, ori_shape)
                 if module.op.keepdim and ori_shape != input.shape:

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -217,26 +217,16 @@ class _AugmentationBase(_BasicAugmentationBase):
     def _expand_batch_prob(self, batch_prob: Tensor) -> Tensor:
         raise NotImplementedError
 
-    def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         # apply transform for the input image tensor
         raise NotImplementedError
 
-    def apply_non_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         # apply additional transform for the images that are skipped from transformation
         # where batch_prob == False.
         return input
 
-    def transform_inputs(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
-    ) -> Tensor:
+    def transform_inputs(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Tensor:
         self.validate_tensor(input)
 
         params, flags = self._process_kwargs_to_params_and_flags(
@@ -267,13 +257,7 @@ class _AugmentationBase(_BasicAugmentationBase):
             output = output.type(input.dtype)
         return output
 
-    def transform_masks(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
-    ) -> Tensor:
+    def transform_masks(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Tensor:
         self.validate_tensor(input)
 
         params, flags = self._process_kwargs_to_params_and_flags(
@@ -296,13 +280,7 @@ class _AugmentationBase(_BasicAugmentationBase):
         output = _transform_output_shape(output, ori_shape) if self.keepdim else output
         return output
 
-    def transform_boxes(
-        self,
-        input: Boxes,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
-    ) -> Boxes:
+    def transform_boxes(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Boxes:
         if not isinstance(input, Boxes):
             raise RuntimeError(f"Only `Boxes` is supported. Got {type(input)}.")
 
@@ -323,11 +301,7 @@ class _AugmentationBase(_BasicAugmentationBase):
         return output
 
     def transform_keypoints(
-        self,
-        input: Keypoints,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs
     ) -> Keypoints:
         if not isinstance(input, Keypoints):
             raise RuntimeError(f"Only `Keypoints` is supported. Got {type(input)}.")
@@ -349,13 +323,7 @@ class _AugmentationBase(_BasicAugmentationBase):
         output = applied * to_apply[:, None, None] + output * (1 - to_apply[:, None, None])
         return output
 
-    def transform_classes(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        **kwargs,
-    ) -> Tensor:
+    def transform_classes(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], **kwargs) -> Tensor:
         params, flags = self._process_kwargs_to_params_and_flags(
             self._params if params is None else params, flags, **kwargs
         )
@@ -369,27 +337,19 @@ class _AugmentationBase(_BasicAugmentationBase):
         output = applied * to_apply + output * (1 - to_apply)
         return output
 
-    def apply_non_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process masks corresponding to the inputs that are no transformation applied."""
         raise NotImplementedError
 
-    def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process masks corresponding to the inputs that are transformed."""
         raise NotImplementedError
 
-    def apply_non_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def apply_non_transform_box(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         """Process boxes corresponding to the inputs that are no transformation applied."""
         return input
 
-    def apply_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Boxes:
+    def apply_transform_box(self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Boxes:
         """Process boxes corresponding to the inputs that are transformed."""
         raise NotImplementedError
 
@@ -399,21 +359,15 @@ class _AugmentationBase(_BasicAugmentationBase):
         """Process keypoints corresponding to the inputs that are no transformation applied."""
         return input
 
-    def apply_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Keypoints:
+    def apply_transform_keypoint(self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Keypoints:
         """Process keypoints corresponding to the inputs that are transformed."""
         raise NotImplementedError
 
-    def apply_non_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_non_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process class tags corresponding to the inputs that are no transformation applied."""
         return input
 
-    def apply_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def apply_transform_class(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         """Process class tags corresponding to the inputs that are transformed."""
         raise NotImplementedError
 

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -229,13 +229,13 @@ class _AugmentationBase(_BasicAugmentationBase):
     """
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         # apply transform for the input image tensor
         raise NotImplementedError
 
     def apply_non_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         # apply additional transform for the images that are skipped from transformation
         # where batch_prob == False.
@@ -246,7 +246,6 @@ class _AugmentationBase(_BasicAugmentationBase):
         input: Tensor,
         params: Dict[str, Tensor],
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Tensor:
         self.validate_tensor(input)
@@ -260,14 +259,12 @@ class _AugmentationBase(_BasicAugmentationBase):
         ori_shape = input.shape
         in_tensor = self.transform_tensor(input)
         if to_apply.all():
-            output = self.apply_transform(in_tensor, params, flags, transform=transform)
+            output = self.apply_transform(in_tensor, params, flags)
         elif not to_apply.any():
-            output = self.apply_non_transform(in_tensor, params, flags, transform=transform)
+            output = self.apply_non_transform(in_tensor, params, flags)
         else:  # If any tensor needs to be transformed.
-            output = self.apply_non_transform(in_tensor, params, flags, transform=transform)
-            applied = self.apply_transform(
-                in_tensor[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
-            )
+            output = self.apply_non_transform(in_tensor, params, flags)
+            applied = self.apply_transform(in_tensor[to_apply], params, flags)
 
             if is_autocast_enabled():
                 output = output.type(input.dtype)
@@ -284,7 +281,6 @@ class _AugmentationBase(_BasicAugmentationBase):
         input: Tensor,
         params: Dict[str, Tensor],
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Tensor:
         self.validate_tensor(input)
@@ -298,14 +294,12 @@ class _AugmentationBase(_BasicAugmentationBase):
         ori_shape = input.shape
         in_tensor = self.transform_tensor(input)
         if to_apply.all():
-            output = self.apply_transform_mask(in_tensor, params, flags, transform=transform)
+            output = self.apply_transform_mask(in_tensor, params, flags)
         elif not to_apply.any():
-            output = self.apply_non_transform_mask(in_tensor, params, flags, transform=transform)
+            output = self.apply_non_transform_mask(in_tensor, params, flags)
         else:  # If any tensor needs to be transformed.
-            output = self.apply_non_transform_mask(in_tensor, params, flags, transform=transform)
-            applied = self.apply_transform_mask(
-                in_tensor[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
-            )
+            output = self.apply_non_transform_mask(in_tensor, params, flags)
+            applied = self.apply_transform_mask(in_tensor[to_apply], params, flags)
             output = output.index_put((to_apply,), applied)
         output = _transform_output_shape(output, ori_shape) if self.keepdim else output
         return output
@@ -315,7 +309,6 @@ class _AugmentationBase(_BasicAugmentationBase):
         input: Boxes,
         params: Dict[str, Tensor],
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Boxes:
         if not isinstance(input, Boxes):
@@ -329,14 +322,12 @@ class _AugmentationBase(_BasicAugmentationBase):
         to_apply = batch_prob > 0.5  # NOTE: in case of Relaxed Distributions.
         output: Boxes
         if to_apply.bool().all():
-            output = self.apply_transform_box(input, params, flags, transform=transform)
+            output = self.apply_transform_box(input, params, flags)
         elif not to_apply.any():
-            output = self.apply_non_transform_box(input, params, flags, transform=transform)
+            output = self.apply_non_transform_box(input, params, flags)
         else:  # If any tensor needs to be transformed.
-            output = self.apply_non_transform_box(input, params, flags, transform=transform)
-            applied = self.apply_transform_box(
-                input[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
-            )
+            output = self.apply_non_transform_box(input, params, flags)
+            applied = self.apply_transform_box(input[to_apply], params, flags)
             if is_autocast_enabled():
                 output = output.type(input.dtype)
                 applied = applied.type(input.dtype)
@@ -349,7 +340,6 @@ class _AugmentationBase(_BasicAugmentationBase):
         input: Keypoints,
         params: Dict[str, Tensor],
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Keypoints:
         if not isinstance(input, Keypoints):
@@ -362,14 +352,12 @@ class _AugmentationBase(_BasicAugmentationBase):
         batch_prob = params['batch_prob']
         to_apply = batch_prob > 0.5  # NOTE: in case of Relaxed Distributions.
         if to_apply.all():
-            output = self.apply_transform_keypoint(input, params, flags, transform=transform)
+            output = self.apply_transform_keypoint(input, params, flags)
         elif not to_apply.any():
-            output = self.apply_non_transform_keypoint(input, params, flags, transform=transform)
+            output = self.apply_non_transform_keypoint(input, params, flags)
         else:  # If any tensor needs to be transformed.
-            output = self.apply_non_transform_keypoint(input, params, flags, transform=transform)
-            applied = self.apply_transform_keypoint(
-                input[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
-            )
+            output = self.apply_non_transform_keypoint(input, params, flags)
+            applied = self.apply_transform_keypoint(input[to_apply], params, flags)
             if is_autocast_enabled():
                 output = output.type(input.dtype)
                 applied = applied.type(input.dtype)
@@ -381,7 +369,6 @@ class _AugmentationBase(_BasicAugmentationBase):
         input: Tensor,
         params: Dict[str, Tensor],
         flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
         **kwargs,
     ) -> Tensor:
         params, flags = self._process_kwargs_to_params_and_flags(
@@ -391,61 +378,59 @@ class _AugmentationBase(_BasicAugmentationBase):
         batch_prob = params['batch_prob']
         to_apply = batch_prob > 0.5  # NOTE: in case of Relaxed Distributions.
         if to_apply.all():
-            output = self.apply_transform_class(input, params, flags, transform=transform)
+            output = self.apply_transform_class(input, params, flags)
         elif not to_apply.any():
-            output = self.apply_non_transform_class(input, params, flags, transform=transform)
+            output = self.apply_non_transform_class(input, params, flags)
         else:  # If any tensor needs to be transformed.
-            output = self.apply_non_transform_class(input, params, flags, transform=transform)
-            applied = self.apply_transform_class(
-                input[to_apply], params, flags, transform=transform if transform is None else transform[to_apply]
-            )
+            output = self.apply_non_transform_class(input, params, flags)
+            applied = self.apply_transform_class(input[to_apply], params, flags)
             output = output.index_put((to_apply,), applied)
         return output
 
     def apply_non_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         """Process masks corresponding to the inputs that are no transformation applied."""
         raise NotImplementedError
 
     def apply_transform_mask(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         """Process masks corresponding to the inputs that are transformed."""
         raise NotImplementedError
 
     def apply_non_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Boxes:
         """Process boxes corresponding to the inputs that are no transformation applied."""
         return input
 
     def apply_transform_box(
-        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Boxes, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Boxes:
         """Process boxes corresponding to the inputs that are transformed."""
         raise NotImplementedError
 
     def apply_non_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Keypoints:
         """Process keypoints corresponding to the inputs that are no transformation applied."""
         return input
 
     def apply_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Keypoints:
         """Process keypoints corresponding to the inputs that are transformed."""
         raise NotImplementedError
 
     def apply_non_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         """Process class tags corresponding to the inputs that are no transformation applied."""
         return input
 
     def apply_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
     ) -> Tensor:
         """Process class tags corresponding to the inputs that are transformed."""
         raise NotImplementedError

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -303,7 +303,6 @@ def _get_new_batch_shape(param: ParamItem, batch_shape: torch.Size) -> torch.Siz
             # Augmentations that change the image size must be applied equally to all elements in batch.
             # If the augmentation is not applied, return the same batch shape.
             return batch_shape
-        new_batch_shape = list(batch_shape)
-        new_batch_shape[-2:] = param.data['output_size'][0]
-        batch_shape = torch.Size(new_batch_shape)
+        output_size = param.data['output_size'][0]
+        batch_shape = torch.Size((*batch_shape[:-2], *[i.int().item() for i in output_size]))
     return batch_shape

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -196,7 +196,7 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
         """
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
             input = module.transform_masks(
-                input, params=cls.get_instance_module_param(param), flags=module.flags, **extra_args,
+                input, params=cls.get_instance_module_param(param), flags=module.flags, **extra_args
             )
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
@@ -233,7 +233,7 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
             if module.transform_matrix is None:
                 raise ValueError(f"No valid transformation matrix found in {module.__class__}.")
             input = module.inverse_masks(
-                input, params=cls.get_instance_module_param(param), flags=module.flags, **extra_args,
+                input, params=cls.get_instance_module_param(param), flags=module.flags, **extra_args
             )
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
@@ -269,9 +269,7 @@ class BoxSequentialOps(SequentialOpsInterface[Boxes]):
         _input = input.clone()
 
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
-            _input = module.transform_boxes(
-                _input, cls.get_instance_module_param(param), module.flags, **extra_args,
-            )
+            _input = module.transform_boxes(_input, cls.get_instance_module_param(param), module.flags, **extra_args)
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
             raise NotImplementedError(
@@ -346,7 +344,7 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
 
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
             _input = module.transform_keypoints(
-                _input, cls.get_instance_module_param(param), module.flags, **extra_args,
+                _input, cls.get_instance_module_param(param), module.flags, **extra_args
             )
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -196,11 +196,7 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
         """
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
             input = module.transform_masks(
-                input,
-                params=cls.get_instance_module_param(param),
-                flags=module.flags,
-                transform=module.transform_matrix,
-                **extra_args,
+                input, params=cls.get_instance_module_param(param), flags=module.flags, **extra_args,
             )
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
@@ -236,13 +232,8 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
             if module.transform_matrix is None:
                 raise ValueError(f"No valid transformation matrix found in {module.__class__}.")
-            transform = module.compute_inverse_transformation(module.transform_matrix)
             input = module.inverse_masks(
-                input,
-                params=cls.get_instance_module_param(param),
-                flags=module.flags,
-                transform=transform,
-                **extra_args,
+                input, params=cls.get_instance_module_param(param), flags=module.flags, **extra_args,
             )
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
@@ -279,11 +270,7 @@ class BoxSequentialOps(SequentialOpsInterface[Boxes]):
 
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
             _input = module.transform_boxes(
-                _input,
-                cls.get_instance_module_param(param),
-                module.flags,
-                transform=module.transform_matrix,
-                **extra_args,
+                _input, cls.get_instance_module_param(param), module.flags, **extra_args,
             )
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
@@ -319,12 +306,7 @@ class BoxSequentialOps(SequentialOpsInterface[Boxes]):
         _input = input.clone()
 
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
-            if module.transform_matrix is None:
-                raise ValueError(f"No valid transformation matrix found in {module.__class__}.")
-            transform = module.compute_inverse_transformation(module.transform_matrix)
-            _input = module.inverse_boxes(
-                _input, param.data, module.flags, transform=transform, **extra_args  # type: ignore
-            )
+            _input = module.inverse_boxes(_input, cls.get_instance_module_param(param), module.flags, **extra_args)
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
             raise NotImplementedError(
@@ -364,11 +346,7 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
 
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
             _input = module.transform_keypoints(
-                _input,
-                cls.get_instance_module_param(param),
-                module.flags,
-                transform=module.transform_matrix,
-                **extra_args,
+                _input, cls.get_instance_module_param(param), module.flags, **extra_args,
             )
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
@@ -405,12 +383,7 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
         _input = input.clone()
 
         if isinstance(module, (K.GeometricAugmentationBase2D,)):
-            if module.transform_matrix is None:
-                raise ValueError(f"No valid transformation matrix found in {module.__class__}.")
-            transform = module.compute_inverse_transformation(module.transform_matrix)
-            _input = module.inverse_keypoints(
-                _input, cls.get_instance_module_param(param), module.flags, transform=transform, **extra_args
-            )
+            _input = module.inverse_keypoints(_input, cls.get_instance_module_param(param), module.flags, **extra_args)
 
         elif isinstance(module, (K.GeometricAugmentationBase3D,)):
             raise NotImplementedError(

--- a/kornia/augmentation/random_generator/_2d/crop.py
+++ b/kornia/augmentation/random_generator/_2d/crop.py
@@ -285,8 +285,7 @@ class CenterCropGenerator(_BBoxBasedGenerator):
         batch_size = batch_shape[0]
         height, width = (batch_shape[-2], batch_shape[-1])
         if not (height >= self.size[0] and width >= self.size[1]):
-            raise RuntimeError(
-                f"Crop size must be smaller than input size. Got ({height}, {width}) and {self.size}.")
+            raise RuntimeError(f"Crop size must be smaller than input size. Got ({height}, {width}) and {self.size}.")
 
         # unpack input sizes
         dst_h, dst_w = self.size
@@ -309,7 +308,7 @@ class CenterCropGenerator(_BBoxBasedGenerator):
         points_src: Tensor = tensor(
             [[[start_x, start_y], [end_x, start_y], [end_x, end_y], [start_x, end_y]]],
             device=self.device,
-            dtype=torch.long
+            dtype=torch.long,
         ).expand(batch_size, -1, -1)
 
         # [y, x] destination

--- a/kornia/augmentation/random_generator/_2d/planckian_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/planckian_jitter.py
@@ -1,20 +1,105 @@
-from typing import Dict, List
+from typing import Dict, List, Optional, Union
 
 import torch
 from torch.distributions import Uniform
 
 from kornia.augmentation.random_generator.base import RandomGeneratorBase
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check, _range_bound
+from kornia.core import Tensor, stack, tensor
+from kornia.utils import get_cuda_device_if_available
 
 __all__ = ["PlanckianJitterGenerator"]
+
+
+def get_planckian_coeffs(mode: str) -> Tensor:
+    default_device = get_cuda_device_if_available()
+    if mode.lower() == 'blackbody':
+        coefs = tensor(
+            [
+                [0.6743, 0.4029, 0.0013],
+                [0.6281, 0.4241, 0.1665],
+                [0.5919, 0.4372, 0.2513],
+                [0.5623, 0.4457, 0.3154],
+                [0.5376, 0.4515, 0.3672],
+                [0.5163, 0.4555, 0.4103],
+                [0.4979, 0.4584, 0.4468],
+                [0.4816, 0.4604, 0.4782],
+                [0.4672, 0.4619, 0.5053],
+                [0.4542, 0.4630, 0.5289],
+                [0.4426, 0.4638, 0.5497],
+                [0.4320, 0.4644, 0.5681],
+                [0.4223, 0.4648, 0.5844],
+                [0.4135, 0.4651, 0.5990],
+                [0.4054, 0.4653, 0.6121],
+                [0.3980, 0.4654, 0.6239],
+                [0.3911, 0.4655, 0.6346],
+                [0.3847, 0.4656, 0.6444],
+                [0.3787, 0.4656, 0.6532],
+                [0.3732, 0.4656, 0.6613],
+                [0.3680, 0.4655, 0.6688],
+                [0.3632, 0.4655, 0.6756],
+                [0.3586, 0.4655, 0.6820],
+                [0.3544, 0.4654, 0.6878],
+                [0.3503, 0.4653, 0.6933],
+            ],
+            device=default_device,
+        )
+
+    elif mode.upper() == 'CIED':
+        coefs = tensor(
+            [
+                [0.5829, 0.4421, 0.2288],
+                [0.5510, 0.4514, 0.2948],
+                [0.5246, 0.4576, 0.3488],
+                [0.5021, 0.4618, 0.3941],
+                [0.4826, 0.4646, 0.4325],
+                [0.4654, 0.4667, 0.4654],
+                [0.4502, 0.4681, 0.4938],
+                [0.4364, 0.4692, 0.5186],
+                [0.4240, 0.4700, 0.5403],
+                [0.4127, 0.4705, 0.5594],
+                [0.4023, 0.4709, 0.5763],
+                [0.3928, 0.4713, 0.5914],
+                [0.3839, 0.4715, 0.6049],
+                [0.3757, 0.4716, 0.6171],
+                [0.3681, 0.4717, 0.6281],
+                [0.3609, 0.4718, 0.6380],
+                [0.3543, 0.4719, 0.6472],
+                [0.3480, 0.4719, 0.6555],
+                [0.3421, 0.4719, 0.6631],
+                [0.3365, 0.4719, 0.6702],
+                [0.3313, 0.4719, 0.6766],
+                [0.3263, 0.4719, 0.6826],
+                [0.3217, 0.4719, 0.6882],
+            ],
+            device=default_device,
+        )
+    else:
+        raise RuntimeError(f'Unexpected mode. Gotcha {mode}')
+
+    return stack((coefs[:, 0] / coefs[:, 1], coefs[:, 2] / coefs[:, 1]), 1)
 
 
 class PlanckianJitterGenerator(RandomGeneratorBase):
     r"""Generate random planckian jitter parameters for a batch of images."""
 
-    def __init__(self, domain: List[float]) -> None:
+    def __init__(self, mode: str = "blackbody", select_from: Optional[Union[int, List[int]]] = None,) -> None:
         super().__init__()
-        self.domain = domain
+
+        if isinstance(select_from, int):
+            select_from = [select_from]
+
+        _pl = get_planckian_coeffs(mode)
+        if select_from is not None:
+            self.pl = _pl[select_from]
+        else:
+            self.pl = _pl
+
+        # the range of the sampling parameters
+        _param_min: float = 0.0
+        _param_max: float = float(self.pl.shape[0])
+        self.domain = (_param_min, _param_max)
+        self.mode = mode
 
     def make_samplers(self, device: torch.device, dtype: torch.dtype) -> None:
         idx_range = _range_bound(self.domain, 'idx_range', device=device, dtype=dtype)
@@ -27,4 +112,4 @@ class PlanckianJitterGenerator(RandomGeneratorBase):
         _common_param_check(batch_size, same_on_batch)
         pl_idx = _adapted_rsampling((batch_size,), self.pl_idx_dist, same_on_batch)
 
-        return dict(idx=pl_idx.long())
+        return dict(coeffs=get_planckian_coeffs(self.mode)[pl_idx.long()])

--- a/kornia/augmentation/random_generator/_2d/planckian_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/planckian_jitter.py
@@ -83,7 +83,7 @@ def get_planckian_coeffs(mode: str) -> Tensor:
 class PlanckianJitterGenerator(RandomGeneratorBase):
     r"""Generate random planckian jitter parameters for a batch of images."""
 
-    def __init__(self, mode: str = "blackbody", select_from: Optional[Union[int, List[int]]] = None,) -> None:
+    def __init__(self, mode: str = "blackbody", select_from: Optional[Union[int, List[int]]] = None) -> None:
         super().__init__()
 
         if isinstance(select_from, int):

--- a/kornia/augmentation/random_generator/_2d/resize.py
+++ b/kornia/augmentation/random_generator/_2d/resize.py
@@ -2,16 +2,17 @@ from typing import Dict, Tuple, Union
 
 import torch
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
 from kornia.augmentation.utils import _common_param_check
 from kornia.core import Device, Tensor, tensor
 from kornia.geometry.bbox import bbox_generator
 from kornia.geometry.transform.affwarp import _side_to_image_size
 
+from .util import _BBoxBasedGenerator
+
 __all__ = ["ResizeGenerator"]
 
 
-class ResizeGenerator(RandomGeneratorBase):
+class ResizeGenerator(_BBoxBasedGenerator):
     r"""Get parameters for ```resize``` transformation for resize transform.
 
     Args:

--- a/kornia/augmentation/random_generator/_2d/util.py
+++ b/kornia/augmentation/random_generator/_2d/util.py
@@ -1,4 +1,5 @@
 from typing import Dict
+
 import torch
 
 from kornia.augmentation.random_generator.base import RandomGeneratorBase
@@ -7,7 +8,6 @@ from kornia.geometry.bbox import bbox_generator
 
 
 class _BBoxBasedGenerator(RandomGeneratorBase):
-
     has_fit_batch_prob = True
 
     def fit_batch_prob(

--- a/kornia/augmentation/random_generator/_2d/util.py
+++ b/kornia/augmentation/random_generator/_2d/util.py
@@ -1,0 +1,30 @@
+from typing import Dict
+import torch
+
+from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.core import Tensor, tensor
+from kornia.geometry.bbox import bbox_generator
+
+
+class _BBoxBasedGenerator(RandomGeneratorBase):
+
+    has_fit_batch_prob = True
+
+    def fit_batch_prob(
+        self, batch_shape: torch.Size, batch_prob: Tensor, params: Dict[str, Tensor]
+    ) -> Dict[str, Tensor]:
+        to_apply = batch_prob.round()
+        batch_size = batch_shape[0]
+        size = tensor(
+            (batch_shape[-2], batch_shape[-1]), device=params["dst"].device, dtype=params["dst"].dtype
+        ).repeat(batch_size, 1)
+        crop_src = bbox_generator(
+            tensor([0] * batch_size, device=params["dst"].device, dtype=params["dst"].dtype),
+            tensor([0] * batch_size, device=params["dst"].device, dtype=params["dst"].dtype),
+            size[:, 1],
+            size[:, 0],
+        )
+        crop_src = params["src"] * to_apply[:, None, None] + crop_src * (1 - to_apply[:, None, None])
+        crop_dst = params["dst"] * to_apply[:, None, None] + crop_src * (1 - to_apply[:, None, None])
+        output_size = params["output_size"] * to_apply[:, None] + params["input_size"] * (1 - to_apply[:, None])
+        return dict(src=crop_src, dst=crop_dst, input_size=params["input_size"], output_size=output_size)

--- a/kornia/augmentation/random_generator/_3d/crop.py
+++ b/kornia/augmentation/random_generator/_3d/crop.py
@@ -11,7 +11,6 @@ from kornia.utils.helpers import _extract_device_dtype
 
 
 class _CropGeneratorBase3D(RandomGeneratorBase):
-
     has_fit_batch_prob = True
 
     def fit_batch_prob(
@@ -197,7 +196,8 @@ class CenterCropGenerator3D(_CropGeneratorBase3D):
         depth, height, width = (batch_shape[-3], batch_shape[-2], batch_shape[-1])
         if not (depth >= self.size[0] and height >= self.size[1] and width >= self.size[2]):
             raise AssertionError(
-                f"Crop size must be smaller than input size. Got ({depth}, {height}, {width}) and {self.size}.")
+                f"Crop size must be smaller than input size. Got ({depth}, {height}, {width}) and {self.size}."
+            )
 
         # unpack input sizes
         dst_d, dst_h, dst_w = self.size

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -20,6 +20,8 @@ class RandomGeneratorBase(Module, metaclass=_PostInitInjectionMetaClass):
 
     device: Optional[Device] = None
     dtype: torch.dtype
+    # If can the generator process conditional parameters according to batch_prob
+    has_fit_batch_prob: bool = False
 
     def __init__(self) -> None:
         super().__init__()
@@ -50,6 +52,11 @@ class RandomGeneratorBase(Module, metaclass=_PostInitInjectionMetaClass):
         raise NotImplementedError
 
     def forward(self, batch_shape: torch.Size, same_on_batch: bool = False) -> Dict[str, Tensor]:
+        raise NotImplementedError
+
+    def fit_batch_prob(
+        self, batch_shape: torch.Size, batch_prob: Tensor, params: Dict[str, Tensor]
+    ) -> Dict[str, Tensor]:
         raise NotImplementedError
 
 

--- a/kornia/core/__init__.py
+++ b/kornia/core/__init__.py
@@ -9,6 +9,7 @@ from ._backend import (
     eye,
     linspace,
     normalize,
+    ones,
     pad,
     rand,
     stack,
@@ -16,7 +17,6 @@ from ._backend import (
     where,
     zeros,
     zeros_like,
-    ones,
 )
 
 __all__ = [

--- a/kornia/core/__init__.py
+++ b/kornia/core/__init__.py
@@ -16,6 +16,7 @@ from ._backend import (
     where,
     zeros,
     zeros_like,
+    ones,
 )
 
 __all__ = [
@@ -33,6 +34,7 @@ __all__ = [
     "where",
     "eye",
     "zeros",
+    "ones",
     "complex",
     "zeros_like",
     "linspace",

--- a/kornia/core/_backend.py
+++ b/kornia/core/_backend.py
@@ -20,6 +20,7 @@ pad = F.pad
 eye = torch.eye
 zeros = torch.zeros
 zeros_like = torch.zeros_like
+ones = torch.ones
 where = torch.where
 complex = torch.complex
 

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union, cast
+from typing import Any, List, Optional, Tuple, Union, cast
 
 import torch
 
@@ -225,6 +225,16 @@ class Boxes:
     def __setitem__(self, key, value: "Boxes") -> "Boxes":
         self._data[key] = value._data
         return self
+
+    def __mul__(self, other: "Boxes") -> "Boxes":
+        obj = self.clone()
+        obj._data = self.data * other.data
+        return obj
+
+    def __rmul__(self, other: Any) -> "Boxes":
+        obj = self.clone()
+        obj._data = self.data * other
+        return obj
 
     @property
     def shape(self):

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -57,9 +57,7 @@ def _transform_boxes(boxes: Tensor, M: Tensor) -> Tensor:
     return transformed_boxes
 
 
-def _boxes_to_polygons(
-    xmin: Tensor, ymin: Tensor, width: Tensor, height: Tensor
-) -> Tensor:
+def _boxes_to_polygons(xmin: Tensor, ymin: Tensor, width: Tensor, height: Tensor) -> Tensor:
     if not xmin.ndim == ymin.ndim == width.ndim == height.ndim == 2:
         raise ValueError("We expect to create a batch of 2D boxes (quadrilaterals) in vertices format (B, N, 4, 2)")
 
@@ -134,12 +132,7 @@ def _boxes_to_quadrilaterals(boxes: Tensor, mode: str = "xyxy", validate_boxes: 
 
 
 def _boxes3d_to_polygons3d(
-    xmin: Tensor,
-    ymin: Tensor,
-    zmin: Tensor,
-    width: Tensor,
-    height: Tensor,
-    depth: Tensor,
+    xmin: Tensor, ymin: Tensor, zmin: Tensor, width: Tensor, height: Tensor, depth: Tensor
 ) -> Tensor:
     if not xmin.ndim == ymin.ndim == zmin.ndim == width.ndim == height.ndim == depth.ndim == 2:
         raise ValueError("We expect to create a batch of 3D boxes (hexahedrons) in vertices format (B, N, 8, 3)")
@@ -188,10 +181,7 @@ class Boxes:
     """
 
     def __init__(
-        self,
-        boxes: Union[Tensor, List[Tensor]],
-        raise_if_not_floating_point: bool = True,
-        mode: str = "vertices_plus",
+        self, boxes: Union[Tensor, List[Tensor]], raise_if_not_floating_point: bool = True, mode: str = "vertices_plus"
     ) -> None:
         self._N: Optional[List[int]] = None
 
@@ -415,9 +405,7 @@ class Boxes:
         return w * h
 
     @classmethod
-    def from_tensor(
-        cls, boxes: Union[Tensor, List[Tensor]], mode: str = "xyxy", validate_boxes: bool = True
-    ) -> T:
+    def from_tensor(cls, boxes: Union[Tensor, List[Tensor]], mode: str = "xyxy", validate_boxes: bool = True) -> T:
         r"""Helper method to easily create :class:`Boxes` from boxes stored in another format.
 
         Args:
@@ -469,9 +457,7 @@ class Boxes:
         # constructing the class from inside of a method.
         return cls(quadrilaterals, False, mode)
 
-    def to_tensor(
-        self, mode: Optional[str] = None, as_padded_sequence: bool = False
-    ) -> Union[Tensor, List[Tensor]]:
+    def to_tensor(self, mode: Optional[str] = None, as_padded_sequence: bool = False) -> Union[Tensor, List[Tensor]]:
         r"""Cast :class:`Boxes` to a tensor. ``mode`` controls which 2D boxes format should be use to represent
         boxes in the tensor.
 
@@ -705,9 +691,7 @@ class VideoBoxes(Boxes):
         out.temporal_channel_size = temporal_channel_size
         return out
 
-    def to_tensor(  # type: ignore[override]
-        self, mode: Optional[str] = None
-    ) -> Union[Tensor, List[Tensor]]:
+    def to_tensor(self, mode: Optional[str] = None) -> Union[Tensor, List[Tensor]]:  # type: ignore[override]
         out = super().to_tensor(mode, as_padded_sequence=False)
         if isinstance(out, Tensor):
             return out.view(-1, self.temporal_channel_size, *out.shape[1:])
@@ -740,9 +724,7 @@ class Boxes3D:
         `hexahedrons <https://en.wikipedia.org/wiki/Hexahedron>`_ are cubes and rhombohedrons.
     """
 
-    def __init__(
-        self, boxes: Tensor, raise_if_not_floating_point: bool = True, mode: str = "xyzxyz_plus"
-    ) -> None:
+    def __init__(self, boxes: Tensor, raise_if_not_floating_point: bool = True, mode: str = "xyzxyz_plus") -> None:
         if not isinstance(boxes, Tensor):
             raise TypeError(f"Input boxes is not a Tensor. Got: {type(boxes)}.")
 

--- a/kornia/geometry/keypoints.py
+++ b/kornia/geometry/keypoints.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union, cast
+from typing import Any, List, Optional, Tuple, TypeVar, Union, cast
 
 import torch
 
@@ -8,6 +8,9 @@ from kornia.geometry import transform_points
 
 def _merge_keypoint_list(keypoints: List[Tensor]) -> Tensor:
     raise NotImplementedError
+
+
+T = TypeVar("T", bound="Keypoints")
 
 
 class Keypoints:
@@ -38,13 +41,28 @@ class Keypoints:
 
         self._data = keypoints
 
-    def __getitem__(self, key) -> "Keypoints":
+    def __getitem__(self, key) -> T:
         new_obj = type(self)(self._data[key], False)
         return new_obj
 
-    def __setitem__(self, key, value: "Keypoints") -> "Keypoints":
+    def __setitem__(self, key, value: T) -> T:
         self._data[key] = value._data
         return self
+
+    def __mul__(self, other: T) -> T:
+        obj = self.clone()
+        obj._data = self.data * other.data
+        return obj
+
+    def __rmul__(self, other: Any) -> T:
+        obj = self.clone()
+        obj._data = self.data * other
+        return obj
+
+    def __add__(self, other: T) -> T:
+        obj = self.clone()
+        obj._data = self.data + other.data
+        return obj
 
     @property
     def shape(self):

--- a/kornia/geometry/transform/crop2d.py
+++ b/kornia/geometry/transform/crop2d.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -309,7 +309,7 @@ def crop_by_indices(
         antialias: if True, then image will be filtered with Gaussian before downscaling.
             No effect for upscaling.
         shape_compensation: if the cropped slice sizes are not exactly align `size`, the image can either be padded
-            or resized.
+            or resized.  ``'resize'`` | ``'pad'`` | ``'none'``
     """
     B, C, _, _ = input_tensor.shape
     src = as_tensor(src_box, device=input_tensor.device, dtype=torch.long)
@@ -348,8 +348,12 @@ def crop_by_indices(
                     side="short",
                     antialias=antialias,
                 )
-            else:
+            elif shape_compensation == "pad":
                 out[i] = pad(_out, [0, size[1] - _out.shape[-1], 0, size[0] - _out.shape[-2]])
+            elif shape_compensation == "none":
+                out[i] = _out
+            else:
+                raise NotImplementedError(f"Method `{shape_compensation}` is not implemented.")
         else:
             out[i] = _out
     return out

--- a/kornia/geometry/transform/crop2d.py
+++ b/kornia/geometry/transform/crop2d.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 import torch
 

--- a/test/augmentation/test_base.py
+++ b/test/augmentation/test_base.py
@@ -52,7 +52,7 @@ class TestBasicAugmentationBase:
             }
             output = augmentation.forward_parameters(input_shape)
             assert "batch_prob" in output
-            assert len(output['degrees']) == output['batch_prob'].sum().item() == num
+            assert len(output['degrees']) == output['batch_prob'].round().sum().item() == num
 
     @pytest.mark.parametrize('keepdim', (True, False))
     def test_forward(self, device, dtype, keepdim):
@@ -137,7 +137,7 @@ class TestAugmentationBase2D:
         output = utils.tensor_to_gradcheck_var(output)  # to var
         other_transform = utils.tensor_to_gradcheck_var(other_transform)  # to var
 
-        input_param = {'batch_prob': torch.tensor([True]), 'x': input_transform, 'y': {}}
+        input_param = {'batch_prob': torch.tensor([1.]), 'x': input_transform, 'y': {}}
 
         augmentation = AugmentationBase2D(p=1.0)
 
@@ -147,7 +147,7 @@ class TestAugmentationBase2D:
 
 
 class TestGeometricAugmentationBase2D:
-    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
@@ -168,7 +168,7 @@ class TestGeometricAugmentationBase2D:
 
 
 class TestIntensityAugmentationBase2D:
-    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
@@ -189,7 +189,7 @@ class TestIntensityAugmentationBase2D:
 
 
 class TestIntensityAugmentationBase3D:
-    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
@@ -210,7 +210,7 @@ class TestIntensityAugmentationBase3D:
 
 
 class TestGeometricAugmentationBase3D:
-    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")

--- a/test/augmentation/test_base.py
+++ b/test/augmentation/test_base.py
@@ -137,7 +137,7 @@ class TestAugmentationBase2D:
         output = utils.tensor_to_gradcheck_var(output)  # to var
         other_transform = utils.tensor_to_gradcheck_var(other_transform)  # to var
 
-        input_param = {'batch_prob': torch.tensor([1.]), 'x': input_transform, 'y': {}}
+        input_param = {'batch_prob': torch.tensor([1.0]), 'x': input_transform, 'y': {}}
 
         augmentation = AugmentationBase2D(p=1.0)
 
@@ -147,7 +147,7 @@ class TestAugmentationBase2D:
 
 
 class TestGeometricAugmentationBase2D:
-    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
+    @pytest.mark.parametrize("batch_prob", [[1.0, 1.0], [0.0, 1.0], [0.0, 0.0]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
@@ -168,7 +168,7 @@ class TestGeometricAugmentationBase2D:
 
 
 class TestIntensityAugmentationBase2D:
-    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
+    @pytest.mark.parametrize("batch_prob", [[1.0, 1.0], [0.0, 1.0], [0.0, 0.0]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
@@ -189,7 +189,7 @@ class TestIntensityAugmentationBase2D:
 
 
 class TestIntensityAugmentationBase3D:
-    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
+    @pytest.mark.parametrize("batch_prob", [[1.0, 1.0], [0.0, 1.0], [0.0, 0.0]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
@@ -210,7 +210,7 @@ class TestIntensityAugmentationBase3D:
 
 
 class TestGeometricAugmentationBase3D:
-    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
+    @pytest.mark.parametrize("batch_prob", [[1.0, 1.0], [0.0, 1.0], [0.0, 0.0]])
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -649,7 +649,7 @@ class TestAugmentationSequential:
         op_jit = torch.jit.script(op)
         assert_close(op(img), op_jit(img))
 
-    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
+    @pytest.mark.parametrize("batch_prob", [[1.0, 1.0], [0.0, 1.0], [0.0, 0.0]])
     @pytest.mark.parametrize("box", ['bbox', 'bbox_xyxy', 'bbox_xywh'])
     def test_autocast(self, batch_prob, box, device, dtype):
         if not hasattr(torch, "autocast"):

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -649,7 +649,7 @@ class TestAugmentationSequential:
         op_jit = torch.jit.script(op)
         assert_close(op(img), op_jit(img))
 
-    @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
+    @pytest.mark.parametrize("batch_prob", [[1., 1.], [0., 1.], [0., 0.]])
     @pytest.mark.parametrize("box", ['bbox', 'bbox_xyxy', 'bbox_xywh'])
     def test_autocast(self, batch_prob, box, device, dtype):
         if not hasattr(torch, "autocast"):

--- a/test/augmentation/test_motionblur.py
+++ b/test/augmentation/test_motionblur.py
@@ -63,7 +63,7 @@ class TestRandomMotionBlur:
         inp = tensor_to_gradcheck_var(inp)  # to var
         # TODO: Gradcheck for param random gen failed. Suspect get_motion_kernel2d issue.
         params = {
-            'batch_prob': torch.tensor([True]),
+            'batch_prob': torch.tensor([1.]),
             'ksize_factor': torch.tensor([31]),
             'angle_factor': torch.tensor([30.0]),
             'direction_factor': torch.tensor([-0.5]),
@@ -131,7 +131,7 @@ class TestRandomMotionBlur3D:
         inp = torch.rand((1, 3, 6, 7), device=device, dtype=dtype)
         inp = tensor_to_gradcheck_var(inp)  # to var
         params = {
-            'batch_prob': torch.tensor([True]),
+            'batch_prob': torch.tensor([1.]),
             'ksize_factor': torch.tensor([31]),
             'angle_factor': torch.tensor([[30.0, 30.0, 30.0]]),
             'direction_factor': torch.tensor([-0.5]),

--- a/test/augmentation/test_motionblur.py
+++ b/test/augmentation/test_motionblur.py
@@ -63,7 +63,7 @@ class TestRandomMotionBlur:
         inp = tensor_to_gradcheck_var(inp)  # to var
         # TODO: Gradcheck for param random gen failed. Suspect get_motion_kernel2d issue.
         params = {
-            'batch_prob': torch.tensor([1.]),
+            'batch_prob': torch.tensor([1.0]),
             'ksize_factor': torch.tensor([31]),
             'angle_factor': torch.tensor([30.0]),
             'direction_factor': torch.tensor([-0.5]),
@@ -131,7 +131,7 @@ class TestRandomMotionBlur3D:
         inp = torch.rand((1, 3, 6, 7), device=device, dtype=dtype)
         inp = tensor_to_gradcheck_var(inp)  # to var
         params = {
-            'batch_prob': torch.tensor([1.]),
+            'batch_prob': torch.tensor([1.0]),
             'ksize_factor': torch.tensor([31]),
             'angle_factor': torch.tensor([[30.0, 30.0, 30.0]]),
             'direction_factor': torch.tensor([-0.5]),

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -16,7 +16,7 @@ from kornia.augmentation.random_generator import (
     ProbabilityGenerator,
     RectangleEraseGenerator,
     ResizedCropGenerator,
-    center_crop_generator,
+    CenterCropGenerator,
 )
 from kornia.testing import assert_close
 from kornia.utils._compat import torch_version_ge
@@ -842,7 +842,7 @@ class TestCenterCropGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize('width', [200])
     @pytest.mark.parametrize('size', [(100, 100)])
     def test_valid_param_combinations(self, batch_size, height, width, size, device, dtype):
-        center_crop_generator(batch_size=batch_size, height=height, width=width, size=size)
+        CenterCropGenerator(size).to(device=device, dtype=dtype)(torch.Size(batch_size, 3, height, width))
 
     @pytest.mark.parametrize(
         'height,width,size',
@@ -857,11 +857,11 @@ class TestCenterCropGen(RandomGeneratorBaseTests):
     def test_invalid_param_combinations(self, height, width, size, device, dtype):
         batch_size = 2
         with pytest.raises(Exception):
-            center_crop_generator(batch_size=batch_size, height=height, width=width, size=size)
+            CenterCropGenerator(size).to(device=device, dtype=dtype)(torch.Size(batch_size, 3, height, width))
 
     def test_random_gen(self, device, dtype):
         torch.manual_seed(42)
-        res = center_crop_generator(batch_size=2, height=200, width=200, size=(120, 150))
+        res = CenterCropGenerator((120, 150)).to(device=device, dtype=dtype)(torch.Size(2, 3, 200, 200))
         expected = dict(
             src=torch.tensor(
                 [[[25, 40], [174, 40], [174, 159], [25, 159]], [[25, 40], [174, 40], [174, 159], [25, 159]]],

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -842,7 +842,7 @@ class TestCenterCropGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize('width', [200])
     @pytest.mark.parametrize('size', [(100, 100)])
     def test_valid_param_combinations(self, batch_size, height, width, size, device, dtype):
-        CenterCropGenerator(size).to(device=device, dtype=dtype)(torch.Size(batch_size, 3, height, width))
+        CenterCropGenerator(size).to(device=device, dtype=dtype)(torch.Size((batch_size, 3, height, width)))
 
     @pytest.mark.parametrize(
         'height,width,size',
@@ -857,11 +857,11 @@ class TestCenterCropGen(RandomGeneratorBaseTests):
     def test_invalid_param_combinations(self, height, width, size, device, dtype):
         batch_size = 2
         with pytest.raises(Exception):
-            CenterCropGenerator(size).to(device=device, dtype=dtype)(torch.Size(batch_size, 3, height, width))
+            CenterCropGenerator(size).to(device=device, dtype=dtype)(torch.Size((batch_size, 3, height, width)))
 
     def test_random_gen(self, device, dtype):
         torch.manual_seed(42)
-        res = CenterCropGenerator((120, 150)).to(device=device, dtype=dtype)(torch.Size(2, 3, 200, 200))
+        res = CenterCropGenerator((120, 150)).to(device=device, dtype=dtype)(torch.Size((2, 3, 200, 200)))
         expected = dict(
             src=torch.tensor(
                 [[[25, 40], [174, 40], [174, 159], [25, 159]], [[25, 40], [174, 40], [174, 159], [25, 159]]],

--- a/test/augmentation/test_random_generator.py
+++ b/test/augmentation/test_random_generator.py
@@ -4,6 +4,7 @@ from torch import Tensor
 
 from kornia.augmentation.random_generator import (
     AffineGenerator,
+    CenterCropGenerator,
     ColorJiggleGenerator,
     ColorJitterGenerator,
     CropGenerator,
@@ -16,7 +17,6 @@ from kornia.augmentation.random_generator import (
     ProbabilityGenerator,
     RectangleEraseGenerator,
     ResizedCropGenerator,
-    CenterCropGenerator,
 )
 from kornia.testing import assert_close
 from kornia.utils._compat import torch_version_ge

--- a/test/augmentation/test_random_generator_3d.py
+++ b/test/augmentation/test_random_generator_3d.py
@@ -3,11 +3,11 @@ import torch
 
 from kornia.augmentation.random_generator import (
     AffineGenerator3D,
+    CenterCropGenerator3D,
     CropGenerator3D,
     MotionBlurGenerator3D,
     PerspectiveGenerator3D,
     RotationGenerator3D,
-    CenterCropGenerator3D,
 )
 from kornia.testing import assert_close
 

--- a/test/augmentation/test_random_generator_3d.py
+++ b/test/augmentation/test_random_generator_3d.py
@@ -7,7 +7,7 @@ from kornia.augmentation.random_generator import (
     MotionBlurGenerator3D,
     PerspectiveGenerator3D,
     RotationGenerator3D,
-    center_crop_generator3d,
+    CenterCropGenerator3D,
 )
 from kornia.testing import assert_close
 
@@ -528,7 +528,7 @@ class TestCenterCropGen3D(RandomGeneratorBaseTests):
     @pytest.mark.parametrize('depth,height,width', [(200, 200, 200)])
     @pytest.mark.parametrize('size', [(100, 100, 100)])
     def test_valid_param_combinations(self, batch_size, depth, height, width, size, device, dtype):
-        center_crop_generator3d(batch_size=batch_size, depth=depth, height=height, width=width, size=size)
+        CenterCropGenerator3D(size)((batch_size, 3, depth, height, width))
 
     @pytest.mark.parametrize(
         'depth,height,width,size',
@@ -542,11 +542,11 @@ class TestCenterCropGen3D(RandomGeneratorBaseTests):
     )
     def test_invalid_param_combinations(self, depth, height, width, size, device, dtype):
         with pytest.raises(Exception):
-            center_crop_generator3d(batch_size=2, depth=depth, height=height, width=width, size=size)
+            CenterCropGenerator3D(size)((2, 3, depth, height, width))
 
     def test_random_gen(self, device, dtype):
         torch.manual_seed(42)
-        res = center_crop_generator3d(batch_size=2, depth=200, height=200, width=200, size=(120, 150, 100))
+        res = CenterCropGenerator3D((120, 150, 100))((2, 3, 200, 200, 200))
         expected = dict(
             src=torch.tensor(
                 [


### PR DESCRIPTION
#2189 

- Move `transform_matrix` to augmentation params, making the whole augmentation instance stateless.
- Update augmentation `apply_transform` logic, making it differentiable as in `auto_augment` module. 
