### PR TITLE
Remove print contrast

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -343,7 +343,7 @@ def adjust_contrast(image: Tensor, factor: Union[float, Tensor], clip_output: bo
     while len(factor.shape) != len(image.shape):
         factor = factor[..., None]
 
-    KORNIA_CHECK(any(factor >= 0), f"Contrast factor must be positive. Got {factor}")
+    KORNIA_CHECK(any(factor >= 0), "Contrast factor must be positive.")
 
     # Apply contrast factor to each channel
     img_adjust: Tensor = image * factor
@@ -397,7 +397,7 @@ def adjust_contrast_with_mean_subtraction(image: Tensor, factor: Union[float, Te
     while len(factor.shape) != len(image.shape):
         factor = factor[..., None]
 
-    KORNIA_CHECK(any(factor >= 0), f"Contrast factor must be positive. Got {factor}")
+    KORNIA_CHECK(any(factor >= 0), "Contrast factor must be positive.")
 
     if image.shape[-3] == 3:
         img_mean = rgb_to_grayscale(image).mean((-2, -1), True)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Hello, during the profiling of my code, we noticed a slowness due to a print of a tensor in the function `adjust_contrast_with_mean_subtraction`. This is due to the fact that the tensor is on cuda which causes a synchronization.

This pull request aims to remove such a slowdown by simply removing the print of the tensor as the error seems already self-explanatory. 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
