### PR TITLE
RandomGrayscale: add rgb_weights parameter

### DIFF
--- a/kornia/augmentation/_2d/intensity/grayscale.py
+++ b/kornia/augmentation/_2d/intensity/grayscale.py
@@ -52,7 +52,7 @@ class RandomGrayscale(IntensityAugmentationBase2D):
     """
 
     def __init__(
-        self, rgb_weights: Optional[Tensor], same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False
+        self, rgb_weights: Optional[Tensor] = None, same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False
     ) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
         self.rgb_weights = rgb_weights

--- a/kornia/augmentation/_2d/intensity/grayscale.py
+++ b/kornia/augmentation/_2d/intensity/grayscale.py
@@ -51,13 +51,14 @@ class RandomGrayscale(IntensityAugmentationBase2D):
         tensor(True)
     """
 
-    def __init__(self, same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False) -> None:
+    def __init__(self, rgb_weights: Optional[Tensor], same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
+        self.rgb_weights = rgb_weights
 
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
         # Make sure it returns (*, 3, H, W)
         grayscale = torch.ones_like(input)
-        grayscale[:] = rgb_to_grayscale(input)
+        grayscale[:] = rgb_to_grayscale(input, rgb_weights=self.rgb_weights)
         return grayscale

--- a/kornia/augmentation/_2d/intensity/grayscale.py
+++ b/kornia/augmentation/_2d/intensity/grayscale.py
@@ -51,7 +51,9 @@ class RandomGrayscale(IntensityAugmentationBase2D):
         tensor(True)
     """
 
-    def __init__(self, rgb_weights: Optional[Tensor], same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False) -> None:
+    def __init__(
+        self, rgb_weights: Optional[Tensor], same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False
+    ) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
         self.rgb_weights = rgb_weights
 


### PR DESCRIPTION
#### Changes

The [RandomGrayscale](https://kornia.readthedocs.io/en/stable/augmentation.module.html#kornia.augmentation.RandomGrayscale) augmentation documents a `rgb_weights` parameter, but this parameter doesn't actually exist. This PR adds and uses this parameter, matching the implementation in `kornia.color.RgbToGrayscale`. Alternatively, we could also remove this parameter from the documentation.

#### Type of change

- [x] 🔬 New feature (non-breaking change which adds functionality)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
