### PR TITLE
improve local feature orientation

### DIFF
--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -108,7 +108,7 @@ class PatchDominantGradientOrientation(nn.Module):
         l = torch.gather(ang_bins, 1, indices_left.reshape(-1, 1)).reshape(-1)
         c = values
         r = torch.gather(ang_bins, 1, indices_right.reshape(-1, 1)).reshape(-1)
-        c_subpix = 0.5 * (l - r)  / (l + r - 2.0 * c)
+        c_subpix = 0.5 * (l - r) / (l + r - 2.0 * c)
         angle = -((2.0 * pi * (indices.to(patch.dtype) + c_subpix) / float(self.num_ang_bins)) - pi)
         return angle
 

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -105,10 +105,10 @@ class PatchDominantGradientOrientation(nn.Module):
         values, indices = ang_bins.max(1)
         indices_left = (self.num_ang_bins + indices - 1) % self.num_ang_bins
         indices_right = (indices + 1) % self.num_ang_bins
-        l = torch.gather(ang_bins, 1, indices_left.reshape(-1, 1)).reshape(-1)
-        c = values
-        r = torch.gather(ang_bins, 1, indices_right.reshape(-1, 1)).reshape(-1)
-        c_subpix = 0.5 * (l - r) / (l + r - 2.0 * c)
+        left = torch.gather(ang_bins, 1, indices_left.reshape(-1, 1)).reshape(-1)
+        center = values
+        right = torch.gather(ang_bins, 1, indices_right.reshape(-1, 1)).reshape(-1)
+        c_subpix = 0.5 * (left - right)  / (left + right - 2.0 * center)
         angle = -((2.0 * pi * (indices.to(patch.dtype) + c_subpix) / float(self.num_ang_bins)) - pi)
         return angle
 

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -50,7 +50,7 @@ class PatchDominantGradientOrientation(nn.Module):
         self.eps = eps
         self.angular_smooth = nn.Conv1d(1, 1, kernel_size=5, padding=2, bias=False, padding_mode="circular")
         with torch.no_grad():
-            self.angular_smooth.weight[:] = get_gaussian_discrete_kernel1d(5, 2.0)
+            self.angular_smooth.weight[:] = get_gaussian_discrete_kernel1d(5, 1.6)
         sigma: float = float(self.patch_size) / 6.0
         self.weighting = get_gaussian_kernel2d((self.patch_size, self.patch_size), (sigma, sigma), True)
 

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -108,7 +108,7 @@ class PatchDominantGradientOrientation(nn.Module):
         left = torch.gather(ang_bins, 1, indices_left.reshape(-1, 1)).reshape(-1)
         center = values
         right = torch.gather(ang_bins, 1, indices_right.reshape(-1, 1)).reshape(-1)
-        c_subpix = 0.5 * (left - right)  / (left + right - 2.0 * center)
+        c_subpix = 0.5 * (left - right) / (left + right - 2.0 * center)
         angle = -((2.0 * pi * (indices.to(patch.dtype) + c_subpix) / float(self.num_ang_bins)) - pi)
         return angle
 

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -1,4 +1,3 @@
-import math
 from typing import Dict, Optional
 
 import torch

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -108,7 +108,7 @@ class PatchDominantGradientOrientation(nn.Module):
         l = torch.gather(ang_bins, 1, indices_left.reshape(-1, 1)).reshape(-1)
         c = values
         r = torch.gather(ang_bins, 1, indices_right.reshape(-1, 1)).reshape(-1)
-        c_subpix = 0.5 * (l - r)  / (l + r - 2*c)
+        c_subpix = 0.5 * (l - r)  / (l + r - 2.0 * c)
         angle = -((2.0 * pi * (indices.to(patch.dtype) + c_subpix) / float(self.num_ang_bins)) - pi)
         return angle
 

--- a/test/feature/test_local_features_orientation.py
+++ b/test/feature/test_local_features_orientation.py
@@ -154,7 +154,7 @@ class TestLAFOrienter:
     def test_toy(self, device):
         ori = LAFOrienter(32).to(device)
         inp = torch.zeros(1, 1, 19, 19, device=device)
-        inp[:, :, 5:, :10] = 1
+        inp[:, :, :, :10] = 1
         laf = torch.tensor([[[[5.0, 0.0, 8.0], [0.0, 5.0, 8.0]]]], device=device)
         new_laf = ori(laf, inp)
         expected = torch.tensor([[[[-5.0, 0.0, 8.0], [0.0, -5.0, 8.0]]]], device=device)


### PR DESCRIPTION
#### Changes

- Added subpix interpolation of the angle, improving the the angular consistency
- Tuned constants and fix the bug of not using weighting kernel


Previous results (https://github.com/kornia/kornia-benchmark/blob/master/local-features/benchmarking-orientation-consistency.ipynb):

```
data/hpatches_selected/i_porta_e1.png
mean consistency error wrt 90.0 deg rot = 0.0
mean consistency error wrt 60.0 deg rot = 13.4
mean consistency error wrt 45.0 deg rot = 18.7
mean consistency error wrt 30.0 deg rot = 14.8
data/hpatches_selected/v_graffiti_e1.png
mean consistency error wrt 90.0 deg rot = 0.0
mean consistency error wrt 60.0 deg rot = 14.4
mean consistency error wrt 45.0 deg rot = 18.1
mean consistency error wrt 30.0 deg rot = 14.7
```

New results:

```
data/hpatches_selected/i_porta_e1.png
mean consistency error wrt 90.0 deg rot = 0.0
mean consistency error wrt 60.0 deg rot = 1.7
mean consistency error wrt 45.0 deg rot = 2.0
mean consistency error wrt 30.0 deg rot = 1.9
data/hpatches_selected/v_graffiti_e1.png
mean consistency error wrt 90.0 deg rot = 0.0
mean consistency error wrt 60.0 deg rot = 0.8
mean consistency error wrt 45.0 deg rot = 1.0
mean consistency error wrt 30.0 deg rot = 0.7
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


