### PR TITLE
Fix docs build - `sphinx==7.0.1`

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -3,7 +3,7 @@ kornia_moons
 matplotlib
 opencv-python
 PyYAML>=5.1
-sphinx>=4
+sphinx==7.0.1 # TODO: Unpin after sphinx-doc/sphinx/issues/11543 be solved
 sphinx-autodoc-defaultargs
 sphinx-autodoc-typehints
 sphinx-copybutton>=0.3


### PR DESCRIPTION
we have warnings after >= 7.1.0 release of sphinx
- https://github.com/sphinx-doc/sphinx/issues/11543

this pr has a temporary solution before the issue is solved, and we had a new sphinx version -- optionally we can remove the falling flag if we had a warning on the docs building https://github.com/kornia/kornia/blob/796045f5a31b194f491c99f0258ac9a81b701fe1/.github/workflows/docs.yml#L50