### PR TITLE
Remove typecheck for 2D kernel size on filters

### DIFF
--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -7,7 +7,7 @@ from typing import Any
 import torch
 
 from kornia.core import Device, Dtype, Tensor, concatenate, stack, tensor, where, zeros, zeros_like
-from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
+from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
 from kornia.utils import deprecated
 
 
@@ -27,8 +27,7 @@ def _unpack_2d_ks(kernel_size: tuple[int, int] | int) -> tuple[int, int]:
     if isinstance(kernel_size, int):
         kx = ky = kernel_size
     else:
-        KORNIA_CHECK_TYPE(kernel_size, tuple, 'Kernel size should be an integer or a tuple of integer.')
-        KORNIA_CHECK(len(kernel_size) == 2, '2D Kernel size tuple should have a length of 2.')
+        KORNIA_CHECK(len(kernel_size) == 2, '2D Kernel size should have a length of 2.')
         kx, ky = kernel_size
 
     kx = int(kx)

--- a/test/filters/test_blur.py
+++ b/test/filters/test_blur.py
@@ -17,13 +17,10 @@ class TestBoxBlur(BaseTester):
 
     def test_exception(self):
         inpt = torch.rand(1, 1, 3, 3)
-        with pytest.raises(TypeError) as errinfo:
-            box_blur(inpt, '1')
-        assert 'Kernel size should be an integer or a tuple of integer.' in str(errinfo)
 
         with pytest.raises(Exception) as errinfo:
             box_blur(inpt, (1,))
-        assert '2D Kernel size tuple should have a length of 2.' in str(errinfo)
+        assert '2D Kernel size should have a length of 2.' in str(errinfo)
 
     @pytest.mark.parametrize('kernel_size', [(3, 3), 5, (5, 7)])
     @pytest.mark.parametrize('batch_size', [1, 2])


### PR DESCRIPTION
#### Changes
This is kinda a fix for a regression from #2187

Fixes #2258 

Before #2187 we don't have runtime type checking on this code -- in theory with this patch, all `sequence` should be allowed to be a kernel size but typing all functions with `Sequence[int]` seems to become less intuitive for what the parameter should be