### PR TITLE
Fix bugs in Bilateral filter tests

### DIFF
--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -156,8 +156,8 @@ class _BilateralBlur(Module):
     def __init__(
         self,
         kernel_size: tuple[int, int] | int,
-        sigma_color: float,
-        sigma_space: tuple[float, float],
+        sigma_color: float | Tensor,
+        sigma_space: tuple[float, float] | Tensor,
         border_type: str = 'reflect',
         color_distance_type: str = "l1",
     ) -> None:

--- a/test/filters/test_bilateral.py
+++ b/test/filters/test_bilateral.py
@@ -53,8 +53,16 @@ class TestBilateralBlur(BaseTester):
 
     def test_gradcheck(self, device):
         img = torch.rand(1, 2, 5, 4, device=device)
+        sigma_color = torch.rand(1, device=device)
+        sigma_space = torch.rand(1, 2, device=device)
         img = tensor_to_gradcheck_var(img)  # to var
+        sigma_color = tensor_to_gradcheck_var(sigma_color)
+        sigma_space = tensor_to_gradcheck_var(sigma_space)
+
         self.gradcheck(bilateral_blur, (img, 3, 1, (1, 1)))
+        self.gradcheck(bilateral_blur, (img, 3, sigma_color, (1, 1)))
+        self.gradcheck(bilateral_blur, (img, 3, 1, sigma_space))
+        self.gradcheck(bilateral_blur, (img, 3, sigma_color, sigma_space))
 
     @pytest.mark.parametrize("shape", [(1, 1, 8, 15), (2, 3, 11, 7)])
     @pytest.mark.parametrize("kernel_size", [5, (3, 5)])

--- a/test/filters/test_bilateral.py
+++ b/test/filters/test_bilateral.py
@@ -8,10 +8,8 @@ from kornia.testing import BaseTester, tensor_to_gradcheck_var
 class TestBilateralBlur(BaseTester):
     @pytest.mark.parametrize("shape", [(1, 1, 8, 15), (2, 3, 11, 7)])
     @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
-    @pytest.mark.parametrize("sigma_color", [1, 0.1])
-    @pytest.mark.parametrize("sigma_space", [(1, 1), (1.5, 1)])
     @pytest.mark.parametrize("color_distance_type", ["l1", "l2"])
-    def test_smoke(self, shape, kernel_size, sigma_color, sigma_space, color_distance_type, device, dtype):
+    def test_smoke(self, shape, kernel_size, color_distance_type, device, dtype):
         inp = torch.zeros(shape, device=device, dtype=dtype)
 
         # tensor sigmas -> with batch dim

--- a/test/filters/test_bilateral.py
+++ b/test/filters/test_bilateral.py
@@ -260,7 +260,13 @@ class TestJointBilateralBlur(BaseTester):
 
         # Expected output generated with OpenCV:
         # import cv2
-        # expected = cv2.ximgproc.jointBilateralFilter(img[0, 0].numpy(), guide[0, 0].numpy(), 5, 0.1, 0.5)
+        # expected = cv2.ximgproc.jointBilateralFilter(
+        #   guide.squeeze().numpy(),
+        #   img.squeeze().numpy(),
+        #   kernel_size,
+        #   sigma_color,
+        #   sigma_distance[0],
+        # )
         expected = [
             [0.38221005, 0.5027215, 0.49131155, 0.8937083],
             [0.3976327, 0.55548316, 0.69680846, 0.65291953],
@@ -270,7 +276,7 @@ class TestJointBilateralBlur(BaseTester):
         expected = torch.tensor(expected, device=device, dtype=dtype).view(1, 1, 4, 4)
 
         out = joint_bilateral_blur(img, guide, kernel_size, sigma_color, sigma_distance)
-        self.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+        self.assert_close(out, expected)
 
     def test_opencv_rgb(self, device, dtype):
         img = [
@@ -294,10 +300,12 @@ class TestJointBilateralBlur(BaseTester):
         # Expected output generated with OpenCV:
         # import cv2
         # expected = cv2.ximgproc.jointBilateralFilter(
-        #     img[0].permute(1, 2, 0).numpy(),
-        #     guide[0].permute(1, 2, 0).numpy(),
-        #     5, 0.1, 0.5
-        # )
+        #   guide.squeeze().permute(1, 2, 0).numpy(),
+        #   img.squeeze().permute(1, 2, 0).numpy(),
+        #   kernel_size,
+        #   sigma_color,
+        #   sigma_distance[0],
+        # ).transpose(2, 0, 1)
         expected = [
             [
                 [0.6671455, 0.74172455, 0.7328562, 1.0],
@@ -321,4 +329,4 @@ class TestJointBilateralBlur(BaseTester):
         expected = torch.tensor(expected, device=device, dtype=dtype).view(1, 3, 4, 4)
 
         out = joint_bilateral_blur(img, guide, kernel_size, sigma_color, sigma_distance)
-        self.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+        self.assert_close(out, expected)

--- a/test/filters/test_bilateral.py
+++ b/test/filters/test_bilateral.py
@@ -78,8 +78,8 @@ class TestBilateralBlur(BaseTester):
 
         self.assert_close(op(inpt), op_optimized(inpt))
 
-        sigma_color = torch.rand(inpt.shape[0], device=device, dtype=dtype)
-        sigma_space = torch.rand(inpt.shape[0], 2, device=device, dtype=dtype)
+        sigma_color = torch.rand(1, device=device, dtype=dtype)
+        sigma_space = torch.rand(1, 2, device=device, dtype=dtype)
         op = BilateralBlur(kernel_size, sigma_color, sigma_space, color_distance_type=color_distance_type)
         op_optimized = torch_optimizer(op)
 
@@ -240,8 +240,8 @@ class TestJointBilateralBlur(BaseTester):
 
         self.assert_close(op(inpt, guide), op_optimized(inpt, guide))
 
-        sigma_color = torch.rand(inpt.shape[0], device=device, dtype=dtype)
-        sigma_space = torch.rand(inpt.shape[0], 2, device=device, dtype=dtype)
+        sigma_color = torch.rand(1, device=device, dtype=dtype)
+        sigma_space = torch.rand(1, 2, device=device, dtype=dtype)
         op = JointBilateralBlur(kernel_size, sigma_color, sigma_space, color_distance_type=color_distance_type)
         op_optimized = torch_optimizer(op)
 


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

When working on guided filter, I discovered some mistakes in my Bilateral filter test code:

- In smoke test, `sigma_color` and `sigma_space` are generated from random (L16-17), thus having them as parameters is redundant and does nothing.
- In dynamo test, `sigma_color` and `sigma_space` batch dimension should be 1 when they are torch Tensor. This is because `sigma_color` and `sigma_space` cannot possibly have different values for each sample, since batch size is not fixed.
- In testing against OpenCV implementation, fix OpenCV code that was used to generate the expected results. Also, use default `rtol` and `atol` values for closeness check.
- Add gradcheck for `sigma_color` and `sigma_space`

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
