### PR TITLE
Batched quaternion to matrix

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -566,7 +566,7 @@ def quaternion_to_rotation_matrix(
     tzz: Tensor = tz * z
     one: Tensor = tensor(1.0)
 
-    matrix: Tensor = stack(
+    matrix_flat: Tensor = stack(
         (
             one - (tyy + tzz),
             txy - twz,
@@ -579,10 +579,12 @@ def quaternion_to_rotation_matrix(
             one - (txx + tyy),
         ),
         dim=-1,
-    ).view(-1, 3, 3)
+    )
 
-    if len(quaternion.shape) == 1:
-        matrix = torch.squeeze(matrix, dim=0)
+    # this slightly awkward construction of the output shape is to satisfy torchscript
+    output_shape = list(quaternion.shape[:-1]) + [3, 3]
+    matrix = matrix_flat.reshape(output_shape)
+
     return matrix
 
 

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -239,7 +239,7 @@ class Quaternion(Module):
             >>> m
             tensor([[1., 0., 0.],
                     [0., 1., 0.],
-                    [0., 0., 1.]], grad_fn=<SqueezeBackward1>)
+                    [0., 0., 1.]], grad_fn=<ReshapeAliasBackward0>)
         """
         return quaternion_to_rotation_matrix(self.data, order=QuaternionCoeffOrder.WXYZ)
 

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -544,20 +544,20 @@ class TestRotationMatrixToQuaternion:
 
 
 class TestQuaternionToRotationMatrix:
-    @pytest.mark.parametrize("batch_size", (1, 3, 8))
-    def test_smoke_batch_xyzw(self, batch_size, device, dtype):
-        quaternion = torch.zeros(batch_size, 4, device=device, dtype=dtype)
+    @pytest.mark.parametrize("batch_dims", ((1, ), (3, ), (8, ), (1, 1), (5, 6)))
+    def test_smoke_batch_xyzw(self, batch_dims, device, dtype):
+        quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
         with pytest.warns(UserWarning):
             matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
                 quaternion, order=QuaternionCoeffOrder.XYZW
             )
-        assert matrix.shape == (batch_size, 3, 3)
+        assert matrix.shape == (*batch_dims, 3, 3)
 
-    @pytest.mark.parametrize("batch_size", (1, 3, 8))
-    def test_smoke_batch(self, batch_size, device, dtype):
-        quaternion = torch.zeros(batch_size, 4, device=device, dtype=dtype)
+    @pytest.mark.parametrize("batch_dims", ((1, ), (3, ), (8, ), (1, 1), (5, 6)))
+    def test_smoke_batch(self, batch_dims, device, dtype):
+        quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
-        assert matrix.shape == (batch_size, 3, 3)
+        assert matrix.shape == (*batch_dims, 3, 3)
 
     def test_unit_quaternion_xyzw(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -544,7 +544,7 @@ class TestRotationMatrixToQuaternion:
 
 
 class TestQuaternionToRotationMatrix:
-    @pytest.mark.parametrize("batch_dims", ((1, ), (3, ), (8, ), (1, 1), (5, 6)))
+    @pytest.mark.parametrize("batch_dims", ((), (1, ), (3, ), (8, ), (1, 1), (5, 6)))
     def test_smoke_batch_xyzw(self, batch_dims, device, dtype):
         quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
         with pytest.warns(UserWarning):
@@ -553,7 +553,7 @@ class TestQuaternionToRotationMatrix:
             )
         assert matrix.shape == (*batch_dims, 3, 3)
 
-    @pytest.mark.parametrize("batch_dims", ((1, ), (3, ), (8, ), (1, 1), (5, 6)))
+    @pytest.mark.parametrize("batch_dims", ((), (1, ), (3, ), (8, ), (1, 1), (5, 6)))
     def test_smoke_batch(self, batch_dims, device, dtype):
         quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -544,7 +544,7 @@ class TestRotationMatrixToQuaternion:
 
 
 class TestQuaternionToRotationMatrix:
-    @pytest.mark.parametrize("batch_dims", ((), (1, ), (3, ), (8, ), (1, 1), (5, 6)))
+    @pytest.mark.parametrize("batch_dims", ((), (1,), (3,), (8,), (1, 1), (5, 6)))
     def test_smoke_batch_xyzw(self, batch_dims, device, dtype):
         quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
         with pytest.warns(UserWarning):
@@ -553,7 +553,7 @@ class TestQuaternionToRotationMatrix:
             )
         assert matrix.shape == (*batch_dims, 3, 3)
 
-    @pytest.mark.parametrize("batch_dims", ((), (1, ), (3, ), (8, ), (1, 1), (5, 6)))
+    @pytest.mark.parametrize("batch_dims", ((), (1,), (3,), (8,), (1, 1), (5, 6)))
     def test_smoke_batch(self, batch_dims, device, dtype):
         quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)


### PR DESCRIPTION
#### Changes
The docs for `quaternion_to_rotation_matrix` state that the input can be of shape `(*, 4)` leading to output of shape `(*, 3, 3)` but in actuality only a single batch dimension worked. This PR adjust tests to catch that case and fixes the issue.


#### Type of change
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
