### PR TITLE
Make transforms Spawn Multiprocessing Context Friendly

### DIFF
--- a/kornia/augmentation/_2d/intensity/planckian_jitter.py
+++ b/kornia/augmentation/_2d/intensity/planckian_jitter.py
@@ -174,6 +174,7 @@ class RandomPlanckianJitter(IntensityAugmentationBase2D):
     ) -> Tensor:
         list_idx = params['idx'].tolist()
 
+        print(f"{input.device=}, {self.pl.device=}, {self.pl=}, {input=}")
         self.pl = self.pl.to(device=input.device)
 
         coeffs = self.pl[list_idx]

--- a/kornia/augmentation/_2d/intensity/planckian_jitter.py
+++ b/kornia/augmentation/_2d/intensity/planckian_jitter.py
@@ -174,7 +174,6 @@ class RandomPlanckianJitter(IntensityAugmentationBase2D):
     ) -> Tensor:
         list_idx = params['idx'].tolist()
 
-        print(f"{input.device=}, {self.pl.device=}, {self.pl=}, {input=}")
         self.pl = self.pl.to(device=input.device)
 
         coeffs = self.pl[list_idx]

--- a/kornia/augmentation/random_generator/_2d/affine.py
+++ b/kornia/augmentation/random_generator/_2d/affine.py
@@ -109,23 +109,23 @@ class AffineGenerator(RandomGeneratorBase):
         shear_y_sampler: Optional[Uniform] = None
 
         if _translate is not None:
-            translate_x_sampler = Uniform(-_translate[0], _translate[0], validate_args=False)
-            translate_y_sampler = Uniform(-_translate[1], _translate[1], validate_args=False)
+            translate_x_sampler = Uniform(-_translate[0].clone(), _translate[0].clone(), validate_args=False)
+            translate_y_sampler = Uniform(-_translate[1].clone(), _translate[1].clone(), validate_args=False)
         if _scale is not None:
             if len(_scale) == 2:
-                scale_2_sampler = Uniform(_scale[0], _scale[1], validate_args=False)
+                scale_2_sampler = Uniform(_scale[0].clone(), _scale[1].clone(), validate_args=False)
             elif len(_scale) == 4:
-                scale_2_sampler = Uniform(_scale[0], _scale[1], validate_args=False)
-                scale_4_sampler = Uniform(_scale[2], _scale[3], validate_args=False)
+                scale_2_sampler = Uniform(_scale[0].clone(), _scale[1].clone(), validate_args=False)
+                scale_4_sampler = Uniform(_scale[2].clone(), _scale[3].clone(), validate_args=False)
             else:
                 raise ValueError(f"'scale' expected to be either 2 or 4 elements. Got {self.scale}")
         if _shear is not None:
             _joint_range_check(_shear[0], "shear")
             _joint_range_check(_shear[1], "shear")
-            shear_x_sampler = Uniform(_shear[0][0], _shear[0][1], validate_args=False)
-            shear_y_sampler = Uniform(_shear[1][0], _shear[1][1], validate_args=False)
+            shear_x_sampler = Uniform(_shear[0][0].clone(), _shear[0][1].clone(), validate_args=False)
+            shear_y_sampler = Uniform(_shear[1][0].clone(), _shear[1][1].clone(), validate_args=False)
 
-        self.degree_sampler = Uniform(_degrees[0], _degrees[1], validate_args=False)
+        self.degree_sampler = Uniform(_degrees[0].clone(), _degrees[1].clone(), validate_args=False)
         self.translate_x_sampler = translate_x_sampler
         self.translate_y_sampler = translate_y_sampler
         self.scale_2_sampler = scale_2_sampler

--- a/kornia/augmentation/random_generator/_2d/affine.py
+++ b/kornia/augmentation/random_generator/_2d/affine.py
@@ -1,9 +1,8 @@
 from typing import Dict, Optional, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check, _range_bound
 from kornia.core import Tensor, as_tensor, concatenate, stack, tensor, zeros
 from kornia.utils.helpers import _extract_device_dtype
@@ -101,31 +100,31 @@ class AffineGenerator(RandomGeneratorBase):
                     ]
                 )
 
-        translate_x_sampler: Optional[Uniform] = None
-        translate_y_sampler: Optional[Uniform] = None
-        scale_2_sampler: Optional[Uniform] = None
-        scale_4_sampler: Optional[Uniform] = None
-        shear_x_sampler: Optional[Uniform] = None
-        shear_y_sampler: Optional[Uniform] = None
+        translate_x_sampler: Optional[UniformDistribution] = None
+        translate_y_sampler: Optional[UniformDistribution] = None
+        scale_2_sampler: Optional[UniformDistribution] = None
+        scale_4_sampler: Optional[UniformDistribution] = None
+        shear_x_sampler: Optional[UniformDistribution] = None
+        shear_y_sampler: Optional[UniformDistribution] = None
 
         if _translate is not None:
-            translate_x_sampler = Uniform(-_translate[0].clone(), _translate[0].clone(), validate_args=False)
-            translate_y_sampler = Uniform(-_translate[1].clone(), _translate[1].clone(), validate_args=False)
+            translate_x_sampler = UniformDistribution(-_translate[0], _translate[0], validate_args=False)
+            translate_y_sampler = UniformDistribution(-_translate[1], _translate[1], validate_args=False)
         if _scale is not None:
             if len(_scale) == 2:
-                scale_2_sampler = Uniform(_scale[0].clone(), _scale[1].clone(), validate_args=False)
+                scale_2_sampler = UniformDistribution(_scale[0], _scale[1], validate_args=False)
             elif len(_scale) == 4:
-                scale_2_sampler = Uniform(_scale[0].clone(), _scale[1].clone(), validate_args=False)
-                scale_4_sampler = Uniform(_scale[2].clone(), _scale[3].clone(), validate_args=False)
+                scale_2_sampler = UniformDistribution(_scale[0], _scale[1], validate_args=False)
+                scale_4_sampler = UniformDistribution(_scale[2], _scale[3], validate_args=False)
             else:
                 raise ValueError(f"'scale' expected to be either 2 or 4 elements. Got {self.scale}")
         if _shear is not None:
             _joint_range_check(_shear[0], "shear")
             _joint_range_check(_shear[1], "shear")
-            shear_x_sampler = Uniform(_shear[0][0].clone(), _shear[0][1].clone(), validate_args=False)
-            shear_y_sampler = Uniform(_shear[1][0].clone(), _shear[1][1].clone(), validate_args=False)
+            shear_x_sampler = UniformDistribution(_shear[0][0], _shear[0][1], validate_args=False)
+            shear_y_sampler = UniformDistribution(_shear[1][0], _shear[1][1], validate_args=False)
 
-        self.degree_sampler = Uniform(_degrees[0].clone(), _degrees[1].clone(), validate_args=False)
+        self.degree_sampler = UniformDistribution(_degrees[0], _degrees[1], validate_args=False)
         self.translate_x_sampler = translate_x_sampler
         self.translate_y_sampler = translate_y_sampler
         self.scale_2_sampler = scale_2_sampler

--- a/kornia/augmentation/random_generator/_2d/color_jiggle.py
+++ b/kornia/augmentation/random_generator/_2d/color_jiggle.py
@@ -2,9 +2,8 @@ from functools import partial
 from typing import Dict, List, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check, _range_bound
 from kornia.core import Tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -67,10 +66,10 @@ class ColorJiggleGenerator(RandomGeneratorBase):
         _joint_range_check(hue, "hue", (-0.5, 0.5))
         _joint_range_check(saturation, "saturation", (0, float('inf')))
 
-        self.brightness_sampler = Uniform(brightness[0].clone(), brightness[1].clone(), validate_args=False)
-        self.contrast_sampler = Uniform(contrast[0].clone(), contrast[1].clone(), validate_args=False)
-        self.hue_sampler = Uniform(hue[0].clone(), hue[1].clone(), validate_args=False)
-        self.saturation_sampler = Uniform(saturation[0].clone(), saturation[1].clone(), validate_args=False)
+        self.brightness_sampler = UniformDistribution(brightness[0], brightness[1], validate_args=False)
+        self.contrast_sampler = UniformDistribution(contrast[0], contrast[1], validate_args=False)
+        self.hue_sampler = UniformDistribution(hue[0], hue[1], validate_args=False)
+        self.saturation_sampler = UniformDistribution(saturation[0], saturation[1], validate_args=False)
         self.randperm = partial(torch.randperm, device=device, dtype=dtype)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:

--- a/kornia/augmentation/random_generator/_2d/color_jiggle.py
+++ b/kornia/augmentation/random_generator/_2d/color_jiggle.py
@@ -67,10 +67,10 @@ class ColorJiggleGenerator(RandomGeneratorBase):
         _joint_range_check(hue, "hue", (-0.5, 0.5))
         _joint_range_check(saturation, "saturation", (0, float('inf')))
 
-        self.brightness_sampler = Uniform(brightness[0], brightness[1], validate_args=False)
-        self.contrast_sampler = Uniform(contrast[0], contrast[1], validate_args=False)
-        self.hue_sampler = Uniform(hue[0], hue[1], validate_args=False)
-        self.saturation_sampler = Uniform(saturation[0], saturation[1], validate_args=False)
+        self.brightness_sampler = Uniform(brightness[0].clone(), brightness[1].clone(), validate_args=False)
+        self.contrast_sampler = Uniform(contrast[0].clone(), contrast[1].clone(), validate_args=False)
+        self.hue_sampler = Uniform(hue[0].clone(), hue[1].clone(), validate_args=False)
+        self.saturation_sampler = Uniform(saturation[0].clone(), saturation[1].clone(), validate_args=False)
         self.randperm = partial(torch.randperm, device=device, dtype=dtype)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:

--- a/kornia/augmentation/random_generator/_2d/color_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/color_jitter.py
@@ -2,9 +2,8 @@ from functools import partial
 from typing import Dict, List, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check, _range_bound
 from kornia.core import Tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -71,10 +70,10 @@ class ColorJitterGenerator(RandomGeneratorBase):
         _joint_range_check(hue, "hue", (-0.5, 0.5))
         _joint_range_check(saturation, "saturation", (0, float('inf')))
 
-        self.brightness_sampler = Uniform(brightness[0].clone(), brightness[1].clone(), validate_args=False)
-        self.contrast_sampler = Uniform(contrast[0].clone(), contrast[1].clone(), validate_args=False)
-        self.hue_sampler = Uniform(hue[0].clone(), hue[1].clone(), validate_args=False)
-        self.saturation_sampler = Uniform(saturation[0].clone(), saturation[1].clone(), validate_args=False)
+        self.brightness_sampler = UniformDistribution(brightness[0], brightness[1], validate_args=False)
+        self.contrast_sampler = UniformDistribution(contrast[0], contrast[1], validate_args=False)
+        self.hue_sampler = UniformDistribution(hue[0], hue[1], validate_args=False)
+        self.saturation_sampler = UniformDistribution(saturation[0], saturation[1], validate_args=False)
         self.randperm = partial(torch.randperm, device=device, dtype=dtype)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:

--- a/kornia/augmentation/random_generator/_2d/color_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/color_jitter.py
@@ -71,10 +71,10 @@ class ColorJitterGenerator(RandomGeneratorBase):
         _joint_range_check(hue, "hue", (-0.5, 0.5))
         _joint_range_check(saturation, "saturation", (0, float('inf')))
 
-        self.brightness_sampler = Uniform(brightness[0], brightness[1], validate_args=False)
-        self.contrast_sampler = Uniform(contrast[0], contrast[1], validate_args=False)
-        self.hue_sampler = Uniform(hue[0], hue[1], validate_args=False)
-        self.saturation_sampler = Uniform(saturation[0], saturation[1], validate_args=False)
+        self.brightness_sampler = Uniform(brightness[0].clone(), brightness[1].clone(), validate_args=False)
+        self.contrast_sampler = Uniform(contrast[0].clone(), contrast[1].clone(), validate_args=False)
+        self.hue_sampler = Uniform(hue[0].clone(), hue[1].clone(), validate_args=False)
+        self.saturation_sampler = Uniform(saturation[0].clone(), saturation[1].clone(), validate_args=False)
         self.randperm = partial(torch.randperm, device=device, dtype=dtype)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:

--- a/kornia/augmentation/random_generator/_2d/gaussian_blur.py
+++ b/kornia/augmentation/random_generator/_2d/gaussian_blur.py
@@ -2,9 +2,8 @@ from typing import Dict, Tuple, Union
 
 import torch
 from torch import Tensor
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check
 from kornia.utils.helpers import _extract_device_dtype
 
@@ -46,7 +45,7 @@ class RandomGaussianBlurGenerator(RandomGeneratorBase):
 
         _joint_range_check(sigma, "sigma", (0, float('inf')))
 
-        self.sigma_sampler = Uniform(sigma[0].clone(), sigma[1].clone(), validate_args=False)
+        self.sigma_sampler = UniformDistribution(sigma[0], sigma[1], validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/gaussian_blur.py
+++ b/kornia/augmentation/random_generator/_2d/gaussian_blur.py
@@ -46,7 +46,7 @@ class RandomGaussianBlurGenerator(RandomGeneratorBase):
 
         _joint_range_check(sigma, "sigma", (0, float('inf')))
 
-        self.sigma_sampler = Uniform(sigma[0], sigma[1], validate_args=False)
+        self.sigma_sampler = Uniform(sigma[0].clone(), sigma[1].clone(), validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/mixup.py
+++ b/kornia/augmentation/random_generator/_2d/mixup.py
@@ -44,7 +44,7 @@ class MixupGenerator(RandomGeneratorBase):
             lambda_val = torch.as_tensor(self.lambda_val, device=device, dtype=dtype)
 
         _joint_range_check(lambda_val, 'lambda_val', bounds=(0, 1))
-        self.lambda_sampler = Uniform(lambda_val[0], lambda_val[1], validate_args=False)
+        self.lambda_sampler = Uniform(lambda_val[0].clone(), lambda_val[1].clone(), validate_args=False)
         self.prob_sampler = Bernoulli(torch.tensor(float(self.p), device=device, dtype=dtype))
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, torch.Tensor]:

--- a/kornia/augmentation/random_generator/_2d/mixup.py
+++ b/kornia/augmentation/random_generator/_2d/mixup.py
@@ -1,9 +1,9 @@
 from typing import Dict, Optional, Tuple, Union
 
 import torch
-from torch.distributions import Bernoulli, Uniform
+from torch.distributions import Bernoulli
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _adapted_sampling, _common_param_check, _joint_range_check
 from kornia.utils.helpers import _extract_device_dtype
 
@@ -44,7 +44,7 @@ class MixupGenerator(RandomGeneratorBase):
             lambda_val = torch.as_tensor(self.lambda_val, device=device, dtype=dtype)
 
         _joint_range_check(lambda_val, 'lambda_val', bounds=(0, 1))
-        self.lambda_sampler = Uniform(lambda_val[0].clone(), lambda_val[1].clone(), validate_args=False)
+        self.lambda_sampler = UniformDistribution(lambda_val[0], lambda_val[1], validate_args=False)
         self.prob_sampler = Bernoulli(torch.tensor(float(self.p), device=device, dtype=dtype))
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, torch.Tensor]:

--- a/kornia/augmentation/random_generator/_2d/motion_blur.py
+++ b/kornia/augmentation/random_generator/_2d/motion_blur.py
@@ -1,9 +1,8 @@
 from typing import Dict, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -60,17 +59,17 @@ class MotionBlurGenerator(RandomGeneratorBase):
         if isinstance(self.kernel_size, int):
             if not (self.kernel_size >= 3 and self.kernel_size % 2 == 1):
                 raise AssertionError(f"`kernel_size` must be odd and greater than 3. Got {self.kernel_size}.")
-            self.ksize_sampler = Uniform(self.kernel_size // 2, self.kernel_size // 2, validate_args=False)
+            self.ksize_sampler = UniformDistribution(self.kernel_size // 2, self.kernel_size // 2, validate_args=False)
         elif isinstance(self.kernel_size, tuple):
             # kernel_size is fixed across the batch
             if len(self.kernel_size) != 2:
                 raise AssertionError(f"`kernel_size` must be (2,) if it is a tuple. Got {self.kernel_size}.")
-            self.ksize_sampler = Uniform(self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False)
+            self.ksize_sampler = UniformDistribution(self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False)
         else:
             raise TypeError(f"Unsupported type: {type(self.kernel_size)}")
 
-        self.angle_sampler = Uniform(angle[0].clone(), angle[1].clone(), validate_args=False)
-        self.direction_sampler = Uniform(direction[0].clone(), direction[1].clone(), validate_args=False)
+        self.angle_sampler = UniformDistribution(angle[0], angle[1], validate_args=False)
+        self.direction_sampler = UniformDistribution(direction[0], direction[1], validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/motion_blur.py
+++ b/kornia/augmentation/random_generator/_2d/motion_blur.py
@@ -64,7 +64,9 @@ class MotionBlurGenerator(RandomGeneratorBase):
             # kernel_size is fixed across the batch
             if len(self.kernel_size) != 2:
                 raise AssertionError(f"`kernel_size` must be (2,) if it is a tuple. Got {self.kernel_size}.")
-            self.ksize_sampler = UniformDistribution(self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False)
+            self.ksize_sampler = UniformDistribution(
+                self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False
+            )
         else:
             raise TypeError(f"Unsupported type: {type(self.kernel_size)}")
 

--- a/kornia/augmentation/random_generator/_2d/motion_blur.py
+++ b/kornia/augmentation/random_generator/_2d/motion_blur.py
@@ -69,8 +69,8 @@ class MotionBlurGenerator(RandomGeneratorBase):
         else:
             raise TypeError(f"Unsupported type: {type(self.kernel_size)}")
 
-        self.angle_sampler = Uniform(angle[0], angle[1], validate_args=False)
-        self.direction_sampler = Uniform(direction[0], direction[1], validate_args=False)
+        self.angle_sampler = Uniform(angle[0].clone(), angle[1].clone(), validate_args=False)
+        self.direction_sampler = Uniform(direction[0].clone(), direction[1].clone(), validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/plain_uniform.py
+++ b/kornia/augmentation/random_generator/_2d/plain_uniform.py
@@ -71,7 +71,7 @@ class PlainUniformGenerator(RandomGeneratorBase):
                 raise ValueError(f"`center` and `bound` should be both None or provided. Got {center} and {bound}.")
             else:
                 factor = _range_bound(factor, name, center=center, bounds=bound, device=device, dtype=dtype)
-            self.sampler_dict.update({name: Uniform(factor[0], factor[1], validate_args=False)})
+            self.sampler_dict.update({name: Uniform(factor[0].clone(), factor[1].clone(), validate_args=False)})
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/plain_uniform.py
+++ b/kornia/augmentation/random_generator/_2d/plain_uniform.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, Optional, Tuple
 
 import torch
-from torch.distributions import Distribution, Uniform
+from torch.distributions import Distribution
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor, as_tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -71,7 +71,7 @@ class PlainUniformGenerator(RandomGeneratorBase):
                 raise ValueError(f"`center` and `bound` should be both None or provided. Got {center} and {bound}.")
             else:
                 factor = _range_bound(factor, name, center=center, bounds=bound, device=device, dtype=dtype)
-            self.sampler_dict.update({name: Uniform(factor[0].clone(), factor[1].clone(), validate_args=False)})
+            self.sampler_dict.update({name: UniformDistribution(factor[0], factor[1], validate_args=False)})
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/planckian_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/planckian_jitter.py
@@ -1,9 +1,8 @@
 from typing import Dict, List, Tuple
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check, _range_bound
 
 __all__ = ["PlanckianJitterGenerator"]
@@ -20,7 +19,7 @@ class PlanckianJitterGenerator(RandomGeneratorBase):
         idx_range = _range_bound(self.domain, 'idx_range', device=device, dtype=dtype)
 
         _joint_range_check(idx_range, 'idx_range', (0, self.domain[1]))
-        self.pl_idx_dist = Uniform(idx_range[0].clone(), idx_range[1].clone(), validate_args=False)
+        self.pl_idx_dist = UniformDistribution(idx_range[0], idx_range[1], validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, torch.Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/planckian_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/planckian_jitter.py
@@ -20,7 +20,7 @@ class PlanckianJitterGenerator(RandomGeneratorBase):
         idx_range = _range_bound(self.domain, 'idx_range', device=device, dtype=dtype)
 
         _joint_range_check(idx_range, 'idx_range', (0, self.domain[1]))
-        self.pl_idx_dist = Uniform(idx_range[0], idx_range[1], validate_args=False)
+        self.pl_idx_dist = Uniform(idx_range[0].clone(), idx_range[1].clone(), validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, torch.Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/posterize.py
+++ b/kornia/augmentation/random_generator/_2d/posterize.py
@@ -45,7 +45,7 @@ class PosterizeGenerator(RandomGeneratorBase):
         elif not (len(bits.size()) == 1 and bits.size(0) == 2):
             raise ValueError(f"'bits' shall be either a scalar or a length 2 tensor. Got {bits}.")
         _joint_range_check(bits, 'bits', (0, 8))
-        self.bit_sampler = Uniform(bits[0], bits[1], validate_args=False)
+        self.bit_sampler = Uniform(bits[0].clone(), bits[1].clone(), validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/posterize.py
+++ b/kornia/augmentation/random_generator/_2d/posterize.py
@@ -1,9 +1,8 @@
 from typing import Dict, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check
 from kornia.core import Tensor, as_tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -45,7 +44,7 @@ class PosterizeGenerator(RandomGeneratorBase):
         elif not (len(bits.size()) == 1 and bits.size(0) == 2):
             raise ValueError(f"'bits' shall be either a scalar or a length 2 tensor. Got {bits}.")
         _joint_range_check(bits, 'bits', (0, 8))
-        self.bit_sampler = Uniform(bits[0].clone(), bits[1].clone(), validate_args=False)
+        self.bit_sampler = UniformDistribution(bits[0], bits[1], validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
 from kornia.utils import _extract_device_dtype
@@ -45,13 +44,13 @@ class RainGenerator(RandomGeneratorBase):
         drop_coordinates = _range_bound((0, 1), 'drops_coordinate', center=0.5, bounds=(0, 1)).to(
             device=device, dtype=dtype
         )
-        self.number_of_drops_sampler = Uniform(
-            number_of_drops[0].clone(), number_of_drops[1].clone(), validate_args=False
+        self.number_of_drops_sampler = UniformDistribution(
+            number_of_drops[0], number_of_drops[1], validate_args=False
         )
-        self.drop_height_sampler = Uniform(drop_height[0].clone(), drop_height[1].clone(), validate_args=False)
-        self.drop_width_sampler = Uniform(drop_width[0].clone(), drop_width[1].clone(), validate_args=False)
-        self.coordinates_sampler = Uniform(
-            drop_coordinates[0].clone(), drop_coordinates[1].clone(), validate_args=False
+        self.drop_height_sampler = UniformDistribution(drop_height[0], drop_height[1], validate_args=False)
+        self.drop_width_sampler = UniformDistribution(drop_width[0], drop_width[1], validate_args=False)
+        self.coordinates_sampler = UniformDistribution(
+            drop_coordinates[0], drop_coordinates[1], validate_args=False
         )
 
     def forward(self, batch_shape: tuple[int, ...], same_on_batch: bool = False) -> dict[str, Tensor]:

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -44,14 +44,10 @@ class RainGenerator(RandomGeneratorBase):
         drop_coordinates = _range_bound((0, 1), 'drops_coordinate', center=0.5, bounds=(0, 1)).to(
             device=device, dtype=dtype
         )
-        self.number_of_drops_sampler = UniformDistribution(
-            number_of_drops[0], number_of_drops[1], validate_args=False
-        )
+        self.number_of_drops_sampler = UniformDistribution(number_of_drops[0], number_of_drops[1], validate_args=False)
         self.drop_height_sampler = UniformDistribution(drop_height[0], drop_height[1], validate_args=False)
         self.drop_width_sampler = UniformDistribution(drop_width[0], drop_width[1], validate_args=False)
-        self.coordinates_sampler = UniformDistribution(
-            drop_coordinates[0], drop_coordinates[1], validate_args=False
-        )
+        self.coordinates_sampler = UniformDistribution(drop_coordinates[0], drop_coordinates[1], validate_args=False)
 
     def forward(self, batch_shape: tuple[int, ...], same_on_batch: bool = False) -> dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -45,10 +45,14 @@ class RainGenerator(RandomGeneratorBase):
         drop_coordinates = _range_bound((0, 1), 'drops_coordinate', center=0.5, bounds=(0, 1)).to(
             device=device, dtype=dtype
         )
-        self.number_of_drops_sampler = Uniform(number_of_drops[0].clone(), number_of_drops[1].clone(), validate_args=False)
+        self.number_of_drops_sampler = Uniform(
+            number_of_drops[0].clone(), number_of_drops[1].clone(), validate_args=False
+        )
         self.drop_height_sampler = Uniform(drop_height[0].clone(), drop_height[1].clone(), validate_args=False)
         self.drop_width_sampler = Uniform(drop_width[0].clone(), drop_width[1].clone(), validate_args=False)
-        self.coordinates_sampler = Uniform(drop_coordinates[0].clone(), drop_coordinates[1].clone(), validate_args=False)
+        self.coordinates_sampler = Uniform(
+            drop_coordinates[0].clone(), drop_coordinates[1].clone(), validate_args=False
+        )
 
     def forward(self, batch_shape: tuple[int, ...], same_on_batch: bool = False) -> dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -45,10 +45,10 @@ class RainGenerator(RandomGeneratorBase):
         drop_coordinates = _range_bound((0, 1), 'drops_coordinate', center=0.5, bounds=(0, 1)).to(
             device=device, dtype=dtype
         )
-        self.number_of_drops_sampler = Uniform(number_of_drops[0], number_of_drops[1], validate_args=False)
-        self.drop_height_sampler = Uniform(drop_height[0], drop_height[1], validate_args=False)
-        self.drop_width_sampler = Uniform(drop_width[0], drop_width[1], validate_args=False)
-        self.coordinates_sampler = Uniform(drop_coordinates[0], drop_coordinates[1], validate_args=False)
+        self.number_of_drops_sampler = Uniform(number_of_drops[0].clone(), number_of_drops[1].clone(), validate_args=False)
+        self.drop_height_sampler = Uniform(drop_height[0].clone(), drop_height[1].clone(), validate_args=False)
+        self.drop_width_sampler = Uniform(drop_width[0].clone(), drop_width[1].clone(), validate_args=False)
+        self.coordinates_sampler = Uniform(drop_coordinates[0].clone(), drop_coordinates[1].clone(), validate_args=False)
 
     def forward(self, batch_shape: tuple[int, ...], same_on_batch: bool = False) -> dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/rectangle_earase.py
+++ b/kornia/augmentation/random_generator/_2d/rectangle_earase.py
@@ -1,9 +1,8 @@
 from typing import Dict, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check
 from kornia.core import Tensor, as_tensor, tensor, where
 from kornia.utils.helpers import _extract_device_dtype
@@ -57,17 +56,17 @@ class RectangleEraseGenerator(RandomGeneratorBase):
         _joint_range_check(scale, 'scale', bounds=(0, float('inf')))
         _joint_range_check(ratio, 'ratio', bounds=(0, float('inf')))
 
-        self.scale_sampler = Uniform(scale[0].clone(), scale[1].clone(), validate_args=False)
+        self.scale_sampler = UniformDistribution(scale[0], scale[1], validate_args=False)
 
         if ratio[0] < 1.0 and ratio[1] > 1.0:
-            self.ratio_sampler1 = Uniform(ratio[0].clone(), 1, validate_args=False)
-            self.ratio_sampler2 = Uniform(1, ratio[1].clone(), validate_args=False)
-            self.index_sampler = Uniform(
+            self.ratio_sampler1 = UniformDistribution(ratio[0], 1, validate_args=False)
+            self.ratio_sampler2 = UniformDistribution(1, ratio[1], validate_args=False)
+            self.index_sampler = UniformDistribution(
                 tensor(0, device=device, dtype=dtype), tensor(1, device=device, dtype=dtype), validate_args=False
             )
         else:
-            self.ratio_sampler = Uniform(ratio[0].clone(), ratio[1].clone(), validate_args=False)
-        self.uniform_sampler = Uniform(
+            self.ratio_sampler = UniformDistribution(ratio[0], ratio[1], validate_args=False)
+        self.uniform_sampler = UniformDistribution(
             tensor(0, device=device, dtype=dtype), tensor(1, device=device, dtype=dtype), validate_args=False
         )
 

--- a/kornia/augmentation/random_generator/_2d/rectangle_earase.py
+++ b/kornia/augmentation/random_generator/_2d/rectangle_earase.py
@@ -57,16 +57,16 @@ class RectangleEraseGenerator(RandomGeneratorBase):
         _joint_range_check(scale, 'scale', bounds=(0, float('inf')))
         _joint_range_check(ratio, 'ratio', bounds=(0, float('inf')))
 
-        self.scale_sampler = Uniform(scale[0], scale[1], validate_args=False)
+        self.scale_sampler = Uniform(scale[0].clone(), scale[1].clone(), validate_args=False)
 
         if ratio[0] < 1.0 and ratio[1] > 1.0:
-            self.ratio_sampler1 = Uniform(ratio[0], 1, validate_args=False)
-            self.ratio_sampler2 = Uniform(1, ratio[1], validate_args=False)
+            self.ratio_sampler1 = Uniform(ratio[0].clone(), 1, validate_args=False)
+            self.ratio_sampler2 = Uniform(1, ratio[1].clone(), validate_args=False)
             self.index_sampler = Uniform(
                 tensor(0, device=device, dtype=dtype), tensor(1, device=device, dtype=dtype), validate_args=False
             )
         else:
-            self.ratio_sampler = Uniform(ratio[0], ratio[1], validate_args=False)
+            self.ratio_sampler = Uniform(ratio[0].clone(), ratio[1].clone(), validate_args=False)
         self.uniform_sampler = Uniform(
             tensor(0, device=device, dtype=dtype), tensor(1, device=device, dtype=dtype), validate_args=False
         )

--- a/kornia/augmentation/random_generator/_2d/shear.py
+++ b/kornia/augmentation/random_generator/_2d/shear.py
@@ -58,11 +58,11 @@ class ShearGenerator(RandomGeneratorBase):
 
         _joint_range_check(_shear[0], "shear")
         _joint_range_check(_shear[1], "shear")
-        self.shear_x = _shear[0]
-        self.shear_y = _shear[1]
+        self.shear_x = _shear[0].clone()
+        self.shear_y = _shear[1].clone()
 
-        shear_x_sampler = Uniform(_shear[0][0], _shear[0][1], validate_args=False)
-        shear_y_sampler = Uniform(_shear[1][0], _shear[1][1], validate_args=False)
+        shear_x_sampler = Uniform(_shear[0][0].clone(), _shear[0][1].clone(), validate_args=False)
+        shear_y_sampler = Uniform(_shear[1][0].clone(), _shear[1][1].clone(), validate_args=False)
 
         self.shear_x_sampler = shear_x_sampler
         self.shear_y_sampler = shear_y_sampler

--- a/kornia/augmentation/random_generator/_2d/shear.py
+++ b/kornia/augmentation/random_generator/_2d/shear.py
@@ -1,9 +1,8 @@
 from typing import Dict, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check, _range_bound
 from kornia.core import Tensor, as_tensor, stack, tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -61,8 +60,8 @@ class ShearGenerator(RandomGeneratorBase):
         self.shear_x = _shear[0].clone()
         self.shear_y = _shear[1].clone()
 
-        shear_x_sampler = Uniform(_shear[0][0].clone(), _shear[0][1].clone(), validate_args=False)
-        shear_y_sampler = Uniform(_shear[1][0].clone(), _shear[1][1].clone(), validate_args=False)
+        shear_x_sampler = UniformDistribution(_shear[0][0], _shear[0][1], validate_args=False)
+        shear_y_sampler = UniformDistribution(_shear[1][0], _shear[1][1], validate_args=False)
 
         self.shear_x_sampler = shear_x_sampler
         self.shear_y_sampler = shear_y_sampler

--- a/kornia/augmentation/random_generator/_2d/translate.py
+++ b/kornia/augmentation/random_generator/_2d/translate.py
@@ -52,14 +52,18 @@ class TranslateGenerator(RandomGeneratorBase):
                 device=device, dtype=dtype
             )
 
-            self.translate_x_sampler = Uniform(_translate_x[..., 0].clone(), _translate_x[..., 1].clone(), validate_args=False)
+            self.translate_x_sampler = Uniform(
+                _translate_x[..., 0].clone(), _translate_x[..., 1].clone(), validate_args=False
+            )
 
         if self.translate_y is not None:
             _translate_y = _range_bound(self.translate_y, 'translate_y', bounds=(-1, 1), check='joint').to(
                 device=device, dtype=dtype
             )
 
-            self.translate_y_sampler = Uniform(_translate_y[..., 0].clone(), _translate_y[..., 1].clone(), validate_args=False)
+            self.translate_y_sampler = Uniform(
+                _translate_y[..., 0].clone(), _translate_y[..., 1].clone(), validate_args=False
+            )
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/translate.py
+++ b/kornia/augmentation/random_generator/_2d/translate.py
@@ -52,14 +52,14 @@ class TranslateGenerator(RandomGeneratorBase):
                 device=device, dtype=dtype
             )
 
-            self.translate_x_sampler = Uniform(_translate_x[..., 0], _translate_x[..., 1], validate_args=False)
+            self.translate_x_sampler = Uniform(_translate_x[..., 0].clone(), _translate_x[..., 1].clone(), validate_args=False)
 
         if self.translate_y is not None:
             _translate_y = _range_bound(self.translate_y, 'translate_y', bounds=(-1, 1), check='joint').to(
                 device=device, dtype=dtype
             )
 
-            self.translate_y_sampler = Uniform(_translate_y[..., 0], _translate_y[..., 1], validate_args=False)
+            self.translate_y_sampler = Uniform(_translate_y[..., 0].clone(), _translate_y[..., 1].clone(), validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_2d/translate.py
+++ b/kornia/augmentation/random_generator/_2d/translate.py
@@ -1,9 +1,8 @@
 from typing import Dict, Optional, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -52,8 +51,8 @@ class TranslateGenerator(RandomGeneratorBase):
                 device=device, dtype=dtype
             )
 
-            self.translate_x_sampler = Uniform(
-                _translate_x[..., 0].clone(), _translate_x[..., 1].clone(), validate_args=False
+            self.translate_x_sampler = UniformDistribution(
+                _translate_x[..., 0], _translate_x[..., 1], validate_args=False
             )
 
         if self.translate_y is not None:
@@ -61,8 +60,8 @@ class TranslateGenerator(RandomGeneratorBase):
                 device=device, dtype=dtype
             )
 
-            self.translate_y_sampler = Uniform(
-                _translate_y[..., 0].clone(), _translate_y[..., 1].clone(), validate_args=False
+            self.translate_y_sampler = UniformDistribution(
+                _translate_y[..., 0], _translate_y[..., 1], validate_args=False
             )
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:

--- a/kornia/augmentation/random_generator/_3d/affine.py
+++ b/kornia/augmentation/random_generator/_3d/affine.py
@@ -1,9 +1,8 @@
 from typing import Dict, Optional, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _singular_range_check, _tuple_range_reader
 from kornia.utils.helpers import _extract_device_dtype
 
@@ -103,12 +102,12 @@ class AffineGenerator3D(RandomGeneratorBase):
         shear: Optional[torch.Tensor] = None
         if self.shears is not None:
             shear = _tuple_range_reader(self.shears, 6, device, dtype)
-            self.sxy_sampler = Uniform(shear[0, 0].clone(), shear[0, 1].clone(), validate_args=False)
-            self.sxz_sampler = Uniform(shear[1, 0].clone(), shear[1, 1].clone(), validate_args=False)
-            self.syx_sampler = Uniform(shear[2, 0].clone(), shear[2, 1].clone(), validate_args=False)
-            self.syz_sampler = Uniform(shear[3, 0].clone(), shear[3, 1].clone(), validate_args=False)
-            self.szx_sampler = Uniform(shear[4, 0].clone(), shear[4, 1].clone(), validate_args=False)
-            self.szy_sampler = Uniform(shear[5, 0].clone(), shear[5, 1].clone(), validate_args=False)
+            self.sxy_sampler = UniformDistribution(shear[0, 0], shear[0, 1], validate_args=False)
+            self.sxz_sampler = UniformDistribution(shear[1, 0], shear[1, 1], validate_args=False)
+            self.syx_sampler = UniformDistribution(shear[2, 0], shear[2, 1], validate_args=False)
+            self.syz_sampler = UniformDistribution(shear[3, 0], shear[3, 1], validate_args=False)
+            self.szx_sampler = UniformDistribution(shear[4, 0], shear[4, 1], validate_args=False)
+            self.szy_sampler = UniformDistribution(shear[5, 0], shear[5, 1], validate_args=False)
 
         # check translation range
         self._translate: Optional[torch.Tensor] = None
@@ -129,15 +128,15 @@ class AffineGenerator3D(RandomGeneratorBase):
             _singular_range_check(self._scale[0], 'scale-x', bounds=(0, float('inf')), mode='2d')
             _singular_range_check(self._scale[1], 'scale-y', bounds=(0, float('inf')), mode='2d')
             _singular_range_check(self._scale[2], 'scale-z', bounds=(0, float('inf')), mode='2d')
-            self.scale_1_sampler = Uniform(self._scale[0, 0].clone(), self._scale[0, 1].clone(), validate_args=False)
-            self.scale_2_sampler = Uniform(self._scale[1, 0].clone(), self._scale[1, 1].clone(), validate_args=False)
-            self.scale_3_sampler = Uniform(self._scale[2, 0].clone(), self._scale[2, 1].clone(), validate_args=False)
+            self.scale_1_sampler = UniformDistribution(self._scale[0, 0], self._scale[0, 1], validate_args=False)
+            self.scale_2_sampler = UniformDistribution(self._scale[1, 0], self._scale[1, 1], validate_args=False)
+            self.scale_3_sampler = UniformDistribution(self._scale[2, 0], self._scale[2, 1], validate_args=False)
 
-        self.yaw_sampler = Uniform(degrees[0][0].clone(), degrees[0][1].clone(), validate_args=False)
-        self.pitch_sampler = Uniform(degrees[1][0].clone(), degrees[1][1].clone(), validate_args=False)
-        self.roll_sampler = Uniform(degrees[2][0].clone(), degrees[2][1].clone(), validate_args=False)
+        self.yaw_sampler = UniformDistribution(degrees[0][0], degrees[0][1], validate_args=False)
+        self.pitch_sampler = UniformDistribution(degrees[1][0], degrees[1][1], validate_args=False)
+        self.roll_sampler = UniformDistribution(degrees[2][0], degrees[2][1], validate_args=False)
 
-        self.uniform_sampler = Uniform(
+        self.uniform_sampler = UniformDistribution(
             torch.tensor(0, device=device, dtype=dtype),
             torch.tensor(1, device=device, dtype=dtype),
             validate_args=False,

--- a/kornia/augmentation/random_generator/_3d/affine.py
+++ b/kornia/augmentation/random_generator/_3d/affine.py
@@ -103,12 +103,12 @@ class AffineGenerator3D(RandomGeneratorBase):
         shear: Optional[torch.Tensor] = None
         if self.shears is not None:
             shear = _tuple_range_reader(self.shears, 6, device, dtype)
-            self.sxy_sampler = Uniform(shear[0, 0], shear[0, 1], validate_args=False)
-            self.sxz_sampler = Uniform(shear[1, 0], shear[1, 1], validate_args=False)
-            self.syx_sampler = Uniform(shear[2, 0], shear[2, 1], validate_args=False)
-            self.syz_sampler = Uniform(shear[3, 0], shear[3, 1], validate_args=False)
-            self.szx_sampler = Uniform(shear[4, 0], shear[4, 1], validate_args=False)
-            self.szy_sampler = Uniform(shear[5, 0], shear[5, 1], validate_args=False)
+            self.sxy_sampler = Uniform(shear[0, 0].clone(), shear[0, 1].clone(), validate_args=False)
+            self.sxz_sampler = Uniform(shear[1, 0].clone(), shear[1, 1].clone(), validate_args=False)
+            self.syx_sampler = Uniform(shear[2, 0].clone(), shear[2, 1].clone(), validate_args=False)
+            self.syz_sampler = Uniform(shear[3, 0].clone(), shear[3, 1].clone(), validate_args=False)
+            self.szx_sampler = Uniform(shear[4, 0].clone(), shear[4, 1].clone(), validate_args=False)
+            self.szy_sampler = Uniform(shear[5, 0].clone(), shear[5, 1].clone(), validate_args=False)
 
         # check translation range
         self._translate: Optional[torch.Tensor] = None
@@ -129,13 +129,13 @@ class AffineGenerator3D(RandomGeneratorBase):
             _singular_range_check(self._scale[0], 'scale-x', bounds=(0, float('inf')), mode='2d')
             _singular_range_check(self._scale[1], 'scale-y', bounds=(0, float('inf')), mode='2d')
             _singular_range_check(self._scale[2], 'scale-z', bounds=(0, float('inf')), mode='2d')
-            self.scale_1_sampler = Uniform(self._scale[0, 0], self._scale[0, 1], validate_args=False)
-            self.scale_2_sampler = Uniform(self._scale[1, 0], self._scale[1, 1], validate_args=False)
-            self.scale_3_sampler = Uniform(self._scale[2, 0], self._scale[2, 1], validate_args=False)
+            self.scale_1_sampler = Uniform(self._scale[0, 0].clone(), self._scale[0, 1].clone(), validate_args=False)
+            self.scale_2_sampler = Uniform(self._scale[1, 0].clone(), self._scale[1, 1].clone(), validate_args=False)
+            self.scale_3_sampler = Uniform(self._scale[2, 0].clone(), self._scale[2, 1].clone(), validate_args=False)
 
-        self.yaw_sampler = Uniform(degrees[0][0], degrees[0][1], validate_args=False)
-        self.pitch_sampler = Uniform(degrees[1][0], degrees[1][1], validate_args=False)
-        self.roll_sampler = Uniform(degrees[2][0], degrees[2][1], validate_args=False)
+        self.yaw_sampler = Uniform(degrees[0][0].clone(), degrees[0][1].clone(), validate_args=False)
+        self.pitch_sampler = Uniform(degrees[1][0].clone(), degrees[1][1].clone(), validate_args=False)
+        self.roll_sampler = Uniform(degrees[2][0].clone(), degrees[2][1].clone(), validate_args=False)
 
         self.uniform_sampler = Uniform(
             torch.tensor(0, device=device, dtype=dtype),

--- a/kornia/augmentation/random_generator/_3d/motion_blur.py
+++ b/kornia/augmentation/random_generator/_3d/motion_blur.py
@@ -67,7 +67,9 @@ class MotionBlurGenerator3D(RandomGeneratorBase):
             # kernel_size is fixed across the batch
             if len(self.kernel_size) != 2:
                 raise AssertionError(f"`kernel_size` must be (2,) if it is a tuple. Got {self.kernel_size}.")
-            self.ksize_sampler = UniformDistribution(self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False)
+            self.ksize_sampler = UniformDistribution(
+                self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False
+            )
         else:
             raise TypeError(f"Unsupported type: {type(self.kernel_size)}")
 

--- a/kornia/augmentation/random_generator/_3d/motion_blur.py
+++ b/kornia/augmentation/random_generator/_3d/motion_blur.py
@@ -72,10 +72,10 @@ class MotionBlurGenerator3D(RandomGeneratorBase):
         else:
             raise TypeError(f"Unsupported type: {type(self.kernel_size)}")
 
-        self.yaw_sampler = Uniform(angle[0][0], angle[0][1], validate_args=False)
-        self.pitch_sampler = Uniform(angle[1][0], angle[1][1], validate_args=False)
-        self.roll_sampler = Uniform(angle[2][0], angle[2][1], validate_args=False)
-        self.direction_sampler = Uniform(direction[0], direction[1], validate_args=False)
+        self.yaw_sampler = Uniform(angle[0][0].clone(), angle[0][1].clone(), validate_args=False)
+        self.pitch_sampler = Uniform(angle[1][0].clone(), angle[1][1].clone(), validate_args=False)
+        self.roll_sampler = Uniform(angle[2][0].clone(), angle[2][1].clone(), validate_args=False)
+        self.direction_sampler = Uniform(direction[0].clone(), direction[1].clone(), validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_3d/motion_blur.py
+++ b/kornia/augmentation/random_generator/_3d/motion_blur.py
@@ -1,9 +1,8 @@
 from typing import Dict, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound, _tuple_range_reader
 from kornia.core import Tensor, stack
 from kornia.utils.helpers import _extract_device_dtype
@@ -63,19 +62,19 @@ class MotionBlurGenerator3D(RandomGeneratorBase):
         if isinstance(self.kernel_size, int):
             if not (self.kernel_size >= 3 and self.kernel_size % 2 == 1):
                 raise AssertionError(f"`kernel_size` must be odd and greater than 3. Got {self.kernel_size}.")
-            self.ksize_sampler = Uniform(self.kernel_size // 2, self.kernel_size // 2, validate_args=False)
+            self.ksize_sampler = UniformDistribution(self.kernel_size // 2, self.kernel_size // 2, validate_args=False)
         elif isinstance(self.kernel_size, tuple):
             # kernel_size is fixed across the batch
             if len(self.kernel_size) != 2:
                 raise AssertionError(f"`kernel_size` must be (2,) if it is a tuple. Got {self.kernel_size}.")
-            self.ksize_sampler = Uniform(self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False)
+            self.ksize_sampler = UniformDistribution(self.kernel_size[0] // 2, self.kernel_size[1] // 2, validate_args=False)
         else:
             raise TypeError(f"Unsupported type: {type(self.kernel_size)}")
 
-        self.yaw_sampler = Uniform(angle[0][0].clone(), angle[0][1].clone(), validate_args=False)
-        self.pitch_sampler = Uniform(angle[1][0].clone(), angle[1][1].clone(), validate_args=False)
-        self.roll_sampler = Uniform(angle[2][0].clone(), angle[2][1].clone(), validate_args=False)
-        self.direction_sampler = Uniform(direction[0].clone(), direction[1].clone(), validate_args=False)
+        self.yaw_sampler = UniformDistribution(angle[0][0], angle[0][1], validate_args=False)
+        self.pitch_sampler = UniformDistribution(angle[1][0], angle[1][1], validate_args=False)
+        self.roll_sampler = UniformDistribution(angle[2][0], angle[2][1], validate_args=False)
+        self.direction_sampler = UniformDistribution(direction[0], direction[1], validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_3d/rotation.py
+++ b/kornia/augmentation/random_generator/_3d/rotation.py
@@ -1,9 +1,8 @@
 from typing import Dict, Tuple, Union
 
 import torch
-from torch.distributions import Uniform
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase
+from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _tuple_range_reader
 from kornia.core import Tensor
 from kornia.utils.helpers import _extract_device_dtype
@@ -52,9 +51,9 @@ class RotationGenerator3D(RandomGeneratorBase):
 
     def make_samplers(self, device: torch.device, dtype: torch.dtype) -> None:
         degrees = _tuple_range_reader(self.degrees, 3, device, dtype)
-        self.yaw_sampler = Uniform(degrees[0][0].clone(), degrees[0][1].clone(), validate_args=False)
-        self.pitch_sampler = Uniform(degrees[1][0].clone(), degrees[1][1].clone(), validate_args=False)
-        self.roll_sampler = Uniform(degrees[2][0].clone(), degrees[2][1].clone(), validate_args=False)
+        self.yaw_sampler = UniformDistribution(degrees[0][0], degrees[0][1], validate_args=False)
+        self.pitch_sampler = UniformDistribution(degrees[1][0], degrees[1][1], validate_args=False)
+        self.roll_sampler = UniformDistribution(degrees[2][0], degrees[2][1], validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/_3d/rotation.py
+++ b/kornia/augmentation/random_generator/_3d/rotation.py
@@ -52,9 +52,9 @@ class RotationGenerator3D(RandomGeneratorBase):
 
     def make_samplers(self, device: torch.device, dtype: torch.dtype) -> None:
         degrees = _tuple_range_reader(self.degrees, 3, device, dtype)
-        self.yaw_sampler = Uniform(degrees[0][0], degrees[0][1], validate_args=False)
-        self.pitch_sampler = Uniform(degrees[1][0], degrees[1][1], validate_args=False)
-        self.roll_sampler = Uniform(degrees[2][0], degrees[2][1], validate_args=False)
+        self.yaw_sampler = Uniform(degrees[0][0].clone(), degrees[0][1].clone(), validate_args=False)
+        self.pitch_sampler = Uniform(degrees[1][0].clone(), degrees[1][1].clone(), validate_args=False)
+        self.roll_sampler = Uniform(degrees[2][0].clone(), degrees[2][1].clone(), validate_args=False)
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/augmentation/random_generator/__init__.py
+++ b/kornia/augmentation/random_generator/__init__.py
@@ -1,4 +1,4 @@
 from kornia.augmentation.random_generator._2d import *
 from kornia.augmentation.random_generator._3d import *
 
-from .base import DistributionWithMapper
+from .base import DistributionWithMapper, UniformDistribution

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar
 
 import torch
-from torch.distributions import Distribution
+from torch.distributions import Distribution, Uniform
 
 from kornia.core import Device, Module, Tensor
 
@@ -107,3 +107,19 @@ class DistributionWithMapper(Distribution):
             return getattr(self, attr)
         except AttributeError:
             return getattr(self.dist, attr)
+
+
+class UniformDistribution(Uniform):
+    """Wrapper around torch Uniform distribution which makes it work with the
+    'spawn' multiprocessing context.
+    """
+
+    def __init__(self, low, high, validate_args=None):
+        if isinstance(low, torch.Tensor):
+            low = low.clone()
+        if isinstance(high, torch.Tensor):
+            high = high.clone()
+        # we could clone self.low and self.high after the init but given the
+        # tensors are broadcast in the init this would mean copying more data
+        # which would be slower
+        super().__init__(low, high, validate_args)

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union
 
 import torch
 from torch.distributions import Distribution, Uniform
@@ -112,7 +112,7 @@ class DistributionWithMapper(Distribution):
 class UniformDistribution(Uniform):
     """Wrapper around torch Uniform distribution which makes it work with the 'spawn' multiprocessing context."""
 
-    def __init__(self, low, high, validate_args=None):
+    def __init__(self, low: Union[Tensor, float], high: Union[Tensor, float], validate_args: Optional[bool] = None):
         if isinstance(low, torch.Tensor):
             low = low.clone()
         if isinstance(high, torch.Tensor):

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -110,9 +110,7 @@ class DistributionWithMapper(Distribution):
 
 
 class UniformDistribution(Uniform):
-    """Wrapper around torch Uniform distribution which makes it work with the
-    'spawn' multiprocessing context.
-    """
+    """Wrapper around torch Uniform distribution which makes it work with the 'spawn' multiprocessing context."""
 
     def __init__(self, low, high, validate_args=None):
         if isinstance(low, torch.Tensor):

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Dict, Optional, Tuple, Type
 from unittest.mock import patch
 
@@ -4336,7 +4337,7 @@ class DummyMPDataset(torch.utils.data.Dataset):
 class TestMultiprocessing:
     torch.manual_seed(0)  # for random reproductibility
 
-    @pytest.mark.parametrize('context', ['spawn', 'forkserver', 'fork'])
+    @pytest.mark.parametrize('context', ['spawn', 'forkserver', 'fork'] if os.name != 'nt' else ['spawn'])
     def test_spawn_multiprocessing_context(self, context: str):
         dataset = DummyMPDataset(context=context)
         dataloader = torch.utils.data.DataLoader(

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -4283,7 +4283,7 @@ class DummyMPDataset(torch.utils.data.Dataset):
         super().__init__()
         # we add all transforms that could potentially fail in
         # multiprocessing with a spawn context below, that is all the
-        # trasnforms that define a RNG
+        # transforms that define a RNG
         self._transform = torch.nn.Sequential(
             RandomTranslate(),
             RandomShear(0.1),
@@ -4297,7 +4297,8 @@ class DummyMPDataset(torch.utils.data.Dataset):
             ColorJiggle(),
             RandomJigsaw(),
             RandomAffine(degrees=15),
-            RandomMotionBlur3D(kernel_size=3, angle=(0, 360), direction=(-1, 1)),
+            RandomMotionBlur3D(kernel_size=3, angle=(0, 360),
+                               direction=(-1, 1)),
             RandomPerspective3D(),
             RandomAffine3D(degrees=15),
             RandomRotation3D(degrees=15),
@@ -4309,7 +4310,8 @@ class DummyMPDataset(torch.utils.data.Dataset):
         self._crop3d = RandomCrop3D((5, 5, 5))
         self._mixup = RandomMixUpV2()
         self._cutmix = RandomCutMixV2()
-        self._rain = RandomRain(p=1, drop_height=(1, 2), drop_width=(1, 2), number_of_drops=(1, 1))
+        self._rain = RandomRain(p=1, drop_height=(1, 2),
+                                drop_width=(1, 2), number_of_drops=(1, 1))
 
     def __len__(self):
         return 10
@@ -4329,7 +4331,8 @@ class DummyMPDataset(torch.utils.data.Dataset):
 class TestMultiprocessing:
     torch.manual_seed(0)  # for random reproductibility
 
-    def test_spawn_multiprocessing_context(self):
+    @pytest.mark.parametrize('context', ['spawn', 'forkserver', 'fork'])
+    def test_spawn_multiprocessing_context(self, context: str):
         dataset = DummyMPDataset()
         dataloader = torch.utils.data.DataLoader(
             dataset,
@@ -4337,7 +4340,7 @@ class TestMultiprocessing:
             num_workers=4,
             pin_memory=True,
             persistent_workers=True,
-            multiprocessing_context='spawn',
+            multiprocessing_context=context,
         )
 
         for _ in dataloader:

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -38,9 +38,9 @@ from kornia.augmentation import (
     RandomInvert,
     RandomJigsaw,
     RandomMedianBlur,
+    RandomMixUpV2,
     RandomMosaic,
     RandomMotionBlur,
-    RandomMixUpV2,
     RandomMotionBlur3D,
     RandomPerspective,
     RandomPerspective3D,
@@ -51,14 +51,14 @@ from kornia.augmentation import (
     RandomPosterize,
     RandomRain,
     RandomResizedCrop,
-    RandomRotation3D,
     RandomRGBShift,
     RandomRotation,
-    RandomTranslate,
+    RandomRotation3D,
     RandomSaturation,
     RandomShear,
     RandomSnow,
     RandomThinPlateSpline,
+    RandomTranslate,
     RandomVerticalFlip,
     Resize,
     SmallestMaxSize,
@@ -4278,7 +4278,6 @@ class TestRandomRain(BaseTester):
         pass
 
 
-
 class DummyMPDataset(torch.utils.data.Dataset):
     def __init__(self):
         super().__init__()
@@ -4291,30 +4290,27 @@ class DummyMPDataset(torch.utils.data.Dataset):
             RandomPosterize(),
             RandomErasing(),
             RandomPlanckianJitter(),
-            RandomMotionBlur(kernel_size=3, angle=(0, 360),
-                            direction=(-1, 1)),
+            RandomMotionBlur(kernel_size=3, angle=(0, 360), direction=(-1, 1)),
             RandomGaussianBlur(3, (0.1, 2.0)),
             RandomPerspective(),
             ColorJitter(),
             ColorJiggle(),
             RandomJigsaw(),
-            RandomAffine(degrees = 15),
-            RandomMotionBlur3D(kernel_size=3, angle=(0, 360),
-                            direction=(-1, 1)),
+            RandomAffine(degrees=15),
+            RandomMotionBlur3D(kernel_size=3, angle=(0, 360), direction=(-1, 1)),
             RandomPerspective3D(),
-            RandomAffine3D(degrees = 15),
-            RandomRotation3D(degrees = 15),
+            RandomAffine3D(degrees=15),
+            RandomRotation3D(degrees=15),
         )
 
         self._resize = Resize((10, 10))
         self._mosaic = RandomMosaic((2, 2))
         self._crop = RandomCrop((5, 5))
-        self._crop3d = RandomCrop3D((5, 5,5))
+        self._crop3d = RandomCrop3D((5, 5, 5))
         self._mixup = RandomMixUpV2()
         self._cutmix = RandomCutMixV2()
-        self._rain = RandomRain(p=1, drop_height=(1,  2),
-                                drop_width=(1, 2),
-                                number_of_drops=(1, 1))
+        self._rain = RandomRain(p=1, drop_height=(1, 2), drop_width=(1, 2), number_of_drops=(1, 1))
+
     def __len__(self):
         return 10
 
@@ -4324,16 +4320,10 @@ class DummyMPDataset(torch.utils.data.Dataset):
         rain = self._resize(rain)
         cropped = self._crop(torch.rand(3, 3, 64, 64))
         cropped3d = self._crop3d(torch.rand(3, 64, 64, 64))
-        mixed = self._mixup(torch.rand(3, 3, 64, 64),
-                            torch.rand(3, 3, 64, 64))
+        mixed = self._mixup(torch.rand(3, 3, 64, 64), torch.rand(3, 3, 64, 64))
         mixed = self._cutmix(torch.rand(3, 3, 64, 64), mixed)
 
-        return (self._transform(mixed),
-                cropped,
-                cropped3d,
-                mixed,
-                mosaic,
-                rain)
+        return (self._transform(mixed), cropped, cropped3d, mixed, mosaic, rain)
 
 
 class TestMultiprocessing:
@@ -4347,7 +4337,7 @@ class TestMultiprocessing:
             num_workers=4,
             pin_memory=True,
             persistent_workers=True,
-            multiprocessing_context='spawn'
+            multiprocessing_context='spawn',
         )
 
         for _ in dataloader:

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -4297,8 +4297,7 @@ class DummyMPDataset(torch.utils.data.Dataset):
             ColorJiggle(),
             RandomJigsaw(),
             RandomAffine(degrees=15),
-            RandomMotionBlur3D(kernel_size=3, angle=(0, 360),
-                               direction=(-1, 1)),
+            RandomMotionBlur3D(kernel_size=3, angle=(0, 360), direction=(-1, 1)),
             RandomPerspective3D(),
             RandomAffine3D(degrees=15),
             RandomRotation3D(degrees=15),
@@ -4310,8 +4309,7 @@ class DummyMPDataset(torch.utils.data.Dataset):
         self._crop3d = RandomCrop3D((5, 5, 5))
         self._mixup = RandomMixUpV2()
         self._cutmix = RandomCutMixV2()
-        self._rain = RandomRain(p=1, drop_height=(1, 2),
-                                drop_width=(1, 2), number_of_drops=(1, 1))
+        self._rain = RandomRain(p=1, drop_height=(1, 2), drop_width=(1, 2), number_of_drops=(1, 1))
 
     def __len__(self):
         return 10


### PR DESCRIPTION
#### Changes
Clones the tensors passed as argument (instead of passing a reference) to `Uniform` samplers in RandomGenerators `make_samplers` method to allow use of transforms in 'spawn' multiprocessing context. Also adds a test to ensure this works (including for transform using RNGs I haven't modified).

While this may seem like a niche issue, the use-case for using the 'spawn' multiprocessing context is that it would allow for using the GPU to perform data augmentation inside a dataloader, which is significantly faster, especially on 3D medical images for instance.

####  Fixes the following issue:

Upon spawning processes with the 'spawn' context (rather than the default `fork`), I am getting the following error, when using certain geometric 3d transforms:

```
  File "/usr/lib/python3.8/multiprocessing/util.py", line 452, in spawnv_passfds
    return _posixsubprocess.fork_exec(
ValueError: bad value(s) in fds_to_keep
```

Upon investigation, it appears that the issue lies in the `make_samplers` method of the RNG attribute of the transforms that do fail. I believe this is because, in the spawn context, the variables id changes in each new process and when passing the parameters for the Uniform samplers, they are passed as references, which upon spawning new processes will become invalid, hence the error.

To fix this I think there are 2 options: only calling `make_samplers` upon the first `forward` call, but this wound fundamentally change the inner workings of the RNGs, or pass a copy of the tensor parameters, suing `.clone()` I decided to use the latter.

To reproduce the bug:

```
import kornia
import torch

class DummyDataset(torch.utils.data.Dataset):
    def __init__(self):
        super().__init__()
        self._transform = kornia.augmentation.RandomAffine3D(degrees = 15)

    def __len__(self):
        return 100

    def __get_item__(self, idx):
        return self._transform(torch.rand(1, 3, 32, 32, 32))


def test():
    dataset = DummyDataset()
    dataloader = torch.utils.data.DataLoader(
        dataset,
        batch_size=4,
        num_workers=4,
        pin_memory=True,
        persistent_workers=True,
        multiprocessing_context='spawn'
    )

    for _ in dataloader:
        pass

    print('all good')


if __name__ == '__main__':
    test()
```

This should throw the error in vanilla kornia, but work just fine after this fix.

I have added a test that runs all the augmentations that use a random number generator, inside a spawn multiprocessing context to ensure this works. 



#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [X] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] Did you update CHANGELOG in case of a major change?
