### PR TITLE
Fix RandomGaussianBlur error when sigma is passed as a tensor.

### DIFF
--- a/kornia/augmentation/random_generator/_2d/gaussian_blur.py
+++ b/kornia/augmentation/random_generator/_2d/gaussian_blur.py
@@ -42,7 +42,7 @@ class RandomGaussianBlurGenerator(RandomGeneratorBase):
         if not isinstance(self.sigma, (torch.Tensor)):
             sigma = torch.tensor(self.sigma, device=device, dtype=dtype)
         else:
-            sigma = sigma.to(device=device, dtype=dtype)
+            sigma = self.sigma.to(device=device, dtype=dtype)
 
         _joint_range_check(sigma, "sigma", (0, float('inf')))
 

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -3398,6 +3398,24 @@ class TestRandomGaussianBlur(BaseTester):
         img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
         self.assert_close(op(img, *func_params), op_module(img))
 
+    def test_module_kernel_int(self, device, dtype):
+        func_params = [3, torch.tensor([1.5, 1.5]).view(1, -1)]
+        params = [3, (1.5, 1.5)]
+        op = kornia.filters.gaussian_blur2d
+        op_module = RandomGaussianBlur(*params)
+
+        img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
+        self.assert_close(op(img, *func_params), op_module(img))
+
+    def test_module_sigma_tensor(self, device, dtype):
+        func_params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
+        params = [(3, 3), torch.tensor((1.5, 1.5))]
+        op = kornia.filters.gaussian_blur2d
+        op_module = RandomGaussianBlur(*params)
+
+        img = torch.ones(1, 3, 5, 5, device=device, dtype=dtype)
+        self.assert_close(op(img, *func_params), op_module(img))
+
     @pytest.mark.skip(reason="not implemented yet")
     def test_exception(self, device, dtype):
         pass


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes a bug I missed in #1663 that is when sigma is passed as a tensor to `RandomGaussianBlur` an error is raised, sorry for the inconvenience.

I added some tests to check this case as well as `kernel_size` passed as an int in addition to passed as a tuple of int. 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
