### PR TITLE
Feat/dice loss averaging

### DIFF
--- a/kornia/losses/dice.py
+++ b/kornia/losses/dice.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 from kornia.core import Tensor
-from kornia.core.check import KORNIA_CHECK
+from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR
 from kornia.utils.one_hot import one_hot
 
 # based on:
@@ -55,8 +54,7 @@ def dice_loss(input: Tensor, target: Tensor, average: str = "micro", eps: float 
         >>> output = dice_loss(input, target)
         >>> output.backward()
     """
-    if not isinstance(input, Tensor):
-        raise TypeError(f"Input type is not a torch.Tensor. Got {type(input)}")
+    KORNIA_CHECK_IS_TENSOR(input, f"Input type is not a torch.Tensor. Got {type(input)}")
 
     if not len(input.shape) == 4:
         raise ValueError(f"Invalid input shape, we expect BxNxHxW. Got: {input.shape}")
@@ -71,7 +69,7 @@ def dice_loss(input: Tensor, target: Tensor, average: str = "micro", eps: float 
     KORNIA_CHECK(average in possible_average, f"The `average` has to be one of {possible_average}. Got: {average}")
 
     # compute softmax over the classes axis
-    input_soft: Tensor = F.softmax(input, dim=1)
+    input_soft: Tensor = input.softmax(dim=1)
 
     # create the labels one hot tensor
     target_one_hot: Tensor = one_hot(target, num_classes=input.shape[1], device=input.device, dtype=input.dtype)

--- a/kornia/losses/dice.py
+++ b/kornia/losses/dice.py
@@ -8,9 +8,12 @@ from kornia.utils.one_hot import one_hot
 
 # based on:
 # https://github.com/kevinzakka/pytorch-goodies/blob/master/losses.py
+# https://github.com/Lightning-AI/metrics/blob/v0.11.3/src/torchmetrics/functional/classification/dice.py#L66-L207
 
 
-def dice_loss(input: torch.Tensor, target: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+def dice_loss(
+    input: torch.Tensor, target: torch.Tensor, average: str | None = "micro", eps: float | None = 1e-8
+) -> torch.Tensor:
     r"""Criterion that computes Sørensen-Dice Coefficient loss.
 
     According to [1], we compute the Sørensen-Dice Coefficient as follows:
@@ -36,10 +39,14 @@ def dice_loss(input: torch.Tensor, target: torch.Tensor, eps: float = 1e-8) -> t
         input: logits tensor with shape :math:`(N, C, H, W)` where C = number of classes.
         labels: labels tensor with shape :math:`(N, H, W)` where each value
           is :math:`0 ≤ targets[i] ≤ C−1`.
+        average:
+            Reduction applied in multi-class scenario:
+            - ``'micro'`` [default]: Calculate the loss across all classes.
+            - ``'macro'``: Calculate the loss for each class separately and average the metrics across classes.
         eps: Scalar to enforce numerical stabiliy.
 
     Return:
-        the computed loss.
+        One-element tensor of the computed loss.
 
     Example:
         >>> N = 5  # num_classes
@@ -60,20 +67,32 @@ def dice_loss(input: torch.Tensor, target: torch.Tensor, eps: float = 1e-8) -> t
     if not input.device == target.device:
         raise ValueError(f"input and target must be in the same device. Got: {input.device} and {target.device}")
 
+    possible_average = ("micro", "macro")
+    if average not in possible_average:
+        raise ValueError(f"The `average` has to be one of {possible_average}. Got: {average}")
+
     # compute softmax over the classes axis
     input_soft: torch.Tensor = F.softmax(input, dim=1)
 
     # create the labels one hot tensor
     target_one_hot: torch.Tensor = one_hot(target, num_classes=input.shape[1], device=input.device, dtype=input.dtype)
 
+    # set dimensions for the appropriate averaging
+    dims = (2, 3)
+    if average == "micro":
+        dims = (1,) + dims
+
     # compute the actual dice score
-    dims = (1, 2, 3)
     intersection = torch.sum(input_soft * target_one_hot, dims)
     cardinality = torch.sum(input_soft + target_one_hot, dims)
 
     dice_score = 2.0 * intersection / (cardinality + eps)
+    dice_loss = -dice_score + 1.0
 
-    return torch.mean(-dice_score + 1.0)
+    # reduce the loss across samples (and classes in case of `macro` averaging)
+    dice_loss = torch.mean(dice_loss)
+
+    return dice_loss
 
 
 class DiceLoss(nn.Module):
@@ -99,6 +118,10 @@ class DiceLoss(nn.Module):
         [1] https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
 
     Args:
+        average:
+            Reduction applied in multi-class scenario:
+            - ``'micro'`` [default]: Calculate the loss across all classes.
+            - ``'macro'``: Calculate the loss for each class separately and average the metrics across classes.
         eps: Scalar to enforce numerical stabiliy.
 
     Shape:
@@ -115,9 +138,10 @@ class DiceLoss(nn.Module):
         >>> output.backward()
     """
 
-    def __init__(self, eps: float = 1e-8) -> None:
+    def __init__(self, average: str | None = "micro", eps: float | None = 1e-8) -> None:
         super().__init__()
+        self.average: str = average
         self.eps: float = eps
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-        return dice_loss(input, target, self.eps)
+        return dice_loss(input, target, self.average, self.eps)

--- a/kornia/losses/dice.py
+++ b/kornia/losses/dice.py
@@ -54,7 +54,7 @@ def dice_loss(input: Tensor, target: Tensor, average: str = "micro", eps: float 
         >>> output = dice_loss(input, target)
         >>> output.backward()
     """
-    KORNIA_CHECK_IS_TENSOR(input, f"Input type is not a torch.Tensor. Got {type(input)}")
+    KORNIA_CHECK_IS_TENSOR(input)
 
     if not len(input.shape) == 4:
         raise ValueError(f"Invalid input shape, we expect BxNxHxW. Got: {input.shape}")


### PR DESCRIPTION
#### Changes
Added optional argument `average` to Dice Loss module and function. The current version of the Dice Loss performs only "micro" averaging for multi-class scenario. However, the documentation states that loss is computed for each individual class. `average` by default takes `"micro"` value and leaves the the current behaviour unchanged. I added another option `"macro"` that calculates Dice Loss for each class separately and then averages between classes and samples. The motivation is to add the possibility to handle imbalanced class data (e.g. segmentation of small objects compared to the background). Also added relevant testcases and updated documentation. See [link](https://torchmetrics.readthedocs.io/en/stable/classification/dice.html#functional-interface) for details

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
