### PR TITLE
Add bilateral filter

### DIFF
--- a/docs/generate_example_images.py
+++ b/docs/generate_example_images.py
@@ -361,6 +361,7 @@ def main():
     mod = importlib.import_module("kornia.filters")
     kernel = torch.tensor([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
     transforms: dict = {
+        "bilateral_blur": (((11, 11), 0.1, (3, 3)), 1),
         "box_blur": (((5, 5),), 1),
         "median_blur": (((5, 5),), 1),
         "gaussian_blur2d": (((5, 5), (1.5, 1.5)), 1),

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -8,6 +8,7 @@ The functions in this sections perform various image filtering operations.
 Blurring
 --------
 
+.. autofunction:: bilateral_blur
 .. autofunction:: blur_pool2d
 .. autofunction:: box_blur
 .. autofunction:: gaussian_blur2d
@@ -76,6 +77,7 @@ Kernels
 Module
 ------
 
+.. autoclass:: BilateralBlur
 .. autoclass:: BlurPool2D
 .. autoclass:: BoxBlur
 .. autoclass:: MaxBlurPool2D

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .bilateral import BilateralBlur, bilateral_blur
 from .blur import BoxBlur, box_blur
 from .blur_pool import (
     BlurPool2D,
@@ -97,4 +98,6 @@ __all__ = [
     "get_gaussian_kernel1d_t",
     "get_gaussian_kernel2d_t",
     "get_gaussian_kernel3d_t",
+    "bilateral_blur",
+    "BilateralBlur",
 ]

--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import torch.nn.functional as F
+
+from kornia.core import Module, Tensor
+from kornia.core.check import KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+
+from .gaussian import get_gaussian_kernel2d
+from .kernels import _unpack_2d_ks
+from .median import _compute_zero_padding
+
+
+def bilateral_blur(
+    input: Tensor,
+    kernel_size: tuple[int, int] | int,
+    sigma_color: float,
+    sigma_space: tuple[float, float],
+    border_type: str = 'reflect',
+    color_distance_type: str = "l1",
+) -> Tensor:
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ['B', 'C', 'H', 'W'])
+
+    kx, ky = _unpack_2d_ks(kernel_size)
+    pad_x, pad_y = _compute_zero_padding(kernel_size)
+
+    padded = F.pad(input, (pad_x, pad_x, pad_y, pad_y), mode=border_type)
+    unfolded = padded.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, K x K)
+
+    diff = unfolded - input.unsqueeze(-1)
+    if color_distance_type == "l1":
+        color_distance_sq = diff.abs().sum(1, keepdim=True).square()
+    elif color_distance_type == "l2":
+        color_distance_sq = diff.square().sum(1, keepdim=True)
+    else:
+        raise ValueError("color_distance_type only acceps l1 or l2")
+    color_kernel = (-0.5 / sigma_color**2 * color_distance_sq).exp()  # (B, 1, H, W, K x K)
+
+    space_kernel = get_gaussian_kernel2d(kernel_size, sigma_space, device=input.device, dtype=input.dtype).view(
+        1, 1, 1, 1, -1
+    )
+
+    kernel = space_kernel * color_kernel
+    out = (unfolded * kernel).sum(-1) / kernel.sum(-1)
+    return out
+
+
+class BilateralBlur(Module):
+    def __init__(
+        self,
+        kernel_size: tuple[int, int] | int,
+        sigma_color: float,
+        sigma_space: tuple[float, float],
+        border_type: str = 'reflect',
+        color_distance_type: str = "l1",
+    ) -> None:
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.sigma_color = sigma_color
+        self.sigma_space = sigma_space
+        self.border_type = border_type
+        self.color_distance_type = color_distance_type
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}"
+            f"(kernel_size={self.kernel_size}, "
+            f"sigma_color={self.sigma_color}, "
+            f"sigma_space={self.sigma_space}, "
+            f"border_type={self.border_type}, "
+            f"color_distance_type={self.color_distance_type})"
+        )
+
+    def forward(self, input: Tensor) -> Tensor:
+        return bilateral_blur(
+            input, self.kernel_size, self.sigma_color, self.sigma_space, self.border_type, self.color_distance_type
+        )

--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -30,7 +30,7 @@ def bilateral_blur(
         sigma_color: the standard deviation for intensity/color Gaussian kernel.
           Smaller values preserve more edges.
         sigma_space: the standard deviation for spatial Gaussian kernel.
-          This is similar to ``sigma`` in gaussian_blur2d.
+          This is similar to ``sigma`` in :func:`gaussian_blur2d()`.
         border_type: the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``,
           ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.

--- a/test/filters/test_bilateral.py
+++ b/test/filters/test_bilateral.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+
+from kornia.filters import BilateralBlur, bilateral_blur
+from kornia.testing import BaseTester, tensor_to_gradcheck_var
+
+
+class TestBilateralBlur(BaseTester):
+    @pytest.mark.parametrize("shape", [(1, 1, 8, 15), (2, 3, 11, 7)])
+    @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
+    @pytest.mark.parametrize("sigma_color", [1, 0.1])
+    @pytest.mark.parametrize("sigma_space", [(1, 1), (1.5, 1)])
+    @pytest.mark.parametrize("color_distance_type", ["l1", "l2"])
+    def test_smoke(self, shape, kernel_size, sigma_color, sigma_space, color_distance_type, device, dtype):
+        inp = torch.zeros(shape, device=device, dtype=dtype)
+        actual = bilateral_blur(inp, kernel_size, sigma_color, sigma_space, color_distance_type=color_distance_type)
+        assert isinstance(actual, torch.Tensor)
+        assert actual.shape == shape
+
+    @pytest.mark.parametrize("shape", [(1, 1, 8, 15), (2, 3, 11, 7)])
+    @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
+    def test_cardinality(self, shape, kernel_size, device, dtype):
+        inp = torch.zeros(shape, device=device, dtype=dtype)
+        actual = bilateral_blur(inp, kernel_size, 0.1, (1, 1))
+        assert actual.shape == shape
+
+    def test_exception(self):
+        with pytest.raises(Exception) as errinfo:
+            bilateral_blur(torch.rand(1, 1, 5, 5), 3, 1, 1)
+        assert 'Not a Tensor type. Go' in str(errinfo)
+
+        with pytest.raises(ValueError) as errinfo:
+            bilateral_blur(torch.rand(1, 1, 5, 5), 3, 0.1, (1, 1), color_distance_type="l3")
+        assert 'color_distance_type only acceps l1 or l2' in str(errinfo)
+
+    def test_noncontiguous(self, device, dtype):
+        batch_size = 3
+        inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+
+        actual = bilateral_blur(inp, 3, 1, (1, 1))
+        assert actual.is_contiguous()
+
+    def test_gradcheck(self, device):
+        img = torch.rand(1, 2, 5, 4, device=device)
+        img = tensor_to_gradcheck_var(img)  # to var
+        self.gradcheck(bilateral_blur, (img, 3, 1, (1, 1)))
+
+    @pytest.mark.parametrize("shape", [(1, 1, 8, 15), (2, 3, 11, 7)])
+    @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
+    @pytest.mark.parametrize("sigma_color", [1, 0.1])
+    @pytest.mark.parametrize("sigma_space", [(1, 1), (1.5, 1)])
+    @pytest.mark.parametrize("color_distance_type", ["l1", "l2"])
+    def test_module(self, shape, kernel_size, sigma_color, sigma_space, color_distance_type, device, dtype):
+        img = torch.rand(shape, device=device, dtype=dtype)
+        params = (kernel_size, sigma_color, sigma_space, "reflect", color_distance_type)
+
+        op = bilateral_blur
+        op_module = BilateralBlur(*params)
+        self.assert_close(op_module(img), op(img, *params))
+
+    @pytest.mark.parametrize("shape", [(1, 3, 8, 15), (2, 1, 11, 7)])
+    @pytest.mark.parametrize('kernel_size', [5, (5, 7)])
+    @pytest.mark.parametrize('color_distance_type', ["l1", "l2"])
+    def test_dynamo(self, shape, kernel_size, color_distance_type, device, dtype, torch_optimizer):
+        inpt = torch.ones(shape, device=device, dtype=dtype)
+        op = BilateralBlur(kernel_size, 1, (1, 1), color_distance_type=color_distance_type)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(inpt), op_optimized(inpt))

--- a/test/filters/test_bilateral.py
+++ b/test/filters/test_bilateral.py
@@ -97,7 +97,7 @@ class TestBilateralBlur(BaseTester):
 
         # Expected output generated with OpenCV:
         # import cv2
-        # expected = cv2.bilateralFilter(img[0].permute(1, 2, 0).numpy(), 5, 0.1, 0.5)
+        # expected = cv2.bilateralFilter(img[0, 0].numpy(), 5, 0.1, 0.5)
         expected = [
             [0.38708255, 0.5060622, 0.43372786, 0.8876763],
             [0.39813757, 0.55695623, 0.72320986, 0.6593296],

--- a/test/filters/test_bilateral.py
+++ b/test/filters/test_bilateral.py
@@ -67,3 +67,65 @@ class TestBilateralBlur(BaseTester):
         op_optimized = torch_optimizer(op)
 
         self.assert_close(op(inpt), op_optimized(inpt))
+
+    def test_opencv_grayscale(self, device, dtype):
+        img = [[95, 130, 108, 228], [98, 142, 187, 166], [114, 166, 190, 141], [150, 83, 174, 216]]
+        img = torch.tensor(img, device=device, dtype=dtype).view(1, 1, 4, 4) / 255
+
+        kernel_size = 5
+        sigma_color = 0.1
+        sigma_distance = (0.5, 0.5)
+
+        # Expected output generated with OpenCV:
+        # import cv2
+        # expected = cv2.bilateralFilter(img[0].permute(1, 2, 0).numpy(), 5, 0.1, 0.5)
+        expected = [
+            [0.38708255, 0.5060622, 0.43372786, 0.8876763],
+            [0.39813757, 0.55695623, 0.72320986, 0.6593296],
+            [0.4527661, 0.6484203, 0.7295754, 0.5705908],
+            [0.5774919, 0.32919288, 0.6949335, 0.83184093],
+        ]
+        expected = torch.tensor(expected, device=device, dtype=dtype).view(1, 1, 4, 4)
+
+        out = bilateral_blur(img, kernel_size, sigma_color, sigma_distance)
+        self.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+
+    def test_opencv_rgb(self, device, dtype):
+        img = [
+            [[170, 189, 182, 255], [169, 209, 216, 215], [196, 213, 228, 191], [207, 126, 224, 249]],
+            [[61, 104, 74, 225], [65, 112, 176, 148], [78, 147, 176, 120], [124, 61, 155, 211]],
+            [[73, 111, 90, 175], [77, 117, 163, 130], [83, 139, 163, 120], [132, 84, 137, 155]],
+        ]
+        img = torch.tensor(img, device=device, dtype=dtype).view(1, 3, 4, 4) / 255
+
+        kernel_size = 5
+        sigma_color = 0.1
+        sigma_distance = (0.5, 0.5)
+
+        # Expected output generated with OpenCV:
+        # import cv2
+        # expected = cv2.bilateralFilter(img[0].permute(1, 2, 0).numpy(), 5, 0.1, 0.5)
+        expected = [
+            [
+                [0.6658919, 0.7486991, 0.7140039, 0.9999949],
+                [0.6656203, 0.815614, 0.852062, 0.84256846],
+                [0.7658699, 0.83580506, 0.88873357, 0.7496973],
+                [0.8123873, 0.49414372, 0.87789816, 0.97619873],
+            ],
+            [
+                [0.24242306, 0.40987095, 0.29138556, 0.8823465],
+                [0.2543548, 0.43856043, 0.68934506, 0.58119816],
+                [0.3045888, 0.5758538, 0.6885629, 0.47137713],
+                [0.48865014, 0.23922202, 0.6099074, 0.82698977],
+            ],
+            [
+                [0.28948042, 0.43686634, 0.35377124, 0.686273],
+                [0.30078027, 0.4582056, 0.63826954, 0.5113827],
+                [0.32491508, 0.5446742, 0.63721484, 0.47087318],
+                [0.51836246, 0.32941142, 0.5409612, 0.60793126],
+            ],
+        ]
+        expected = torch.tensor(expected, device=device, dtype=dtype).view(1, 3, 4, 4)
+
+        out = bilateral_blur(img, kernel_size, sigma_color, sigma_distance)
+        self.assert_close(out, expected, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Closes #702 

Implement bilateral. Function signature follows OpenCV.

Regarding `color_distance_type`, use L1 to match OpenCV. Use L2 to match Matlab.

TODO

- [x] Add documentation
- [x] Add tests to compare against OpenCV (grayscale and RGB images)
- [x] Add ability to use batch of `sigma_color` and `sigma_distance`

@edgarriba @ducha-aiki Let me know your thoughts and feedback.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
