### PR TITLE
AdaLAM for the same image [WIP]

### DIFF
--- a/test/feature/test_matching.py
+++ b/test/feature/test_matching.py
@@ -450,3 +450,17 @@ class TestAdalam:
         assert dists.shape[0] <= data_dev['descs2'].shape[0]
         expected_idxs = data_dev['expected_idxs'].long()
         assert_close(idxs, expected_idxs, rtol=1e-4, atol=1e-4)
+
+    @pytest.mark.parametrize("data", ["adalam_idxs"], indirect=True)
+    def test_same_image(self, device, dtype, data):
+        torch.random.manual_seed(0)
+        # This is not unit test, but that is quite good integration test
+        data_dev = utils.dict_to(data, device, dtype)
+        matcher = GeometryAwareDescriptorMatcher('adalam', {"device": device}).to(device, dtype)
+        with torch.no_grad():
+            dists, idxs = matcher(data_dev['descs1'], data_dev['descs1'], data_dev['lafs1'], data_dev['lafs1'])
+        assert idxs.shape[1] == 2
+        assert dists.shape[1] == 1
+        assert idxs.shape[0] == dists.shape[0]
+        expected_idxs = torch.arange(data_dev['descs1'].shape[0]).to(device).view(-1, 1).repeat(1, 2)
+        assert_close(idxs, expected_idxs, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
#### Changes
Adds failing test and fixes   https://github.com/kornia/kornia/issues/2221
Not yet now, though. The seeming reason for failing to match same image, is because https://github.com/kornia/kornia/blob/master/kornia/feature/adalam/ransac.py#L58 AdaLAM RANSAC filters out "too perfect fits" and then some division by zero happening as well. 
It is not clear where exactly fix should be.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
