### PR TITLE
Use ruff to discover and limit code complexity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: pyproject-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.276
+    rev: v0.0.277
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,12 @@ requires = [
 
 [tool.black]
   line-length = 120
-  skip-string-normalization = true
   skip-magic-trailing-comma = true
+  skip-string-normalization = true
 
 [tool.ruff]
   line-length = 120
-  target-version = "py37"
+  target-version = "py38"
   select = ["C9", "E", "F", "I", "PL", "S", "UP", "W", "YTT", "BLE", "C4", "RUF"]
   ignore = [
     "PLW2901", # Allow overwritten values on loops
@@ -87,55 +87,56 @@ requires = [
     known-first-party = ["examples", "kornia", "test"]
 
   [tool.ruff.mccabe]
-    max-complexity = 40
+    max-complexity = 20
 
   [tool.ruff.pylint]
-    max-args = 20
-    max-branches = 32
-    max-returns = 16
-    max-statements = 124
-    allow-magic-value-types = ["str", "bytes", "int", "float"]
+    allow-magic-value-types = ["bytes", "float", "int", "str"]
+    max-args = 17  # Recommended: 5
+    max-branches = 21  # Recommended: 12
+    max-returns = 13  # Recommended: 6
+    max-statements = 64  # Recommended: 50
 
   [tool.ruff.per-file-ignores]
     "*/__init__.py" = ["F401", "F403"] # Allow unused imports and star imports
+    "docs/*" = ["S101", "PLR0912", "PLR0915"] # allow assert, ignore max branches and statements
+    "docs/generate_examples.py" = ["C901"] # Allow too complex function
     "kornia/__init__.py" = ["I001"] # Allow unsorted imports
     "test/*" = ["S101", "S311", "BLE", "RUF012"] # allow assert, random, ignore BLE, mutable class attr
-    "docs/*" = ["S101", "PLR0912", "PLR0915"] # allow assert, ignore max branches and statements
 
 [tool.pytest.ini_options]
   addopts = "--color=yes"
   testpaths = ["test"]
   markers =[
-    "jit: mark a test as torchscript test",
     "grad: mark a test as gradcheck test",
+    "jit: mark a test as torchscript test",
     "nn: mark a test as module test"
 ]
 
 [tool.coverage.report]
 exclude_lines = [
-  "pragma: no cover",
   "def __repr__",
-  "if self.debug:",
-  "raise",
-  "if 0:",
   "if __name__ == .__main__.:",
+  "if 0:",
+  "if self.debug:",
+  "pragma: no cover",
+  "raise",
 ]
 
 [tool.mypy]
-  files = ["kornia/"]
-  pretty = true
   check_untyped_defs = true
   disallow_any_generics = true
   disallow_incomplete_defs = true
-  show_error_codes = true
+  files = ["kornia/"]
   ignore_missing_imports = true
   no_implicit_optional = true
-  warn_unused_ignores = true
+  pretty = true
+  show_error_codes = true
   warn_redundant_casts = true
+  warn_unused_ignores = true
 
 [tool.distutils.bdist_wheel]
   universal = true
 
 [tool.pydocstyle]
-  match = '.*\.py'
   ignore = ['D105','D107','D203','D204','D213','D406','D407']
+  match = '.*\.py'


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

[Ruff](https://beta.ruff.rs) helps us to find Python __code complexity__ with five key rules:
* `C901` McCabe code complexity
* `PLR0911` Too many return statements
* `PLR0912` Too many branches
* `PLR0913` Too many arguments to function call
* `PLR0915` Too many statements

This pull request sets up ruff `per-file-ignores` on the file that contains our most complex Python function:
```
"docs/generate_examples.py" = ["C901", "PLR091"]
```
Doing so allows us to:
1. substantially lower all five ruff complexity thresholds to spot any new attempts to increase code complexity.
2. create a new issue to address the code complexity in the `main()` function in `docs/generate_examples.py`
    * [ ] #2443

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
