### PR TITLE
Make TinyViT available as a standalone image classifier

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -121,6 +121,8 @@ Image Classification
 
 .. autoclass:: VisionTransformer
 .. autoclass:: MobileViT
+.. autoclass:: TinyViT
+    :members:
 .. autoclass:: ClassificationHead
 
 Image Stitching

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,6 +96,7 @@ Join the community
    models/yunet
    models/vit
    models/vit_mobile
+   models/tiny_vit
    models/loftr
    models/defmo
    models/hardnet

--- a/docs/source/models/tiny_vit.rst
+++ b/docs/source/models/tiny_vit.rst
@@ -1,0 +1,36 @@
+.. _kornia_tiny_vit:
+
+TinyViT
+.........
+
+.. card::
+    :link: https://arxiv.org/abs/2110.02178
+
+    **TinyViT: Fast Pretraining Distillation for Small Vision Transformers**
+    ^^^
+    **Abstract:** Vision transformer (ViT) recently has drawn great attention in computer vision due to its remarkable model capability. However, most prevailing ViT models suffer from huge number of parameters, restricting their applicability on devices with limited resources. To alleviate this issue, we propose TinyViT, a new family of tiny and efficient small vision transformers pretrained on large-scale datasets with our proposed fast distillation framework. The central idea is to transfer knowledge from large pretrained models to small ones, while enabling small models to get the dividends of massive pretraining data. More specifically, we apply distillation during pretraining for knowledge transfer. The logits of large teacher models are sparsified and stored in disk in advance to save the memory cost and computation overheads. The tiny student transformers are automatically scaled down from a large pretrained model with computation and parameter constraints. Comprehensive experiments demonstrate the efficacy of TinyViT. It achieves a top-1 accuracy of 84.8% on ImageNet-1k with only 21M parameters, being comparable to Swin-B pretrained on ImageNet-21k while using 4.2 times fewer parameters. Moreover, increasing image resolutions, TinyViT can reach 86.5% accuracy, being slightly better than Swin-L while using only 11% parameters. Last but not the least, we demonstrate a good transfer ability of TinyViT on various downstream tasks. Code and models are available at https://github.com/microsoft/Cream/tree/main/TinyViT.
+
+    **Tasks:** Image Classification, Object Detection
+
+    **Datasets:** ImageNet, MS-COCO
+
+    +++
+    **Authors:**  Kan Wu, Jinnian Zhang, Houwen Peng, Mengchen Liu, Bin Xiao, Jianlong Fu, Lu Yuan
+
+.. image:: https://github.com/microsoft/Cream/blob/main/TinyViT/.figure/framework.png?raw=true
+   :align: center
+
+Usage
+~~~~~
+
+You can use TinyViT models as follows.
+
+.. code:: python
+
+    import torch
+    from kornia.contrib.models.tiny_vit import TinyViT
+
+    model = TinyViT.from_config("5m", pretrained=True)  # ImageNet-1k pre-trained
+
+    img = torch.rand(1, 3, 224, 224)
+    out = classifier(img)     # 1x1000

--- a/kornia/contrib/__init__.py
+++ b/kornia/contrib/__init__.py
@@ -14,6 +14,7 @@ from .face_detection import *
 from .histogram_matching import histogram_matching, interp
 from .image_stitching import ImageStitcher
 from .lambda_module import Lambda
+from .models.tiny_vit import TinyViT
 from .object_detection import ObjectDetector
 from .vit import VisionTransformer
 from .vit_mobile import MobileViT
@@ -29,6 +30,7 @@ __all__ = [
     "interp",
     "VisionTransformer",
     "MobileViT",
+    "TinyViT",
     "ClassificationHead",
     "Lambda",
     "ImageStitcher",

--- a/kornia/contrib/models/sam/architecture/image_encoder.py
+++ b/kornia/contrib/models/sam/architecture/image_encoder.py
@@ -9,9 +9,9 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from kornia.contrib.models.common import LayerNorm2d
+from kornia.contrib.models.common import LayerNorm2d, window_partition, window_unpartition
 from kornia.contrib.models.sam.architecture.common import MLPBlock
-from kornia.core import Module, Tensor, pad, zeros
+from kornia.core import Module, Tensor, zeros
 
 
 # This class and its supporting functions below lightly adapted from the ViTDet backbone available at: https://github.com/facebookresearch/detectron2/blob/main/detectron2/modeling/backbone/vit.py # noqa
@@ -221,53 +221,6 @@ class Attention(Module):
         x = self.proj(x)
 
         return x
-
-
-def window_partition(x: Tensor, window_size: int) -> tuple[Tensor, tuple[int, int]]:
-    """Partition into non-overlapping windows with padding if needed.
-
-    Args:
-        x: input tokens with [B, H, W, C].
-        window_size: window size.
-
-    Returns:
-        windows: windows after partition with [B * num_windows, window_size, window_size, C].
-        (Hp, Wp): padded height and width before partition
-    """
-    B, H, W, C = x.shape
-
-    pad_h = (window_size - H % window_size) % window_size
-    pad_w = (window_size - W % window_size) % window_size
-    if pad_h > 0 or pad_w > 0:
-        x = pad(x, (0, 0, 0, pad_w, 0, pad_h))
-    Hp, Wp = H + pad_h, W + pad_w
-
-    x = x.view(B, Hp // window_size, window_size, Wp // window_size, window_size, C)
-    windows = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(-1, window_size, window_size, C)
-    return windows, (Hp, Wp)
-
-
-def window_unpartition(windows: Tensor, window_size: int, pad_hw: tuple[int, int], hw: tuple[int, int]) -> Tensor:
-    """Window unpartition into original sequences and removing padding.
-
-    Args:
-        x: input tokens with [B * num_windows, window_size, window_size, C].
-        window_size: window size.
-        pad_hw: padded height and width (Hp, Wp).
-        hw: original height and width (H, W) before padding.
-
-    Returns:
-        x: unpartitioned sequences with [B, H, W, C].
-    """
-    Hp, Wp = pad_hw
-    H, W = hw
-    B = windows.shape[0] // (Hp * Wp // window_size // window_size)
-    x = windows.view(B, Hp // window_size, Wp // window_size, window_size, window_size, -1)
-    x = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(B, Hp, Wp, -1)
-
-    if Hp > H or Wp > W:
-        x = x[:, :H, :W, :].contiguous()
-    return x
 
 
 def get_rel_pos(q_size: int, k_size: int, rel_pos: Tensor) -> Tensor:

--- a/kornia/contrib/models/sam/model.py
+++ b/kornia/contrib/models/sam/model.py
@@ -20,8 +20,8 @@ from kornia.contrib.models.sam.architecture.common import LayerNorm
 from kornia.contrib.models.sam.architecture.image_encoder import ImageEncoderViT
 from kornia.contrib.models.sam.architecture.mask_decoder import MaskDecoder
 from kornia.contrib.models.sam.architecture.prompt_encoder import PromptEncoder
-from kornia.contrib.models.sam.architecture.tiny_vit import TinyViT, tiny_vit_5m
 from kornia.contrib.models.sam.architecture.transformer import TwoWayTransformer
+from kornia.contrib.models.tiny_vit import TinyViT, tiny_vit_5m
 from kornia.core import Tensor
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 

--- a/kornia/contrib/models/sam/model.py
+++ b/kornia/contrib/models/sam/model.py
@@ -21,7 +21,7 @@ from kornia.contrib.models.sam.architecture.image_encoder import ImageEncoderViT
 from kornia.contrib.models.sam.architecture.mask_decoder import MaskDecoder
 from kornia.contrib.models.sam.architecture.prompt_encoder import PromptEncoder
 from kornia.contrib.models.sam.architecture.transformer import TwoWayTransformer
-from kornia.contrib.models.tiny_vit import TinyViT, tiny_vit_5m
+from kornia.contrib.models.tiny_vit import TinyViT
 from kornia.core import Tensor
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 
@@ -138,7 +138,7 @@ class Sam(ModelBase[SamConfig]):
             image_embedding_size = image_size // vit_patch_size
 
             model = Sam(
-                image_encoder=tiny_vit_5m(image_size, mobile_sam=True),
+                image_encoder=TinyViT.from_config("5m", img_size=image_size, mobile_sam=True),
                 prompt_encoder=PromptEncoder(
                     embed_dim=prompt_embed_dim,
                     image_embedding_size=(image_embedding_size, image_embedding_size),

--- a/kornia/contrib/models/tiny_vit.py
+++ b/kornia/contrib/models/tiny_vit.py
@@ -12,8 +12,7 @@ import torch.nn.functional as F
 from torch import nn
 from torch.utils import checkpoint
 
-from kornia.contrib.models.common import DropPath, LayerNorm2d
-from kornia.contrib.models.sam.architecture.image_encoder import window_partition, window_unpartition
+from kornia.contrib.models.common import DropPath, LayerNorm2d, window_partition, window_unpartition
 from kornia.core import Module, Tensor
 from kornia.core.check import KORNIA_CHECK
 

--- a/test/contrib/models/test_tiny_vit.py
+++ b/test/contrib/models/test_tiny_vit.py
@@ -1,0 +1,61 @@
+import pytest
+import torch
+
+from kornia.contrib.models.tiny_vit import TinyViT, tiny_vit_5m, tiny_vit_11m, tiny_vit_21m
+from kornia.core import Tensor
+from kornia.testing import BaseTester
+
+
+class TestTinyViT(BaseTester):
+    @pytest.mark.parametrize("img_size", [224, 256])
+    def test_smoke(self, device, dtype, img_size):
+        model = TinyViT(img_size=img_size).to(device=device, dtype=dtype)
+        inpt = torch.randn(1, 3, img_size, img_size, device=device, dtype=dtype)
+        out = model(inpt)
+        assert isinstance(out, Tensor)
+
+    @pytest.mark.parametrize('num_classes', [10, 100])
+    @pytest.mark.parametrize('batch_size', [1, 3])
+    def test_cardinality(self, device, dtype, batch_size, num_classes):
+        img_size = 224
+        model = TinyViT(img_size=img_size, num_classes=num_classes).to(device=device, dtype=dtype)
+        inpt = torch.rand(batch_size, 3, img_size, img_size, device=device, dtype=dtype)
+        out = model(inpt)
+        assert out.shape == (batch_size, num_classes)
+
+    def test_exception(self):
+        ...
+
+    def test_gradcheck(self):
+        ...
+
+    def test_module(self):
+        ...
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        img_size = 224
+        img = torch.rand(1, 3, img_size, img_size, device=device, dtype=dtype)
+
+        op = TinyViT(img_size=img_size).to(device=device, dtype=dtype)
+        op_optimized = torch_optimizer(op)
+
+        self.assert_close(op(img), op_optimized(img))
+
+    @pytest.mark.parametrize("factory", [tiny_vit_5m, tiny_vit_11m, tiny_vit_21m])
+    def test_pretrained(self, device, dtype, factory):
+        img_size = 224
+        factory(img_size=img_size, pretrained=True).to(device=device, dtype=dtype)
+
+    @pytest.mark.parametrize('num_classes', [1000, 8])
+    @pytest.mark.parametrize("img_size", [224, 256])
+    def test_pretrained_complex(self, device, dtype, img_size, num_classes):
+        tiny_vit_5m(img_size=img_size, num_classes=num_classes, pretrained=True).to(device=device, dtype=dtype)
+
+    def test_mobile_sam_backbone(self, device, dtype):
+        img_size = 1024
+        batch_size = 1
+        model = tiny_vit_5m(img_size=img_size, mobile_sam=True).to(device=device, dtype=dtype)
+        inpt = torch.randn(batch_size, 3, img_size, img_size, device=device, dtype=dtype)
+        out = model(inpt)
+
+        assert out.shape == (batch_size, 256, img_size // 16, img_size // 16)

--- a/test/contrib/models/test_tiny_vit.py
+++ b/test/contrib/models/test_tiny_vit.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from kornia.contrib.models.tiny_vit import TinyViT, tiny_vit_5m, tiny_vit_11m, tiny_vit_21m
+from kornia.contrib.models.tiny_vit import TinyViT
 from kornia.core import Tensor
 from kornia.testing import BaseTester
 
@@ -11,15 +11,16 @@ class TestTinyViT(BaseTester):
     def test_smoke(self, device, dtype, img_size):
         model = TinyViT(img_size=img_size).to(device=device, dtype=dtype)
         inpt = torch.randn(1, 3, img_size, img_size, device=device, dtype=dtype)
+
         out = model(inpt)
         assert isinstance(out, Tensor)
 
     @pytest.mark.parametrize('num_classes', [10, 100])
     @pytest.mark.parametrize('batch_size', [1, 3])
     def test_cardinality(self, device, dtype, batch_size, num_classes):
-        img_size = 224
-        model = TinyViT(img_size=img_size, num_classes=num_classes).to(device=device, dtype=dtype)
-        inpt = torch.rand(batch_size, 3, img_size, img_size, device=device, dtype=dtype)
+        model = TinyViT(num_classes=num_classes).to(device=device, dtype=dtype)
+        inpt = torch.rand(batch_size, 3, model.img_size, model.img_size, device=device, dtype=dtype)
+
         out = model(inpt)
         assert out.shape == (batch_size, num_classes)
 
@@ -33,29 +34,29 @@ class TestTinyViT(BaseTester):
         ...
 
     def test_dynamo(self, device, dtype, torch_optimizer):
-        img_size = 224
-        img = torch.rand(1, 3, img_size, img_size, device=device, dtype=dtype)
+        op = TinyViT().to(device=device, dtype=dtype)
+        img = torch.rand(1, 3, op.img_size, op.img_size, device=device, dtype=dtype)
 
-        op = TinyViT(img_size=img_size).to(device=device, dtype=dtype)
         op_optimized = torch_optimizer(op)
-
         self.assert_close(op(img), op_optimized(img))
 
-    @pytest.mark.parametrize("factory", [tiny_vit_5m, tiny_vit_11m, tiny_vit_21m])
-    def test_pretrained(self, device, dtype, factory):
-        img_size = 224
-        factory(img_size=img_size, pretrained=True).to(device=device, dtype=dtype)
+    @pytest.mark.parametrize("pretrained", [False, True])
+    @pytest.mark.parametrize("variant", ["5m", "11m", "21m"])
+    def test_from_config(self, variant, pretrained):
+        model = TinyViT.from_config(variant, pretrained=pretrained)
+        assert isinstance(model, TinyViT)
 
     @pytest.mark.parametrize('num_classes', [1000, 8])
     @pytest.mark.parametrize("img_size", [224, 256])
-    def test_pretrained_complex(self, device, dtype, img_size, num_classes):
-        tiny_vit_5m(img_size=img_size, num_classes=num_classes, pretrained=True).to(device=device, dtype=dtype)
+    def test_pretrained(self, img_size, num_classes):
+        model = TinyViT.from_config("5m", img_size=img_size, num_classes=num_classes, pretrained=True)
+        assert isinstance(model, TinyViT)
 
     def test_mobile_sam_backbone(self, device, dtype):
         img_size = 1024
         batch_size = 1
-        model = tiny_vit_5m(img_size=img_size, mobile_sam=True).to(device=device, dtype=dtype)
+        model = TinyViT.from_config("5m", img_size=img_size, mobile_sam=True).to(device=device, dtype=dtype)
         inpt = torch.randn(batch_size, 3, img_size, img_size, device=device, dtype=dtype)
-        out = model(inpt)
 
+        out = model(inpt)
         assert out.shape == (batch_size, 256, img_size // 16, img_size // 16)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2451 

Some notes:

- Attention biases will be bicubic interpolated when image size is different (following official code)
- When `pretrained=True`, it will load ImageNet-1k checkpoint by default. Users also have the option to select ImageNet-22k checkpoint by passing `pretrained="in22k"`
- When the number of classes are different, the classification head will be zero-init

Furthermore, I also moved `window_partition()` and `window_unpartition()` from `kornia.contrib.models.sam.architecture.image_encoder` to `kornia.contrib.models.common` so that TinyViT can re-use it.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
