### PR TITLE
remove inplace operation

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -337,9 +337,7 @@ def angle_axis_to_rotation_matrix(angle_axis: Tensor) -> Tensor:
     mask_pos = (mask).type_as(theta2)
     mask_neg = (~mask).type_as(theta2)
 
-    # create output pose matrix
-    rotation_matrix = eye_like(3, angle_axis, shared_memory=False)
-    # fill output matrix with masked values
+    # create output pose matrix with masked values
     rotation_matrix = mask_pos * rotation_matrix_normal + mask_neg * rotation_matrix_taylor
     return rotation_matrix  # Nx3x3
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -340,7 +340,7 @@ def angle_axis_to_rotation_matrix(angle_axis: Tensor) -> Tensor:
     # create output pose matrix
     rotation_matrix = eye_like(3, angle_axis, shared_memory=False)
     # fill output matrix with masked values
-    rotation_matrix[..., :3, :3] = mask_pos * rotation_matrix_normal + mask_neg * rotation_matrix_taylor
+    rotation_matrix = mask_pos * rotation_matrix_normal + mask_neg * rotation_matrix_taylor
     return rotation_matrix  # Nx3x3
 
 


### PR DESCRIPTION
remove inplace update of rotation matrix in angle_axis_to_rotation_matrix

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
The in place operation raises errors when trying to vmap it. There does not seem to be any specific need for the operation to be in place, so I simply removed the in place part.

I have not done checked that tests/CI runs.