### PR TITLE
Remove deprecated code from `kornia.geometry.conversion`

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import enum
-import warnings
 
 import torch
 import torch.nn.functional as F

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -373,19 +373,16 @@ def rotation_matrix_to_angle_axis(rotation_matrix: Tensor) -> Tensor:
 
 
 def rotation_matrix_to_quaternion(
-    rotation_matrix: Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW
+    rotation_matrix: Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.WXYZ
 ) -> Tensor:
     r"""Convert 3x3 rotation matrix to 4d quaternion vector.
 
-    The quaternion vector has components in (w, x, y, z) or (x, y, z, w) format.
-
-    .. note::
-        The (x, y, z, w) order is going to be deprecated in favor of efficiency.
+    The quaternion vector has components in (w, x, y, z) format.
 
     Args:
         rotation_matrix: the rotation matrix to convert with shape :math:`(*, 3, 3)`.
         eps: small value to avoid zero division.
-        order: quaternion coefficient order. Note: 'xyzw' will be deprecated in favor of 'wxyz'.
+        order: quaternion coefficient order.
 
     Return:
         the rotation in quaternion with shape :math:`(*, 4)`.
@@ -488,16 +485,16 @@ def normalize_quaternion(quaternion: Tensor, eps: float = 1.0e-12) -> Tensor:
 
 
 def quaternion_to_rotation_matrix(
-    quaternion: Tensor, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW
+    quaternion: Tensor, order: QuaternionCoeffOrder = QuaternionCoeffOrder.WXYZ
 ) -> Tensor:
     r"""Convert a quaternion to a rotation matrix.
 
-    The quaternion should be in (x, y, z, w) or (w, x, y, z) format.
+    The quaternion should be in (w, x, y, z) format.
 
     Args:
         quaternion: a tensor containing a quaternion to be converted.
           The tensor can be of shape :math:`(*, 4)`.
-        order: quaternion coefficient order. Note: 'xyzw' will be deprecated in favor of 'wxyz'.
+        order: quaternion coefficient order.
 
     Return:
         the rotation matrix of shape :math:`(*, 3, 3)`.
@@ -561,16 +558,16 @@ def quaternion_to_rotation_matrix(
     return matrix
 
 
-def quaternion_to_angle_axis(quaternion: Tensor, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW) -> Tensor:
+def quaternion_to_angle_axis(quaternion: Tensor, order: QuaternionCoeffOrder = QuaternionCoeffOrder.WXYZ) -> Tensor:
     """Convert quaternion vector to angle axis of rotation in radians.
 
-    The quaternion should be in (x, y, z, w) or (w, x, y, z) format.
+    The quaternion should be in (w, x, y, z) format.
 
     Adapted from ceres C++ library: ceres-solver/include/ceres/rotation.h
 
     Args:
         quaternion: tensor with quaternions.
-        order: quaternion coefficient order. Note: 'xyzw' will be deprecated in favor of 'wxyz'.
+        order: quaternion coefficient order.
 
     Return:
         tensor with angle axis of rotation.
@@ -623,17 +620,17 @@ def quaternion_to_angle_axis(quaternion: Tensor, order: QuaternionCoeffOrder = Q
 
 
 def quaternion_log_to_exp(
-    quaternion: Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW
+    quaternion: Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.WXYZ
 ) -> Tensor:
     r"""Apply exponential map to log quaternion.
 
-    The quaternion should be in (x, y, z, w) or (w, x, y, z) format.
+    The quaternion should be in (w, x, y, z) format.
 
     Args:
         quaternion: a tensor containing a quaternion to be converted.
           The tensor can be of shape :math:`(*, 3)`.
         eps: a small number for clamping.
-        order: quaternion coefficient order. Note: 'xyzw' will be deprecated in favor of 'wxyz'.
+        order: quaternion coefficient order.
 
     Return:
         the quaternion exponential map of shape :math:`(*, 4)`.
@@ -668,17 +665,17 @@ def quaternion_log_to_exp(
 
 
 def quaternion_exp_to_log(
-    quaternion: Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW
+    quaternion: Tensor, eps: float = 1.0e-8, order: QuaternionCoeffOrder = QuaternionCoeffOrder.WXYZ
 ) -> Tensor:
     r"""Apply the log map to a quaternion.
 
-    The quaternion should be in (x, y, z, w) format.
+    The quaternion should be in (w, x, y, z) format.
 
     Args:
         quaternion: a tensor containing a quaternion to be converted.
           The tensor can be of shape :math:`(*, 4)`.
         eps: a small number for clamping.
-        order: quaternion coefficient order. Note: 'xyzw' will be deprecated in favor of 'wxyz'.
+        order: quaternion coefficient order.
 
     Return:
         the quaternion log map of shape :math:`(*, 3)`.
@@ -718,16 +715,16 @@ def quaternion_exp_to_log(
 # https://github.com/facebookresearch/QuaterNet/blob/master/common/quaternion.py#L138
 
 
-def angle_axis_to_quaternion(angle_axis: Tensor, order: QuaternionCoeffOrder = QuaternionCoeffOrder.XYZW) -> Tensor:
+def angle_axis_to_quaternion(angle_axis: Tensor, order: QuaternionCoeffOrder = QuaternionCoeffOrder.WXYZ) -> Tensor:
     r"""Convert an angle axis to a quaternion.
 
-    The quaternion vector has components in (x, y, z, w) or (w, x, y, z) format.
+    The quaternion vector has components in (w, x, y, z) format.
 
     Adapted from ceres C++ library: ceres-solver/include/ceres/rotation.h
 
     Args:
         angle_axis: tensor with angle axis in radians.
-        order: quaternion coefficient order. Note: 'xyzw' will be deprecated in favor of 'wxyz'.
+        order: quaternion coefficient order.
 
     Return:
         tensor with quaternion.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -365,9 +365,7 @@ def rotation_matrix_to_angle_axis(rotation_matrix: Tensor) -> Tensor:
     return quaternion_to_angle_axis(quaternion)
 
 
-def rotation_matrix_to_quaternion(
-    rotation_matrix: Tensor, eps: float = 1.0e-8
-) -> Tensor:
+def rotation_matrix_to_quaternion(rotation_matrix: Tensor, eps: float = 1.0e-8) -> Tensor:
     r"""Convert 3x3 rotation matrix to 4d quaternion vector.
 
     The quaternion vector has components in (w, x, y, z) format.
@@ -472,9 +470,7 @@ def normalize_quaternion(quaternion: Tensor, eps: float = 1.0e-12) -> Tensor:
 # https://github.com/tensorflow/graphics/blob/master/tensorflow_graphics/geometry/transformation/rotation_matrix_3d.py#L247
 
 
-def quaternion_to_rotation_matrix(
-    quaternion: Tensor
-) -> Tensor:
+def quaternion_to_rotation_matrix(quaternion: Tensor) -> Tensor:
     r"""Convert a quaternion to a rotation matrix.
 
     The quaternion should be in (w, x, y, z) format.
@@ -602,9 +598,7 @@ def quaternion_to_angle_axis(quaternion: Tensor) -> Tensor:
     return angle_axis
 
 
-def quaternion_log_to_exp(
-    quaternion: Tensor, eps: float = 1.0e-8
-) -> Tensor:
+def quaternion_log_to_exp(quaternion: Tensor, eps: float = 1.0e-8) -> Tensor:
     r"""Apply exponential map to log quaternion.
 
     The quaternion should be in (w, x, y, z) format.
@@ -642,9 +636,7 @@ def quaternion_log_to_exp(
     return quaternion_exp
 
 
-def quaternion_exp_to_log(
-    quaternion: Tensor, eps: float = 1.0e-8
-) -> Tensor:
+def quaternion_exp_to_log(quaternion: Tensor, eps: float = 1.0e-8) -> Tensor:
     r"""Apply the log map to a quaternion.
 
     The quaternion should be in (w, x, y, z) format.

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -8,7 +8,6 @@ from typing import Optional, Tuple, Union
 from kornia.core import Device, Dtype, Module, Parameter, Tensor, concatenate, rand, stack, tensor, where
 from kornia.core.check import KORNIA_CHECK_TYPE
 from kornia.geometry.conversions import (
-    QuaternionCoeffOrder,
     angle_axis_to_quaternion,
     normalize_quaternion,
     quaternion_to_rotation_matrix,
@@ -241,7 +240,7 @@ class Quaternion(Module):
                     [0., 1., 0.],
                     [0., 0., 1.]], grad_fn=<ReshapeAliasBackward0>)
         """
-        return quaternion_to_rotation_matrix(self.data, order=QuaternionCoeffOrder.WXYZ)
+        return quaternion_to_rotation_matrix(self.data)
 
     @classmethod
     def from_matrix(cls, matrix: Tensor) -> 'Quaternion':
@@ -257,7 +256,7 @@ class Quaternion(Module):
             Parameter containing:
             tensor([[1., 0., 0., 0.]], requires_grad=True)
         """
-        return cls(rotation_matrix_to_quaternion(matrix, order=QuaternionCoeffOrder.WXYZ))
+        return cls(rotation_matrix_to_quaternion(matrix))
 
     @classmethod
     def from_axis_angle(cls, axis_angle: Tensor) -> 'Quaternion':
@@ -273,7 +272,7 @@ class Quaternion(Module):
             Parameter containing:
             tensor([[0.8776, 0.4794, 0.0000, 0.0000]], requires_grad=True)
         """
-        return cls(angle_axis_to_quaternion(axis_angle, order=QuaternionCoeffOrder.WXYZ))
+        return cls(angle_axis_to_quaternion(axis_angle))
 
     @classmethod
     def identity(

--- a/kornia/nerf/camera_utils.py
+++ b/kornia/nerf/camera_utils.py
@@ -5,7 +5,7 @@ import torch
 
 from kornia.core import Device, Tensor
 from kornia.geometry.camera import PinholeCamera
-from kornia.geometry.conversions import QuaternionCoeffOrder, quaternion_to_rotation_matrix
+from kornia.geometry.conversions import quaternion_to_rotation_matrix
 
 
 def parse_colmap_output(
@@ -94,7 +94,7 @@ def parse_colmap_output(
 
             # Extrinsic
             q = torch.tensor([qw, qx, qy, qz], device=device)
-            R = quaternion_to_rotation_matrix(q, order=QuaternionCoeffOrder.WXYZ)
+            R = quaternion_to_rotation_matrix(q)
             t = torch.tensor([tx, ty, tz], device=device)
             extrinsic = torch.eye(4, device=device, dtype=dtype)
             extrinsic[:3, :3] = R

--- a/test/geometry/liegroup/test_se3.py
+++ b/test/geometry/liegroup/test_se3.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from kornia.geometry.conversions import QuaternionCoeffOrder, euler_from_quaternion, rotation_matrix_to_quaternion
+from kornia.geometry.conversions import euler_from_quaternion, rotation_matrix_to_quaternion
 from kornia.geometry.liegroup import Se3, So3
 from kornia.geometry.quaternion import Quaternion
 from kornia.geometry.vector import Vector3
@@ -201,7 +201,7 @@ class TestSe3(BaseTester):
     def test_rot_x(self, device, dtype, batch_size):
         x = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         se3 = Se3.rot_x(x)
-        quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
+        quat = rotation_matrix_to_quaternion(se3.so3.matrix())
         quat = Quaternion(quat)
         roll, _, _ = euler_from_quaternion(*quat.coeffs)
         self.assert_close(x, roll)
@@ -211,7 +211,7 @@ class TestSe3(BaseTester):
     def test_rot_y(self, device, dtype, batch_size):
         y = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         se3 = Se3.rot_y(y)
-        quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
+        quat = rotation_matrix_to_quaternion(se3.so3.matrix())
         quat = Quaternion(quat)
         _, pitch, _ = euler_from_quaternion(*quat.coeffs)
         self.assert_close(y, pitch)
@@ -221,7 +221,7 @@ class TestSe3(BaseTester):
     def test_rot_z(self, device, dtype, batch_size):
         z = self._make_rand_data(device, dtype, batch_size, dims=1).squeeze(-1)
         se3 = Se3.rot_z(z)
-        quat = rotation_matrix_to_quaternion(se3.so3.matrix(), order=QuaternionCoeffOrder.WXYZ)
+        quat = rotation_matrix_to_quaternion(se3.so3.matrix())
         quat = Quaternion(quat)
         _, _, yaw = euler_from_quaternion(*quat.coeffs)
         self.assert_close(z, yaw)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -243,7 +243,7 @@ class TestRotationMatrixToQuaternion:
             fast_mode=True,
         )
 
-    def test_dynamo(self, device, dtype, torch_optimizer, order):
+    def test_dynamo(self, device, dtype, torch_optimizer):
         quaternion = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_log_to_exp
         op_optimized = torch_optimizer(op)
@@ -296,7 +296,7 @@ class TestQuaternionToRotationMatrix:
             fast_mode=True,
         )
 
-    def test_dynamo(self, device, dtype, torch_optimizer, order):
+    def test_dynamo(self, device, dtype, torch_optimizer):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_to_rotation_matrix
         op_optimized = torch_optimizer(op)
@@ -365,7 +365,7 @@ class TestQuaternionLogToExp:
             fast_mode=True,
         )
 
-    def test_dynamo(self, device, dtype, torch_optimizer, order):
+    def test_dynamo(self, device, dtype, torch_optimizer):
         quaternion = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_log_to_exp
         op_optimized = torch_optimizer(op)
@@ -431,7 +431,7 @@ class TestQuaternionExpToLog:
             fast_mode=True,
         )
 
-    def test_dynamo(self, device, dtype, torch_optimizer, order):
+    def test_dynamo(self, device, dtype, torch_optimizer):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_exp_to_log
         op_optimized = torch_optimizer(op)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -8,7 +8,6 @@ from torch.autograd import gradcheck
 import kornia
 from kornia.geometry.conversions import (
     ARKitQTVecs_to_ColmapQTVecs,
-    QuaternionCoeffOrder,
     Rt_to_matrix4x4,
     camtoworld_graphics_to_vision_4x4,
     camtoworld_graphics_to_vision_Rt,
@@ -47,61 +46,61 @@ def rtol(device, dtype):
 class TestAngleAxisToQuaternion:
     def test_smoke(self, device, dtype):
         angle_axis = torch.zeros(3, dtype=dtype, device=device)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert quaternion.shape == (4,)
 
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
         angle_axis = torch.zeros(batch_size, 3, device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert quaternion.shape == (batch_size, 4)
 
     def test_zero_angle(self, device, dtype, atol, rtol):
         angle_axis = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_x(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         angle_axis = torch.tensor((theta, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((np.cos(theta / 2.0), np.sin(theta / 2.0), 0.0, 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_y(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         angle_axis = torch.tensor((0.0, theta, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((np.cos(theta / 2.0), 0.0, np.sin(theta / 2.0), 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_z(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         angle_axis = torch.tensor((0.0, 0.0, theta), device=device, dtype=dtype)
         expected = torch.tensor((np.cos(theta / 2.0), 0.0, 0.0, np.sin(theta / 2.0)), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_x_rotation(self, device, dtype, atol, rtol):
         half_sqrt2 = 0.5 * np.sqrt(2.0)
         angle_axis = torch.tensor((kornia.pi / 2.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((half_sqrt2, half_sqrt2, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_y_rotation(self, device, dtype, atol, rtol):
         half_sqrt2 = 0.5 * np.sqrt(2.0)
         angle_axis = torch.tensor((0.0, kornia.pi / 2.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((half_sqrt2, 0.0, half_sqrt2, 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_z_rotation(self, device, dtype, atol, rtol):
         half_sqrt2 = 0.5 * np.sqrt(2.0)
         angle_axis = torch.tensor((0.0, 0.0, kornia.pi / 2.0), device=device, dtype=dtype)
         expected = torch.tensor((half_sqrt2, 0.0, 0.0, half_sqrt2), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_gradcheck(self, device, dtype):
@@ -110,7 +109,7 @@ class TestAngleAxisToQuaternion:
         angle_axis = tensor_to_gradcheck_var(angle_axis)
         # evaluate function gradient
         assert gradcheck(
-            partial(kornia.geometry.conversions.angle_axis_to_quaternion, order=QuaternionCoeffOrder.WXYZ),
+            partial(kornia.geometry.conversions.angle_axis_to_quaternion),
             (angle_axis,),
             raise_exception=True,
             fast_mode=True,
@@ -120,58 +119,58 @@ class TestAngleAxisToQuaternion:
 class TestQuaternionToAngleAxis:
     def test_smoke(self, device, dtype):
         quaternion = torch.zeros(4, device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert angle_axis.shape == (3,)
 
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
         quaternion = torch.zeros(batch_size, 4, device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert angle_axis.shape == (batch_size, 3)
 
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_x_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((kornia.pi, 0.0, 0.0), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_y_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, kornia.pi, 0.0), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_z_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((np.sqrt(3.0) / 2.0, 0.0, 0.0, 0.5), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, kornia.pi / 3.0), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_x(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         quaternion = torch.tensor((np.cos(theta / 2.0), np.sin(theta / 2.0), 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((theta, 0.0, 0.0), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_y(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         quaternion = torch.tensor((np.cos(theta / 2), 0.0, np.sin(theta / 2), 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, theta, 0.0), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_z(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         quaternion = torch.tensor((np.cos(theta / 2), 0.0, 0.0, np.sin(theta / 2)), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, theta), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_gradcheck(self, device, dtype):
@@ -180,7 +179,7 @@ class TestQuaternionToAngleAxis:
         quaternion = tensor_to_gradcheck_var(quaternion)
         # evaluate function gradient
         assert gradcheck(
-            partial(kornia.geometry.conversions.quaternion_to_angle_axis, order=QuaternionCoeffOrder.WXYZ),
+            partial(kornia.geometry.conversions.quaternion_to_angle_axis),
             (quaternion,),
             raise_exception=True,
             fast_mode=True,
@@ -191,30 +190,30 @@ class TestRotationMatrixToQuaternion:
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
         matrix = torch.zeros(batch_size, 3, 3, device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix)
         assert quaternion.shape == (batch_size, 4)
 
     def test_identity(self, device, dtype, atol, rtol):
         matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
         expected = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_rot_x_45(self, device, dtype, atol, rtol):
         matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, 1.0, 0.0)), device=device, dtype=dtype)
         pi_half2 = torch.cos(kornia.pi / 4.0).to(device=device, dtype=dtype)
         expected = torch.tensor((pi_half2, pi_half2, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_back_and_forth(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, 1.0, 0.0)), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            matrix, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            matrix, eps=eps
         )
         matrix_hat = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-            quaternion, order=QuaternionCoeffOrder.WXYZ
+            quaternion
         )
         assert_close(matrix, matrix_hat, atol=atol, rtol=rtol)
 
@@ -233,7 +232,7 @@ class TestRotationMatrixToQuaternion:
             (0.177614107728004, 0.280136495828629, -0.440902262926102, 0.834015488624573), device=device, dtype=dtype
         )
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            matrix, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            matrix, eps=eps
         )
         torch.set_printoptions(precision=10)
         assert_close(quaternion_true, quaternion, atol=atol, rtol=rtol)
@@ -245,21 +244,20 @@ class TestRotationMatrixToQuaternion:
         # evaluate function gradient
         assert gradcheck(
             partial(
-                kornia.geometry.conversions.rotation_matrix_to_quaternion, eps=eps, order=QuaternionCoeffOrder.WXYZ
+                kornia.geometry.conversions.rotation_matrix_to_quaternion, eps=eps
             ),
             (matrix,),
             raise_exception=True,
             fast_mode=True,
         )
 
-    @pytest.mark.parametrize('order', ['wxyz', 'xyzw'])
     def test_dynamo(self, device, dtype, torch_optimizer, order):
         quaternion = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_log_to_exp
         op_optimized = torch_optimizer(op)
 
-        actual = op_optimized(quaternion, order=QuaternionCoeffOrder(order))
-        expected = op(quaternion, order=QuaternionCoeffOrder(order))
+        actual = op_optimized(quaternion)
+        expected = op(quaternion)
 
         assert_close(actual, expected)
 
@@ -268,31 +266,31 @@ class TestQuaternionToRotationMatrix:
     @pytest.mark.parametrize("batch_dims", ((), (1,), (3,), (8,), (1, 1), (5, 6)))
     def test_smoke_batch(self, batch_dims, device, dtype):
         quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
-        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert matrix.shape == (*batch_dims, 3, 3)
 
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
-        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert_close(matrix, expected, atol=atol, rtol=rtol)
 
     def test_x_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor(((1.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, -1.0)), device=device, dtype=dtype)
-        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert_close(matrix, expected, atol=atol, rtol=rtol)
 
     def test_y_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor(((-1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, -1.0)), device=device, dtype=dtype)
-        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert_close(matrix, expected, atol=atol, rtol=rtol)
 
     def test_z_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
         expected = torch.tensor(((-1.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
-        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert_close(matrix, expected, atol=atol, rtol=rtol)
 
     def test_gradcheck(self, device, dtype):
@@ -300,20 +298,19 @@ class TestQuaternionToRotationMatrix:
         quaternion = tensor_to_gradcheck_var(quaternion)
         # evaluate function gradient
         assert gradcheck(
-            partial(kornia.geometry.conversions.quaternion_to_rotation_matrix, order=QuaternionCoeffOrder.WXYZ),
+            partial(kornia.geometry.conversions.quaternion_to_rotation_matrix),
             (quaternion,),
             raise_exception=True,
             fast_mode=True,
         )
 
-    @pytest.mark.parametrize('order', ['wxyz', 'xyzw'])
     def test_dynamo(self, device, dtype, torch_optimizer, order):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_to_rotation_matrix
         op_optimized = torch_optimizer(op)
 
-        actual = op_optimized(quaternion, order=QuaternionCoeffOrder(order))
-        expected = op(quaternion, order=QuaternionCoeffOrder(order))
+        actual = op_optimized(quaternion)
+        expected = op(quaternion)
 
         assert_close(actual, expected)
 
@@ -323,7 +320,7 @@ class TestQuaternionLogToExp:
     def test_smoke_batch(self, batch_size, device, dtype):
         quaternion_log = torch.zeros(batch_size, 3, device=device, dtype=dtype)
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, order=QuaternionCoeffOrder.WXYZ
+            quaternion_log
         )
         assert quaternion_exp.shape == (batch_size, 4)
 
@@ -332,7 +329,7 @@ class TestQuaternionLogToExp:
         quaternion_log = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_log, eps=eps
         )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
@@ -342,7 +339,7 @@ class TestQuaternionLogToExp:
         quaternion_log = torch.tensor((1.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((torch.cos(one), torch.sin(one), 0.0, 0.0), device=device, dtype=dtype)
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_log, eps=eps
         )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
@@ -352,7 +349,7 @@ class TestQuaternionLogToExp:
         quaternion_log = torch.tensor((0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((torch.cos(one), 0.0, torch.sin(one), 0.0), device=device, dtype=dtype)
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_log, eps=eps
         )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
@@ -362,7 +359,7 @@ class TestQuaternionLogToExp:
         quaternion_log = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
         expected = torch.tensor((torch.cos(one), 0.0, 0.0, torch.sin(one)), device=device, dtype=dtype)
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_log, eps=eps
         )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
@@ -371,10 +368,10 @@ class TestQuaternionLogToExp:
         quaternion_log = torch.tensor((1.0, 0.0, 0.0), device=device, dtype=dtype)
 
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_log, eps=eps
         )
         quaternion_log_hat = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_exp, eps=eps
         )
         assert_close(quaternion_log, quaternion_log_hat, atol=atol, rtol=rtol)
 
@@ -384,20 +381,19 @@ class TestQuaternionLogToExp:
         quaternion = tensor_to_gradcheck_var(quaternion)
         # evaluate function gradient
         assert gradcheck(
-            partial(kornia.geometry.conversions.quaternion_log_to_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ),
+            partial(kornia.geometry.conversions.quaternion_log_to_exp, eps=eps),
             (quaternion,),
             raise_exception=True,
             fast_mode=True,
         )
 
-    @pytest.mark.parametrize('order', ['wxyz', 'xyzw'])
     def test_dynamo(self, device, dtype, torch_optimizer, order):
         quaternion = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_log_to_exp
         op_optimized = torch_optimizer(op)
 
-        actual = op_optimized(quaternion, order=QuaternionCoeffOrder(order))
-        expected = op(quaternion, order=QuaternionCoeffOrder(order))
+        actual = op_optimized(quaternion)
+        expected = op(quaternion)
 
         assert_close(actual, expected)
 
@@ -408,7 +404,7 @@ class TestQuaternionExpToLog:
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.zeros(batch_size, 4, device=device, dtype=dtype)
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_exp, eps=eps
         )
         assert quaternion_log.shape == (batch_size, 3)
 
@@ -417,7 +413,7 @@ class TestQuaternionExpToLog:
         quaternion_exp = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_exp, eps=eps
         )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
@@ -426,7 +422,7 @@ class TestQuaternionExpToLog:
         quaternion_exp = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((kornia.pi / 2.0, 0.0, 0.0), device=device, dtype=dtype)
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_exp, eps=eps
         )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
@@ -435,7 +431,7 @@ class TestQuaternionExpToLog:
         quaternion_exp = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, kornia.pi / 2.0, 0.0), device=device, dtype=dtype)
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_exp, eps=eps
         )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
@@ -444,7 +440,7 @@ class TestQuaternionExpToLog:
         quaternion_exp = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, kornia.pi / 2.0), device=device, dtype=dtype)
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_exp, eps=eps
         )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
@@ -452,10 +448,10 @@ class TestQuaternionExpToLog:
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_exp, eps=eps
         )
         quaternion_exp_hat = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            quaternion_log, eps=eps
         )
         assert_close(quaternion_exp, quaternion_exp_hat, atol=atol, rtol=rtol)
 
@@ -465,20 +461,19 @@ class TestQuaternionExpToLog:
         quaternion = tensor_to_gradcheck_var(quaternion)
         # evaluate function gradient
         assert gradcheck(
-            partial(kornia.geometry.conversions.quaternion_exp_to_log, eps=eps, order=QuaternionCoeffOrder.WXYZ),
+            partial(kornia.geometry.conversions.quaternion_exp_to_log, eps=eps),
             (quaternion,),
             raise_exception=True,
             fast_mode=True,
         )
 
-    @pytest.mark.parametrize('order', ['wxyz', 'xyzw'])
     def test_dynamo(self, device, dtype, torch_optimizer, order):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         op = kornia.geometry.conversions.quaternion_exp_to_log
         op_optimized = torch_optimizer(op)
 
-        actual = op_optimized(quaternion, order=QuaternionCoeffOrder(order))
-        expected = op(quaternion, order=QuaternionCoeffOrder(order))
+        actual = op_optimized(quaternion)
+        expected = op(quaternion)
 
         assert_close(actual, expected)
 
@@ -540,7 +535,7 @@ class TestRotationMatrixToAngleAxis:
         quaternion = torch.rand(batch_size, 4, device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.normalize_quaternion(quaternion + 1e-6)
         rotation_matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-            quaternion=quaternion, order=QuaternionCoeffOrder.WXYZ
+            quaternion=quaternion
         )
 
         eye_batch = create_eye_batch(batch_size, 3, device=device, dtype=dtype)
@@ -553,7 +548,7 @@ class TestRotationMatrixToAngleAxis:
         quaternion = torch.rand(batch_size, 4, device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.normalize_quaternion(quaternion + 1e-6)
         rotation_matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-            quaternion=quaternion, order=QuaternionCoeffOrder.WXYZ
+            quaternion=quaternion
         )
         # evaluate function gradient
         rotation_matrix = tensor_to_gradcheck_var(rotation_matrix)  # to var
@@ -1229,11 +1224,11 @@ class TestCARKitToColmap:
         t = torch.tensor([1, 0, 0], device=device, dtype=dtype).view(1, 3, 1)
         ang_deg = torch.tensor([45, 60.0, 0.0], device=device, dtype=dtype)[None]
         ang_rad = kornia.geometry.conversions.deg2rad(ang_deg)
-        qvec = kornia.geometry.angle_axis_to_quaternion(ang_rad, order=QuaternionCoeffOrder.WXYZ)
+        qvec = kornia.geometry.angle_axis_to_quaternion(ang_rad)
 
         q_colmap, t_colmap = ARKitQTVecs_to_ColmapQTVecs(qvec, t)
 
-        angles_colmap = kornia.geometry.conversions.quaternion_to_angle_axis(q_colmap, order=QuaternionCoeffOrder.WXYZ)
+        angles_colmap = kornia.geometry.conversions.quaternion_to_angle_axis(q_colmap)
         angles_colmap = kornia.geometry.conversions.rad2deg(angles_colmap)
         expected_angles = torch.tensor([[116.8870620728, 0.0, -71.7524719238]], device=device, dtype=dtype)
         expected_t = torch.tensor([[[-0.5256], [0.3558], [0.7727]]], device=device, dtype=dtype)

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -45,27 +45,10 @@ def rtol(device, dtype):
 
 
 class TestAngleAxisToQuaternion:
-    def test_smoke_xyzw(self, device, dtype):
-        angle_axis = torch.zeros(3, dtype=dtype, device=device)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert quaternion.shape == (4,)
-
     def test_smoke(self, device, dtype):
         angle_axis = torch.zeros(3, dtype=dtype, device=device)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
         assert quaternion.shape == (4,)
-
-    @pytest.mark.parametrize("batch_size", (1, 3, 8))
-    def test_smoke_batch_xyzw(self, batch_size, device, dtype):
-        angle_axis = torch.zeros(batch_size, 3, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert quaternion.shape == (batch_size, 4)
 
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
@@ -73,29 +56,10 @@ class TestAngleAxisToQuaternion:
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
         assert quaternion.shape == (batch_size, 4)
 
-    def test_zero_angle_xyzw(self, device, dtype, atol, rtol):
-        angle_axis = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
     def test_zero_angle(self, device, dtype, atol, rtol):
         angle_axis = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
-    def test_small_angle_x_xyzw(self, device, dtype, atol, rtol):
-        theta = 1.0e-2
-        angle_axis = torch.tensor((theta, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((np.sin(theta / 2.0), 0.0, 0.0, np.cos(theta / 2.0)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_x(self, device, dtype, atol, rtol):
@@ -105,31 +69,11 @@ class TestAngleAxisToQuaternion:
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
-    def test_small_angle_y_xyzw(self, device, dtype, atol, rtol):
-        theta = 1.0e-2
-        angle_axis = torch.tensor((0.0, theta, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, np.sin(theta / 2.0), 0.0, np.cos(theta / 2.0)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
     def test_small_angle_y(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         angle_axis = torch.tensor((0.0, theta, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((np.cos(theta / 2.0), 0.0, np.sin(theta / 2.0), 0.0), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
-    def test_small_angle_z_xyzw(self, device, dtype, atol, rtol):
-        theta = 1.0e-2
-        angle_axis = torch.tensor((0.0, 0.0, theta), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, np.sin(theta / 2.0), np.cos(theta / 2.0)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_z(self, device, dtype, atol, rtol):
@@ -139,31 +83,11 @@ class TestAngleAxisToQuaternion:
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
-    def test_x_rotation_xyzw(self, device, dtype, atol, rtol):
-        half_sqrt2 = 0.5 * np.sqrt(2.0)
-        angle_axis = torch.tensor((kornia.pi / 2.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((half_sqrt2, 0.0, 0.0, half_sqrt2), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
     def test_x_rotation(self, device, dtype, atol, rtol):
         half_sqrt2 = 0.5 * np.sqrt(2.0)
         angle_axis = torch.tensor((kornia.pi / 2.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((half_sqrt2, half_sqrt2, 0.0, 0.0), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
-    def test_y_rotation_xyzw(self, device, dtype, atol, rtol):
-        half_sqrt2 = 0.5 * np.sqrt(2.0)
-        angle_axis = torch.tensor((0.0, kornia.pi / 2.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, half_sqrt2, 0.0, half_sqrt2), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_y_rotation(self, device, dtype, atol, rtol):
@@ -173,35 +97,12 @@ class TestAngleAxisToQuaternion:
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
-    def test_z_rotation_xyzw(self, device, dtype, atol, rtol):
-        half_sqrt2 = 0.5 * np.sqrt(2.0)
-        angle_axis = torch.tensor((0.0, 0.0, kornia.pi / 2.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, half_sqrt2, half_sqrt2), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
     def test_z_rotation(self, device, dtype, atol, rtol):
         half_sqrt2 = 0.5 * np.sqrt(2.0)
         angle_axis = torch.tensor((0.0, 0.0, kornia.pi / 2.0), device=device, dtype=dtype)
         expected = torch.tensor((half_sqrt2, 0.0, 0.0, half_sqrt2), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
-    def test_gradcheck_xyzw(self, device, dtype):
-        eps = torch.finfo(dtype).eps
-        angle_axis = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype) + eps
-        angle_axis = tensor_to_gradcheck_var(angle_axis)
-        # evaluate function gradient
-        with pytest.warns(UserWarning):
-            assert gradcheck(
-                partial(kornia.geometry.conversions.angle_axis_to_quaternion, order=QuaternionCoeffOrder.XYZW),
-                (angle_axis,),
-                raise_exception=True,
-                fast_mode=True,
-            )
 
     def test_gradcheck(self, device, dtype):
         eps = torch.finfo(dtype).eps
@@ -217,27 +118,10 @@ class TestAngleAxisToQuaternion:
 
 
 class TestQuaternionToAngleAxis:
-    def test_smoke_xyzw(self, device, dtype):
-        quaternion = torch.zeros(4, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert angle_axis.shape == (3,)
-
     def test_smoke(self, device, dtype):
         quaternion = torch.zeros(4, device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert angle_axis.shape == (3,)
-
-    @pytest.mark.parametrize("batch_size", (1, 3, 8))
-    def test_smoke_batch_xyzw(self, batch_size, device, dtype):
-        quaternion = torch.zeros(batch_size, 4, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert angle_axis.shape == (batch_size, 3)
 
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
@@ -245,28 +129,10 @@ class TestQuaternionToAngleAxis:
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert angle_axis.shape == (batch_size, 3)
 
-    def test_unit_quaternion_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
-    def test_x_rotation_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((kornia.pi, 0.0, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_x_rotation(self, device, dtype, atol, rtol):
@@ -275,44 +141,16 @@ class TestQuaternionToAngleAxis:
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
-    def test_y_rotation_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, kornia.pi, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
     def test_y_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, kornia.pi, 0.0), device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
-    def test_z_rotation_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((0.0, 0.0, 0.5, np.sqrt(3.0) / 2.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, kornia.pi / 3.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
     def test_z_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((np.sqrt(3.0) / 2.0, 0.0, 0.0, 0.5), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, kornia.pi / 3.0), device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
-    def test_small_angle_x_xyzw(self, device, dtype, atol, rtol):
-        theta = 1.0e-2
-        quaternion = torch.tensor((np.sin(theta / 2.0), 0.0, 0.0, np.cos(theta / 2.0)), device=device, dtype=dtype)
-        expected = torch.tensor((theta, 0.0, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_x(self, device, dtype, atol, rtol):
@@ -322,31 +160,11 @@ class TestQuaternionToAngleAxis:
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
-    def test_small_angle_y_xyzw(self, device, dtype, atol, rtol):
-        theta = 1.0e-2
-        quaternion = torch.tensor((0.0, np.sin(theta / 2), 0.0, np.cos(theta / 2)), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, theta, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
     def test_small_angle_y(self, device, dtype, atol, rtol):
         theta = 1.0e-2
         quaternion = torch.tensor((np.cos(theta / 2), 0.0, np.sin(theta / 2), 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, theta, 0.0), device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
-    def test_small_angle_z_xyzw(self, device, dtype, atol, rtol):
-        theta = 1.0e-2
-        quaternion = torch.tensor((0.0, 0.0, np.sin(theta / 2), np.cos(theta / 2)), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, theta), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
 
     def test_small_angle_z(self, device, dtype, atol, rtol):
@@ -355,19 +173,6 @@ class TestQuaternionToAngleAxis:
         expected = torch.tensor((0.0, 0.0, theta), device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert_close(angle_axis, expected, atol=atol, rtol=rtol)
-
-    def test_gradcheck_xyzw(self, device, dtype):
-        eps = torch.finfo(dtype).eps
-        quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype) + eps
-        quaternion = tensor_to_gradcheck_var(quaternion)
-        # evaluate function gradient
-        with pytest.warns(UserWarning):
-            assert gradcheck(
-                partial(kornia.geometry.conversions.quaternion_to_angle_axis, order=QuaternionCoeffOrder.XYZW),
-                (quaternion,),
-                raise_exception=True,
-                fast_mode=True,
-            )
 
     def test_gradcheck(self, device, dtype):
         eps = torch.finfo(dtype).eps
@@ -384,43 +189,15 @@ class TestQuaternionToAngleAxis:
 
 class TestRotationMatrixToQuaternion:
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
-    def test_smoke_batch_xyzw(self, batch_size, device, dtype):
-        matrix = torch.zeros(batch_size, 3, 3, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                matrix, order=QuaternionCoeffOrder.XYZW
-            )
-        assert quaternion.shape == (batch_size, 4)
-
-    @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
         matrix = torch.zeros(batch_size, 3, 3, device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, order=QuaternionCoeffOrder.WXYZ)
         assert quaternion.shape == (batch_size, 4)
 
-    def test_identity_xyzw(self, device, dtype, atol, rtol):
-        matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                matrix, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
     def test_identity(self, device, dtype, atol, rtol):
         matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
         expected = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
-    def test_rot_x_45_xyzw(self, device, dtype, atol, rtol):
-        matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, 1.0, 0.0)), device=device, dtype=dtype)
-        pi_half2 = torch.cos(kornia.pi / 4.0).to(device=device, dtype=dtype)
-        expected = torch.tensor((pi_half2, 0.0, 0.0, pi_half2), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                matrix, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
 
     def test_rot_x_45(self, device, dtype, atol, rtol):
@@ -429,18 +206,6 @@ class TestRotationMatrixToQuaternion:
         expected = torch.tensor((pi_half2, pi_half2, 0.0, 0.0), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, order=QuaternionCoeffOrder.WXYZ)
         assert_close(quaternion, expected, atol=atol, rtol=rtol)
-
-    def test_back_and_forth_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, 1.0, 0.0)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                matrix, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-            matrix_hat = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(matrix, matrix_hat, atol=atol, rtol=rtol)
 
     def test_back_and_forth(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
@@ -452,27 +217,6 @@ class TestRotationMatrixToQuaternion:
             quaternion, order=QuaternionCoeffOrder.WXYZ
         )
         assert_close(matrix, matrix_hat, atol=atol, rtol=rtol)
-
-    def test_corner_case_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        matrix = torch.tensor(
-            (
-                (-0.7799533010, -0.5432914495, 0.3106555045),
-                (0.0492402576, -0.5481169224, -0.8349509239),
-                (0.6238971353, -0.6359263659, 0.4542570710),
-            ),
-            device=device,
-            dtype=dtype,
-        )
-        quaternion_true = torch.tensor(
-            (0.280136495828629, -0.440902262926102, 0.834015488624573, 0.177614107728004), device=device, dtype=dtype
-        )
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                matrix, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        torch.set_printoptions(precision=10)
-        assert_close(quaternion_true, quaternion, atol=atol, rtol=rtol)
 
     def test_corner_case(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
@@ -493,21 +237,6 @@ class TestRotationMatrixToQuaternion:
         )
         torch.set_printoptions(precision=10)
         assert_close(quaternion_true, quaternion, atol=atol, rtol=rtol)
-
-    def test_gradcheck_xyzw(self, device, dtype):
-        eps = torch.finfo(dtype).eps
-        matrix = torch.eye(3, device=device, dtype=dtype)
-        matrix = tensor_to_gradcheck_var(matrix)
-        # evaluate function gradient
-        with pytest.warns(UserWarning):
-            assert gradcheck(
-                partial(
-                    kornia.geometry.conversions.rotation_matrix_to_quaternion, eps=eps, order=QuaternionCoeffOrder.XYZW
-                ),
-                (matrix,),
-                raise_exception=True,
-                fast_mode=True,
-            )
 
     def test_gradcheck(self, device, dtype):
         eps = torch.finfo(dtype).eps
@@ -537,42 +266,15 @@ class TestRotationMatrixToQuaternion:
 
 class TestQuaternionToRotationMatrix:
     @pytest.mark.parametrize("batch_dims", ((), (1,), (3,), (8,), (1, 1), (5, 6)))
-    def test_smoke_batch_xyzw(self, batch_dims, device, dtype):
-        quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert matrix.shape == (*batch_dims, 3, 3)
-
-    @pytest.mark.parametrize("batch_dims", ((), (1,), (3,), (8,), (1, 1), (5, 6)))
     def test_smoke_batch(self, batch_dims, device, dtype):
         quaternion = torch.zeros(*batch_dims, 4, device=device, dtype=dtype)
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert matrix.shape == (*batch_dims, 3, 3)
 
-    def test_unit_quaternion_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        expected = torch.tensor(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(matrix, expected, atol=atol, rtol=rtol)
-
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(matrix, expected, atol=atol, rtol=rtol)
-
-    def test_x_rotation_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor(((1.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, -1.0)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(matrix, expected, atol=atol, rtol=rtol)
 
     def test_x_rotation(self, device, dtype, atol, rtol):
@@ -581,29 +283,10 @@ class TestQuaternionToRotationMatrix:
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert_close(matrix, expected, atol=atol, rtol=rtol)
 
-    def test_y_rotation_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor(((-1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, -1.0)), device=device, dtype=dtype)
-
-        with pytest.warns(UserWarning):
-            matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(matrix, expected, atol=atol, rtol=rtol)
-
     def test_y_rotation(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor(((-1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, -1.0)), device=device, dtype=dtype)
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
-        assert_close(matrix, expected, atol=atol, rtol=rtol)
-
-    def test_z_rotation_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor(((-1.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(matrix, expected, atol=atol, rtol=rtol)
 
     def test_z_rotation(self, device, dtype, atol, rtol):
@@ -611,18 +294,6 @@ class TestQuaternionToRotationMatrix:
         expected = torch.tensor(((-1.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=dtype)
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
         assert_close(matrix, expected, atol=atol, rtol=rtol)
-
-    def test_gradcheck_xyzw(self, device, dtype):
-        quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        quaternion = tensor_to_gradcheck_var(quaternion)
-        # evaluate function gradient
-        with pytest.warns(UserWarning):
-            assert gradcheck(
-                partial(kornia.geometry.conversions.quaternion_to_rotation_matrix, order=QuaternionCoeffOrder.XYZW),
-                (quaternion,),
-                raise_exception=True,
-                fast_mode=True,
-            )
 
     def test_gradcheck(self, device, dtype):
         quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
@@ -649,31 +320,12 @@ class TestQuaternionToRotationMatrix:
 
 class TestQuaternionLogToExp:
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
-    def test_smoke_batch_xyzw(self, batch_size, device, dtype):
-        quaternion_log = torch.zeros(batch_size, 3, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-                quaternion_log, order=QuaternionCoeffOrder.XYZW
-            )
-        assert quaternion_exp.shape == (batch_size, 4)
-
-    @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
         quaternion_log = torch.zeros(batch_size, 3, device=device, dtype=dtype)
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
             quaternion_log, order=QuaternionCoeffOrder.WXYZ
         )
         assert quaternion_exp.shape == (batch_size, 4)
-
-    def test_unit_quaternion_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        quaternion_log = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-                quaternion_log, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
@@ -682,17 +334,6 @@ class TestQuaternionLogToExp:
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
             quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
         )
-        assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
-
-    def test_pi_quaternion_x_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        one = torch.tensor(1.0, device=device, dtype=dtype)
-        quaternion_log = torch.tensor((1.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((torch.sin(one), 0.0, 0.0, torch.cos(one)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-                quaternion_log, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_x(self, device, dtype, atol, rtol):
@@ -705,17 +346,6 @@ class TestQuaternionLogToExp:
         )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
-    def test_pi_quaternion_y_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        one = torch.tensor(1.0, device=device, dtype=dtype)
-        quaternion_log = torch.tensor((0.0, 1.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, torch.sin(one), 0.0, torch.cos(one)), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-                quaternion_log, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
-
     def test_pi_quaternion_y(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         one = torch.tensor(1.0, device=device, dtype=dtype)
@@ -724,18 +354,6 @@ class TestQuaternionLogToExp:
         quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
             quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
         )
-        assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
-
-    def test_pi_quaternion_z_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        one = torch.tensor(1.0, device=device, dtype=dtype)
-        quaternion_log = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, torch.sin(one), torch.cos(one)), device=device, dtype=dtype)
-
-        with pytest.warns(UserWarning):
-            quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-                quaternion_log, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_z(self, device, dtype, atol, rtol):
@@ -748,20 +366,6 @@ class TestQuaternionLogToExp:
         )
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
-    def test_back_and_forth_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        quaternion_log = torch.tensor((1.0, 0.0, 0.0), device=device, dtype=dtype)
-
-        with pytest.warns(UserWarning):
-            quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-                quaternion_log, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        with pytest.warns(UserWarning):
-            quaternion_log_hat = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion_exp, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_log, quaternion_log_hat, atol=atol, rtol=rtol)
-
     def test_back_and_forth(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_log = torch.tensor((1.0, 0.0, 0.0), device=device, dtype=dtype)
@@ -773,19 +377,6 @@ class TestQuaternionLogToExp:
             quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
         )
         assert_close(quaternion_log, quaternion_log_hat, atol=atol, rtol=rtol)
-
-    def test_gradcheck_xyzw(self, device, dtype):
-        eps = torch.finfo(dtype).eps
-        quaternion = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
-        quaternion = tensor_to_gradcheck_var(quaternion)
-        # evaluate function gradient
-        with pytest.warns(UserWarning):
-            assert gradcheck(
-                partial(kornia.geometry.conversions.quaternion_log_to_exp, eps=eps, order=QuaternionCoeffOrder.XYZW),
-                (quaternion,),
-                raise_exception=True,
-                fast_mode=True,
-            )
 
     def test_gradcheck(self, device, dtype):
         eps = torch.finfo(dtype).eps
@@ -813,16 +404,6 @@ class TestQuaternionLogToExp:
 
 class TestQuaternionExpToLog:
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
-    def test_smoke_batch_xyzw(self, batch_size, device, dtype):
-        eps = torch.finfo(dtype).eps
-        quaternion_exp = torch.zeros(batch_size, 4, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion_exp, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        assert quaternion_log.shape == (batch_size, 3)
-
-    @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.zeros(batch_size, 4, device=device, dtype=dtype)
@@ -831,16 +412,6 @@ class TestQuaternionExpToLog:
         )
         assert quaternion_log.shape == (batch_size, 3)
 
-    def test_unit_quaternion_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        quaternion_exp = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion_exp, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
-
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
@@ -848,16 +419,6 @@ class TestQuaternionExpToLog:
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
             quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
         )
-        assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
-
-    def test_pi_quaternion_x_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        quaternion_exp = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((kornia.pi / 2.0, 0.0, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion_exp, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_x(self, device, dtype, atol, rtol):
@@ -869,16 +430,6 @@ class TestQuaternionExpToLog:
         )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
-    def test_pi_quaternion_y_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        quaternion_exp = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, kornia.pi / 2.0, 0.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion_exp, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
-
     def test_pi_quaternion_y(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
@@ -886,16 +437,6 @@ class TestQuaternionExpToLog:
         quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
             quaternion_exp, eps=eps, order=QuaternionCoeffOrder.WXYZ
         )
-        assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
-
-    def test_pi_quaternion_z_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        quaternion_exp = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
-        expected = torch.tensor((0.0, 0.0, kornia.pi / 2.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion_exp, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_z(self, device, dtype, atol, rtol):
@@ -907,20 +448,6 @@ class TestQuaternionExpToLog:
         )
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
-    def test_back_and_forth_xyzw(self, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        quaternion_exp = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-
-        with pytest.warns(UserWarning):
-            quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion_exp, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        with pytest.warns(UserWarning):
-            quaternion_exp_hat = kornia.geometry.conversions.quaternion_log_to_exp(
-                quaternion_log, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_exp, quaternion_exp_hat, atol=atol, rtol=rtol)
-
     def test_back_and_forth(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
@@ -931,19 +458,6 @@ class TestQuaternionExpToLog:
             quaternion_log, eps=eps, order=QuaternionCoeffOrder.WXYZ
         )
         assert_close(quaternion_exp, quaternion_exp_hat, atol=atol, rtol=rtol)
-
-    def test_gradcheck_xyzw(self, device, dtype):
-        eps = torch.finfo(dtype).eps
-        quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion = tensor_to_gradcheck_var(quaternion)
-        # evaluate function gradient
-        with pytest.warns(UserWarning):
-            assert gradcheck(
-                partial(kornia.geometry.conversions.quaternion_exp_to_log, eps=eps, order=QuaternionCoeffOrder.XYZW),
-                (quaternion,),
-                raise_exception=True,
-                fast_mode=True,
-            )
 
     def test_gradcheck(self, device, dtype):
         eps = torch.finfo(dtype).eps

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -209,12 +209,8 @@ class TestRotationMatrixToQuaternion:
     def test_back_and_forth(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         matrix = torch.tensor(((1.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, 1.0, 0.0)), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            matrix, eps=eps
-        )
-        matrix_hat = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-            quaternion
-        )
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, eps=eps)
+        matrix_hat = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert_close(matrix, matrix_hat, atol=atol, rtol=rtol)
 
     def test_corner_case(self, device, dtype, atol, rtol):
@@ -231,9 +227,7 @@ class TestRotationMatrixToQuaternion:
         quaternion_true = torch.tensor(
             (0.177614107728004, 0.280136495828629, -0.440902262926102, 0.834015488624573), device=device, dtype=dtype
         )
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            matrix, eps=eps
-        )
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(matrix, eps=eps)
         torch.set_printoptions(precision=10)
         assert_close(quaternion_true, quaternion, atol=atol, rtol=rtol)
 
@@ -243,9 +237,7 @@ class TestRotationMatrixToQuaternion:
         matrix = tensor_to_gradcheck_var(matrix)
         # evaluate function gradient
         assert gradcheck(
-            partial(
-                kornia.geometry.conversions.rotation_matrix_to_quaternion, eps=eps
-            ),
+            partial(kornia.geometry.conversions.rotation_matrix_to_quaternion, eps=eps),
             (matrix,),
             raise_exception=True,
             fast_mode=True,
@@ -319,18 +311,14 @@ class TestQuaternionLogToExp:
     @pytest.mark.parametrize("batch_size", (1, 3, 8))
     def test_smoke_batch(self, batch_size, device, dtype):
         quaternion_log = torch.zeros(batch_size, 3, device=device, dtype=dtype)
-        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log
-        )
+        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(quaternion_log)
         assert quaternion_exp.shape == (batch_size, 4)
 
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_log = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps
-        )
+        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(quaternion_log, eps=eps)
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_x(self, device, dtype, atol, rtol):
@@ -338,9 +326,7 @@ class TestQuaternionLogToExp:
         one = torch.tensor(1.0, device=device, dtype=dtype)
         quaternion_log = torch.tensor((1.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((torch.cos(one), torch.sin(one), 0.0, 0.0), device=device, dtype=dtype)
-        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps
-        )
+        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(quaternion_log, eps=eps)
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_y(self, device, dtype, atol, rtol):
@@ -348,9 +334,7 @@ class TestQuaternionLogToExp:
         one = torch.tensor(1.0, device=device, dtype=dtype)
         quaternion_log = torch.tensor((0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((torch.cos(one), 0.0, torch.sin(one), 0.0), device=device, dtype=dtype)
-        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps
-        )
+        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(quaternion_log, eps=eps)
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_z(self, device, dtype, atol, rtol):
@@ -358,21 +342,15 @@ class TestQuaternionLogToExp:
         one = torch.tensor(1.0, device=device, dtype=dtype)
         quaternion_log = torch.tensor((0.0, 0.0, 1.0), device=device, dtype=dtype)
         expected = torch.tensor((torch.cos(one), 0.0, 0.0, torch.sin(one)), device=device, dtype=dtype)
-        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps
-        )
+        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(quaternion_log, eps=eps)
         assert_close(quaternion_exp, expected, atol=atol, rtol=rtol)
 
     def test_back_and_forth(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_log = torch.tensor((1.0, 0.0, 0.0), device=device, dtype=dtype)
 
-        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps
-        )
-        quaternion_log_hat = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps
-        )
+        quaternion_exp = kornia.geometry.conversions.quaternion_log_to_exp(quaternion_log, eps=eps)
+        quaternion_log_hat = kornia.geometry.conversions.quaternion_exp_to_log(quaternion_exp, eps=eps)
         assert_close(quaternion_log, quaternion_log_hat, atol=atol, rtol=rtol)
 
     def test_gradcheck(self, device, dtype):
@@ -403,56 +381,42 @@ class TestQuaternionExpToLog:
     def test_smoke_batch(self, batch_size, device, dtype):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.zeros(batch_size, 4, device=device, dtype=dtype)
-        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps
-        )
+        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(quaternion_exp, eps=eps)
         assert quaternion_log.shape == (batch_size, 3)
 
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps
-        )
+        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(quaternion_exp, eps=eps)
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_x(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((kornia.pi / 2.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps
-        )
+        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(quaternion_exp, eps=eps)
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_y(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((0.0, 0.0, 1.0, 0.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, kornia.pi / 2.0, 0.0), device=device, dtype=dtype)
-        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps
-        )
+        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(quaternion_exp, eps=eps)
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
     def test_pi_quaternion_z(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
         expected = torch.tensor((0.0, 0.0, kornia.pi / 2.0), device=device, dtype=dtype)
-        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps
-        )
+        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(quaternion_exp, eps=eps)
         assert_close(quaternion_log, expected, atol=atol, rtol=rtol)
 
     def test_back_and_forth(self, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         quaternion_exp = torch.tensor((0.0, 1.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(
-            quaternion_exp, eps=eps
-        )
-        quaternion_exp_hat = kornia.geometry.conversions.quaternion_log_to_exp(
-            quaternion_log, eps=eps
-        )
+        quaternion_log = kornia.geometry.conversions.quaternion_exp_to_log(quaternion_exp, eps=eps)
+        quaternion_exp_hat = kornia.geometry.conversions.quaternion_log_to_exp(quaternion_log, eps=eps)
         assert_close(quaternion_exp, quaternion_exp_hat, atol=atol, rtol=rtol)
 
     def test_gradcheck(self, device, dtype):
@@ -534,9 +498,7 @@ class TestRotationMatrixToAngleAxis:
         # generate input data
         quaternion = torch.rand(batch_size, 4, device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.normalize_quaternion(quaternion + 1e-6)
-        rotation_matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-            quaternion=quaternion
-        )
+        rotation_matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion=quaternion)
 
         eye_batch = create_eye_batch(batch_size, 3, device=device, dtype=dtype)
         rotation_matrix_eye = torch.matmul(rotation_matrix, rotation_matrix.transpose(-2, -1))
@@ -547,9 +509,7 @@ class TestRotationMatrixToAngleAxis:
     def test_gradcheck(self, batch_size, device, dtype):
         quaternion = torch.rand(batch_size, 4, device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.normalize_quaternion(quaternion + 1e-6)
-        rotation_matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-            quaternion=quaternion
-        )
+        rotation_matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion=quaternion)
         # evaluate function gradient
         rotation_matrix = tensor_to_gradcheck_var(rotation_matrix)  # to var
         assert gradcheck(

--- a/test/integration/test_conversions.py
+++ b/test/integration/test_conversions.py
@@ -3,7 +3,6 @@ import pytest
 import torch
 
 import kornia
-from kornia.geometry.conversions import QuaternionCoeffOrder
 from kornia.testing import assert_close
 
 
@@ -26,9 +25,9 @@ def rtol(device, dtype):
 class TestAngleAxisToQuaternionToAngleAxis:
     def test_zero_angle(self, device, dtype, atol, rtol):
         angle_axis = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion, order=QuaternionCoeffOrder.WXYZ
+            quaternion
         )
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
@@ -38,9 +37,9 @@ class TestAngleAxisToQuaternionToAngleAxis:
         array = [0.0, 0.0, 0.0]
         array[axis] = theta
         angle_axis = torch.tensor(array, device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion, order=QuaternionCoeffOrder.WXYZ
+            quaternion
         )
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
@@ -50,9 +49,9 @@ class TestAngleAxisToQuaternionToAngleAxis:
         array = [0.0, 0.0, 0.0]
         array[axis] = kornia.pi / 2.0
         angle_axis = torch.tensor(array, device=device, dtype=dtype)
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion, order=QuaternionCoeffOrder.WXYZ
+            quaternion
         )
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
@@ -60,9 +59,9 @@ class TestAngleAxisToQuaternionToAngleAxis:
 class TestQuaternionToAngleAxisToQuaternion:
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis, order=QuaternionCoeffOrder.WXYZ
+            angle_axis
         )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
@@ -71,9 +70,9 @@ class TestQuaternionToAngleAxisToQuaternion:
         array = [0.0, 0.0, 0.0, 0.0]
         array[1 + axis] = 1.0
         quaternion = torch.tensor(array, device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis, order=QuaternionCoeffOrder.WXYZ
+            angle_axis
         )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
@@ -83,9 +82,9 @@ class TestQuaternionToAngleAxisToQuaternion:
         array = [np.cos(theta / 2), 0.0, 0.0, 0.0]
         array[1 + axis] = np.sin(theta / 2.0)
         quaternion = torch.tensor(array, device=device, dtype=dtype)
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis, order=QuaternionCoeffOrder.WXYZ
+            angle_axis
         )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
@@ -98,7 +97,7 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         quaternion = torch.tensor(array, device=device, dtype=dtype)
         assert quaternion.shape[-1] == 4
 
-        mm = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        mm = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert mm.shape[-1] == 3
         assert mm.shape[-2] == 3
 
@@ -110,7 +109,7 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         assert_close(angle_axis, angle_axis_expected, atol=atol, rtol=rtol)
 
         quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis, order=QuaternionCoeffOrder.WXYZ
+            angle_axis
         )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
@@ -121,7 +120,7 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         quaternion = torch.tensor(array, device=device, dtype=dtype)
         assert quaternion.shape[-1] == 4
 
-        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert angle_axis.shape[-1] == 3
 
         rot_m = kornia.geometry.conversions.angle_axis_to_rotation_matrix(angle_axis)
@@ -129,7 +128,7 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         assert rot_m.shape[-2] == 3
 
         quaternion_hat = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            rot_m, order=QuaternionCoeffOrder.WXYZ
+            rot_m
         )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
@@ -144,11 +143,11 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         assert rot_m.shape[-1] == 3
         assert rot_m.shape[-2] == 3
 
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(rot_m, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(rot_m)
         assert quaternion.shape[-1] == 4
 
         angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion, order=QuaternionCoeffOrder.WXYZ
+            quaternion
         )
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
@@ -159,10 +158,10 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         angle_axis = torch.tensor(array, device=device, dtype=dtype)
         assert angle_axis.shape[-1] == 3
 
-        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis, order=QuaternionCoeffOrder.WXYZ)
+        quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert quaternion.shape[-1] == 4
 
-        rot_m = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.WXYZ)
+        rot_m = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
         assert rot_m.shape[-1] == 3
         assert rot_m.shape[-2] == 3
 
@@ -262,7 +261,7 @@ class TestAngleOfRotations:
             axis_name=axis_name, angle=angle, device=device, dtype=dtype
         )
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            rot_m, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            rot_m, eps=eps
         )
         # compute quaternion rotation angle
         # See Section 2.4.4 Equation (105a) in https://arxiv.org/pdf/1711.02508.pdf
@@ -310,9 +309,9 @@ class TestAngleOfRotations:
             axis_name=axis_name, angle=angle, device=device, dtype=dtype
         )
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            rot_m, eps=eps, order=QuaternionCoeffOrder.WXYZ
+            rot_m, eps=eps
         )
-        log_q = kornia.geometry.conversions.quaternion_exp_to_log(quaternion, eps=eps, order=QuaternionCoeffOrder.WXYZ)
+        log_q = kornia.geometry.conversions.quaternion_exp_to_log(quaternion, eps=eps)
         # compute angle_axis rotation angle
         angle_hat = 2.0 * log_q.norm(p=2, dim=-1, keepdim=True)
         # make sure it lands between [-pi..pi)

--- a/test/integration/test_conversions.py
+++ b/test/integration/test_conversions.py
@@ -26,9 +26,7 @@ class TestAngleAxisToQuaternionToAngleAxis:
     def test_zero_angle(self, device, dtype, atol, rtol):
         angle_axis = torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
-        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion
-        )
+        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -38,9 +36,7 @@ class TestAngleAxisToQuaternionToAngleAxis:
         array[axis] = theta
         angle_axis = torch.tensor(array, device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
-        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion
-        )
+        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -50,9 +46,7 @@ class TestAngleAxisToQuaternionToAngleAxis:
         array[axis] = kornia.pi / 2.0
         angle_axis = torch.tensor(array, device=device, dtype=dtype)
         quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
-        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion
-        )
+        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
 
@@ -60,9 +54,7 @@ class TestQuaternionToAngleAxisToQuaternion:
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
-        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis
-        )
+        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -71,9 +63,7 @@ class TestQuaternionToAngleAxisToQuaternion:
         array[1 + axis] = 1.0
         quaternion = torch.tensor(array, device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
-        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis
-        )
+        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -83,9 +73,7 @@ class TestQuaternionToAngleAxisToQuaternion:
         array[1 + axis] = np.sin(theta / 2.0)
         quaternion = torch.tensor(array, device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
-        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis
-        )
+        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
 
@@ -108,9 +96,7 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         angle_axis_expected = torch.tensor(angle_axis_expected, device=device, dtype=dtype)
         assert_close(angle_axis, angle_axis_expected, atol=atol, rtol=rtol)
 
-        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-            angle_axis
-        )
+        quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(angle_axis)
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -127,9 +113,7 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         assert rot_m.shape[-1] == 3
         assert rot_m.shape[-2] == 3
 
-        quaternion_hat = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            rot_m
-        )
+        quaternion_hat = kornia.geometry.conversions.rotation_matrix_to_quaternion(rot_m)
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -146,9 +130,7 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(rot_m)
         assert quaternion.shape[-1] == 4
 
-        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-            quaternion
-        )
+        angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion)
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -260,9 +242,7 @@ class TestAngleOfRotations:
         rot_m, axis = TestAngleOfRotations.axis_and_angle_to_rotation_matrix(
             axis_name=axis_name, angle=angle, device=device, dtype=dtype
         )
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            rot_m, eps=eps
-        )
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(rot_m, eps=eps)
         # compute quaternion rotation angle
         # See Section 2.4.4 Equation (105a) in https://arxiv.org/pdf/1711.02508.pdf
         angle_hat = 2.0 * torch.atan2(quaternion[..., 1:4].norm(p=2, dim=-1, keepdim=True), quaternion[..., 0:1])
@@ -308,9 +288,7 @@ class TestAngleOfRotations:
         rot_m, axis = TestAngleOfRotations.axis_and_angle_to_rotation_matrix(
             axis_name=axis_name, angle=angle, device=device, dtype=dtype
         )
-        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-            rot_m, eps=eps
-        )
+        quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(rot_m, eps=eps)
         log_q = kornia.geometry.conversions.quaternion_exp_to_log(quaternion, eps=eps)
         # compute angle_axis rotation angle
         angle_hat = 2.0 * log_q.norm(p=2, dim=-1, keepdim=True)

--- a/test/integration/test_conversions.py
+++ b/test/integration/test_conversions.py
@@ -58,39 +58,12 @@ class TestAngleAxisToQuaternionToAngleAxis:
 
 
 class TestQuaternionToAngleAxisToQuaternion:
-    def test_unit_quaternion_xyzw(self, device, dtype, atol, rtol):
-        quaternion = torch.tensor((0.0, 0.0, 0.0, 1.0), device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        with pytest.warns(UserWarning):
-            quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
-
     def test_unit_quaternion(self, device, dtype, atol, rtol):
         quaternion = torch.tensor((1.0, 0.0, 0.0, 0.0), device=device, dtype=dtype)
         angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(quaternion, order=QuaternionCoeffOrder.WXYZ)
         quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
             angle_axis, order=QuaternionCoeffOrder.WXYZ
         )
-        assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
-
-    @pytest.mark.parametrize("axis", (0, 1, 2))
-    def test_rotation_xyzw(self, axis, device, dtype, atol, rtol):
-        array = [0.0, 0.0, 0.0, 0.0]
-        array[axis] = 1.0
-        quaternion = torch.tensor(array, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        with pytest.warns(UserWarning):
-            quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -102,29 +75,6 @@ class TestQuaternionToAngleAxisToQuaternion:
         quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
             angle_axis, order=QuaternionCoeffOrder.WXYZ
         )
-        assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
-
-        # just to be sure, check that mixing orders fails
-        with pytest.warns(UserWarning):
-            quaternion_hat_wrong = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert not torch.allclose(quaternion_hat_wrong, quaternion, atol=atol, rtol=rtol)
-
-    @pytest.mark.parametrize("axis", (0, 1, 2))
-    def test_small_angle_xyzw(self, axis, device, dtype, atol, rtol):
-        theta = 1.0e-2
-        array = [0.0, 0.0, 0.0, np.cos(theta / 2)]
-        array[axis] = np.sin(theta / 2.0)
-        quaternion = torch.tensor(array, device=device, dtype=dtype)
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        with pytest.warns(UserWarning):
-            quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -139,40 +89,8 @@ class TestQuaternionToAngleAxisToQuaternion:
         )
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
-        # just to be sure, check that mixing orders fails
-        with pytest.warns(UserWarning):
-            quaternion_hat_wrong = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert not torch.allclose(quaternion_hat_wrong, quaternion, atol=atol, rtol=rtol)
-
 
 class TestQuaternionToRotationMatrixToAngleAxis:
-    @pytest.mark.parametrize("axis", (0, 1, 2))
-    def test_triplet_qma_xyzw(self, axis, device, dtype, atol, rtol):
-        array = [[0.0, 0.0, 0.0, 0.0]]
-        array[0][axis] = 1.0  # `0 + axis` should fail when WXYZ
-        quaternion = torch.tensor(array, device=device, dtype=dtype)
-        assert quaternion.shape[-1] == 4
-
-        with pytest.warns(UserWarning):
-            mm = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion, order=QuaternionCoeffOrder.XYZW)
-        assert mm.shape[-1] == 3
-        assert mm.shape[-2] == 3
-
-        angle_axis = kornia.geometry.conversions.rotation_matrix_to_angle_axis(mm)
-        assert angle_axis.shape[-1] == 3
-        angle_axis_expected = [[0.0, 0.0, 0.0]]
-        angle_axis_expected[0][axis] = kornia.pi
-        angle_axis_expected = torch.tensor(angle_axis_expected, device=device, dtype=dtype)
-        assert_close(angle_axis, angle_axis_expected, atol=atol, rtol=rtol)
-
-        with pytest.warns(UserWarning):
-            quaternion_hat = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
-
     @pytest.mark.parametrize("axis", (0, 1, 2))
     def test_triplet_qma(self, axis, device, dtype, atol, rtol):
         array = [[0.0, 0.0, 0.0, 0.0]]
@@ -197,29 +115,6 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
-    def test_triplet_qam_xyzw(self, axis, device, dtype, atol, rtol):
-        array = [[0.0, 0.0, 0.0, 0.0]]
-        array[0][axis] = 1.0
-        quaternion = torch.tensor(array, device=device, dtype=dtype)
-        assert quaternion.shape[-1] == 4
-
-        with pytest.warns(UserWarning):
-            angle_axis = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert angle_axis.shape[-1] == 3
-
-        rot_m = kornia.geometry.conversions.angle_axis_to_rotation_matrix(angle_axis)
-        assert rot_m.shape[-1] == 3
-        assert rot_m.shape[-2] == 3
-
-        with pytest.warns(UserWarning):
-            quaternion_hat = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                rot_m, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
-
-    @pytest.mark.parametrize("axis", (0, 1, 2))
     def test_triplet_qam(self, axis, device, dtype, atol, rtol):
         array = [[0.0, 0.0, 0.0, 0.0]]
         array[0][1 + axis] = 1.0
@@ -239,29 +134,6 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
-    def test_triplet_amq_xyzw(self, axis, device, dtype, atol, rtol):
-        array = [[0.0, 0.0, 0.0]]
-        array[0][axis] = kornia.pi / 2.0
-        angle_axis = torch.tensor(array, device=device, dtype=dtype)
-        assert angle_axis.shape[-1] == 3
-
-        rot_m = kornia.geometry.conversions.angle_axis_to_rotation_matrix(angle_axis)
-        assert rot_m.shape[-1] == 3
-        assert rot_m.shape[-2] == 3
-
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                rot_m, order=QuaternionCoeffOrder.XYZW
-            )
-        assert quaternion.shape[-1] == 4
-
-        with pytest.warns(UserWarning):
-            angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
-
-    @pytest.mark.parametrize("axis", (0, 1, 2))
     def test_triplet_amq(self, axis, device, dtype, atol, rtol):
         array = [[0.0, 0.0, 0.0]]
         array[0][axis] = kornia.pi / 2.0
@@ -278,29 +150,6 @@ class TestQuaternionToRotationMatrixToAngleAxis:
         angle_axis_hat = kornia.geometry.conversions.quaternion_to_angle_axis(
             quaternion, order=QuaternionCoeffOrder.WXYZ
         )
-        assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
-
-    @pytest.mark.parametrize("axis", (0, 1, 2))
-    def test_triplet_aqm_xyzw(self, axis, device, dtype, atol, rtol):
-        array = [[0.0, 0.0, 0.0]]
-        array[0][axis] = kornia.pi / 2.0
-        angle_axis = torch.tensor(array, device=device, dtype=dtype)
-        assert angle_axis.shape[-1] == 3
-
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.angle_axis_to_quaternion(
-                angle_axis, order=QuaternionCoeffOrder.XYZW
-            )
-        assert quaternion.shape[-1] == 4
-
-        with pytest.warns(UserWarning):
-            rot_m = kornia.geometry.conversions.quaternion_to_rotation_matrix(
-                quaternion, order=QuaternionCoeffOrder.XYZW
-            )
-        assert rot_m.shape[-1] == 3
-        assert rot_m.shape[-2] == 3
-
-        angle_axis_hat = kornia.geometry.conversions.rotation_matrix_to_angle_axis(rot_m)
         assert_close(angle_axis_hat, angle_axis, atol=atol, rtol=rtol)
 
     @pytest.mark.parametrize("axis", (0, 1, 2))
@@ -404,37 +253,6 @@ class TestAngleOfRotations:
 
     @pytest.mark.parametrize('axis_name', ('x', 'y', 'z'))
     @pytest.mark.parametrize("angle_deg", (-179.9, -90.0, -45.0, 0.0, 45, 90, 179.9))
-    def test_quaternion_xyzw(self, axis_name, angle_deg, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        angle = torch.tensor((angle_deg * kornia.pi / 180.0,), device=device, dtype=dtype).repeat(2, 1)
-        pi = torch.ones_like(angle) * kornia.pi
-        assert 2 <= len(angle.shape)
-        rot_m, axis = TestAngleOfRotations.axis_and_angle_to_rotation_matrix(
-            axis_name=axis_name, angle=angle, device=device, dtype=dtype
-        )
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                rot_m, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        # compute quaternion rotation angle
-        # See Section 2.4.4 Equation (105a) in https://arxiv.org/pdf/1711.02508.pdf
-        angle_hat = 2.0 * torch.atan2(quaternion[..., :3].norm(p=2, dim=-1, keepdim=True), quaternion[..., 3:4])
-        # make sure it lands between [-pi..pi)
-        mask = pi < angle_hat
-        while torch.any(mask):
-            angle_hat = torch.where(mask, angle_hat - 2.0 * kornia.pi, angle_hat)
-            mask = pi < angle_hat
-        # invert angle, if quaternion axis points in the opposite direction of the original axis
-        dots = (quaternion[..., :3] * axis).sum(dim=-1, keepdim=True)
-        angle_hat = torch.where(dots < 0.0, angle_hat * -1.0, angle_hat)
-        # quaternion angle should match input angle
-        assert_close(angle_hat, angle, atol=atol, rtol=rtol)
-        # magnitude of angle should match matrix rotation angle
-        matrix_angle_abs = TestAngleOfRotations.matrix_angle_abs(rot_m)
-        assert_close(torch.abs(angle_hat), matrix_angle_abs, atol=atol, rtol=rtol)
-
-    @pytest.mark.parametrize('axis_name', ('x', 'y', 'z'))
-    @pytest.mark.parametrize("angle_deg", (-179.9, -90.0, -45.0, 0.0, 45, 90, 179.9))
     def test_quaternion(self, axis_name, angle_deg, device, dtype, atol, rtol):
         eps = torch.finfo(dtype).eps
         angle = torch.tensor((angle_deg * kornia.pi / 180.0,), device=device, dtype=dtype).repeat(2, 1)
@@ -475,39 +293,6 @@ class TestAngleOfRotations:
         angle_hat = angle_axis.norm(p=2, dim=-1, keepdim=True)
         # invert angle, if angle_axis axis points in the opposite direction of the original axis
         dots = (angle_axis * axis).sum(dim=-1, keepdim=True)
-        angle_hat = torch.where(dots < 0.0, angle_hat * -1.0, angle_hat)
-        # angle_axis angle should match input angle
-        assert_close(angle_hat, angle, atol=atol, rtol=rtol)
-        # magnitude of angle should match matrix rotation angle
-        matrix_angle_abs = TestAngleOfRotations.matrix_angle_abs(rot_m)
-        assert_close(torch.abs(angle_hat), matrix_angle_abs, atol=atol, rtol=rtol)
-
-    @pytest.mark.parametrize('axis_name', ('x', 'y', 'z'))
-    @pytest.mark.parametrize("angle_deg", (-179.9, -90.0, -45.0, 0, 45, 90, 179.9))
-    def test_log_quaternion_xyzw(self, axis_name, angle_deg, device, dtype, atol, rtol):
-        eps = torch.finfo(dtype).eps
-        angle = (angle_deg * kornia.pi / 180.0).to(dtype).to(device).repeat(2, 1)
-        pi = torch.ones_like(angle) * kornia.pi
-        rot_m, axis = TestAngleOfRotations.axis_and_angle_to_rotation_matrix(
-            axis_name=axis_name, angle=angle, device=device, dtype=dtype
-        )
-        with pytest.warns(UserWarning):
-            quaternion = kornia.geometry.conversions.rotation_matrix_to_quaternion(
-                rot_m, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        with pytest.warns(UserWarning):
-            log_q = kornia.geometry.conversions.quaternion_exp_to_log(
-                quaternion, eps=eps, order=QuaternionCoeffOrder.XYZW
-            )
-        # compute angle_axis rotation angle
-        angle_hat = 2.0 * log_q.norm(p=2, dim=-1, keepdim=True)
-        # make sure it lands between [-pi..pi)
-        mask = pi < angle_hat
-        while torch.any(mask):
-            angle_hat = torch.where(mask, angle_hat - 2.0 * kornia.pi, angle_hat)
-            mask = pi < angle_hat
-        # invert angle, if angle_axis axis points in the opposite direction of the original axis
-        dots = (log_q * axis).sum(dim=-1, keepdim=True)
         angle_hat = torch.where(dots < 0.0, angle_hat * -1.0, angle_hat)
         # angle_axis angle should match input angle
         assert_close(angle_hat, angle, atol=atol, rtol=rtol)

--- a/test/nerf/test_camera_utils.py
+++ b/test/nerf/test_camera_utils.py
@@ -4,7 +4,7 @@ import urllib.request
 import pytest
 import torch
 
-from kornia.geometry.conversions import QuaternionCoeffOrder, quaternion_to_rotation_matrix
+from kornia.geometry.conversions import quaternion_to_rotation_matrix
 from kornia.nerf.camera_utils import create_spiral_path, parse_colmap_output
 from kornia.testing import assert_close
 
@@ -66,7 +66,7 @@ def test_parse_colmap_output(device, dtype, colmap_cameras_path, colmap_images_p
     tz = -1.0631749488011808
 
     q = torch.tensor([qw, qx, qy, qz], device=device, dtype=dtype)
-    R = quaternion_to_rotation_matrix(q, order=QuaternionCoeffOrder.WXYZ)
+    R = quaternion_to_rotation_matrix(q)
     t = torch.tensor([tx, ty, tz], device=device, dtype=dtype)
 
     assert_close(R, cameras.rotation_matrix[2])


### PR DESCRIPTION
#### Changes
PR removed the deprecated code (`XYZW` quaternion coefficient order) and corresponding tests.

Fixes #2427 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
