### PR TITLE
torch.jit.script -> torch.jit.script_if_tracing

### DIFF
--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -164,7 +164,7 @@ def _boxes3d_to_polygons3d(
     return polygons3d
 
 
-# @torch.jit.script
+# @torch.jit.script_if_tracing
 class Boxes:
     r"""2D boxes containing N or BxN boxes.
 
@@ -705,7 +705,7 @@ class VideoBoxes(Boxes):
         return obj
 
 
-@torch.jit.script
+@torch.jit.script_if_tracing
 class Boxes3D:
     r"""3D boxes containing N or BxN boxes.
 


### PR DESCRIPTION
#### Changes
Executables generated using PyInstaller fail because the source code is not included. According to [1] library code should use torch.jit.script_if_tracing.

[1]: https://pytorch.org/docs/stable/generated/torch.jit.script_if_tracing.html

Fixes # (issue)
Executables generated with PyInstaller will fail because they cannot find the source code.
```
OSError: could not get source code
```

#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
