### PR TITLE
Optional raise in kornia check functions

### DIFF
--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -46,7 +46,7 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str], raises: bool = True) -> bool
         True
 
         >>> x = torch.rand(2, 3, 4, 4)
-        >>> KORNIA_CHECK_SHAPE(x, ["2","3", "H", "W"])  # explicit
+        >>> KORNIA_CHECK_SHAPE(x, ["2", "3", "H", "W"])  # explicit
         True
     """
     if '*' == shape[0]:

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -42,7 +42,7 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str], raises: bool = True) -> bool
 
     Example:
         >>> x = torch.rand(2, 3, 4, 4)
-        >>> KORNIA_CHECK_SHAPE(x, ["B","C", "H", "W"])  # implicit
+        >>> KORNIA_CHECK_SHAPE(x, ["B", "C", "H", "W"])  # implicit
         True
 
         >>> x = torch.rand(2, 3, 4, 4)

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -114,13 +114,14 @@ T = TypeVar('T', bound=type)
 
 
 # TODO: fix mypy typeguard issue
-def KORNIA_CHECK_TYPE(x: object, typ: T | tuple[T, ...], msg: str | None = None) -> TypeGuard[T]:
+def KORNIA_CHECK_TYPE(x: object, typ: T | tuple[T, ...], msg: str | None = None, raises: bool = True) -> TypeGuard[T]:
     """Check the type of an aribratry variable.
 
     Args:
         x: any input variable.
         typ: the expected type of the variable.
         msg: message to show in the exception.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
         TypeException: if the input variable does not match with the expected.
@@ -131,7 +132,9 @@ def KORNIA_CHECK_TYPE(x: object, typ: T | tuple[T, ...], msg: str | None = None)
     """
     # TODO: Move to use typeguard here dropping support for JIT
     if not isinstance(x, typ):
-        raise TypeError(f"Invalid type: {type(x)}.\n{msg}")
+        if raises:
+            raise TypeError(f"Invalid type: {type(x)}.\n{msg}")
+        return False
 
     return True
 

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -43,9 +43,11 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str], raises: bool = True) -> bool
     Example:
         >>> x = torch.rand(2, 3, 4, 4)
         >>> KORNIA_CHECK_SHAPE(x, ["B","C", "H", "W"])  # implicit
+        True
 
         >>> x = torch.rand(2, 3, 4, 4)
         >>> KORNIA_CHECK_SHAPE(x, ["2","3", "H", "W"])  # explicit
+        True
     """
     if '*' == shape[0]:
         shape_to_check = shape[1:]
@@ -92,6 +94,7 @@ def KORNIA_CHECK(condition: bool, msg: str | None = None, raises: bool = True) -
     Example:
         >>> x = torch.rand(2, 3, 3)
         >>> KORNIA_CHECK(x.shape[-2:] == (3, 3), "Invalid homography")
+        True
     """
     if not condition:
         if raises:
@@ -178,7 +181,7 @@ def KORNIA_CHECK_IS_LIST_OF_TENSOR(x: Sequence[object] | None, raises: bool = Tr
 
     Example:
         >>> x = torch.rand(2, 3, 3)
-        >>> KORNIA_CHECK_IS_LIST_OF_TENSOR(x)
+        >>> KORNIA_CHECK_IS_LIST_OF_TENSOR(x, raises=False)
         False
         >>> KORNIA_CHECK_IS_LIST_OF_TENSOR([x])
         True
@@ -207,6 +210,7 @@ def KORNIA_CHECK_SAME_DEVICE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
         >>> x1 = torch.rand(2, 3, 3)
         >>> x2 = torch.rand(1, 3, 1)
         >>> KORNIA_CHECK_SAME_DEVICE(x1, x2)
+        True
     """
     if x.device != y.device:
         if raises:
@@ -230,6 +234,7 @@ def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None, rai
         >>> x1 = torch.rand(2, 3, 3)
         >>> x2 = torch.rand(1, 3, 1)
         >>> KORNIA_CHECK_SAME_DEVICES([x1, x2], "Tensors not in the same device")
+        True
     """
     KORNIA_CHECK(isinstance(tensors, list) and len(tensors) >= 1, "Expected a list with at least one element", raises)
     if not all(tensors[0].device == x.device for x in tensors):
@@ -375,5 +380,6 @@ def KORNIA_CHECK_LAF(laf: Tensor, raises: bool = True) -> bool:
     Example:
         >>> lafs = torch.rand(2, 10, 2, 3)
         >>> KORNIA_CHECK_LAF(lafs)
+        True
     """
     return KORNIA_CHECK_SHAPE(laf, ["B", "N", "2", "3"], raises)

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -139,15 +139,16 @@ def KORNIA_CHECK_TYPE(x: object, typ: T | tuple[T, ...], msg: str | None = None,
     return True
 
 
-def KORNIA_CHECK_IS_TENSOR(x: object, msg: str | None = None) -> TypeGuard[Tensor]:
+def KORNIA_CHECK_IS_TENSOR(x: object, msg: str | None = None, raises: bool = True) -> TypeGuard[Tensor]:
     """Check the input variable is a Tensor.
 
     Args:
         x: any input variable.
         msg: message to show in the exception.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the input variable does not match with the expected.
+        TypeException: if the input variable does not match with the expected and raises is False.
 
     Example:
         >>> x = torch.rand(2, 3, 3)
@@ -156,8 +157,9 @@ def KORNIA_CHECK_IS_TENSOR(x: object, msg: str | None = None) -> TypeGuard[Tenso
     """
     # TODO: Move to use typeguard here dropping support for JIT
     if not isinstance(x, Tensor):
-        raise TypeError(f"Not a Tensor type. Got: {type(x)}.\n{msg}")
-
+        if raises:
+            raise TypeError(f"Not a Tensor type. Got: {type(x)}.\n{msg}")
+        return False
     return True
 
 

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -180,13 +180,14 @@ def KORNIA_CHECK_IS_LIST_OF_TENSOR(x: Sequence[object] | None) -> TypeGuard[list
     return isinstance(x, list) and all(isinstance(d, Tensor) for d in x)
 
 
-def KORNIA_CHECK_SAME_DEVICE(x: Tensor, y: Tensor) -> None:
+def KORNIA_CHECK_SAME_DEVICE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
     """Check whether two tensor in the same device.
 
     Args:
         x: first tensor to evaluate.
         y: sencod tensor to evaluate.
         msg: message to show in the exception.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
         TypeException: if the two tensors are not in the same device.
@@ -197,7 +198,10 @@ def KORNIA_CHECK_SAME_DEVICE(x: Tensor, y: Tensor) -> None:
         >>> KORNIA_CHECK_SAME_DEVICE(x1, x2)
     """
     if x.device != y.device:
-        raise TypeError(f"Not same device for tensors. Got: {x.device} and {y.device}")
+        if raises:
+            raise TypeError(f"Not same device for tensors. Got: {x.device} and {y.device}")
+        return False
+    return True
 
 
 def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None) -> None:

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -227,13 +227,14 @@ def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None, rai
         return False
     return True
 
-def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor) -> bool:
+def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
     """Check whether two tensor have the same shape.
 
     Args:
         x: first tensor to evaluate.
         y: sencod tensor to evaluate.
         msg: message to show in the exception.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
         TypeException: if the two tensors have not the same shape.
@@ -245,7 +246,9 @@ def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor) -> bool:
         True
     """
     if x.shape != y.shape:
-        raise TypeError(f"Not same shape for tensors. Got: {x.shape} and {y.shape}")
+        if raises:
+            raise TypeError(f"Not same shape for tensors. Got: {x.shape} and {y.shape}")
+        return False
 
     return True
 

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -356,17 +356,18 @@ def KORNIA_CHECK_DM_DESC(desc1: Tensor, desc2: Tensor, dm: Tensor) -> bool:
     return True
 
 
-def KORNIA_CHECK_LAF(laf: Tensor) -> None:
+def KORNIA_CHECK_LAF(laf: Tensor, raises: bool = True) -> None:
     """Check whether a Local Affine Frame (laf) has a valid shape.
 
     Args:
         laf: local affine frame tensor to evaluate.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        Exception: if the input laf does not have a shape :math:`(B,N,2,3)`.
+        Exception: if the input laf does not have a shape :math:`(B,N,2,3)` and raises is True.
 
     Example:
         >>> lafs = torch.rand(2, 10, 2, 3)
         >>> KORNIA_CHECK_LAF(lafs)
     """
-    KORNIA_CHECK_SHAPE(laf, ["B", "N", "2", "3"])
+    return KORNIA_CHECK_SHAPE(laf, ["B", "N", "2", "3"], raises)

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -330,16 +330,17 @@ def KORNIA_CHECK_IS_COLOR_OR_GRAY(x: Tensor, msg: str | None = None) -> bool:
     return True
 
 
-def KORNIA_CHECK_DM_DESC(desc1: Tensor, desc2: Tensor, dm: Tensor) -> bool:
+def KORNIA_CHECK_DM_DESC(desc1: Tensor, desc2: Tensor, dm: Tensor, raises: bool = True) -> bool:
     """Check whether the provided descriptors match with a distance matrix.
 
     Args:
         desc1: first descriptor tensor to evaluate.
         desc2: second descriptor tensor to evaluate.
         dm: distance matrix tensor to evaluate.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the descriptors shape do not match with the distance matrix.
+        TypeException: if the descriptors shape do not match with the distance matrix and raises is True.
 
     Example:
         >>> desc1 = torch.rand(4)
@@ -349,10 +350,12 @@ def KORNIA_CHECK_DM_DESC(desc1: Tensor, desc2: Tensor, dm: Tensor) -> bool:
         True
     """
     if not ((dm.size(0) == desc1.size(0)) and (dm.size(1) == desc2.size(0))):
-        raise TypeError(
-            f"distance matrix shape {dm.shape} is not onsistent with descriptors shape: desc1 {desc1.shape} "
-            f"desc2 {desc2.shape}"
-        )
+        if raises:
+            raise TypeError(
+                f"distance matrix shape {dm.shape} is not onsistent with descriptors shape: desc1 {desc1.shape} "
+                f"desc2 {desc2.shape}"
+            )
+        return False
     return True
 
 

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -310,15 +310,16 @@ def KORNIA_CHECK_IS_GRAY(x: Tensor, msg: str | None = None, raises: bool = True)
     return True
 
 
-def KORNIA_CHECK_IS_COLOR_OR_GRAY(x: Tensor, msg: str | None = None) -> bool:
+def KORNIA_CHECK_IS_COLOR_OR_GRAY(x: Tensor, msg: str | None = None, raises: bool = True) -> bool:
     """Check whether an image tensor is grayscale or color.
 
     Args:
         x: image tensor to evaluate.
         msg: message to show in the exception.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the tensor has not a shape :math:`(1,H,W)` or :math:`(3,H,W)`.
+        TypeException: if the tensor has not a shape :math:`(1,H,W)` or :math:`(3,H,W)` and raises is True.
 
     Example:
         >>> img = torch.rand(2, 3, 4, 4)
@@ -326,7 +327,9 @@ def KORNIA_CHECK_IS_COLOR_OR_GRAY(x: Tensor, msg: str | None = None) -> bool:
         True
     """
     if len(x.shape) < 3 or x.shape[-3] not in [1, 3]:
-        raise TypeError(f"Not a color or gray tensor. Got: {type(x)}.\n{msg}")
+        if raises:
+            raise TypeError(f"Not a color or gray tensor. Got: {type(x)}.\n{msg}")
+        return False
     return True
 
 

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -76,10 +76,10 @@ def KORNIA_CHECK(condition: bool, msg: str | None = None, raises: bool = True) -
     Args:
         condition: the condition to evaluate.
         msg: message to show in the exception.
-        raises: bool indicates whether an exception should be raised upon failure.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        Exception: if the confition is met & raises=false.
+        Exception: if the condition is met & raises is False.
 
     Example:
         >>> x = torch.rand(2, 3, 3)
@@ -239,10 +239,10 @@ def KORNIA_CHECK_IS_COLOR(x: Tensor, msg: str | None = None, raises: bool = True
     Args:
         x: image tensor to evaluate.
         msg: message to show in the exception.
-        raises: bool indicates whether an exception should be raised upon failure.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if all the input tensor has not a shape :math:`(3,H,W)` and raises=False.
+        TypeException: if all the input tensor has not a shape :math:`(3,H,W)` and raises is False.
 
     Example:
         >>> img = torch.rand(2, 3, 4, 4)
@@ -256,15 +256,16 @@ def KORNIA_CHECK_IS_COLOR(x: Tensor, msg: str | None = None, raises: bool = True
     return True
 
 
-def KORNIA_CHECK_IS_GRAY(x: Tensor, msg: str | None = None) -> bool:
+def KORNIA_CHECK_IS_GRAY(x: Tensor, msg: str | None = None, raises: bool = True) -> bool:
     """Check whether an image tensor is grayscale.
 
     Args:
         x: image tensor to evaluate.
         msg: message to show in the exception.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the tensor has not a shape :math:`(1,H,W)` or :math:`(H,W)`.
+        TypeException: if the tensor has not a shape :math:`(1,H,W)` or :math:`(H,W)` and raises is False.
 
     Example:
         >>> img = torch.rand(2, 1, 4, 4)
@@ -272,7 +273,9 @@ def KORNIA_CHECK_IS_GRAY(x: Tensor, msg: str | None = None) -> bool:
         True
     """
     if len(x.shape) < 2 or (len(x.shape) >= 3 and x.shape[-3] != 1):
-        raise TypeError(f"Not a gray tensor. Got: {type(x)}.\n{msg}")
+        if raises:
+            raise TypeError(f"Not a gray tensor. Got: {type(x)}.\n{msg}")
+        return False
     return True
 
 

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -26,7 +26,7 @@ __all__ = [
 
 
 # TODO: add somehow type check, or enforce to do it before
-def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str]) -> None:
+def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str], raises: bool = True) -> bool:
     """Check whether a tensor has a specified shape.
 
     The shape can be specified with a implicit or explicit list of strings.
@@ -35,9 +35,10 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str]) -> None:
     Args:
         x: the tensor to evaluate.
         shape: a list with strings with the expected shape.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        Exception: if the input tensor is has not the expected shape.
+        Exception: if the input tensor is has not the expected shape and raises if False.
 
     Example:
         >>> x = torch.rand(2, 3, 4, 4)
@@ -57,7 +58,10 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str]) -> None:
         x_shape_to_check = x.shape
 
     if len(x_shape_to_check) != len(shape_to_check):
-        raise TypeError(f"{x} shape must be [{shape}]. Got {x.shape}")
+        if raises:
+            raise TypeError(f"{x} shape must be [{shape}]. Got {x.shape}")
+        else:
+            return False
 
     for i in range(len(x_shape_to_check)):
         # The voodoo below is because torchscript does not like
@@ -67,8 +71,11 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str]) -> None:
             continue
         dim = int(dim_)
         if x_shape_to_check[i] != dim:
-            raise TypeError(f"{x} shape must be [{shape}]. Got {x.shape}")
-
+            if raises:
+                raise TypeError(f"{x} shape must be [{shape}]. Got {x.shape}")
+            else:
+                return False
+    return True
 
 def KORNIA_CHECK(condition: bool, msg: str | None = None, raises: bool = True) -> bool:
     """Check any arbitrary boolean condition.

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -233,15 +233,16 @@ def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor) -> bool:
     return True
 
 
-def KORNIA_CHECK_IS_COLOR(x: Tensor, msg: str | None = None) -> bool:
+def KORNIA_CHECK_IS_COLOR(x: Tensor, msg: str | None = None, raises: bool = True) -> bool:
     """Check whether an image tensor is a color images.
 
     Args:
         x: image tensor to evaluate.
         msg: message to show in the exception.
+        raises: bool indicates whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if all the input tensor has not a shape :math:`(3,H,W)`.
+        TypeException: if all the input tensor has not a shape :math:`(3,H,W)` and raises=False.
 
     Example:
         >>> img = torch.rand(2, 3, 4, 4)
@@ -249,7 +250,9 @@ def KORNIA_CHECK_IS_COLOR(x: Tensor, msg: str | None = None) -> bool:
         True
     """
     if len(x.shape) < 3 or x.shape[-3] != 3:
-        raise TypeError(f"Not a color tensor. Got: {type(x)}.\n{msg}")
+        if raises:
+            raise TypeError(f"Not a color tensor. Got: {type(x)}.\n{msg}")
+        return False
     return True
 
 

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -38,7 +38,7 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str], raises: bool = True) -> bool
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        Exception: if the input tensor is has not the expected shape and raises if False.
+        Exception: if the input tensor is has not the expected shape and raises is True.
 
     Example:
         >>> x = torch.rand(2, 3, 4, 4)
@@ -86,7 +86,7 @@ def KORNIA_CHECK(condition: bool, msg: str | None = None, raises: bool = True) -
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        Exception: if the condition is met & raises is False.
+        Exception: if the condition is met and raises is True.
 
     Example:
         >>> x = torch.rand(2, 3, 3)
@@ -124,7 +124,7 @@ def KORNIA_CHECK_TYPE(x: object, typ: T | tuple[T, ...], msg: str | None = None,
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the input variable does not match with the expected.
+        TypeException: if the input variable does not match with the expected and raises is True.
 
     Example:
         >>> KORNIA_CHECK_TYPE("foo", str, "Invalid string")
@@ -135,7 +135,6 @@ def KORNIA_CHECK_TYPE(x: object, typ: T | tuple[T, ...], msg: str | None = None,
         if raises:
             raise TypeError(f"Invalid type: {type(x)}.\n{msg}")
         return False
-
     return True
 
 
@@ -148,7 +147,7 @@ def KORNIA_CHECK_IS_TENSOR(x: object, msg: str | None = None, raises: bool = Tru
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the input variable does not match with the expected and raises is False.
+        TypeException: if the input variable does not match with the expected and raises is True.
 
     Example:
         >>> x = torch.rand(2, 3, 3)
@@ -171,7 +170,7 @@ def KORNIA_CHECK_IS_LIST_OF_TENSOR(x: Sequence[object] | None, raises: bool = Tr
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the input variable does not match with the expected and raises is False.
+        TypeException: if the input variable does not match with the expected and raises is True.
 
     Return:
         True if the input is a list of Tensors, otherwise return False.
@@ -201,7 +200,7 @@ def KORNIA_CHECK_SAME_DEVICE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the two tensors are not in the same device.
+        TypeException: if the two tensors are not in the same device and raises is True.
 
     Example:
         >>> x1 = torch.rand(2, 3, 3)
@@ -224,7 +223,7 @@ def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None, rai
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        Exception: if all the tensors are not in the same device.
+        Exception: if all the tensors are not in the same device and raises is True.
 
     Example:
         >>> x1 = torch.rand(2, 3, 3)
@@ -248,7 +247,7 @@ def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the two tensors have not the same shape.
+        TypeException: if the two tensors have not the same shape and raises is True.
 
     Example:
         >>> x1 = torch.rand(2, 3, 3)
@@ -260,7 +259,6 @@ def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
         if raises:
             raise TypeError(f"Not same shape for tensors. Got: {x.shape} and {y.shape}")
         return False
-
     return True
 
 
@@ -273,7 +271,7 @@ def KORNIA_CHECK_IS_COLOR(x: Tensor, msg: str | None = None, raises: bool = True
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if all the input tensor has not a shape :math:`(3,H,W)` and raises is False.
+        TypeException: if all the input tensor has not a shape :math:`(3,H,W)` and raises is True.
 
     Example:
         >>> img = torch.rand(2, 3, 4, 4)
@@ -296,7 +294,7 @@ def KORNIA_CHECK_IS_GRAY(x: Tensor, msg: str | None = None, raises: bool = True)
         raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
-        TypeException: if the tensor has not a shape :math:`(1,H,W)` or :math:`(H,W)` and raises is False.
+        TypeException: if the tensor has not a shape :math:`(1,H,W)` or :math:`(H,W)` and raises is True.
 
     Example:
         >>> img = torch.rand(2, 1, 4, 4)
@@ -362,7 +360,7 @@ def KORNIA_CHECK_DM_DESC(desc1: Tensor, desc2: Tensor, dm: Tensor, raises: bool 
     return True
 
 
-def KORNIA_CHECK_LAF(laf: Tensor, raises: bool = True) -> None:
+def KORNIA_CHECK_LAF(laf: Tensor, raises: bool = True) -> bool:
     """Check whether a Local Affine Frame (laf) has a valid shape.
 
     Args:

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -204,12 +204,13 @@ def KORNIA_CHECK_SAME_DEVICE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
     return True
 
 
-def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None) -> None:
+def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None, raises: bool = True) -> bool:
     """Check whether a list provided tensors live in the same device.
 
     Args:
         x: a list of tensors.
         msg: message to show in the exception.
+        raises: bool indicating whether an exception should be raised upon failure.
 
     Raises:
         Exception: if all the tensors are not in the same device.
@@ -219,10 +220,12 @@ def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None) -> 
         >>> x2 = torch.rand(1, 3, 1)
         >>> KORNIA_CHECK_SAME_DEVICES([x1, x2], "Tensors not in the same device")
     """
-    KORNIA_CHECK(isinstance(tensors, list) and len(tensors) >= 1, "Expected a list with at least one element")
+    KORNIA_CHECK(isinstance(tensors, list) and len(tensors) >= 1, "Expected a list with at least one element", raises)
     if not all(tensors[0].device == x.device for x in tensors):
-        raise Exception(f"Not same device for tensors. Got: {[x.device for x in tensors]}.\n{msg}")
-
+        if raises:
+            raise Exception(f"Not same device for tensors. Got: {[x.device for x in tensors]}.\n{msg}")
+        return False
+    return True
 
 def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor) -> bool:
     """Check whether two tensor have the same shape.

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -70,22 +70,26 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str]) -> None:
             raise TypeError(f"{x} shape must be [{shape}]. Got {x.shape}")
 
 
-def KORNIA_CHECK(condition: bool, msg: str | None = None) -> None:
+def KORNIA_CHECK(condition: bool, msg: str | None = None, raises: bool = True) -> bool:
     """Check any arbitrary boolean condition.
 
     Args:
         condition: the condition to evaluate.
         msg: message to show in the exception.
+        raises: bool indicates whether an exception should be raised upon failure.
 
     Raises:
-        Exception: if the confition is met.
+        Exception: if the confition is met & raises=false.
 
     Example:
         >>> x = torch.rand(2, 3, 3)
         >>> KORNIA_CHECK(x.shape[-2:] == (3, 3), "Invalid homography")
     """
     if not condition:
-        raise Exception(f"{condition} not true.\n{msg}")
+        if raises:
+            raise Exception(f"{condition} not true.\n{msg}")
+        return False
+    return True
 
 
 def KORNIA_UNWRAP(maybe_obj: object, typ: Any) -> Any:

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -163,11 +163,15 @@ def KORNIA_CHECK_IS_TENSOR(x: object, msg: str | None = None, raises: bool = Tru
     return True
 
 
-def KORNIA_CHECK_IS_LIST_OF_TENSOR(x: Sequence[object] | None) -> TypeGuard[list[Tensor]]:
+def KORNIA_CHECK_IS_LIST_OF_TENSOR(x: Sequence[object] | None, raises: bool = True) -> TypeGuard[list[Tensor]]:
     """Check the input variable is a List of Tensors.
 
     Args:
         x: Any sequence of objects
+        raises: bool indicating whether an exception should be raised upon failure.
+
+    Raises:
+        TypeException: if the input variable does not match with the expected and raises is False.
 
     Return:
         True if the input is a list of Tensors, otherwise return False.
@@ -179,7 +183,12 @@ def KORNIA_CHECK_IS_LIST_OF_TENSOR(x: Sequence[object] | None) -> TypeGuard[list
         >>> KORNIA_CHECK_IS_LIST_OF_TENSOR([x])
         True
     """
-    return isinstance(x, list) and all(isinstance(d, Tensor) for d in x)
+    are_tensors = isinstance(x, list) and all(isinstance(d, Tensor) for d in x)
+    if not are_tensors:
+        if raises:
+            raise TypeError(f"Provided container of type {type(x)} is not a list of tensors")
+        return False
+    return True
 
 
 def KORNIA_CHECK_SAME_DEVICE(x: Tensor, y: Tensor, raises: bool = True) -> bool:

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -77,6 +77,7 @@ def KORNIA_CHECK_SHAPE(x: Tensor, shape: list[str], raises: bool = True) -> bool
                 return False
     return True
 
+
 def KORNIA_CHECK(condition: bool, msg: str | None = None, raises: bool = True) -> bool:
     """Check any arbitrary boolean condition.
 
@@ -236,6 +237,7 @@ def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: str | None = None, rai
             raise Exception(f"Not same device for tensors. Got: {[x.device for x in tensors]}.\n{msg}")
         return False
     return True
+
 
 def KORNIA_CHECK_SAME_SHAPE(x: Tensor, y: Tensor, raises: bool = True) -> bool:
     """Check whether two tensor have the same shape.

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -129,9 +129,9 @@ class TestCheckSameDevices:
 
 class TestCheckIsColor:
     def test_valid(self):
-        KORNIA_CHECK_IS_COLOR(torch.rand(3, 4, 4))
-        KORNIA_CHECK_IS_COLOR(torch.rand(1, 3, 4, 4))
-        KORNIA_CHECK_IS_COLOR(torch.rand(2, 3, 4, 4))
+        assert KORNIA_CHECK_IS_COLOR(torch.rand(3, 4, 4)) is True
+        assert KORNIA_CHECK_IS_COLOR(torch.rand(1, 3, 4, 4)) is True
+        assert KORNIA_CHECK_IS_COLOR(torch.rand(2, 3, 4, 4)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
@@ -143,6 +143,8 @@ class TestCheckIsColor:
         with pytest.raises(Exception):
             KORNIA_CHECK_IS_COLOR(torch.rand(1, 3, 4, 4, 4))
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_IS_COLOR(torch.rand(1, 4, 4), raises=False) is False
 
 class TestCheckIsGray:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -107,14 +107,16 @@ class TestCheckIsTensor:
 
 class TestCheckIsListOfTensor:
     def test_valid(self):
-        assert KORNIA_CHECK_IS_LIST_OF_TENSOR([torch.rand(1), torch.rand(1), torch.rand(1)])
+        assert KORNIA_CHECK_IS_LIST_OF_TENSOR([torch.rand(1), torch.rand(1), torch.rand(1)]) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
-            assert KORNIA_CHECK_IS_LIST_OF_TENSOR([torch.rand(1), [2, 3], torch.rand(1)])
+            KORNIA_CHECK_IS_LIST_OF_TENSOR([torch.rand(1), [2, 3], torch.rand(1)])
         with pytest.raises(Exception):
-            assert KORNIA_CHECK_IS_LIST_OF_TENSOR([1, 2, 3])
+            KORNIA_CHECK_IS_LIST_OF_TENSOR([1, 2, 3])
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_IS_LIST_OF_TENSOR([torch.rand(1), [2, 3], torch.rand(1)], raises=False) is False
 
 class TestCheckSameDevice:
     def test_valid(self, device):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -40,7 +40,7 @@ class TestCheckShape:
         ],
     )
     def test_valid(self, data, shape):
-        KORNIA_CHECK_SHAPE(data, shape) is True
+        assert KORNIA_CHECK_SHAPE(data, shape) is True
 
     @pytest.mark.parametrize(
         "data,shape",
@@ -60,9 +60,9 @@ class TestCheckShape:
 
 class TestCheckSameShape:
     def test_valid(self):
-        KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3), torch.rand(2, 3))
-        KORNIA_CHECK_SAME_SHAPE(torch.rand(1, 2, 3), torch.rand(1, 2, 3))
-        KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3, 3), torch.rand(2, 3, 3))
+        assert KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3), torch.rand(2, 3)) is True
+        assert KORNIA_CHECK_SAME_SHAPE(torch.rand(1, 2, 3), torch.rand(1, 2, 3)) is True
+        assert KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3, 3), torch.rand(2, 3, 3)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
@@ -113,7 +113,7 @@ class TestCheckIsListOfTensor:
 
 class TestCheckSameDevice:
     def test_valid(self, device):
-        KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device=device), torch.rand(1, device=device)) is True
+        assert KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device=device), torch.rand(1, device=device)) is True
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
     def test_invalid(self):
@@ -126,7 +126,7 @@ class TestCheckSameDevice:
 
 class TestCheckSameDevices:
     def test_valid(self, device):
-        KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device=device), torch.rand(1, device=device)]) is True
+        assert KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device=device), torch.rand(1, device=device)]) is True
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
     def test_invalid(self):
@@ -135,7 +135,7 @@ class TestCheckSameDevices:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
     def test_invalid(self):
-        KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device="cpu"), torch.rand(1, device="cuda")], raises=False) is False
+        assert KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device="cpu"), torch.rand(1, device="cuda")], raises=False) is False
 
 class TestCheckIsColor:
     def test_valid(self):
@@ -158,9 +158,9 @@ class TestCheckIsColor:
 
 class TestCheckIsGray:
     def test_valid(self):
-        KORNIA_CHECK_IS_GRAY(torch.rand(1, 4, 4)) is True
-        KORNIA_CHECK_IS_GRAY(torch.rand(2, 1, 4, 4)) is True
-        KORNIA_CHECK_IS_GRAY(torch.rand(3, 1, 4, 4)) is True
+        assert KORNIA_CHECK_IS_GRAY(torch.rand(1, 4, 4)) is True
+        assert KORNIA_CHECK_IS_GRAY(torch.rand(2, 1, 4, 4)) is True
+        assert KORNIA_CHECK_IS_GRAY(torch.rand(3, 1, 4, 4)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -215,7 +215,7 @@ class TestCheckDmDesc:
 
 class TestCheckLaf:
     def test_valid(self):
-        KORNIA_CHECK_LAF(torch.rand(4, 2, 2, 3))
+        assert KORNIA_CHECK_LAF(torch.rand(4, 2, 2, 3)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
@@ -226,3 +226,6 @@ class TestCheckLaf:
             KORNIA_CHECK_LAF(torch.rand(4, 2, 2, 2))
         with pytest.raises(Exception):
             KORNIA_CHECK_LAF(torch.rand(4, 2, 3, 3, 3))
+
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_LAF(torch.rand(4, 2, 2), raises=False) is False

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -29,6 +29,7 @@ class TestCheck:
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK(False, "This should not raise", raises=False) is False
 
+
 class TestCheckShape:
     @pytest.mark.parametrize(
         "data,shape",
@@ -58,6 +59,7 @@ class TestCheckShape:
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_SHAPE(torch.rand(2, 3), ["1", "H", "W"], raises=False) is False
 
+
 class TestCheckSameShape:
     def test_valid(self):
         assert KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3), torch.rand(2, 3)) is True
@@ -74,6 +76,7 @@ class TestCheckSameShape:
 
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3), torch.rand(2, 2, 3), raises=False) is False
+
 
 class TestCheckType:
     def test_valid(self):
@@ -92,6 +95,7 @@ class TestCheckType:
 
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_TYPE("world", int, raises=False) is False
+
 
 class TestCheckIsTensor:
     def test_valid(self):
@@ -118,6 +122,7 @@ class TestCheckIsListOfTensor:
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_IS_LIST_OF_TENSOR([torch.rand(1), [2, 3], torch.rand(1)], raises=False) is False
 
+
 class TestCheckSameDevice:
     def test_valid(self, device):
         assert KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device=device), torch.rand(1, device=device)) is True
@@ -129,7 +134,10 @@ class TestCheckSameDevice:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
     def test_invalid_raises_false(self):
-        assert KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device="cpu"), torch.rand(1, device="cuda", raises=False)) is False
+        assert (
+            KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device="cpu"), torch.rand(1, device="cuda", raises=False)) is False
+        )
+
 
 class TestCheckSameDevices:
     def test_valid(self, device):
@@ -141,8 +149,12 @@ class TestCheckSameDevices:
             KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device="cpu"), torch.rand(1, device="cuda")])
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
-    def test_invalid(self):
-        assert KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device="cpu"), torch.rand(1, device="cuda")], raises=False) is False
+    def test_invalid_raises_false(self):
+        assert (
+            KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device="cpu"), torch.rand(1, device="cuda")], raises=False)
+            is False
+        )
+
 
 class TestCheckIsColor:
     def test_valid(self):
@@ -163,6 +175,7 @@ class TestCheckIsColor:
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_IS_COLOR(torch.rand(1, 4, 4), raises=False) is False
 
+
 class TestCheckIsGray:
     def test_valid(self):
         assert KORNIA_CHECK_IS_GRAY(torch.rand(1, 4, 4)) is True
@@ -182,6 +195,7 @@ class TestCheckIsGray:
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_IS_GRAY(torch.rand(1, 3, 4, 4, 4), raises=False) is False
 
+
 class TestCheckIsColorOrGray:
     def test_valid(self):
         assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(3, 4, 4)) is True
@@ -200,6 +214,7 @@ class TestCheckIsColorOrGray:
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(1, 4, 4, 4), raises=False) is False
 
+
 class TestCheckDmDesc:
     def test_valid(self):
         assert KORNIA_CHECK_DM_DESC(torch.rand(4), torch.rand(8), torch.rand(4, 8)) is True
@@ -216,6 +231,7 @@ class TestCheckDmDesc:
 
     def test_invalid_raises_false(self):
         assert KORNIA_CHECK_DM_DESC(torch.rand(4), torch.rand(8), torch.rand(4, 7), raises=False) is False
+
 
 class TestCheckLaf:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -113,7 +113,7 @@ class TestCheckIsListOfTensor:
 
 class TestCheckSameDevice:
     def test_valid(self, device):
-        KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device=device), torch.rand(1, device=device))
+        KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device=device), torch.rand(1, device=device)) is True
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
     def test_invalid(self):
@@ -126,13 +126,16 @@ class TestCheckSameDevice:
 
 class TestCheckSameDevices:
     def test_valid(self, device):
-        KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device=device), torch.rand(1, device=device)])
+        KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device=device), torch.rand(1, device=device)]) is True
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
     def test_invalid(self):
         with pytest.raises(Exception):
             KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device="cpu"), torch.rand(1, device="cuda")])
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
+    def test_invalid(self):
+        KORNIA_CHECK_SAME_DEVICES([torch.rand(1, device="cpu"), torch.rand(1, device="cuda")], raises=False) is False
 
 class TestCheckIsColor:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -148,9 +148,9 @@ class TestCheckIsColor:
 
 class TestCheckIsGray:
     def test_valid(self):
-        KORNIA_CHECK_IS_GRAY(torch.rand(1, 4, 4))
-        KORNIA_CHECK_IS_GRAY(torch.rand(2, 1, 4, 4))
-        KORNIA_CHECK_IS_GRAY(torch.rand(3, 1, 4, 4))
+        KORNIA_CHECK_IS_GRAY(torch.rand(1, 4, 4)) is True
+        KORNIA_CHECK_IS_GRAY(torch.rand(2, 1, 4, 4)) is True
+        KORNIA_CHECK_IS_GRAY(torch.rand(3, 1, 4, 4)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
@@ -162,6 +162,8 @@ class TestCheckIsGray:
         with pytest.raises(Exception):
             KORNIA_CHECK_IS_GRAY(torch.rand(1, 3, 4, 4, 4))
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_IS_GRAY(torch.rand(1, 3, 4, 4, 4), raises=False) is False
 
 class TestCheckIsColorOrGray:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -75,10 +75,10 @@ class TestCheckSameShape:
 
 class TestCheckType:
     def test_valid(self):
-        KORNIA_CHECK_TYPE("hello", str)
-        KORNIA_CHECK_TYPE(23, int)
-        KORNIA_CHECK_TYPE(torch.rand(1), torch.Tensor)
-        KORNIA_CHECK_TYPE(torch.rand(1), (int, torch.Tensor))
+        assert KORNIA_CHECK_TYPE("hello", str) is True
+        assert KORNIA_CHECK_TYPE(23, int) is True
+        assert KORNIA_CHECK_TYPE(torch.rand(1), torch.Tensor) is True
+        assert KORNIA_CHECK_TYPE(torch.rand(1), (int, torch.Tensor)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
@@ -88,6 +88,8 @@ class TestCheckType:
         with pytest.raises(Exception):
             KORNIA_CHECK_TYPE(23, (float, str))
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_TYPE("world", int, raises=False) is False
 
 class TestCheckIsTensor:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -184,12 +184,12 @@ class TestCheckIsGray:
 
 class TestCheckIsColorOrGray:
     def test_valid(self):
-        KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(3, 4, 4))
-        KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(1, 3, 4, 4))
-        KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(2, 3, 4, 4))
-        KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(1, 4, 4))
-        KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(2, 1, 4, 4))
-        KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(3, 1, 4, 4))
+        assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(3, 4, 4)) is True
+        assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(1, 3, 4, 4)) is True
+        assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(2, 3, 4, 4)) is True
+        assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(1, 4, 4)) is True
+        assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(2, 1, 4, 4)) is True
+        assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(3, 1, 4, 4)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
@@ -197,6 +197,8 @@ class TestCheckIsColorOrGray:
         with pytest.raises(Exception):
             KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(1, 3, 4, 4, 4))
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_IS_COLOR_OR_GRAY(torch.rand(1, 4, 4, 4), raises=False) is False
 
 class TestCheckDmDesc:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -72,6 +72,8 @@ class TestCheckSameShape:
         with pytest.raises(Exception):
             KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3), torch.rand(2, 3, 3))
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_SAME_SHAPE(torch.rand(2, 3), torch.rand(2, 2, 3), raises=False) is False
 
 class TestCheckType:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -200,7 +200,7 @@ class TestCheckIsColorOrGray:
 
 class TestCheckDmDesc:
     def test_valid(self):
-        KORNIA_CHECK_DM_DESC(torch.rand(4), torch.rand(8), torch.rand(4, 8))
+        assert KORNIA_CHECK_DM_DESC(torch.rand(4), torch.rand(8), torch.rand(4, 8)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
@@ -212,6 +212,8 @@ class TestCheckDmDesc:
         with pytest.raises(Exception):
             KORNIA_CHECK_DM_DESC(torch.rand(4), torch.rand(8), torch.rand(4, 3, 8))
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_DM_DESC(torch.rand(4), torch.rand(8), torch.rand(4, 7), raises=False) is False
 
 class TestCheckLaf:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -40,7 +40,7 @@ class TestCheckShape:
         ],
     )
     def test_valid(self, data, shape):
-        KORNIA_CHECK_SHAPE(data, shape)
+        KORNIA_CHECK_SHAPE(data, shape) is True
 
     @pytest.mark.parametrize(
         "data,shape",
@@ -55,6 +55,8 @@ class TestCheckShape:
         with pytest.raises(Exception):
             KORNIA_CHECK_SHAPE(data, shape)
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_SHAPE(torch.rand(2, 3), ["1", "H", "W"], raises=False) is False
 
 class TestCheckSameShape:
     def test_valid(self):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -20,12 +20,14 @@ from kornia.core.check import (
 
 class TestCheck:
     def test_valid(self):
-        KORNIA_CHECK(True, "This is a test")
+        assert KORNIA_CHECK(True, "This is a test") is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
             KORNIA_CHECK(False, "This is a test")
 
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK(False, "This should not raise", raises=False) is False
 
 class TestCheckShape:
     @pytest.mark.parametrize(

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -120,6 +120,9 @@ class TestCheckSameDevice:
         with pytest.raises(Exception):
             KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device="cpu"), torch.rand(1, device="cuda"))
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Skip if no GPU.")
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_SAME_DEVICE(torch.rand(1, device="cpu"), torch.rand(1, device="cuda", raises=False)) is False
 
 class TestCheckSameDevices:
     def test_valid(self, device):

--- a/test/core/test_check.py
+++ b/test/core/test_check.py
@@ -95,11 +95,14 @@ class TestCheckType:
 
 class TestCheckIsTensor:
     def test_valid(self):
-        KORNIA_CHECK_IS_TENSOR(torch.rand(1))
+        assert KORNIA_CHECK_IS_TENSOR(torch.rand(1)) is True
 
     def test_invalid(self):
         with pytest.raises(Exception):
             KORNIA_CHECK_IS_TENSOR([1, 2, 3])
+
+    def test_invalid_raises_false(self):
+        assert KORNIA_CHECK_IS_TENSOR([1, 2, 3], raises=False) is False
 
 
 class TestCheckIsListOfTensor:


### PR DESCRIPTION
#### Changes
- Adds optional `raises` arg to all `KORNIA_CHECK` functions; defaults to `True`, if set to `False`, returns a bool instead of raising an error
- Adds tests for `raises=False` to `KORNIA_CHECK` functions, updates existing tests to check bool return values
- Updates `KORNIA_CHECK_IS_LIST_OF_TENSOR` to raise by default to have consistent behavior with other `KORNIA_CHECK`s

Fixes #2354 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [X] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [X] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
