### PR TITLE
Makefile: Drop Python code formatter yapf in favor of psf/black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,6 @@ lint: FORCE
 mypy: FORCE
 	mypy
 
-yapf: FORCE
-	yapf --in-place --parallel --recursive kornia/ test/
-
 doctest:
 	pytest -v --doctest-modules kornia/
 


### PR DESCRIPTION
As discussed at https://github.com/kornia/kornia/pull/2358#issuecomment-1546592237
* https://github.com/search?q=repo%3Akornia%2Fkornia+yapf&type=code
* https://github.com/search?q=repo%3Akornia%2Fkornia+black&type=code

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update
- [x] Code formatting


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
