### PR TITLE
Fix AugmentationSequential support for RandomResizedCrop

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -159,7 +159,7 @@ class AugmentationSequential(ImageSequential):
         random_apply: Union[int, bool, Tuple[int, int]] = False,
         random_apply_weights: Optional[List[float]] = None,
         transformation_matrix: str = "silence",
-        extra_args: Dict[DataKey, Dict[str, Any]] = {DataKey.MASK: dict(resample=Resample.NEAREST, align_corners=True)},
+        extra_args: Dict[DataKey, Dict[str, Any]] = {DataKey.MASK: dict(resample=Resample.NEAREST, align_corners=None)},
     ) -> None:
         super().__init__(
             *args,

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -450,6 +450,18 @@ class TestAugmentationSequential:
         assert out_inv[3].shape == points.shape
         assert_close(out_inv[3], points, atol=1e-4, rtol=1e-4)
 
+    def test_random_resized_crop(self, device, dtype):
+        size = 50
+        input = torch.randn(3, 3, 100, 100, device=device, dtype=dtype)
+        mask = torch.randn(3, 1, 100, 100, device=device, dtype=dtype)
+        aug = K.AugmentationSequential(K.RandomResizedCrop((size, size), p=1.0), data_keys=["input", "mask"])
+
+        reproducibility_test((input, mask), aug)
+
+        out = aug(input, mask)
+        assert out[0].shape == (3, 3, size, size)
+        assert out[1].shape == (3, 1, size, size)
+
     @pytest.mark.parametrize(
         'bbox',
         [


### PR DESCRIPTION
#### Changes

Fixes support for `AugmentationSequential` to use `RandomResizedCrop` out of the box. Confirmed that the test I added fails without this change.

Fixes #2396

#### Type of change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?

Let me know if you want me to update the Changelog.