### PR TITLE
Apply some ruff pytest fixes

### DIFF
--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -147,7 +147,7 @@ class TestVideoSequential:
             output_2 = output_2.transpose(1, 2)
         assert_close(output_1, output_2)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip(reason="turn off due to Union Type")
     def test_jit(self, device, dtype):
         B, C, D, H, W = 2, 3, 5, 4, 4
@@ -493,7 +493,8 @@ class TestAugmentationSequential:
 
         assert len(transformed) == len(inputs)
         bboxes_transformed = transformed[-1]
-        assert len(bboxes_transformed) == len(bbox) and bboxes_transformed.__class__ == bbox.__class__
+        assert len(bboxes_transformed) == len(bbox)
+        assert bboxes_transformed.__class__ == bbox.__class__
         for i in range(len(bbox)):
             assert len(bboxes_transformed[i]) == len(bbox[i])
 
@@ -650,7 +651,7 @@ class TestAugmentationSequential:
         if random_apply is False:
             reproducibility_test((inp, mask, bbox, keypoints, bbox_2, bbox_wh, bbox_wh_2), aug)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip(reason="turn off due to Union Type")
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4

--- a/test/color/test_gray.py
+++ b/test/color/test_gray.py
@@ -81,7 +81,7 @@ class TestGrayscaleToRgb(BaseTester):
         img_rgb = kornia.color.grayscale_to_rgb(data)
         assert_close(img_rgb, expected)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
@@ -195,7 +195,7 @@ class TestRgbToGrayscale(BaseTester):
         assert img_gray.device == device
         assert img_gray.dtype == dtype
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
@@ -288,7 +288,7 @@ class TestBgrToGrayscale(BaseTester):
         img_gray = kornia.color.bgr_to_grayscale(data)
         assert_close(img_gray, expected)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)

--- a/test/color/test_hls.py
+++ b/test/color/test_hls.py
@@ -124,13 +124,13 @@ class TestRgbToHls(BaseTester):
         ext_rand_slice = (torch.rand((1, 3, 32, 32), dtype=dtype, device=device) >= 0.5).float()
         assert not kornia.color.rgb_to_hls(ext_rand_slice).isnan().any()
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_hls, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         if version.parse(torch.__version__) < version.parse('1.7.0'):
             warnings.warn(
@@ -250,13 +250,13 @@ class TestHlsToRgb(BaseTester):
         data[:, 0] -= 4 * math.pi
         self.assert_close(f(data), expected, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.hls_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         if version.parse(torch.__version__) < version.parse('1.7.0'):
             warnings.warn(

--- a/test/color/test_hsv.py
+++ b/test/color/test_hsv.py
@@ -213,13 +213,13 @@ class TestHsvToRgb(BaseTester):
         data[:, 0] -= 4 * math.pi
         self.assert_close(f(data), expected, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.hsv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/color/test_lab.py
+++ b/test/color/test_lab.py
@@ -97,13 +97,13 @@ class TestRgbToLab(BaseTester):
         data_out = lab(rgb(data, clip=False))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_lab, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -242,14 +242,14 @@ class TestLabToRgb(BaseTester):
         unclipped_data_out = rgb(lab(data), clip=False)
         self.assert_close(unclipped_data_out, data)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         img = kornia.color.rgb_to_lab(img)
         assert gradcheck(kornia.color.lab_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/color/test_luv.py
+++ b/test/color/test_luv.py
@@ -97,13 +97,13 @@ class TestRgbToLuv(BaseTester):
         data_out = luv(rgb(data))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_luv, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -214,14 +214,14 @@ class TestLuvToRgb(BaseTester):
         data_out = rgb(luv(data))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         img = kornia.color.rgb_to_luv(img)
         assert gradcheck(kornia.color.luv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/color/test_raw.py
+++ b/test/color/test_raw.py
@@ -117,13 +117,13 @@ class TestRawToRgb(BaseTester):
         assert_close(bgres[:, :, 1:5, 1:5], grres[:, :, 2:6, 1:5])
         assert_close(bgres[:, :, 1:5, 1:5], rgres[:, :, 2:6, 2:6])
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.raw_to_rgb, (img, kornia.color.raw.CFA.BG), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         if version.parse(torch.__version__) < version.parse('1.7.0'):
             warnings.warn(
@@ -168,13 +168,13 @@ class TestRgbToRaw(BaseTester):
 
         # Reverse test in rawtorgb is sufficient functional test
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_raw, (img, kornia.color.raw.CFA.BG), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         if version.parse(torch.__version__) < version.parse('1.7.0'):
             warnings.warn(

--- a/test/color/test_rgb.py
+++ b/test/color/test_rgb.py
@@ -58,13 +58,13 @@ class TestRgbToBgr(BaseTester):
         f = kornia.color.rgb_to_bgr
         self.assert_close(f(data), expected)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_bgr, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -190,13 +190,13 @@ class TestRgbToRgba(BaseTester):
         aval = torch.full_like(data[:, :1], aval)  # Bx1xHxW
         self.assert_close(kornia.color.rgb_to_rgba(data, aval), expected)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_rgba, (img, 1.0), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck_th(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
@@ -204,7 +204,7 @@ class TestRgbToRgba(BaseTester):
         assert gradcheck(kornia.color.rgb_to_rgba, (img, aval), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="unsupported Union type")
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -321,14 +321,14 @@ class TestLinearRgb(BaseTester):
         f = kornia.color.linear_rgb_to_rgb
         self.assert_close(f(data), expected)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_linear_rgb, (img,), raise_exception=True, fast_mode=True)
         assert gradcheck(kornia.color.linear_rgb_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -336,7 +336,7 @@ class TestLinearRgb(BaseTester):
         op_jit = torch.jit.script(op)
         self.assert_close(op(img), op_jit(img))
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit_linear(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/color/test_xyz.py
+++ b/test/color/test_xyz.py
@@ -95,13 +95,13 @@ class TestRgbToXyz(BaseTester):
         data_out = xyz(rgb(data))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_xyz, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -206,13 +206,13 @@ class TestXyzToRgb(BaseTester):
         data_out = rgb(xyz(data))
         self.assert_close(data_out, data, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.xyz_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/color/test_ycbcr.py
+++ b/test/color/test_ycbcr.py
@@ -104,13 +104,13 @@ class TestRgbToYcbcr(BaseTester):
     # def test_forth_and_back(self, device, dtype):
     #    pass
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_ycbcr, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -217,13 +217,13 @@ class TestYcbcrToRgb(BaseTester):
     # def test_forth_and_back(self, device, dtype):
     #    pass
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.ycbcr_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/color/test_yuv.py
+++ b/test/color/test_yuv.py
@@ -43,13 +43,13 @@ class TestRgbToYuv(BaseTester):
         data_out = rgb(yuv(data))
         self.assert_close(data_out, data, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_yuv, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -198,13 +198,13 @@ class TestRgbToYuv420(BaseTester):
         data_out = rgb(a, b)
         self.assert_close(data_out, data, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_yuv420, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -268,13 +268,13 @@ class TestRgbToYuv422(BaseTester):
         data_out = rgb(a, b)
         self.assert_close(data_out, data, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_yuv422, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -328,13 +328,13 @@ class TestYuvToRgb(BaseTester):
         data_out = rgb(yuv(data))
         self.assert_close(data_out, data, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.yuv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -431,14 +431,14 @@ class TestYuv420ToRgb(BaseTester):
         self.assert_close(data_outy, datay, low_tolerance=True)
         self.assert_close(data_outuv, datauv, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, H, W = 2, 4, 4
         imgy = torch.rand(B, 1, H, W, device=device, dtype=torch.float64, requires_grad=True)
         imguv = torch.rand(B, 2, int(H / 2), int(W / 2), device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.yuv420_to_rgb, (imgy, imguv), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, H, W = 2, 4, 4
         imgy = torch.ones(B, 1, H, W, device=device, dtype=dtype)
@@ -510,14 +510,14 @@ class TestYuv422ToRgb(BaseTester):
         self.assert_close(data_outy, datay, low_tolerance=True)
         self.assert_close(data_outuv, datauv, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, H, W = 2, 4, 4
         imgy = torch.rand(B, 1, H, W, device=device, dtype=torch.float64, requires_grad=True)
         imguv = torch.rand(B, 2, H, int(W / 2), device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.yuv422_to_rgb, (imgy, imguv), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, H, W = 2, 4, 4
         imgy = torch.ones(B, 1, H, W, device=device, dtype=dtype)

--- a/test/contrib/test_contrib.py
+++ b/test/contrib/test_contrib.py
@@ -50,10 +50,12 @@ class TestVisionTransformer:
         vit = kornia.contrib.VisionTransformer(image_size=image_size, num_heads=H, embed_dim=D).to(device, dtype)
 
         out = vit(img)
-        assert isinstance(out, torch.Tensor) and out.shape == (B, T, D)
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (B, T, D)
 
         feats = vit.encoder_results
-        assert isinstance(feats, list) and len(feats) == 12
+        assert isinstance(feats, list)
+        assert len(feats) == 12
         for f in feats:
             assert f.shape == (B, T, D)
 
@@ -80,7 +82,8 @@ class TestMobileViT:
         mvit = kornia.contrib.MobileViT(mode=mode, patch_size=patch_size).to(device, dtype)
 
         out = mvit(img)
-        assert isinstance(out, torch.Tensor) and out.shape == (B, channel[mode], 8, 8)
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (B, channel[mode], 8, 8)
 
 
 class TestClassificationHead:

--- a/test/enhance/test_adjust.py
+++ b/test/enhance/test_adjust.py
@@ -29,14 +29,14 @@ class TestInvert(BaseTester):
         out = kornia.enhance.invert(img, torch.tensor(255.0))
         self.assert_close(out, torch.zeros_like(out))
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 1, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         max_val = torch.tensor(1.0, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.enhance.invert, (img, max_val), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -781,7 +781,7 @@ class TestAdjustSigmoid(BaseTester):
         op_optimized = torch_optimizer(op)
         self.assert_close(op(img), op_optimized(img))
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         bs, channels, height, width = 1, 2, 3, 3
         inputs = torch.ones(bs, channels, height, width, device=device, dtype=dtype)
@@ -850,7 +850,7 @@ class TestAdjustLog(BaseTester):
         op_optimized = torch_optimizer(op)
         self.assert_close(op(img), op_optimized(img))
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         bs, channels, height, width = 1, 2, 3, 3
         inputs = torch.ones(bs, channels, height, width, device=device, dtype=dtype)
@@ -1183,7 +1183,7 @@ class TestSharpness(BaseTester):
         self.assert_close(TestSharpness.f(inputs, 0.8), expected_08, low_tolerance=True)
         self.assert_close(TestSharpness.f(inputs, torch.tensor([0.8, 1.3])), expected_08_13, low_tolerance=True)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=dtype)
@@ -1191,7 +1191,7 @@ class TestSharpness(BaseTester):
         assert gradcheck(TestSharpness.f, (inputs, 0.8), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="union type input")
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = TestSharpness.f
         op_script = torch.jit.script(TestSharpness.f)
@@ -1273,7 +1273,7 @@ class TestSolarize(BaseTester):
         # TODO(jian): precision is very bad compared to PIL
         self.assert_close(TestSolarize.f(inputs, 0.5), expected, rtol=1e-2, atol=1e-2)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=dtype)
@@ -1282,7 +1282,7 @@ class TestSolarize(BaseTester):
 
     # TODO: implement me
     @pytest.mark.skip(reason="union type input")
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = TestSolarize.f
         op_script = torch.jit.script(op)
@@ -1354,7 +1354,7 @@ class TestPosterize(BaseTester):
         self.assert_close(TestPosterize.f(inputs, 8), inputs)
 
     @pytest.mark.skip(reason="IndexError: tuple index out of range")
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=dtype)
@@ -1363,7 +1363,7 @@ class TestPosterize(BaseTester):
 
     # TODO: implement me
     @pytest.mark.skip(reason="union type input")
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = TestPosterize.f
         op_script = torch.jit.script(op)

--- a/test/enhance/test_histogram.py
+++ b/test/enhance/test_histogram.py
@@ -15,19 +15,22 @@ class TestImageHistogram2d:
     def test_shape(self, device, dtype, kernel):
         sample = torch.ones(32, 32, device=device, dtype=dtype)
         hist, pdf = TestImageHistogram2d.fcn(sample, 0.0, 1.0, 256, kernel=kernel)
-        assert hist.shape == (256,) and pdf.shape == (256,)
+        assert hist.shape == (256,)
+        assert pdf.shape == (256,)
 
     @pytest.mark.parametrize("kernel", ["triangular", "gaussian", "uniform", "epanechnikov"])
     def test_shape_channels(self, device, dtype, kernel):
         sample = torch.ones(3, 32, 32, device=device, dtype=dtype)
         hist, pdf = TestImageHistogram2d.fcn(sample, 0.0, 1.0, 256, kernel=kernel)
-        assert hist.shape == (3, 256) and pdf.shape == (3, 256)
+        assert hist.shape == (3, 256)
+        assert pdf.shape == (3, 256)
 
     @pytest.mark.parametrize("kernel", ["triangular", "gaussian", "uniform", "epanechnikov"])
     def test_shape_batch(self, device, dtype, kernel):
         sample = torch.ones(8, 3, 32, 32, device=device, dtype=dtype)
         hist, pdf = TestImageHistogram2d.fcn(sample, 0.0, 1.0, 256, kernel=kernel)
-        assert hist.shape == (8, 3, 256) and pdf.shape == (8, 3, 256)
+        assert hist.shape == (8, 3, 256)
+        assert pdf.shape == (8, 3, 256)
 
     @pytest.mark.parametrize("kernel", ["triangular", "gaussian", "uniform", "epanechnikov"])
     def test_gradcheck(self, device, dtype, kernel):

--- a/test/enhance/test_normalize.py
+++ b/test/enhance/test_normalize.py
@@ -309,14 +309,14 @@ class TestNormalizeMinMax(BaseTester):
         actual = kornia.enhance.normalize_min_max(x, min_val=-1.0, max_val=1.0)
         self.assert_close(actual, expected, low_tolerance=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         x = torch.ones(1, 1, 1, 1, device=device, dtype=dtype)
         op = kornia.enhance.normalize_min_max
         op_jit = torch.jit.script(op)
         self.assert_close(op(x), op_jit(x))
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         x = torch.ones(1, 1, 1, 1, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.enhance.normalize_min_max, (x,), raise_exception=True, fast_mode=True)

--- a/test/feature/test_defmo.py
+++ b/test/feature/test_defmo.py
@@ -28,7 +28,7 @@ class TestDeFMO:
         defmo = DeFMO().to(patches.device, patches.dtype)
         assert gradcheck(defmo, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 1, 6, 128, 160
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)

--- a/test/feature/test_hardnet.py
+++ b/test/feature/test_hardnet.py
@@ -29,7 +29,7 @@ class TestHardNet:
             hardnet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True
         )
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -59,7 +59,7 @@ class TestHardNet8:
         hardnet = HardNet8().to(patches.device, patches.dtype)
         assert gradcheck(hardnet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/feature/test_hynet.py
+++ b/test/feature/test_hynet.py
@@ -26,7 +26,7 @@ class TestHyNet:
         hynet = HyNet().to(patches.device, patches.dtype)
         assert gradcheck(hynet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8, raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)

--- a/test/feature/test_laf.py
+++ b/test/feature/test_laf.py
@@ -28,7 +28,7 @@ class TestAngleToRotationMatrix:
             kornia.geometry.transform.imgwarp.angle_to_rotation_matrix, (img,), raise_exception=True, fast_mode=True
         )
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip("Problems with kornia.pi")
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
@@ -57,7 +57,7 @@ class TestGetLAFScale:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.feature.get_laf_scale, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width, device=device)
@@ -85,7 +85,7 @@ class TestGetLAFCenter:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.feature.get_laf_center, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width, device=device)
@@ -113,7 +113,7 @@ class TestGetLAFOri:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.feature.get_laf_orientation, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -150,7 +150,7 @@ class TestScaleLAF:
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
         assert gradcheck(kornia.feature.scale_laf, (laf, scale), raise_exception=True, atol=1e-4, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -185,7 +185,7 @@ class TestSetLAFOri:
             kornia.feature.set_laf_orientation, (laf, ori), raise_exception=True, atol=1e-4, fast_mode=True
         )
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -228,7 +228,7 @@ class TestMakeUpright:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.feature.make_upright, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -262,7 +262,7 @@ class TestELL2LAF:
         img = utils.tensor_to_gradcheck_var(img)  # to var
         assert gradcheck(kornia.feature.ellipse_to_laf, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height = 1, 2, 5
         img = torch.rand(batch_size, channels, height, device=device).abs()
@@ -297,7 +297,7 @@ class TestNormalizeLAF:
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
         assert gradcheck(kornia.feature.normalize_laf, (laf, img), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
 
@@ -328,7 +328,7 @@ class TestLAF2pts:
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
         assert gradcheck(kornia.feature.laf_to_boundary_points, (laf), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 3, 2, 2, 3
         laf = torch.rand(batch_size, channels, height, width, device=device)
@@ -361,7 +361,7 @@ class TestDenormalizeLAF:
         laf = utils.tensor_to_gradcheck_var(laf)  # to var
         assert gradcheck(kornia.feature.denormalize_laf, (laf, img), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
 
@@ -496,7 +496,7 @@ class TestLAFIsTouchingBoundary:
         expected = torch.tensor([[False, True]], device=device)
         assert torch.all(kornia.feature.laf_is_inside_image(laf, img) == expected).item()
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         w, h = 10, 5
         img = torch.rand(1, 3, h, w, device=device)
@@ -551,7 +551,7 @@ class TestGetCreateLAF:
         )
 
     @pytest.mark.skip("Depends on angle-to-rotation-matric")
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels = 3, 2
         xy = torch.rand(batch_size, channels, 2, device=device)
@@ -585,7 +585,7 @@ class TestGetLAF3pts:
         inp = utils.tensor_to_gradcheck_var(inp)  # to var
         assert gradcheck(kornia.feature.laf_to_three_points, (inp,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 3, 2, 2, 3
         inp = torch.rand(batch_size, channels, height, width, device=device)
@@ -624,7 +624,7 @@ class TestGetLAFFrom3pts:
         inp = utils.tensor_to_gradcheck_var(inp)  # to var
         assert gradcheck(kornia.feature.laf_from_three_points, (inp,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 3, 2, 2, 3
         inp = torch.rand(batch_size, channels, height, width, device=device)

--- a/test/feature/test_local_features_orientation.py
+++ b/test/feature/test_local_features_orientation.py
@@ -74,7 +74,7 @@ class TestPatchDominantGradientOrientation:
         patches = utils.tensor_to_gradcheck_var(patches)  # to var
         assert gradcheck(ori, (patches,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip(" Compiled functions can't take variable number")
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 13, 13
@@ -123,7 +123,7 @@ class TestOriNet:
         ori = OriNet().to(device=device, dtype=patches.dtype)
         assert gradcheck(ori, (patches,), raise_exception=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/feature/test_matching.py
+++ b/test/feature/test_matching.py
@@ -222,7 +222,7 @@ class TestMatchSMNN:
         assert gradcheck(match_smnn, (desc1, desc2, 0.8), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
         assert gradcheck(matcher, (desc1, desc2), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.parametrize("match_type", ["nn", "snn", "mnn", "smnn"])
     def test_jit(self, match_type, device, dtype):
         desc1 = torch.rand(5, 8, device=device, dtype=dtype)
@@ -334,7 +334,7 @@ class TestMatchFGINN:
             match_fginn, (desc1, desc2, lafs1, lafs2, 0.8, 0.05), raise_exception=True, nondet_tol=1e-4, fast_mode=True
         )
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.skip("keyword-arg expansion is not supported")
     def test_jit(self, device, dtype):
         desc1 = torch.rand(5, 8, device=device, dtype=dtype)

--- a/test/feature/test_mkd.py
+++ b/test/feature/test_mkd.py
@@ -134,7 +134,7 @@ class TestVonMisesKernel:
 
         assert gradcheck(vm_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 13, 13
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
@@ -187,7 +187,7 @@ class TestEmbedGradients:
 
         assert gradcheck(emb_grads_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 2, 13, 13
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
@@ -261,7 +261,7 @@ class TestExplicitSpacialEncoding:
             explicit_spatial_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True
         )
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 2, 13, 13
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
@@ -323,7 +323,7 @@ class TestWhitening:
 
         assert gradcheck(whitening_describe, (patches, in_dims), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, in_dims = 1, 175
         patches = torch.rand(batch_size, in_dims).to(device)
@@ -398,7 +398,7 @@ class TestMKDDescriptor:
         assert gradcheck(mkd_describe, (patches, ps), raise_exception=True, nondet_tol=1e-4, fast_mode=True)
 
     @pytest.mark.skip("neither dict, nor nn.ModuleDict works")
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, ps = 1, 1, 19
         patches = torch.rand(batch_size, channels, ps, ps).to(device)

--- a/test/feature/test_sosnet.py
+++ b/test/feature/test_sosnet.py
@@ -28,7 +28,7 @@ class TestSOSNet:
         sosnet = SOSNet(pretrained=False).to(patches.device, patches.dtype)
         assert gradcheck(sosnet, (patches,), eps=1e-4, atol=1e-4, raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/feature/test_tfeat.py
+++ b/test/feature/test_tfeat.py
@@ -35,7 +35,7 @@ class TestTFeat:
         tfeat = TFeat().to(patches.device, patches.dtype)
         assert gradcheck(tfeat, (patches,), eps=1e-2, atol=1e-2, raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/test/geometry/epipolar/test_triangulation.py
+++ b/test/geometry/epipolar/test_triangulation.py
@@ -28,7 +28,7 @@ class TestTriangulation:
         points3d = epi.triangulate_points(P1, P2, points1, points2)
         assert points3d.shape == (B, N, 3)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail()
     def test_two_view(self, device, dtype):
         num_views: int = 2
         num_points: int = 10

--- a/test/geometry/subpix/test_dsnt.py
+++ b/test/geometry/subpix/test_dsnt.py
@@ -6,7 +6,7 @@ from kornia.testing import assert_close
 
 
 class TestRenderGaussian2d:
-    @pytest.fixture
+    @pytest.fixture()
     def gaussian(self, device, dtype):
         return torch.tensor(
             [

--- a/test/geometry/test_boxes.py
+++ b/test/geometry/test_boxes.py
@@ -50,15 +50,19 @@ class TestBoxes2D:
 
         # Boxes
         h, w = boxes.get_boxes_shape()
-        assert h.ndim == 1 and w.ndim == 1
-        assert len(h) == 2 and len(w) == 2
+        assert h.ndim == 1
+        assert w.ndim == 1
+        assert len(h) == 2
+        assert len(w) == 2
         assert_close(h, torch.as_tensor([2.0, 3.0], device=device, dtype=dtype))
         assert_close(w, torch.as_tensor([3.0, 4.0], device=device, dtype=dtype))
 
         # Box batch
         h, w = boxes_batch.get_boxes_shape()
-        assert h.ndim == 2 and w.ndim == 2
-        assert h.shape == (1, 2) and w.shape == (1, 2)
+        assert h.ndim == 2
+        assert w.ndim == 2
+        assert h.shape == (1, 2)
+        assert w.shape == (1, 2)
         assert_close(h, torch.as_tensor([[2.0, 3.0]], device=device, dtype=dtype))
         assert_close(w, torch.as_tensor([[3.0, 4.0]], device=device, dtype=dtype))
 
@@ -68,8 +72,10 @@ class TestBoxes2D:
         batched_boxes = Boxes(torch.stack([t_box1, t_box2]))
 
         h, w = batched_boxes.get_boxes_shape()
-        assert h.ndim == 2 and w.ndim == 2
-        assert h.shape == (2, 1) and w.shape == (2, 1)
+        assert h.ndim == 2
+        assert w.ndim == 2
+        assert h.shape == (2, 1)
+        assert w.shape == (2, 1)
         assert_close(h, torch.as_tensor([[2], [3]], device=device, dtype=dtype))
         assert_close(w, torch.as_tensor([[3], [4]], device=device, dtype=dtype))
 
@@ -445,16 +451,21 @@ class TestBbox3D:
 
         # Boxes
         d, h, w = boxes.get_boxes_shape()
-        assert h.ndim == 1 and w.ndim == 1
-        assert len(d) == 2 and len(h) == 2 and len(w) == 2
+        assert h.ndim == 1
+        assert w.ndim == 1
+        assert len(d) == 2
+        assert len(h) == 2
+        assert len(w) == 2
         assert_close(d, torch.as_tensor([31.0, 61.0], device=device, dtype=dtype))
         assert_close(h, torch.as_tensor([21.0, 51.0], device=device, dtype=dtype))
         assert_close(w, torch.as_tensor([11.0, 41.0], device=device, dtype=dtype))
 
         # Box batch
         d, h, w = boxes_batch.get_boxes_shape()
-        assert h.ndim == 2 and w.ndim == 2
-        assert h.shape == (1, 2) and w.shape == (1, 2)
+        assert h.ndim == 2
+        assert w.ndim == 2
+        assert h.shape == (1, 2)
+        assert w.shape == (1, 2)
         assert_close(d, torch.as_tensor([[31.0, 61.0]], device=device, dtype=dtype))
         assert_close(h, torch.as_tensor([[21.0, 51.0]], device=device, dtype=dtype))
         assert_close(w, torch.as_tensor([[11.0, 41.0]], device=device, dtype=dtype))
@@ -473,8 +484,12 @@ class TestBbox3D:
         batched_boxes = Boxes3D(torch.stack([t_box1, t_box2]))
 
         d, h, w = batched_boxes.get_boxes_shape()
-        assert d.ndim == 2 and h.ndim == 2 and w.ndim == 2
-        assert d.shape == (2, 1) and h.shape == (2, 1) and w.shape == (2, 1)
+        assert d.ndim == 2
+        assert h.ndim == 2
+        assert w.ndim == 2
+        assert d.shape == (2, 1)
+        assert h.shape == (2, 1)
+        assert w.shape == (2, 1)
         assert_close(d, torch.as_tensor([[31.0], [61.0]], device=device, dtype=dtype))
         assert_close(h, torch.as_tensor([[21.0], [51.0]], device=device, dtype=dtype))
         assert_close(w, torch.as_tensor([[11.0], [41.0]], device=device, dtype=dtype))

--- a/test/geometry/test_conversions.py
+++ b/test/geometry/test_conversions.py
@@ -24,7 +24,7 @@ from kornia.geometry.quaternion import Quaternion
 from kornia.testing import BaseTester, assert_close, create_eye_batch, tensor_to_gradcheck_var
 
 
-@pytest.fixture
+@pytest.fixture()
 def atol(device, dtype):
     """Lower tolerance for cuda-float16 only."""
     if 'cuda' in device.type and dtype == torch.float16:
@@ -32,7 +32,7 @@ def atol(device, dtype):
     return 1.0e-4
 
 
-@pytest.fixture
+@pytest.fixture()
 def rtol(device, dtype):
     """Lower tolerance for cuda-float16 only."""
     if 'cuda' in device.type and dtype == torch.float16:

--- a/test/geometry/test_homography.py
+++ b/test/geometry/test_homography.py
@@ -187,7 +187,8 @@ class TestFindHomographyDLT:
         weights = torch.ones(B, N, device=device, dtype=dtype)
         H_noweights = find_homography_dlt(points1, points2, None)
         H_withweights = find_homography_dlt(points1, points2, weights)
-        assert H_noweights.shape == (B, 3, 3) and H_withweights.shape == (B, 3, 3)
+        assert H_noweights.shape == (B, 3, 3)
+        assert H_withweights.shape == (B, 3, 3)
         assert_close(H_noweights, H_withweights, rtol=1e-3, atol=1e-4)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 5])
@@ -222,7 +223,7 @@ class TestFindHomographyDLT:
 
         assert_close(kornia.geometry.transform_points(dst_homo_src, points_src), points_dst, rtol=1e-3, atol=1e-4)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device):
         points_src = utils.tensor_to_gradcheck_var(
             torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
@@ -239,7 +240,7 @@ class TestFindHomographyDLT:
             fast_mode=True,
         )
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck_lu(self, device):
         points_src = utils.tensor_to_gradcheck_var(
             torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
@@ -328,7 +329,8 @@ class TestFindHomographyFromLinesDLT:
         ls2 = torch.stack([points2st, points2end], dim=2)
         H_noweights = find_homography_lines_dlt(ls1, ls2, None)
         H_withweights = find_homography_lines_dlt(ls1, ls2, weights)
-        assert H_noweights.shape == (B, 3, 3) and H_withweights.shape == (B, 3, 3)
+        assert H_noweights.shape == (B, 3, 3)
+        assert H_withweights.shape == (B, 3, 3)
         assert_close(H_noweights, H_withweights, rtol=1e-3, atol=1e-4)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 5])
@@ -369,7 +371,7 @@ class TestFindHomographyFromLinesDLT:
 
         assert_close(kornia.geometry.transform_points(dst_homo_src, points_src_st), points_dst_st, rtol=1e-3, atol=1e-4)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device):
         points_src_st = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
         points_src_end = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
@@ -421,7 +423,7 @@ class TestFindHomographyDLTIter:
 
         assert_close(kornia.geometry.transform_points(dst_homo_src, points_src), points_dst, rtol=1e-3, atol=1e-4)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device):
         torch.manual_seed(0)
         points_src = utils.tensor_to_gradcheck_var(
@@ -438,7 +440,7 @@ class TestFindHomographyDLTIter:
             fast_mode=True,
         )
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     @pytest.mark.parametrize("batch_size", [1, 2])
     def test_dirty_points_and_gradcheck(self, batch_size, device, dtype):
         # generate input data

--- a/test/geometry/transform/test_pyramid.py
+++ b/test/geometry/transform/test_pyramid.py
@@ -208,7 +208,7 @@ class TestUpscaleDouble(BaseTester):
         op_optimized = torch_optimizer(op)
         self.assert_close(op(img), op_optimized(img))
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device):
         x = self.prepare_data((1, 2, 5, 5), device)
         x = utils.tensor_to_gradcheck_var(x)

--- a/test/geometry/transform/test_thin_plate_spline.py
+++ b/test/geometry/transform/test_thin_plate_spline.py
@@ -50,7 +50,7 @@ class TestTransformParameters:
             src = torch.rand(batch_size, 5)
             assert kornia.geometry.transform.get_tps_transform(src, src)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     @pytest.mark.parametrize('batch_size', [1, 3])
     @pytest.mark.parametrize('requires_grad', [True, False])
     def test_gradcheck(self, batch_size, device, dtype, requires_grad):
@@ -60,7 +60,7 @@ class TestTransformParameters:
         dst.requires_grad_(not requires_grad)
         assert gradcheck(kornia.geometry.transform.get_tps_transform, (src, dst), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.parametrize('batch_size', [1, 3])
     def test_jit(self, batch_size, device, dtype):
         src, dst = _sample_points(batch_size, device)
@@ -121,7 +121,7 @@ class TestWarpPoints:
             affine_bad = torch.rand(batch_size, 3)
             assert kornia.geometry.transform.warp_points_tps(src, src, kernel, affine_bad)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     @pytest.mark.parametrize('batch_size', [1, 3])
     @pytest.mark.parametrize('requires_grad', [True, False])
     def test_gradcheck(self, batch_size, device, dtype, requires_grad):
@@ -134,7 +134,7 @@ class TestWarpPoints:
             kornia.geometry.transform.warp_points_tps, (src, dst, kernel, affine), raise_exception=True, fast_mode=True
         )
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.parametrize('batch_size', [1, 3])
     def test_jit(self, batch_size, device, dtype):
         src, dst = _sample_points(batch_size, device)
@@ -210,7 +210,7 @@ class TestWarpImage:
             affine_bad = torch.rand(batch_size, 3)
             assert kornia.geometry.transform.warp_image_tps(image, dst, kernel, affine_bad)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     @pytest.mark.parametrize('batch_size', [1, 3])
     def test_gradcheck(self, batch_size, device, dtype):
         opts = {'device': device, 'dtype': torch.float64}
@@ -227,7 +227,7 @@ class TestWarpImage:
             fast_mode=True,
         )
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     @pytest.mark.parametrize('batch_size', [1, 3])
     def test_jit(self, batch_size, device, dtype):
         src, dst = _sample_points(batch_size, device)

--- a/test/integration/test_conversions.py
+++ b/test/integration/test_conversions.py
@@ -7,7 +7,7 @@ from kornia.geometry.conversions import QuaternionCoeffOrder
 from kornia.testing import assert_close
 
 
-@pytest.fixture
+@pytest.fixture()
 def atol(device, dtype):
     """Lower tolerance for cuda-float16 only."""
     if 'cuda' in device.type and dtype == torch.float16:
@@ -15,7 +15,7 @@ def atol(device, dtype):
     return 1.0e-4
 
 
-@pytest.fixture
+@pytest.fixture()
 def rtol(device, dtype):
     """Lower tolerance for cuda-float16 only."""
     if 'cuda' in device.type and dtype == torch.float16:

--- a/test/io/test_load_image.py
+++ b/test/io/test_load_image.py
@@ -63,19 +63,24 @@ class TestLoadImage:
             assert os.path.isfile(file_path)
 
             img = load_image(file_path, ImageLoadType.GRAY8)
-            assert img.shape[0] == 1 and img.dtype == torch.uint8
+            assert img.shape[0] == 1
+            assert img.dtype == torch.uint8
 
             img = load_image(file_path, ImageLoadType.GRAY32)
-            assert img.shape[0] == 1 and img.dtype == torch.float32
+            assert img.shape[0] == 1
+            assert img.dtype == torch.float32
 
             img = load_image(file_path, ImageLoadType.RGB8)
-            assert img.shape[0] == 3 and img.dtype == torch.uint8
+            assert img.shape[0] == 3
+            assert img.dtype == torch.uint8
 
             img = load_image(file_path, ImageLoadType.RGB32)
-            assert img.shape[0] == 3 and img.dtype == torch.float32
+            assert img.shape[0] == 3
+            assert img.dtype == torch.float32
 
             img = load_image(file_path, ImageLoadType.RGBA8)
-            assert img.shape[0] == 4 and img.dtype == torch.uint8
+            assert img.shape[0] == 4
+            assert img.dtype == torch.uint8
 
     @pytest.mark.parametrize("ext", ["png", "jpg"])
     def test_types_gray(self, ext):
@@ -87,16 +92,21 @@ class TestLoadImage:
             assert os.path.isfile(file_path)
 
             img = load_image(file_path, ImageLoadType.GRAY8)
-            assert img.shape[0] == 1 and img.dtype == torch.uint8
+            assert img.shape[0] == 1
+            assert img.dtype == torch.uint8
 
             img = load_image(file_path, ImageLoadType.GRAY32)
-            assert img.shape[0] == 1 and img.dtype == torch.float32
+            assert img.shape[0] == 1
+            assert img.dtype == torch.float32
 
             img = load_image(file_path, ImageLoadType.RGB8)
-            assert img.shape[0] == 3 and img.dtype == torch.uint8
+            assert img.shape[0] == 3
+            assert img.dtype == torch.uint8
 
             img = load_image(file_path, ImageLoadType.RGB32)
-            assert img.shape[0] == 3 and img.dtype == torch.float32
+            assert img.shape[0] == 3
+            assert img.dtype == torch.float32
 
             img = load_image(file_path, ImageLoadType.RGBA8)
-            assert img.shape[0] == 4 and img.dtype == torch.uint8
+            assert img.shape[0] == 4
+            assert img.dtype == torch.uint8

--- a/test/losses/test_hd.py
+++ b/test/losses/test_hd.py
@@ -84,7 +84,7 @@ class HausdorffERLossNumpy(nn.Module):
         pred: (b, 1, x, y, z) or (b, 1, x, y)
         target: (b, 1, x, y, z) or (b, 1, x, y)
         """
-        assert pred.dim() == 4 or pred.dim() == 5, "Only 2D and 3D supported"
+        assert pred.dim() in (4, 5), "Only 2D and 3D supported"
         assert pred.dim() == target.dim() and target.size(1) == 1, "Prediction and target need to be of same dimension"
         return torch.stack(
             [

--- a/test/morphology/test_bottom_hat.py
+++ b/test/morphology/test_bottom_hat.py
@@ -63,13 +63,13 @@ class TestBottomHat:
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert bottom_hat(sample, test)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         sample = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
         assert gradcheck(bottom_hat, (sample, kernel), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = bottom_hat
         op_script = torch.jit.script(op)

--- a/test/morphology/test_closing.py
+++ b/test/morphology/test_closing.py
@@ -63,13 +63,13 @@ class TestClosing:
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert closing(tensor, test)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
         assert gradcheck(closing, (tensor, kernel), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = closing
         op_script = torch.jit.script(op)

--- a/test/morphology/test_dilation.py
+++ b/test/morphology/test_dilation.py
@@ -87,13 +87,13 @@ class TestDilate:
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert dilation(tensor, test)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
         assert gradcheck(dilation, (tensor, kernel), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = dilation
         op_script = torch.jit.script(op)

--- a/test/morphology/test_erosion.py
+++ b/test/morphology/test_erosion.py
@@ -86,13 +86,13 @@ class TestErode:
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert erosion(tensor, test)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
         assert gradcheck(erosion, (tensor, kernel), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = erosion
         op_script = torch.jit.script(op)

--- a/test/morphology/test_gradient.py
+++ b/test/morphology/test_gradient.py
@@ -63,13 +63,13 @@ class TestGradient:
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert gradient(tensor, test)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
         assert gradcheck(gradient, (tensor, kernel), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = gradient
         op_script = torch.jit.script(op)

--- a/test/morphology/test_opening.py
+++ b/test/morphology/test_opening.py
@@ -63,13 +63,13 @@ class TestOpening:
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert opening(tensor, test)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         tensor = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
         assert gradcheck(opening, (tensor, kernel), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = opening
         op_script = torch.jit.script(op)

--- a/test/morphology/test_top_hat.py
+++ b/test/morphology/test_top_hat.py
@@ -63,13 +63,13 @@ class TestTopHat:
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert top_hat(sample, test)
 
-    @pytest.mark.grad
+    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         sample = torch.rand(2, 3, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
         kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
         assert gradcheck(top_hat, (sample, kernel), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit
+    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = top_hat
         op_script = torch.jit.script(op)

--- a/test/nerf/test_camera_utils.py
+++ b/test/nerf/test_camera_utils.py
@@ -30,24 +30,24 @@ def _get_data(url: str, sha256: str) -> str:
     return data.decode('utf-8')
 
 
-@pytest.fixture
+@pytest.fixture()
 def colmap_cameras_path(tmp_path):
     data = _get_data(*_ref['cameras'])
 
     p = tmp_path / "camera.txt"
     p.write_text(data)
 
-    yield p
+    return p
 
 
-@pytest.fixture
+@pytest.fixture()
 def colmap_images_path(tmp_path):
     data = _get_data(*_ref['images'])
 
     p = tmp_path / "images.txt"
     p.write_text(data)
 
-    yield p
+    return p
 
 
 def test_parse_colmap_output(device, dtype, colmap_cameras_path, colmap_images_path) -> None:

--- a/test/tracking/test_planar_tracking.py
+++ b/test/tracking/test_planar_tracking.py
@@ -8,7 +8,7 @@ from kornia.tracking import HomographyTracker
 from kornia.utils._compat import torch_version_le
 
 
-@pytest.fixture
+@pytest.fixture()
 def data():
     url = 'https://github.com/kornia/data_test/blob/main/loftr_outdoor_and_homography_data.pt?raw=true'
     return torch.hub.load_state_dict_from_url(url)

--- a/test/x/test_detection.py
+++ b/test/x/test_detection.py
@@ -24,33 +24,33 @@ class DummyModel(nn.Module):
         return self.model(x)
 
 
-@pytest.fixture
+@pytest.fixture()
 def model():
     return DummyModel()
 
 
-@pytest.fixture
+@pytest.fixture()
 def dataloader():
     dataset = DummyDatasetDetection()
     return torch.utils.data.DataLoader(dataset, batch_size=1)
 
 
-@pytest.fixture
+@pytest.fixture()
 def criterion():
     return nn.MSELoss()
 
 
-@pytest.fixture
+@pytest.fixture()
 def optimizer(model):
     return torch.optim.AdamW(model.parameters())
 
 
-@pytest.fixture
+@pytest.fixture()
 def scheduler(optimizer, dataloader):
     return torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, len(dataloader))
 
 
-@pytest.fixture
+@pytest.fixture()
 def configuration():
     config = Configuration()
     config.num_epochs = 1

--- a/test/x/test_image_classification.py
+++ b/test/x/test_image_classification.py
@@ -16,33 +16,33 @@ class DummyDatasetClassification(Dataset):
         return torch.ones(3, 32, 32), torch.tensor(1)
 
 
-@pytest.fixture
+@pytest.fixture()
 def model():
     return nn.Sequential(VisionTransformer(image_size=32), ClassificationHead(num_classes=10))
 
 
-@pytest.fixture
+@pytest.fixture()
 def dataloader():
     dataset = DummyDatasetClassification()
     return torch.utils.data.DataLoader(dataset, batch_size=1)
 
 
-@pytest.fixture
+@pytest.fixture()
 def criterion():
     return nn.CrossEntropyLoss()
 
 
-@pytest.fixture
+@pytest.fixture()
 def optimizer(model):
     return torch.optim.AdamW(model.parameters())
 
 
-@pytest.fixture
+@pytest.fixture()
 def scheduler(optimizer, dataloader):
     return torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, len(dataloader))
 
 
-@pytest.fixture
+@pytest.fixture()
 def configuration():
     config = Configuration()
     config.num_epochs = 1

--- a/test/x/test_segmentation.py
+++ b/test/x/test_segmentation.py
@@ -15,33 +15,33 @@ class DummyDatasetSegmentation(Dataset):
         return torch.ones(3, 32, 32), torch.ones(32, 32).long()
 
 
-@pytest.fixture
+@pytest.fixture()
 def model():
     return nn.Conv2d(3, 10, kernel_size=1)
 
 
-@pytest.fixture
+@pytest.fixture()
 def dataloader():
     dataset = DummyDatasetSegmentation()
     return torch.utils.data.DataLoader(dataset, batch_size=1)
 
 
-@pytest.fixture
+@pytest.fixture()
 def criterion():
     return nn.CrossEntropyLoss()
 
 
-@pytest.fixture
+@pytest.fixture()
 def optimizer(model):
     return torch.optim.AdamW(model.parameters())
 
 
-@pytest.fixture
+@pytest.fixture()
 def scheduler(optimizer, dataloader):
     return torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, len(dataloader))
 
 
-@pytest.fixture
+@pytest.fixture()
 def configuration():
     config = Configuration()
     config.num_epochs = 1

--- a/test/x/test_x.py
+++ b/test/x/test_x.py
@@ -6,7 +6,7 @@ from kornia.x import EarlyStopping, ModelCheckpoint
 from kornia.x.utils import TrainerState
 
 
-@pytest.fixture
+@pytest.fixture()
 def model():
     return nn.Conv2d(3, 10, kernel_size=1)
 


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Use `ruff --select=PT` to find and fix 183 pytest style rule issues.

% `ruff --select=PT001,PT018,PT022,PT023 --statistics . | sort -k2`
```
 27	PT001	[*] Use `@pytest.fixture()` over `@pytest.fixture`
 32	PT018	[ ] Assertion should be broken down into multiple parts
  2	PT022	[*] No teardown in fixture `colmap_cameras_path`, use `return` instead of `yield`
120	PT023	[*] Use `@pytest.mark.grad()` over `@pytest.mark.grad`
```
%  `ruff --select=PT001,PT018,PT022,PT023 --fix .`
```
test/losses/test_hd.py:88:9: PT018 Assertion should be broken down into multiple parts
Found 184 errors (183 fixed, 1 remaining).
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
