### PR TITLE
Fixed RuntimeError, "Subtraction" in conversions.py

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -295,15 +295,15 @@ def angle_axis_to_rotation_matrix(angle_axis: Tensor) -> Tensor:
         cos_theta = torch.cos(theta)
         sin_theta = torch.sin(theta)
 
-        r00 = cos_theta + wx * wx * (k_one - cos_theta)
-        r10 = wz * sin_theta + wx * wy * (k_one - cos_theta)
-        r20 = -wy * sin_theta + wx * wz * (k_one - cos_theta)
-        r01 = wx * wy * (k_one - cos_theta) - wz * sin_theta
-        r11 = cos_theta + wy * wy * (k_one - cos_theta)
-        r21 = wx * sin_theta + wy * wz * (k_one - cos_theta)
-        r02 = wy * sin_theta + wx * wz * (k_one - cos_theta)
-        r12 = -wx * sin_theta + wy * wz * (k_one - cos_theta)
-        r22 = cos_theta + wz * wz * (k_one - cos_theta)
+        r00 = cos_theta + wx * wx * torch.logical_not(cos_theta)
+        r10 = wz * sin_theta + wx * wy * torch.logical_not(cos_theta)
+        r20 = -wy * sin_theta + wx * wz * torch.logical_not(cos_theta)
+        r01 = wx * wy * torch.logical_not(cos_theta) - wz * sin_theta
+        r11 = cos_theta + wy * wy * torch.logical_not(cos_theta)
+        r21 = wx * sin_theta + wy * wz * torch.logical_not(cos_theta)
+        r02 = wy * sin_theta + wx * wz * torch.logical_not(cos_theta)
+        r12 = -wx * sin_theta + wy * wz * torch.logical_not(cos_theta)
+        r22 = cos_theta + wz * wz * torch.logical_not(cos_theta)
         rotation_matrix = concatenate([r00, r01, r02, r10, r11, r12, r20, r21, r22], dim=1)
         return rotation_matrix.view(-1, 3, 3)
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -288,7 +288,6 @@ def angle_axis_to_rotation_matrix(angle_axis: Tensor) -> Tensor:
         # We want to be careful to only evaluate the square root if the
         # norm of the angle_axis vector is greater than zero. Otherwise
         # we get a division by zero.
-        k_one = 1.0
         theta = torch.sqrt(theta2)
         wxyz = angle_axis / (theta + eps)
         wx, wy, wz = torch.chunk(wxyz, 3, dim=1)


### PR DESCRIPTION
  File "/opt/conda/lib/python3.10/site-packages/torchgeometry/core/conversions.py", line 233, in rotation_matrix_to_angle_axis
    quaternion = rotation_matrix_to_quaternion(rotation_matrix)
  File "/opt/conda/lib/python3.10/site-packages/torchgeometry/core/conversions.py", line 302, in rotation_matrix_to_quaternion
    mask_c1 = mask_d2 * (1 - mask_d0_d1)
  File "/opt/conda/lib/python3.10/site-packages/torch/_tensor.py", line 40, in wrapped
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/_tensor.py", line 848, in __rsub__
    return _C._VariableFunctions.rsub(self, other)
RuntimeError: Subtraction, the `-` operator, with a bool tensor is not supported. If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.



Was getting this error and modifying the code; replacing "1-boolean_tensor" with torch.logical_not(boolean_tensor) fixed it.

pytorch-ignite==0.4.12
pytorch-lightning==2.0.4
torch @ file:///tmp/torch/torch-2.0.0-cp310-cp310-linux_x86_64.whl#sha256=de0c947f8c06a637392b3efa76aad3ac1d91effd6481f8154aeeb4303f12d133 torchaudio @ file:///tmp/torch/torchaudio-2.0.1-cp310-cp310-linux_x86_64.whl#sha256=178c0fd167dd56970d14aa26ff4e98d8963ead026f00b4f36d6d7fc93421f317 torchdata==0.6.0
torchgeometry==0.1.2
torchinfo==1.8.0
torchmetrics==1.0.0
torchtext @ file:///tmp/torch/torchtext-0.15.1-cp310-cp310-linux_x86_64.whl#sha256=89c1e3cb8aa36dc34a82501799a7d364ca4a4f6d447d86324a9aec7036fa4702 torchvision @ file:///tmp/torch/torchvision-0.15.1-cp310-cp310-linux_x86_64.whl#sha256=4ed53c3d788b3394127da0e3207891e604d52f3b7ea69e5be0a895cc6029ed4a

Version info of  relevant packages, code was running in kaggle.

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
