### PR TITLE
Use separable filter2d for box filter

### DIFF
--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -18,6 +18,7 @@ from .guided import GuidedBlur, guided_blur
 from .kernels import (
     gaussian,
     get_binary_kernel2d,
+    get_box_kernel1d,
     get_box_kernel2d,
     get_diff_kernel2d,
     get_gaussian_discrete_kernel1d,
@@ -47,6 +48,7 @@ from .unsharp import UnsharpMask, unsharp_mask
 __all__ = [
     "gaussian",
     "get_binary_kernel2d",
+    "get_box_kernel1d",
     "get_box_kernel2d",
     "get_gaussian_kernel1d",
     "get_gaussian_discrete_kernel1d",

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -7,11 +7,7 @@ from .kernels import _unpack_2d_ks, get_box_kernel1d, get_box_kernel2d
 
 
 def box_blur(
-    input: Tensor,
-    kernel_size: tuple[int, int] | int,
-    border_type: str = 'reflect',
-    normalized: bool = True,
-    separable: bool = True,
+    input: Tensor, kernel_size: tuple[int, int] | int, border_type: str = 'reflect', separable: bool = False
 ) -> Tensor:
     r"""Blur an image using the box filter.
 
@@ -33,7 +29,6 @@ def box_blur(
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``, ``'replicate'`` or ``'circular'``.
-        normalized: if True, L1 norm of the kernel is set to 1.
 
     Returns:
         the blurred tensor with shape :math:`(B,C,H,W)`.
@@ -96,16 +91,11 @@ class BoxBlur(Module):
     """
 
     def __init__(
-        self,
-        kernel_size: tuple[int, int] | int,
-        border_type: str = 'reflect',
-        normalized: bool = True,
-        separable: bool = True,
+        self, kernel_size: tuple[int, int] | int, border_type: str = 'reflect', separable: bool = False
     ) -> None:
         super().__init__()
         self.kernel_size = kernel_size
         self.border_type = border_type
-        self.normalized = normalized
         self.separable = separable
 
         if separable:
@@ -122,7 +112,6 @@ class BoxBlur(Module):
         return (
             f"{self.__class__.__name__}"
             f"(kernel_size={self.kernel_size}, "
-            f"normalized={self.normalized}, "
             f"border_type={self.border_type}, "
             f"separable={self.separable})"
         )

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from kornia.core import Module, Tensor
+from kornia.core.check import KORNIA_CHECK_IS_TENSOR
 
 from .filter import filter2d, filter2d_separable
 from .kernels import _unpack_2d_ks, get_box_kernel1d, get_box_kernel2d
@@ -44,6 +45,8 @@ def box_blur(
         >>> output.shape
         torch.Size([2, 4, 5, 7])
     """
+    KORNIA_CHECK_IS_TENSOR(input)
+
     if separable:
         ky, kx = _unpack_2d_ks(kernel_size)
         kernel_y = get_box_kernel1d(ky, device=input.device, dtype=input.dtype)
@@ -52,6 +55,7 @@ def box_blur(
     else:
         kernel = get_box_kernel2d(kernel_size, device=input.device, dtype=input.dtype)
         out = filter2d(input, kernel, border_type)
+
     return out
 
 
@@ -118,7 +122,7 @@ class BoxBlur(Module):
         )
 
     def forward(self, input: Tensor) -> Tensor:
+        KORNIA_CHECK_IS_TENSOR(input)
         if self.separable:
             return filter2d_separable(input, self.kernel_x, self.kernel_y, self.border_type)
-        else:
-            return filter2d(input, self.kernel, self.border_type)
+        return filter2d(input, self.kernel, self.border_type)

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -29,6 +29,7 @@ def box_blur(
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``, ``'replicate'`` or ``'circular'``.
+        separable: run as composition of two 1d-convolutions.
 
     Returns:
         the blurred tensor with shape :math:`(B,C,H,W)`.
@@ -73,7 +74,7 @@ class BoxBlur(Module):
         border_type: the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``,
           ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
-        normalized: if True, L1 norm of the kernel is set to 1.
+        separable: run as composition of two 1d-convolutions.
 
     Returns:
         the blurred input tensor.

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -261,7 +261,16 @@ def laplacian_1d(window_size: int, *, device: Device | None = None, dtype: Dtype
 
 
 def get_box_kernel1d(kernel_size: int, *, device: Device | None = None, dtype: Dtype | None = None) -> Tensor:
-    r"""Utility function that returns a box filter."""
+    r"""Utility function that returns a 1-D box filter.
+
+    Args:
+        kernel_size: the size of the kernel.
+        device: the desired device of returned tensor.
+        dtype: the desired data type of returned tensor.
+    Returns:
+        A tensor with shape :math:`(1, \text{kernel\_size})`, filled with the value
+        :math:`\frac{1}{\text{kernel\_size}}`.
+    """
     scale = tensor(1.0 / kernel_size, device=device, dtype=dtype)
     return scale.expand(1, kernel_size)
 
@@ -269,7 +278,16 @@ def get_box_kernel1d(kernel_size: int, *, device: Device | None = None, dtype: D
 def get_box_kernel2d(
     kernel_size: tuple[int, int] | int, *, device: Device | None = None, dtype: Dtype | None = None
 ) -> Tensor:
-    r"""Utility function that returns a box filter."""
+    r"""Utility function that returns a 2-D box filter.
+
+    Args:
+        kernel_size: the size of the kernel.
+        device: the desired device of returned tensor.
+        dtype: the desired data type of returned tensor.
+    Returns:
+        A tensor with shape :math:`(1, \text{kernel\_size}[0], \text{kernel\_size}[1])`,
+        filled with the value :math:`\frac{1}{\text{kernel\_size}[0] \times \text{kernel\_size}[1]}`.
+    """
     ky, kx = _unpack_2d_ks(kernel_size)
     scale = tensor(1.0 / (kx * ky), device=device, dtype=dtype)
     return scale.expand(1, ky, kx)

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -260,12 +260,18 @@ def laplacian_1d(window_size: int, *, device: Device | None = None, dtype: Dtype
     return filter_1d
 
 
+def get_box_kernel1d(kernel_size: int, *, device: Device | None = None, dtype: Dtype | None = None) -> Tensor:
+    r"""Utility function that returns a box filter."""
+    scale = tensor(1.0 / kernel_size, device=device, dtype=dtype)
+    return scale.expand(1, kernel_size)
+
+
 def get_box_kernel2d(
     kernel_size: tuple[int, int] | int, *, device: Device | None = None, dtype: Dtype | None = None
 ) -> Tensor:
     r"""Utility function that returns a box filter."""
     kx, ky = _unpack_2d_ks(kernel_size)
-    scale = tensor(1.0, device=device, dtype=dtype) / tensor([kx * ky], device=device, dtype=dtype)
+    scale = tensor(1.0 / (kx * ky), device=device, dtype=dtype)
     return scale.expand(1, kx, ky)
 
 

--- a/test/filters/test_blur.py
+++ b/test/filters/test_blur.py
@@ -7,13 +7,20 @@ from kornia.testing import BaseTester, tensor_to_gradcheck_var
 
 class TestBoxBlur(BaseTester):
     @pytest.mark.parametrize('kernel_size', [5, (3, 5)])
-    @pytest.mark.parametrize('normalized', [True, False])
-    def test_smoke(self, kernel_size, normalized, device, dtype):
+    def test_smoke(self, kernel_size, device, dtype):
         inpt = torch.rand(1, 1, 10, 10, device=device, dtype=dtype)
 
-        bb = BoxBlur(kernel_size, 'reflect', normalized)
+        bb = BoxBlur(kernel_size, 'reflect')
         actual = bb(inpt)
         assert actual.shape == (1, 1, 10, 10)
+
+    @pytest.mark.parametrize('kernel_size', [5, (3, 5)])
+    @pytest.mark.parametrize('batch_size', [1, 2])
+    def test_separable(self, batch_size, kernel_size, device, dtype):
+        inpt = torch.randn(batch_size, 3, 10, 10, device=device, dtype=dtype)
+        out1 = box_blur(inpt, kernel_size, separable=False)
+        out2 = box_blur(inpt, kernel_size, separable=True)
+        self.assert_close(out1, out2)
 
     def test_exception(self):
         inpt = torch.rand(1, 1, 3, 3)
@@ -31,10 +38,8 @@ class TestBoxBlur(BaseTester):
         expected = (batch_size, 3, 4, 4)
         assert actual.shape == expected
 
-    # TODO(dmytro): normalized does not make any effect
     @pytest.mark.parametrize('batch_size', [1, 2])
-    @pytest.mark.parametrize('normalized', [True, False])
-    def test_kernel_3x3(self, batch_size, normalized, device, dtype):
+    def test_kernel_3x3(self, batch_size, device, dtype):
         inp = torch.tensor(
             [
                 [
@@ -52,7 +57,7 @@ class TestBoxBlur(BaseTester):
         ).repeat(batch_size, 1, 1, 1)
 
         kernel_size = (3, 3)
-        actual = box_blur(inp, kernel_size, normalized=normalized)
+        actual = box_blur(inp, kernel_size)
         expected = torch.tensor(35.0 * batch_size, device=device, dtype=dtype)
 
         self.assert_close(actual.sum(), expected)
@@ -94,11 +99,12 @@ class TestBoxBlur(BaseTester):
         self.assert_close(actual[0, 0, 0, 0], torch.tensor((4 + 0 + 4) / 3, device=device, dtype=dtype))
         self.assert_close(actual[0, 0, 1, 0], torch.tensor((0 + 4 + 8) / 3, device=device, dtype=dtype))
 
+    @pytest.mark.parametrize('separable', [False, True])
     @pytest.mark.parametrize('batch_size', [1, 2])
-    def test_noncontiguous(self, batch_size, device, dtype):
+    def test_noncontiguous(self, batch_size, separable, device, dtype):
         inp = torch.rand(3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
 
-        actual = box_blur(inp, 3)
+        actual = box_blur(inp, 3, separable=separable)
 
         assert actual.is_contiguous()
 
@@ -122,11 +128,12 @@ class TestBoxBlur(BaseTester):
 
         self.assert_close(actual, expected)
 
+    @pytest.mark.parametrize('separable', [False, True])
     @pytest.mark.parametrize('kernel_size', [5, (5, 7)])
     @pytest.mark.parametrize('batch_size', [1, 2])
-    def test_dynamo(self, batch_size, kernel_size, device, dtype, torch_optimizer):
+    def test_dynamo(self, batch_size, kernel_size, separable, device, dtype, torch_optimizer):
         inpt = torch.ones(batch_size, 3, 10, 10, device=device, dtype=dtype)
-        op = BoxBlur(kernel_size)
+        op = BoxBlur(kernel_size, separable=separable)
         op_optimized = torch_optimizer(op)
 
         self.assert_close(op(inpt), op_optimized(inpt))


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2246 

Following separable filter implementation of Gaussian blur, I add separable filter2d for Box blur.

When I benchmark the speed, it is clear that both kernel size and image size must be large to observe speedup. (device is RTX 3090, PyTorch 2.0, CUDA 11.8)

![box_blur_rtx3090_128x128](https://user-images.githubusercontent.com/26946864/232414659-e28ed10b-a719-44a6-a0b6-b2502bb041ba.png)

![box_blur_rtx3090_1024x1024](https://user-images.githubusercontent.com/26946864/232414675-eb197b46-ac7a-4d80-8791-38c18ed602eb.png)

I also ran the speed benchmark on Mac M1 CPU (PyTorch 2.0). The results are... interesting. At large batch sizes, separable kernels don't help much. `torch.compile()` with 3x3 filter2d is super fast.

![box_blur](https://user-images.githubusercontent.com/26946864/232413205-aa49944b-452e-4e51-b7a6-aa2c88b2500d.png)

Benchmark script

```python
import itertools
import time

import matplotlib.pyplot as plt
import pandas as pd
import torch

from kornia.filters import box_blur


N = 20
device = "cuda"
img_dims = (3, 128, 128)

batch_sizes = [1, 10, 100]
kernel_sizes = [3, 5, 7, 9, 11]
separables = [False, True]
do_compiles = [False, True]

samples = []

for batch_size, kernel_size, separable, do_compile in itertools.product(
    batch_sizes, kernel_sizes, separables, do_compiles
):
    img = torch.randn(batch_size, *img_dims, device=device)
    f = torch.compile(box_blur) if do_compile else box_blur
    for _ in range(5):
        out = f(img, kernel_size, separable=separable)

    torch.cuda.synchronize()
    time0 = time.perf_counter()
    for _ in range(N):
        torch.cuda.synchronize()
        out = f(img, kernel_size, separable=separable)
        torch.cuda.synchronize()
    throughput = N / (time.perf_counter() - time0)

    samples.append((batch_size, kernel_size, separable, do_compile, throughput))
    print(*samples[-1], sep="\t")

df = pd.DataFrame(samples, columns=["batch size", "kernel size", "separable", "torch.compile", "throughput"])
df = df.pivot(index=["batch size", "kernel size"], columns=["separable", "torch.compile"], values="throughput")
df.values[:, :] /= df.values[:, [0]]
print(df)

df.plot.bar(rot=0, figsize=(12, 8))
plt.tight_layout()
plt.savefig("box_blur.png")
```

**Questions**:

- Perhaps I should leave the default value for `separable` as `False`?
- I notice that `normalized` does not do anything since the kernel is already normalized, thus I don't use the parameter `normalized` at all. Shall we deprecate the use of `normalized` parameter here? i.e. raise DeprecationWarning.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
