### PR TITLE
Update tensor equality tests to use`assert_close()`

### DIFF
--- a/test/augmentation/test_augmentation_mix.py
+++ b/test/augmentation/test_augmentation_mix.py
@@ -18,7 +18,7 @@ class TestRandomMixUpV2:
         input = torch.stack(
             [torch.ones(1, 3, 4, device=device, dtype=dtype), torch.zeros(1, 3, 4, device=device, dtype=dtype)]
         )
-        label = torch.tensor([1, 0], device=device)
+        label = torch.tensor([1, 0], device=device, dtype=dtype)
         lam = torch.tensor([0.1320, 0.3074], device=device, dtype=dtype)
 
         expected = torch.stack(
@@ -31,8 +31,8 @@ class TestRandomMixUpV2:
         out_image, out_label = f(input, label)
 
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label[:, 0] == label).all()
-        assert (out_label[:, 1] == torch.tensor([0, 1], device=device, dtype=dtype)).all()
+        assert_close(out_label[:, 0], label)
+        assert_close(out_label[:, 1], torch.tensor([0, 1], device=device, dtype=dtype))
         assert_close(out_label[:, 2], lam, rtol=1e-4, atol=1e-4)
 
     def test_random_mixup_p0(self, device, dtype):
@@ -59,7 +59,7 @@ class TestRandomMixUpV2:
         input = torch.stack(
             [torch.ones(1, 3, 4, device=device, dtype=dtype), torch.zeros(1, 3, 4, device=device, dtype=dtype)]
         )
-        label = torch.tensor([1, 0], device=device)
+        label = torch.tensor([1, 0], device=device, dtype=dtype)
         lam = torch.tensor([0.0, 0.0], device=device, dtype=dtype)
 
         expected = input.clone()
@@ -67,8 +67,8 @@ class TestRandomMixUpV2:
         out_image, out_label = f(input, label)
 
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label[:, 0] == label).all()
-        assert (out_label[:, 1] == torch.tensor([0, 1], device=device)).all()
+        assert_close(out_label[:, 0], label)
+        assert_close(out_label[:, 1], torch.tensor([0, 1], device=device, dtype=dtype))
         assert_close(out_label[:, 2], lam, rtol=1e-4, atol=1e-4)
 
     def test_random_mixup_same_on_batch(self, device, dtype):
@@ -78,7 +78,7 @@ class TestRandomMixUpV2:
         input = torch.stack(
             [torch.ones(1, 3, 4, device=device, dtype=dtype), torch.zeros(1, 3, 4, device=device, dtype=dtype)]
         )
-        label = torch.tensor([1, 0], device=device)
+        label = torch.tensor([1, 0], device=device, dtype=dtype)
         lam = torch.tensor([0.0885, 0.0885], device=device, dtype=dtype)
 
         expected = torch.stack(
@@ -90,8 +90,8 @@ class TestRandomMixUpV2:
 
         out_image, out_label = f(input, label)
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label[:, 0] == label).all()
-        assert (out_label[:, 1] == torch.tensor([0, 1], device=device, dtype=dtype)).all()
+        assert_close(out_label[:, 0], label)
+        assert_close(out_label[:, 1], torch.tensor([0, 1], device=device, dtype=dtype))
         assert_close(out_label[:, 2], lam, rtol=1e-4, atol=1e-4)
 
 
@@ -108,7 +108,7 @@ class TestRandomCutMixV2:
         input = torch.stack(
             [torch.ones(1, 3, 4, device=device, dtype=dtype), torch.zeros(1, 3, 4, device=device, dtype=dtype)]
         )
-        label = torch.tensor([1, 0], device=device)
+        label = torch.tensor([1, 0], device=device, dtype=dtype)
 
         expected = torch.tensor(
             [
@@ -122,9 +122,9 @@ class TestRandomCutMixV2:
         out_image, out_label = f(input, label)
 
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label[0, :, 0] == label).all()
-        assert (out_label[0, :, 1] == torch.tensor([0, 1], device=device, dtype=dtype)).all()
-        assert (out_label[0, :, 2] == torch.tensor([0.5, 0.5], device=device, dtype=dtype)).all()
+        assert_close(out_label[0, :, 0], label)
+        assert_close(out_label[0, :, 1], torch.tensor([0, 1], device=device, dtype=dtype))
+        assert_close(out_label[0, :, 2], torch.tensor([0.5, 0.5], device=device, dtype=dtype))
 
     def test_random_mixup_p0(self, device, dtype):
         torch.manual_seed(76)
@@ -141,7 +141,7 @@ class TestRandomCutMixV2:
         out_image, out_label = f(input, label)
 
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label == exp_label).all()
+        assert_close(out_label, exp_label)
 
     def test_random_mixup_beta0(self, device, dtype):
         torch.manual_seed(76)
@@ -152,7 +152,7 @@ class TestRandomCutMixV2:
         input = torch.stack(
             [torch.ones(1, 3, 4, device=device, dtype=dtype), torch.zeros(1, 3, 4, device=device, dtype=dtype)]
         )
-        label = torch.tensor([1, 0], device=device)
+        label = torch.tensor([1, 0], device=device, dtype=dtype)
 
         expected = torch.tensor(
             [
@@ -166,8 +166,8 @@ class TestRandomCutMixV2:
         out_image, out_label = f(input, label)
 
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label[0, :, 0] == label).all()
-        assert (out_label[0, :, 1] == torch.tensor([0, 1], device=device, dtype=dtype)).all()
+        assert_close(out_label[0, :, 0], label)
+        assert_close(out_label[0, :, 1], torch.tensor([0, 1], device=device, dtype=dtype))
         # cut area = 4 / 12
         assert_close(out_label[0, :, 2], torch.tensor([0.33333, 0.33333], device=device, dtype=dtype))
 
@@ -178,7 +178,7 @@ class TestRandomCutMixV2:
         input = torch.stack(
             [torch.ones(1, 3, 4, device=device, dtype=dtype), torch.zeros(1, 3, 4, device=device, dtype=dtype)]
         )
-        label = torch.tensor([1, 0], device=device)
+        label = torch.tensor([1, 0], device=device, dtype=dtype)
 
         expected = torch.tensor(
             [
@@ -192,8 +192,10 @@ class TestRandomCutMixV2:
         out_image, out_label = f(input, label)
 
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label[:, :, 0] == label).all()
-        assert (out_label[:, :, 1] == torch.tensor([[1, 0], [1, 0], [1, 0], [1, 0], [0, 1]], device=device)).all()
+        assert_close(out_label[:, :, 0], label.view(1, -1).expand(5, 2))
+        assert_close(
+            out_label[:, :, 1], torch.tensor([[1, 0], [1, 0], [1, 0], [1, 0], [0, 1]], device=device, dtype=dtype)
+        )
         assert_close(
             out_label[:, :, 2],
             torch.tensor(
@@ -212,7 +214,7 @@ class TestRandomCutMixV2:
         input = torch.stack(
             [torch.ones(1, 3, 4, device=device, dtype=dtype), torch.zeros(1, 3, 4, device=device, dtype=dtype)]
         )
-        label = torch.tensor([1, 0], device=device)
+        label = torch.tensor([1, 0], device=device, dtype=dtype)
 
         expected = torch.tensor(
             [
@@ -226,8 +228,8 @@ class TestRandomCutMixV2:
         out_image, out_label = f(input, label)
 
         assert_close(out_image, expected, rtol=1e-4, atol=1e-4)
-        assert (out_label[0, :, 0] == label).all()
-        assert (out_label[0, :, 1] == torch.tensor([0, 1], device=device, dtype=dtype)).all()
+        assert_close(out_label[0, :, 0], label)
+        assert_close(out_label[0, :, 1], torch.tensor([0, 1], device=device, dtype=dtype))
         assert_close(
             out_label[0, :, 2], torch.tensor([0.5000, 0.5000], device=device, dtype=dtype), rtol=1e-4, atol=1e-4
         )

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -102,15 +102,15 @@ class TestVideoSequential:
         if data_format == 'BCTHW':
             input = torch.randn(2, 3, 1, 5, 6, device=device, dtype=dtype).repeat(1, 1, 4, 1, 1)
             output = aug_list(input)
-            assert (output[:, :, 0] == output[:, :, 1]).all()
-            assert (output[:, :, 1] == output[:, :, 2]).all()
-            assert (output[:, :, 2] == output[:, :, 3]).all()
+            assert_close(output[:, :, 0], output[:, :, 1])
+            assert_close(output[:, :, 1], output[:, :, 2])
+            assert_close(output[:, :, 2], output[:, :, 3])
         if data_format == 'BTCHW':
             input = torch.randn(2, 1, 3, 5, 6, device=device, dtype=dtype).repeat(1, 4, 1, 1, 1)
             output = aug_list(input)
-            assert (output[:, 0] == output[:, 1]).all()
-            assert (output[:, 1] == output[:, 2]).all()
-            assert (output[:, 2] == output[:, 3]).all()
+            assert_close(output[:, 0], output[:, 1])
+            assert_close(output[:, 1], output[:, 2])
+            assert_close(output[:, 2], output[:, 3])
         reproducibility_test(input, aug_list)
 
     @pytest.mark.parametrize(
@@ -145,7 +145,7 @@ class TestVideoSequential:
             output_2 = output_2.view(2, 4, 3, 5, 6)
         if data_format == 'BCTHW':
             output_2 = output_2.transpose(1, 2)
-        assert (output_1 == output_2).all(), dict(aug_list_1._params)
+        assert_close(output_1, output_2)
 
     @pytest.mark.jit
     @pytest.mark.skip(reason="turn off due to Union Type")

--- a/test/geometry/test_boxes.py
+++ b/test/geometry/test_boxes.py
@@ -52,17 +52,15 @@ class TestBoxes2D:
         h, w = boxes.get_boxes_shape()
         assert h.ndim == 1 and w.ndim == 1
         assert len(h) == 2 and len(w) == 2
-        assert (h == torch.as_tensor([2.0, 3.0], device=device)).all() and (
-            w == torch.as_tensor([3.0, 4.0], device=device)
-        ).all()
+        assert_close(h, torch.as_tensor([2.0, 3.0], device=device, dtype=dtype))
+        assert_close(w, torch.as_tensor([3.0, 4.0], device=device, dtype=dtype))
 
         # Box batch
         h, w = boxes_batch.get_boxes_shape()
         assert h.ndim == 2 and w.ndim == 2
         assert h.shape == (1, 2) and w.shape == (1, 2)
-        assert (h == torch.as_tensor([[2.0, 3.0]], device=device)).all() and (
-            w == torch.as_tensor([[3.0, 4.0]], device=device)
-        ).all()
+        assert_close(h, torch.as_tensor([[2.0, 3.0]], device=device, dtype=dtype))
+        assert_close(w, torch.as_tensor([[3.0, 4.0]], device=device, dtype=dtype))
 
     def test_get_boxes_shape_batch(self, device, dtype):
         t_box1 = torch.tensor([[[1.0, 1.0], [3.0, 2.0], [3.0, 1.0], [1.0, 2.0]]], device=device, dtype=dtype)
@@ -72,9 +70,8 @@ class TestBoxes2D:
         h, w = batched_boxes.get_boxes_shape()
         assert h.ndim == 2 and w.ndim == 2
         assert h.shape == (2, 1) and w.shape == (2, 1)
-        assert (h == torch.as_tensor([[2], [3]], device=device)).all() and (
-            w == torch.as_tensor([[3], [4]], device=device)
-        ).all()
+        assert_close(h, torch.as_tensor([[2], [3]], device=device, dtype=dtype))
+        assert_close(w, torch.as_tensor([[3], [4]], device=device, dtype=dtype))
 
     @pytest.mark.parametrize('shape', [(1, 4), (1, 1, 4)])
     def test_from_tensor(self, shape, device, dtype):
@@ -450,21 +447,17 @@ class TestBbox3D:
         d, h, w = boxes.get_boxes_shape()
         assert h.ndim == 1 and w.ndim == 1
         assert len(d) == 2 and len(h) == 2 and len(w) == 2
-        assert (
-            (d == torch.as_tensor([31.0, 61.0], device=device)).all()
-            and (h == torch.as_tensor([21.0, 51.0], device=device)).all()
-            and (w == torch.as_tensor([11.0, 41.0], device=device)).all()
-        )
+        assert_close(d, torch.as_tensor([31.0, 61.0], device=device, dtype=dtype))
+        assert_close(h, torch.as_tensor([21.0, 51.0], device=device, dtype=dtype))
+        assert_close(w, torch.as_tensor([11.0, 41.0], device=device, dtype=dtype))
 
         # Box batch
         d, h, w = boxes_batch.get_boxes_shape()
         assert h.ndim == 2 and w.ndim == 2
         assert h.shape == (1, 2) and w.shape == (1, 2)
-        assert (
-            (d == torch.as_tensor([[31.0, 61.0]], device=device)).all()
-            and (h == torch.as_tensor([[21.0, 51.0]], device=device)).all()
-            and (w == torch.as_tensor([[11.0, 41.0]], device=device)).all()
-        )
+        assert_close(d, torch.as_tensor([[31.0, 61.0]], device=device, dtype=dtype))
+        assert_close(h, torch.as_tensor([[21.0, 51.0]], device=device, dtype=dtype))
+        assert_close(w, torch.as_tensor([[11.0, 41.0]], device=device, dtype=dtype))
 
     def test_get_boxes_shape_batch(self, device, dtype):
         t_box1 = torch.tensor(
@@ -482,11 +475,9 @@ class TestBbox3D:
         d, h, w = batched_boxes.get_boxes_shape()
         assert d.ndim == 2 and h.ndim == 2 and w.ndim == 2
         assert d.shape == (2, 1) and h.shape == (2, 1) and w.shape == (2, 1)
-        assert (
-            (d == torch.as_tensor([[31.0], [61.0]], device=device)).all()
-            and (h == torch.as_tensor([[21.0], [51.0]], device=device)).all()
-            and (w == torch.as_tensor([[11.0], [41.0]], device=device)).all()
-        )
+        assert_close(d, torch.as_tensor([[31.0], [61.0]], device=device, dtype=dtype))
+        assert_close(h, torch.as_tensor([[21.0], [51.0]], device=device, dtype=dtype))
+        assert_close(w, torch.as_tensor([[11.0], [41.0]], device=device, dtype=dtype))
 
     @pytest.mark.parametrize('shape', [(1, 6), (1, 1, 6)])
     def test_from_tensor(self, shape, device, dtype):

--- a/test/geometry/test_line.py
+++ b/test/geometry/test_line.py
@@ -4,7 +4,7 @@ from torch.autograd import gradcheck
 
 from kornia.geometry.line import ParametrizedLine, fit_line
 from kornia.geometry.plane import Hyperplane
-from kornia.testing import BaseTester
+from kornia.testing import BaseTester, assert_close
 
 
 class TestParametrizedLine(BaseTester):
@@ -124,12 +124,12 @@ class TestFitLine(BaseTester):
         assert line.origin.shape == (B, D)
         assert line.direction.shape == (B, D)
 
-        assert (line.origin == line[0]).all()
-        assert (line.direction == line[1]).all()
+        assert_close(line.origin, line[0])
+        assert_close(line.direction, line[1])
 
         origin, direction = fit_line(points)
-        assert (line.origin == origin).all()
-        assert (line.direction == direction).all()
+        assert_close(line.origin, origin)
+        assert_close(line.direction, direction)
 
     def test_fit_line2(self, device, dtype):
         p0 = torch.tensor([0.0, 0.0], device=device, dtype=dtype)

--- a/test/geometry/transform/test_flip.py
+++ b/test/geometry/transform/test_flip.py
@@ -21,7 +21,7 @@ class TestVflip:
             [[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], device=device, dtype=dtype
         )  # 3 x 3
 
-        assert (f(input) == expected).all()
+        assert_close(f(input), expected)
 
     def test_batch_vflip(self, device, dtype):
         input = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]], device=device, dtype=dtype)  # 3 x 3
@@ -35,7 +35,7 @@ class TestVflip:
 
         expected = expected.repeat(2, 1, 1)  # 2 x 3 x 3
 
-        assert (f(input) == expected).all()
+        assert_close(f(input), expected)
 
     @pytest.mark.skip(reason="turn off all jit for a while")
     def test_jit(self, device, dtype):
@@ -85,7 +85,7 @@ class TestHflip:
             [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]], device=device, dtype=dtype
         )  # 3 x 3
 
-        assert (f(input) == expected).all()
+        assert_close(f(input), expected)
 
     def test_batch_hflip(self, device, dtype):
         input = torch.tensor(
@@ -101,7 +101,7 @@ class TestHflip:
 
         expected = expected.repeat(2, 1, 1)  # 2 x 3 x 3
 
-        assert (f(input) == expected).all()
+        assert_close(f(input), expected)
 
     @pytest.mark.skip(reason="turn off all jit for a while")
     def test_jit(self, device, dtype):
@@ -151,7 +151,7 @@ class TestRot180:
             [[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], device=device, dtype=dtype
         )  # 3 x 3
 
-        assert (f(input) == expected).all()
+        assert_close(f(input), expected)
 
     def test_batch_rot180(self, device, dtype):
         input = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]], device=device, dtype=dtype)  # 3 x 3
@@ -165,7 +165,7 @@ class TestRot180:
 
         expected = expected.repeat(2, 1, 1)  # 2 x 3 x 3
 
-        assert (f(input) == expected).all()
+        assert_close(f(input), expected)
 
     @pytest.mark.skip(reason="turn off all jit for a while")
     def test_jit(self, device, dtype):

--- a/test/geometry/transform/test_homography_warper.py
+++ b/test/geometry/transform/test_homography_warper.py
@@ -32,12 +32,10 @@ class TestHomographyWarper:
         dst_homo_src = utils.create_eye_batch(batch_size=batch_size, eye_size=3, device=device, dtype=dtype)
 
         res = torch.tensor([[[0.5, 0.0, -1.0], [0.0, 2.0, -1.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
-        assert (
-            kornia.geometry.conversions.normal_transform_pixel(height, width, device=device, dtype=dtype) == res
-        ).all()
+        assert_close(kornia.geometry.conversions.normal_transform_pixel(height, width, device=device, dtype=dtype), res)
 
         norm_homo = kornia.geometry.conversions.normalize_homography(dst_homo_src, (height, width), (height, width))
-        assert (norm_homo == dst_homo_src).all()
+        assert_close(norm_homo, dst_homo_src)
 
         # change output scale
         norm_homo = kornia.geometry.conversions.normalize_homography(
@@ -55,12 +53,10 @@ class TestHomographyWarper:
         dst_homo_src = utils.create_eye_batch(batch_size=batch_size, eye_size=3, device=device, dtype=dtype)
 
         res = torch.tensor([[[0.5, 0.0, -1.0], [0.0, 2.0, -1.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
-        assert (
-            kornia.geometry.conversions.normal_transform_pixel(height, width, device=device, dtype=dtype) == res
-        ).all()
+        assert_close(kornia.geometry.conversions.normal_transform_pixel(height, width, device=device, dtype=dtype), res)
 
         denorm_homo = kornia.geometry.conversions.denormalize_homography(dst_homo_src, (height, width), (height, width))
-        assert (denorm_homo == dst_homo_src).all()
+        assert_close(denorm_homo, dst_homo_src)
 
         # change output scale
         denorm_homo = kornia.geometry.conversions.denormalize_homography(
@@ -83,8 +79,10 @@ class TestHomographyWarper:
         dst_homo_src = dst_homo_src.expand(batch_size, -1, -1)
 
         norm_homo = kornia.geometry.conversions.normalize_homography(dst_homo_src, (height, width), (height, width))
-        res = torch.tensor([[[0.5, 0.0, 0.0], [0.0, 2.0, 5.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
-        assert (norm_homo == res).all()
+        res = torch.tensor([[[0.5, 0.0, 0.0], [0.0, 2.0, 5.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype).expand(
+            batch_size, -1, -1
+        )
+        assert_close(norm_homo, res)
 
     @pytest.mark.parametrize("batch_size", [1, 3])
     def test_denormalize_homography_general(self, batch_size, device, dtype):
@@ -98,8 +96,10 @@ class TestHomographyWarper:
         dst_homo_src = dst_homo_src.expand(batch_size, -1, -1)
 
         denorm_homo = kornia.geometry.conversions.denormalize_homography(dst_homo_src, (height, width), (height, width))
-        res = torch.tensor([[[0.5, 0.0, 3.0], [0.0, 2.0, 0.5], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
-        assert (denorm_homo == res).all()
+        res = torch.tensor([[[0.5, 0.0, 3.0], [0.0, 2.0, 0.5], [0.0, 0.0, 1.0]]], device=device, dtype=dtype).expand(
+            batch_size, -1, -1
+        )
+        assert_close(denorm_homo, res)
 
     @pytest.mark.parametrize("batch_size", [1, 3])
     def test_consistency(self, batch_size, device, dtype):
@@ -116,12 +116,12 @@ class TestHomographyWarper:
         norm_denorm_homo = kornia.geometry.conversions.normalize_homography(
             denorm_homo, (height, width), (height, width)
         )
-        assert (dst_homo_src == norm_denorm_homo).all()
+        assert_close(dst_homo_src, norm_denorm_homo)
         norm_homo = kornia.geometry.conversions.normalize_homography(dst_homo_src, (height, width), (height, width))
         denorm_norm_homo = kornia.geometry.conversions.denormalize_homography(
             norm_homo, (height, width), (height, width)
         )
-        assert (dst_homo_src == denorm_norm_homo).all()
+        assert_close(dst_homo_src, denorm_norm_homo)
 
     @pytest.mark.parametrize("offset", [1, 3, 7])
     @pytest.mark.parametrize("shape", [(4, 5), (2, 6), (4, 3), (5, 7)])
@@ -405,8 +405,8 @@ class TestHomographyWarper3D:
             [[[0.5, 0.0, 0.0, 0.0], [0.0, 0.5, 0.0, 3.5], [0.0, 0.0, 2.0, 7.0], [0.0, 0.0, 0.0, 1.0]]],
             device=device,
             dtype=dtype,
-        )
-        assert (norm_homo == res).all()
+        ).expand(batch_size, -1, -1)
+        assert_close(norm_homo, res)
 
     @pytest.mark.parametrize("offset", [1, 3, 7])
     @pytest.mark.parametrize("shape", [(4, 5, 6), (2, 4, 6), (4, 3, 9), (5, 7, 8)])

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -283,7 +283,7 @@ class TestCombineTensorPatches:
         m = kornia.contrib.CombineTensorPatches((4, 4), (2, 2))
         patches = kornia.contrib.extract_tensor_patches(img, window_size=(2, 2), stride=(2, 2))
         assert m(patches).shape == (1, 1, 4, 4)
-        assert (img == m(patches)).all()
+        assert_close(img, m(patches))
 
     def test_error(self, device, dtype):
         patches = kornia.contrib.extract_tensor_patches(
@@ -299,7 +299,7 @@ class TestCombineTensorPatches:
             patches, original_size=(4, 3), window_size=(2, 2), stride=(2, 2), unpadding=(0, 0, 0, 1)
         )
         assert m.shape == (1, 1, 4, 3)
-        assert (img == m).all()
+        assert_close(img, m)
 
     def test_pad_error(self, device, dtype):
         patches = kornia.contrib.extract_tensor_patches(
@@ -333,21 +333,21 @@ class TestCombineTensorPatches:
         patches = kornia.contrib.extract_tensor_patches(img, window_size=(2, 2), stride=(2, 2), padding=1)
         m = kornia.contrib.CombineTensorPatches((4, 6), (2, 2), unpadding=1)
         assert m(patches).shape == (1, 1, 4, 6)
-        assert (img == m(patches)).all()
+        assert_close(img, m(patches))
 
     def test_padding1(self, device, dtype):
         img = torch.arange(16, device=device, dtype=dtype).view(1, 1, 4, 4)
         patches = kornia.contrib.extract_tensor_patches(img, window_size=(2, 2), stride=(2, 2), padding=1)
         m = kornia.contrib.CombineTensorPatches((4, 4), (2, 2), unpadding=1)
         assert m(patches).shape == (1, 1, 4, 4)
-        assert (img == m(patches)).all()
+        assert_close(img, m(patches))
 
     def test_padding2(self, device, dtype):
         img = torch.arange(64, device=device, dtype=dtype).view(1, 1, 8, 8)
         patches = kornia.contrib.extract_tensor_patches(img, window_size=(2, 2), stride=(2, 2), padding=1)
         m = kornia.contrib.CombineTensorPatches((8, 8), (2, 2), unpadding=1)
         assert m(patches).shape == (1, 1, 8, 8)
-        assert (img == m(patches)).all()
+        assert_close(img, m(patches))
 
     def test_autopadding(self, device, dtype):
         img = torch.arange(104, device=device, dtype=dtype).view(1, 1, 8, 13)
@@ -358,7 +358,7 @@ class TestCombineTensorPatches:
         )
         m = kornia.contrib.CombineTensorPatches((8, 13), (3, 3), unpadding=padding)
         assert m(patches).shape == (1, 1, 8, 13)
-        assert (img == m(patches)).all()
+        assert_close(img, m(patches))
 
     def test_gradcheck(self, device, dtype):
         patches = kornia.contrib.extract_tensor_patches(
@@ -624,7 +624,7 @@ class TestHistMatch:
         x = torch.tensor([4, 5, 6], device=device, dtype=dtype)
         x_hat_expected = torch.tensor([-2.0, -4.0, -6.0], device=device, dtype=dtype)
         x_hat = kornia.contrib.interp(x, xp, fp)
-        assert (x_hat_expected == x_hat).all()
+        assert_close(x_hat_expected, x_hat)
 
     def test_histmatch(self, device, dtype):
         torch.manual_seed(44)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Change all remaining equality tests `assert (tensor1 == tensor2).all()` to `assert_close(tensor1, tensor2)`. Hopefully I don't miss any.

Since `assert_close()` also checks for shape and dtype, I also make some edits so that shape and dtype are correct e.g. add extra dimension, add dtype information.

This also prevents some tests running on MPS device from crashing Python. https://github.com/pytorch/pytorch/issues/95538

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
