### PR TITLE
Fix/diamond square normalize

### DIFF
--- a/kornia/contrib/diamond_square.py
+++ b/kornia/contrib/diamond_square.py
@@ -142,7 +142,7 @@ def diamond_square(
     roughness: Union[float, Tensor] = 0.5,
     random_scale: Union[float, Tensor] = 1.0,
     random_fn: Callable[..., Tensor] = torch.rand,
-    normalize_range: Optional[Tuple[int, int]] = None,
+    normalize_range: Optional[Tuple[float, float]] = None,
     device: Optional[torch.device] = None,
     dtype: Optional[torch.dtype] = None,
 ) -> Tensor:

--- a/kornia/contrib/diamond_square.py
+++ b/kornia/contrib/diamond_square.py
@@ -207,5 +207,5 @@ def diamond_square(
     # normalize the output in the range using min-max
     if normalize_range is not None:
         min_val, max_val = normalize_range
-        img = normalize_min_max(img, min_val, max_val)
+        img = normalize_min_max(img.contiguous(), min_val, max_val)
     return img

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -20,6 +20,16 @@ class TestDiamondSquare:
         assert out.shape == output_size
         assert out.device == device
         assert out.dtype == dtype
+    
+    def test_normalize(self, device, dtype):
+        torch.manual_seed(0)
+        output_size = (1, 1, 3, 4)
+        roughness = 0.5
+        random_scale = 1.0
+        normalize_range = (0., 1.)
+        out = kornia.contrib.diamond_square(output_size, roughness, random_scale, normalize_range=normalize_range, device=device, dtype=dtype)
+        assert_close(out.min(), torch.tensor(0.))
+        assert_close(out.max(), torch.tensor(1.))
 
 
 class TestVisionTransformer:

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -27,16 +27,8 @@ class TestDiamondSquare:
         roughness = 0.5
         random_scale = 1.0
         normalize_range = (0.0, 1.0)
-        expected_min = torch.tensor(
-            normalize_range[0],
-            device=device,
-            dtype=dtype,
-        )
-        expected_max = torch.tensor(
-            normalize_range[1],
-            device=device,
-            dtype=dtype,
-        )
+        expected_min = torch.tensor(normalize_range[0], device=device, dtype=dtype)
+        expected_max = torch.tensor(normalize_range[1], device=device, dtype=dtype)
         out = kornia.contrib.diamond_square(
             output_size, roughness, random_scale, normalize_range=normalize_range, device=device, dtype=dtype
         )

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -27,11 +27,21 @@ class TestDiamondSquare:
         roughness = 0.5
         random_scale = 1.0
         normalize_range = (0.0, 1.0)
+        expected_min = torch.tensor(
+            normalize_range[0],
+            device=device,
+            dtype=dtype,
+        )
+        expected_max = torch.tensor(
+            normalize_range[1],
+            device=device,
+            dtype=dtype,
+        )
         out = kornia.contrib.diamond_square(
             output_size, roughness, random_scale, normalize_range=normalize_range, device=device, dtype=dtype
         )
-        assert_close(out.min(), torch.tensor(0.0))
-        assert_close(out.max(), torch.tensor(1.0))
+        assert_close(out.min(), expected_min)
+        assert_close(out.max(), expected_max)
 
 
 class TestVisionTransformer:

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -20,16 +20,18 @@ class TestDiamondSquare:
         assert out.shape == output_size
         assert out.device == device
         assert out.dtype == dtype
-    
+
     def test_normalize(self, device, dtype):
         torch.manual_seed(0)
         output_size = (1, 1, 3, 4)
         roughness = 0.5
         random_scale = 1.0
-        normalize_range = (0., 1.)
-        out = kornia.contrib.diamond_square(output_size, roughness, random_scale, normalize_range=normalize_range, device=device, dtype=dtype)
-        assert_close(out.min(), torch.tensor(0.))
-        assert_close(out.max(), torch.tensor(1.))
+        normalize_range = (0.0, 1.0)
+        out = kornia.contrib.diamond_square(
+            output_size, roughness, random_scale, normalize_range=normalize_range, device=device, dtype=dtype
+        )
+        assert_close(out.min(), torch.tensor(0.0))
+        assert_close(out.max(), torch.tensor(1.0))
 
 
 class TestVisionTransformer:


### PR DESCRIPTION
#### Changes
For most output sizes `kornia.contrib.diamond_square` threw an error when the `normalize_range` argument was supplied (see #2281 ). This PR avoids the error by creating a contiguous copy if necessary. The type annotation for the argument is also fixed and a test is added which catches the failure case that was fixed.

Fixes #2281 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
