### PR TITLE
Fix kernel size ordering

### DIFF
--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -33,18 +33,18 @@ def _bilateral_blur(
         KORNIA_CHECK_SHAPE(sigma_color, ['B'])
         sigma_color = sigma_color.to(device=input.device, dtype=input.dtype).view(-1, 1, 1, 1, 1)
 
-    kx, ky = _unpack_2d_ks(kernel_size)
-    pad_x, pad_y = _compute_zero_padding(kernel_size)
+    ky, kx = _unpack_2d_ks(kernel_size)
+    pad_y, pad_x = _compute_zero_padding(kernel_size)
 
     padded_input = pad(input, (pad_x, pad_x, pad_y, pad_y), mode=border_type)
-    unfolded_input = padded_input.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, K x K)
+    unfolded_input = padded_input.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, Ky x Kx)
 
     if guidance is None:
         guidance = input
         unfolded_guidance = unfolded_input
     else:
         padded_guidance = pad(guidance, (pad_x, pad_x, pad_y, pad_y), mode=border_type)
-        unfolded_guidance = padded_guidance.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, K x K)
+        unfolded_guidance = padded_guidance.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, Ky x Kx)
 
     diff = unfolded_guidance - guidance.unsqueeze(-1)
     if color_distance_type == "l1":
@@ -53,7 +53,7 @@ def _bilateral_blur(
         color_distance_sq = diff.square().sum(1, keepdim=True)
     else:
         raise ValueError("color_distance_type only acceps l1 or l2")
-    color_kernel = (-0.5 / sigma_color**2 * color_distance_sq).exp()  # (B, 1, H, W, K x K)
+    color_kernel = (-0.5 / sigma_color**2 * color_distance_sq).exp()  # (B, 1, H, W, Ky x Kx)
 
     space_kernel = get_gaussian_kernel2d(kernel_size, sigma_space, device=input.device, dtype=input.dtype)
     space_kernel = space_kernel.view(-1, 1, 1, 1, kx * ky)

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -59,10 +59,10 @@ def gaussian_blur2d(
         sigma = sigma.to(device=input.device, dtype=input.dtype)
 
     if separable:
-        ks = _unpack_2d_ks(kernel_size)
+        ky, kx = _unpack_2d_ks(kernel_size)
         bs = sigma.shape[0]
-        kernel_x = get_gaussian_kernel1d(ks[1], sigma[:, 1].view(bs, 1))
-        kernel_y = get_gaussian_kernel1d(ks[0], sigma[:, 0].view(bs, 1))
+        kernel_x = get_gaussian_kernel1d(kx, sigma[:, 1].view(bs, 1))
+        kernel_y = get_gaussian_kernel1d(ky, sigma[:, 0].view(bs, 1))
         out = filter2d_separable(input, kernel_x, kernel_y, border_type)
     else:
         kernel = get_gaussian_kernel2d(kernel_size, sigma)

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -25,29 +25,29 @@ def _check_kernel_size(kernel_size: tuple[int, ...] | int, min_value: int = 0, a
 
 def _unpack_2d_ks(kernel_size: tuple[int, int] | int) -> tuple[int, int]:
     if isinstance(kernel_size, int):
-        kx = ky = kernel_size
+        ky = kx = kernel_size
     else:
         KORNIA_CHECK(len(kernel_size) == 2, '2D Kernel size should have a length of 2.')
-        kx, ky = kernel_size
+        ky, kx = kernel_size
 
-    kx = int(kx)
     ky = int(ky)
+    kx = int(kx)
 
-    return (kx, ky)
+    return (ky, kx)
 
 
 def _unpack_3d_ks(kernel_size: tuple[int, int, int] | int) -> tuple[int, int, int]:
     if isinstance(kernel_size, int):
-        kx = ky = kz = kernel_size
+        kz = ky = kx = kernel_size
     else:
         KORNIA_CHECK(len(kernel_size) == 3, '3D Kernel size should have a length of 3.')
-        kx, ky, kz = kernel_size
+        kz, ky, kx = kernel_size
 
-    kx = int(kx)
-    ky = int(ky)
     kz = int(kz)
+    ky = int(ky)
+    kx = int(kx)
 
-    return (kx, ky, kz)
+    return (kz, ky, kx)
 
 
 def normalize_kernel2d(input: Tensor) -> Tensor:
@@ -264,9 +264,9 @@ def get_box_kernel2d(
     kernel_size: tuple[int, int] | int, *, device: Device | None = None, dtype: Dtype | None = None
 ) -> Tensor:
     r"""Utility function that returns a box filter."""
-    kx, ky = _unpack_2d_ks(kernel_size)
-    scale = tensor(1.0, device=device, dtype=dtype) / tensor([kx * ky], device=device, dtype=dtype)
-    return scale.expand(1, kx, ky)
+    ky, kx = _unpack_2d_ks(kernel_size)
+    scale = tensor(1.0 / (kx * ky), device=device, dtype=dtype)
+    return scale.expand(1, ky, kx)
 
 
 def get_binary_kernel2d(
@@ -278,14 +278,14 @@ def get_binary_kernel2d(
     """
     # TODO: add default dtype as None when kornia relies on torch > 1.12
 
-    kx, ky = _unpack_2d_ks(window_size)
+    ky, kx = _unpack_2d_ks(window_size)
 
     window_range = kx * ky
 
     kernel = zeros((window_range, window_range), device=device, dtype=dtype)
     idx = torch.arange(window_range, device=device)
     kernel[idx, idx] += 1.0
-    return kernel.view(window_range, 1, kx, ky)
+    return kernel.view(window_range, 1, ky, kx)
 
 
 def get_sobel_kernel_3x3(*, device: Device | None = None, dtype: Dtype | None = None) -> Tensor:
@@ -580,8 +580,8 @@ def get_gaussian_kernel2d(
     r"""Function that returns Gaussian filter matrix coefficients.
 
     Args:
-        kernel_size: filter sizes in the x and y direction. Sizes should be odd and positive.
-        sigma: gaussian standard deviation in the x and y.
+        kernel_size: filter sizes in the y and x direction. Sizes should be odd and positive.
+        sigma: gaussian standard deviation in the y and x.
         force_even: overrides requirement for odd kernel size.
         device: This value will be used if sigma is a float. Device desired to compute.
         dtype: This value will be used if sigma is a float. Dtype desired for compute.
@@ -616,13 +616,13 @@ def get_gaussian_kernel2d(
     KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "2"])
 
-    ksize_x, ksize_y = _unpack_2d_ks(kernel_size)
-    sigma_x, sigma_y = sigma[:, 0, None], sigma[:, 1, None]
+    ksize_y, ksize_x = _unpack_2d_ks(kernel_size)
+    sigma_y, sigma_x = sigma[:, 0, None], sigma[:, 1, None]
 
-    kernel_x = get_gaussian_kernel1d(ksize_x, sigma_x, force_even, device=device, dtype=dtype)[..., None]
     kernel_y = get_gaussian_kernel1d(ksize_y, sigma_y, force_even, device=device, dtype=dtype)[..., None]
+    kernel_x = get_gaussian_kernel1d(ksize_x, sigma_x, force_even, device=device, dtype=dtype)[..., None]
 
-    return torch.matmul(kernel_x, kernel_y.transpose(2, 1))
+    return kernel_y * kernel_x.view(-1, 1, ksize_x)
 
 
 def get_gaussian_kernel3d(
@@ -636,8 +636,8 @@ def get_gaussian_kernel3d(
     r"""Function that returns Gaussian filter matrix coefficients.
 
     Args:
-        kernel_size: filter sizes in the x, y and z direction. Sizes should be odd and positive.
-        sigma: gaussian standard deviation in the x, y and z direction.
+        kernel_size: filter sizes in the z, y and x direction. Sizes should be odd and positive.
+        sigma: gaussian standard deviation in the z, y and x direction.
         force_even: overrides requirement for odd kernel size.
         device: This value will be used if sigma is a float. Device desired to compute.
         dtype: This value will be used if sigma is a float. Dtype desired for compute.
@@ -674,17 +674,14 @@ def get_gaussian_kernel3d(
     KORNIA_CHECK_IS_TENSOR(sigma)
     KORNIA_CHECK_SHAPE(sigma, ["B", "3"])
 
-    ksize_x, ksize_y, ksize_z = _unpack_3d_ks(kernel_size)
-    sigma_x, sigma_y, sigma_z = sigma[:, 0, None], sigma[:, 1, None], sigma[:, 2, None]
+    ksize_z, ksize_y, ksize_x = _unpack_3d_ks(kernel_size)
+    sigma_z, sigma_y, sigma_x = sigma[:, 0, None], sigma[:, 1, None], sigma[:, 2, None]
 
-    kernel_x = get_gaussian_kernel1d(ksize_x, sigma_x, force_even, device=device, dtype=dtype)
-    kernel_y = get_gaussian_kernel1d(ksize_y, sigma_y, force_even, device=device, dtype=dtype)
     kernel_z = get_gaussian_kernel1d(ksize_z, sigma_z, force_even, device=device, dtype=dtype)
+    kernel_y = get_gaussian_kernel1d(ksize_y, sigma_y, force_even, device=device, dtype=dtype)
+    kernel_x = get_gaussian_kernel1d(ksize_x, sigma_x, force_even, device=device, dtype=dtype)
 
-    kernel_2d = kernel_x[..., None] @ kernel_y[..., None].transpose(2, 1)
-    kernel_3d = (kernel_z[:, None, :, None] @ (kernel_2d[..., None].transpose(3, 2))).transpose(3, 2)
-
-    return kernel_3d
+    return kernel_z.view(-1, ksize_z, 1, 1) * kernel_y.view(-1, 1, ksize_y, 1) * kernel_x.view(-1, 1, 1, ksize_x)
 
 
 def get_laplacian_kernel1d(kernel_size: int, *, device: Device | None = None, dtype: Dtype = torch.float32) -> Tensor:
@@ -744,14 +741,14 @@ def get_laplacian_kernel2d(
     """
     # TODO: add default dtype as None when kornia relies on torch > 1.12
 
-    kx, ky = _unpack_2d_ks(kernel_size)
-    _check_kernel_size((kx, ky))
+    ky, kx = _unpack_2d_ks(kernel_size)
+    _check_kernel_size((ky, kx))
 
-    kernel = torch.ones((kx, ky), device=device, dtype=dtype)
+    kernel = torch.ones((ky, kx), device=device, dtype=dtype)
     mid_x = kx // 2
     mid_y = ky // 2
 
-    kernel[mid_x, mid_y] = 1 - kernel.sum()
+    kernel[mid_y, mid_x] = 1 - kernel.sum()
     return kernel
 
 
@@ -784,11 +781,11 @@ def get_pascal_kernel_2d(
             [3., 9., 9., 3.],
             [1., 3., 3., 1.]])
     """
-    kx, ky = _unpack_2d_ks(kernel_size)
+    ky, kx = _unpack_2d_ks(kernel_size)
     ax = get_pascal_kernel_1d(kx, device=device, dtype=dtype)
     ay = get_pascal_kernel_1d(ky, device=device, dtype=dtype)
 
-    filt = ax[:, None] * ay[None, :]
+    filt = ay[:, None] * ax[None, :]
     if norm:
         filt = filt / torch.sum(filt)
     return filt

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -10,8 +10,8 @@ from .kernels import _unpack_2d_ks, get_binary_kernel2d
 
 def _compute_zero_padding(kernel_size: tuple[int, int] | int) -> tuple[int, int]:
     r"""Utility function that computes zero padding tuple."""
-    kx, ky = _unpack_2d_ks(kernel_size)
-    return (kx - 1) // 2, (ky - 1) // 2
+    ky, kx = _unpack_2d_ks(kernel_size)
+    return (ky - 1) // 2, (kx - 1) // 2
 
 
 def median_blur(input: Tensor, kernel_size: tuple[int, int] | int) -> Tensor:

--- a/kornia/geometry/subpix/spatial_soft_argmax.py
+++ b/kornia/geometry/subpix/spatial_soft_argmax.py
@@ -287,13 +287,13 @@ def conv_soft_argmax2d(
         raise ValueError(f"Temperature should be positive float or tensor. Got: {temperature}")
 
     b, c, h, w = input.shape
-    kx, ky = kernel_size
+    ky, kx = kernel_size
     device: torch.device = input.device
     dtype: torch.dtype = input.dtype
     input = input.view(b * c, 1, h, w)
 
-    center_kernel: Tensor = _get_center_kernel2d(kx, ky, device).to(dtype)
-    window_kernel: Tensor = _get_window_grid_kernel2d(kx, ky, device).to(dtype)
+    center_kernel: Tensor = _get_center_kernel2d(ky, kx, device).to(dtype)
+    window_kernel: Tensor = _get_window_grid_kernel2d(ky, kx, device).to(dtype)
 
     # applies exponential normalization trick
     # https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/
@@ -407,13 +407,13 @@ def conv_soft_argmax3d(
         raise ValueError(f"Temperature should be positive float or tensor. Got: {temperature}")
 
     b, c, d, h, w = input.shape
-    kx, ky, kz = kernel_size
+    kz, ky, kx = kernel_size
     device: torch.device = input.device
     dtype: torch.dtype = input.dtype
     input = input.view(b * c, 1, d, h, w)
 
-    center_kernel: Tensor = _get_center_kernel3d(kx, ky, kz, device).to(dtype)
-    window_kernel: Tensor = _get_window_grid_kernel3d(kx, ky, kz, device).to(dtype)
+    center_kernel: Tensor = _get_center_kernel3d(kz, ky, kx, device).to(dtype)
+    window_kernel: Tensor = _get_window_grid_kernel3d(kz, ky, kx, device).to(dtype)
 
     # applies exponential normalization trick
     # https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/

--- a/test/filters/test_blur.py
+++ b/test/filters/test_blur.py
@@ -85,6 +85,15 @@ class TestBoxBlur(BaseTester):
 
         self.assert_close(actual[:, 0, 2, 2], expected)
 
+    def test_kernel_3x1(self, device, dtype):
+        inp = torch.arange(16, device=device, dtype=dtype).view(1, 1, 4, 4)
+
+        ky, kx = 3, 1
+        actual = box_blur(inp, (ky, kx))
+
+        self.assert_close(actual[0, 0, 0, 0], torch.tensor((4 + 0 + 4) / 3, device=device, dtype=dtype))
+        self.assert_close(actual[0, 0, 1, 0], torch.tensor((0 + 4 + 8) / 3, device=device, dtype=dtype))
+
     @pytest.mark.parametrize('batch_size', [1, 2])
     def test_noncontiguous(self, batch_size, device, dtype):
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)

--- a/test/filters/test_gaussian.py
+++ b/test/filters/test_gaussian.py
@@ -40,10 +40,10 @@ def test_get_gaussian_kernel1d_tensor(window_size, sigma, device, dtype):
 @pytest.mark.parametrize("ksize_y", [3, 7])
 @pytest.mark.parametrize("sigma", [(1.5, 1.5), (2.1, 2.1)])
 def test_get_gaussian_kernel2d_float(ksize_x, ksize_y, sigma, device, dtype):
-    actual = get_gaussian_kernel2d((ksize_x, ksize_y), sigma, device=device, dtype=dtype)
+    actual = get_gaussian_kernel2d((ksize_y, ksize_x), sigma, device=device, dtype=dtype)
     expected = torch.ones(1, device=device, dtype=dtype)
 
-    assert actual.shape == (1, ksize_x, ksize_y)
+    assert actual.shape == (1, ksize_y, ksize_x)
     assert_close(actual.sum(), expected.sum())
 
 
@@ -54,10 +54,10 @@ def test_get_gaussian_kernel2d_tensor(ksize_x, ksize_y, sigma, device, dtype):
     sigma = torch.tensor(sigma, device=device, dtype=dtype)
     bs = sigma.shape[0]
 
-    actual = get_gaussian_kernel2d((ksize_x, ksize_y), sigma)
+    actual = get_gaussian_kernel2d((ksize_y, ksize_x), sigma)
     expected = torch.ones(bs, device=device, dtype=dtype)
 
-    assert actual.shape == (bs, ksize_x, ksize_y)
+    assert actual.shape == (bs, ksize_y, ksize_x)
     assert_close(actual.sum(), expected.sum())
 
 
@@ -66,10 +66,10 @@ def test_get_gaussian_kernel2d_tensor(ksize_x, ksize_y, sigma, device, dtype):
 @pytest.mark.parametrize("ksize_z", [9, 3])
 @pytest.mark.parametrize("sigma", [(1.5, 1.5, 3.5), (2.1, 1.5, 2.1)])
 def test_get_gaussian_kernel3d_float(ksize_x, ksize_y, ksize_z, sigma, device, dtype):
-    actual = get_gaussian_kernel3d((ksize_x, ksize_y, ksize_z), sigma, device=device, dtype=dtype)
+    actual = get_gaussian_kernel3d((ksize_z, ksize_y, ksize_x), sigma, device=device, dtype=dtype)
     expected = torch.ones(1, device=device, dtype=dtype)
 
-    assert actual.shape == (1, ksize_x, ksize_y, ksize_z)
+    assert actual.shape == (1, ksize_z, ksize_y, ksize_x)
     assert_close(actual.sum(), expected.sum())
 
 
@@ -83,10 +83,10 @@ def test_get_gaussian_kernel3d_tensor(ksize_x, ksize_y, ksize_z, sigma, device, 
     sigma = torch.tensor(sigma, device=device, dtype=dtype)
     bs = sigma.shape[0]
 
-    actual = get_gaussian_kernel3d((ksize_x, ksize_y, ksize_z), sigma)
+    actual = get_gaussian_kernel3d((ksize_z, ksize_y, ksize_x), sigma)
     expected = torch.ones(bs, device=device, dtype=dtype)
 
-    assert actual.shape == (bs, ksize_x, ksize_y, ksize_z)
+    assert actual.shape == (bs, ksize_z, ksize_y, ksize_x)
     assert_close(actual.sum(), expected.sum())
 
 
@@ -142,8 +142,8 @@ def test_get_gaussian_discrete_kernel1d_tensor(window_size, sigma, device, dtype
 def test_gaussian_blur2d_float(ksize_x, ksize_y, sigma, device, dtype):
     sample = torch.rand(1, 3, 16, 16, device=device, dtype=dtype)
 
-    actual = gaussian_blur2d(sample, (ksize_x, ksize_y), sigma, "replicate", separable=False)
-    actual_sep = gaussian_blur2d(sample, (ksize_x, ksize_y), sigma, "replicate", separable=True)
+    actual = gaussian_blur2d(sample, (ksize_y, ksize_x), sigma, "replicate", separable=False)
+    actual_sep = gaussian_blur2d(sample, (ksize_y, ksize_x), sigma, "replicate", separable=True)
 
     assert_close(actual, actual_sep)
 
@@ -155,8 +155,8 @@ def test_gaussian_blur2d_tensor(ksize_x, ksize_y, sigma, device, dtype):
     sigma = torch.tensor(sigma, device=device, dtype=dtype)
     bs = sigma.shape[0]
     sample = torch.rand(bs, 3, 16, 16, device=device, dtype=dtype)
-    actual = gaussian_blur2d(sample, (ksize_x, ksize_y), sigma, "replicate", separable=False)
-    actual_sep = gaussian_blur2d(sample, (ksize_x, ksize_y), sigma, "replicate", separable=True)
+    actual = gaussian_blur2d(sample, (ksize_y, ksize_x), sigma, "replicate", separable=False)
+    actual_sep = gaussian_blur2d(sample, (ksize_y, ksize_x), sigma, "replicate", separable=True)
 
     assert_close(actual, actual_sep)
 

--- a/test/filters/test_median.py
+++ b/test/filters/test_median.py
@@ -54,6 +54,25 @@ class TestMedianBlur(BaseTester):
         self.assert_close(actual[0, 0, 2, 2], torch.tensor(3.0, device=device, dtype=dtype))
         self.assert_close(actual[0, 1, 1, 1], torch.tensor(14.0, device=device, dtype=dtype))
 
+    def test_kernel_3x1(self, device, dtype):
+        inp = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 3.0, 7.0, 5.0, 0.0],
+                [0.0, 3.0, 1.0, 1.0, 0.0],
+                [0.0, 6.0, 9.0, 2.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+            ],
+            device=device,
+            dtype=dtype,
+        ).view(1, 1, 5, 5)
+
+        ky, kx = 3, 1
+        actual = median_blur(inp, (ky, kx))
+
+        self.assert_close(actual[0, 0, 2, 2], torch.tensor(7.0, device=device, dtype=dtype))
+        self.assert_close(actual[0, 0, 1, 1], torch.tensor(3.0, device=device, dtype=dtype))
+
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2324 

- Change (kx,ky) -> (ky,kx) and (kx,ky,kz) -> (kz,ky,kx)
- Add 3x1 kernel test for box blur and median blur
- Simplify 2D and 3D Gaussian kernel creation

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
