### PR TITLE
Replace miniconda for `setup-python@v4` on env setup CI

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -6,46 +6,43 @@ on:
       python-version:
         description: "The python version desired."
         required: true
-        default: '3.7'
+        default: '3.10'
         type: string
 
       pytorch-version:
         description: "The pytorch version desired."
         required: true
-        default: '1.9.1'
+        default: '2.0.1'
         type: string
 
 runs:
   using: "composite"
   steps:
-    - name: Setup environment (conda)
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Setup environment
+      uses: actions/setup-python@v4
       with:
-        auto-update-conda: true
         python-version: ${{ inputs.python-version }}
-
-    - name: Install curl via conda
-      shell: bash -l {0}
-      run: conda install curl -c conda-forge
+        cache: 'pip'
+        cache-dependency-path: |
+          **/pyproject.toml
+          **/requirements*.txt
 
     - if: ${{ contains(fromJson('["nightly"]'), inputs.pytorch-version ) }}
-      name: Install dependencies
-      shell: bash -l {0}
-      run: |
-            pip install numpy --pre torch[dynamo] --force-reinstall --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
-            pip install onnx
+      name: Install PyTorch nightly
+      shell: bash
+      run: pip install numpy --pre torch[dynamo] --force-reinstall --extra-index-url https://download.pytorch.org/whl/nightly/cpu/
 
     - if: ${{ contains(fromJson('["nightly"]'), inputs.pytorch-version ) == false}}
       name: Install pytorch
-      shell: bash -l {0}
-      run: conda install pytorch=${{ inputs.pytorch-version }} cpuonly -c pytorch
+      shell: bash
+      run: pip install torch==${{ inputs.pytorch-version }}
 
     - name: Install Kornia dev
-      shell: bash -l {0}
+      shell: bash
       run: pip install .[dev,x]
 
-    - name: Environment
-      shell: bash -l {0}
+    - name: Check dependencies and kornia version
+      shell: bash
       run: |
-        curl -O https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py
-        python collect_env.py
+        python -c "import torch;print('Pytorch version: ', torch.__version__)"
+        python -c "import kornia;print('Kornia version: ', kornia.__version__)"

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -22,10 +22,6 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
-        cache: 'pip'
-        cache-dependency-path: |
-          **/pyproject.toml
-          **/requirements*.txt
 
     - if: ${{ contains(fromJson('["nightly"]'), inputs.pytorch-version ) }}
       name: Install PyTorch nightly

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -35,7 +35,7 @@ runs:
     - if: ${{ contains(fromJson('["nightly"]'), inputs.pytorch-version ) == false}}
       name: Install pytorch
       shell: bash
-      run: pip install torch==${{ inputs.pytorch-version }}
+      run: pip install torch==${{ inputs.pytorch-version }} --index-url https://download.pytorch.org/whl/cpu
 
     - name: Install Kornia dev
       shell: bash

--- a/.github/actions_info.md
+++ b/.github/actions_info.md
@@ -8,12 +8,12 @@ responsible for the setup of an environment for kornia in development mode on
 CI.
 
 Use the actions:
-- `conda-incubator/setup-miniconda`
+- `setup-python@v4`
 
 Has the inputs:
-- `python-version`: (string, default: `'3.7'`) the python version desired.
-  - The version should be supported by `setup-miniconda` action.
-- `pytorch-version`: (string, default: `'1.9.1`') the pytorch version desired.
+- `python-version`: (string, default: `'3.10'`) the python version desired.
+  - The version should be supported by `setup-python@v4` action.
+- `pytorch-version`: (string, default: `'2.0.1`') the pytorch version desired.
   - This value will be used to install pytorch using conda from pytorch
     channel.
   - If the value passed is `nightly` the nightly version of pytorch with dynamo


### PR DESCRIPTION
This patch replaces the `setup-miniconda` with the default `setup-python`. ~The idea is to use the caching tool already configured on it to try to speed up the CI.~