### PR TITLE
[feat] Add transplantation augmentation

### DIFF
--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -102,7 +102,7 @@ def main():
     BASE_IMAGEOUTDOOR_URL8: str = (
         "https://github.com/kornia/data/raw/main/kornia_banner_pixie.png"  # Response functions
     )
-    MASK_IMAGE_URL2: str = "https://files.jansellner.net/simba_mask.png"
+    MASK_IMAGE_URL2: str = "https://raw.githubusercontent.com/kornia/data/main/simba_mask.png"
 
     OUTPUT_PATH = Path(__file__).absolute().parent / "source/_static/img"
 

--- a/docs/source/augmentation.module.rst
+++ b/docs/source/augmentation.module.rst
@@ -62,6 +62,7 @@ Mix
 .. autoclass:: RandomMixUpV2
 .. autoclass:: RandomMosaic
 .. autoclass:: RandomJigsaw
+.. autoclass:: RandomTransplantation
 
 Transforms3D
 ------------

--- a/docs/source/augmentation.module.rst
+++ b/docs/source/augmentation.module.rst
@@ -86,6 +86,11 @@ Intensity
 .. autoclass:: RandomMotionBlur3D
 .. autoclass:: RandomEqualize3D
 
+Mix
+~~~
+
+.. autoclass:: RandomTransplantation3D
+
 Normalizations
 --------------
 

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -341,3 +341,12 @@ month = {mar}
   archivePrefix={arXiv},
   primaryClass={cs.CV}
 }
+
+@misc{sellner2023semantic,
+  title={Semantic segmentation of surgical hyperspectral images under geometric domain shifts},
+  author={Jan Sellner and Silvia Seidlitz and Alexander Studier-Fischer and Alessandro Motta and Berkin Özdemir and Beat Peter Müller-Stich and Felix Nickel and Lena Maier-Hein},
+  year={2023},
+  eprint={2303.10972},
+  archivePrefix={arXiv},
+  primaryClass={eess.IV}
+}

--- a/kornia/augmentation/_2d/mix/__init__.py
+++ b/kornia/augmentation/_2d/mix/__init__.py
@@ -2,3 +2,4 @@ from kornia.augmentation._2d.mix.cutmix import RandomCutMixV2
 from kornia.augmentation._2d.mix.jigsaw import RandomJigsaw
 from kornia.augmentation._2d.mix.mixup import RandomMixUpV2
 from kornia.augmentation._2d.mix.mosaic import RandomMosaic
+from kornia.augmentation._2d.mix.transplantation import RandomTransplantation

--- a/kornia/augmentation/_2d/mix/transplantation.py
+++ b/kornia/augmentation/_2d/mix/transplantation.py
@@ -45,7 +45,10 @@ class RandomTransplantation(MixAugmentationBaseV2):
     Note:
         - This augmentation requires that segmentation masks are available for all images in the batch and that at
           least some objects in the image are annotated.
-        - This implementation works for arbitrary spatial dimensions including 2D and 3D images.
+        - When using this class directly (`RandomTransplantation()(...)`), it works for arbitrary spatial dimensions
+          including 2D and 3D images. When wrapping in :class:`kornia.augmentation.AugmentationSequential`, use
+          :class:`kornia.augmentation.RandomTransplantation` for 2D and
+          :class:`kornia.augmentation.RandomTransplantation3D` for 3D images.
 
     Inputs:
         - Segmentation mask tensor which is used to determine the objects for transplantation: :math:`(B, *)`.
@@ -97,26 +100,50 @@ class RandomTransplantation(MixAugmentationBaseV2):
                  [2, 0, 1, 0, 0],
                  [0, 0, 0, 0, 2],
                  [2, 1, 0, 0, 0]]])
-
-    You can apply the same augmentation again, but the new mask should contain the same labels for the augmentation
-    to have an effect:
-
         >>> aug._params["selected_labels"]  # Image 0 received label 2 from image 1 and image 1 label 0 from image 0
         tensor([2, 0])
-        >>> mask2 = torch.randint(0, 3, (2, 5, 5))
-        >>> image_out2, mask_out2 = aug(image, mask2, params=aug._params)
-        >>> mask_out2
-        tensor([[[2, 2, 2, 0, 1],
-                 [1, 2, 0, 1, 1],
-                 [0, 0, 1, 2, 2],
-                 [0, 0, 1, 2, 1],
-                 [1, 1, 1, 2, 0]],
+
+    You can apply the same augmentation again in which case the same objects get transplanted between the images:
+
+        >>> aug._params["selection"]  # The pixels (objects) which get transplanted
+        tensor([[[ True, False, False,  True, False],
+                 [ True, False, False,  True, False],
+                 [ True, False, False, False,  True],
+                 [ True,  True,  True, False,  True],
+                 [ True, False, False, False, False]],
         <BLANKLINE>
-                [[0, 2, 2, 0, 0],
-                 [0, 0, 0, 0, 1],
-                 [0, 0, 0, 2, 0],
-                 [0, 0, 1, 0, 1],
-                 [1, 1, 1, 2, 0]]])
+                [[ True,  True, False, False,  True],
+                 [False, False,  True,  True,  True],
+                 [False, False, False, False,  True],
+                 [ True,  True,  True,  True, False],
+                 [False, False, False,  True, False]]])
+        >>> image2 = torch.zeros(2, 3, 5, 5)
+        >>> image2[1] = 1
+        >>> image2[:, 0]
+        tensor([[[0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.],
+                 [0., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                [[1., 1., 1., 1., 1.],
+                 [1., 1., 1., 1., 1.],
+                 [1., 1., 1., 1., 1.],
+                 [1., 1., 1., 1., 1.],
+                 [1., 1., 1., 1., 1.]]])
+        >>> image_out2, mask_out2 = aug(image2, mask, params=aug._params)
+        >>> image_out2[:, 0]
+        tensor([[[1., 0., 0., 1., 0.],
+                 [1., 0., 0., 1., 0.],
+                 [1., 0., 0., 0., 1.],
+                 [1., 1., 1., 0., 1.],
+                 [1., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                [[0., 0., 1., 1., 0.],
+                 [1., 1., 0., 0., 0.],
+                 [1., 1., 1., 1., 0.],
+                 [0., 0., 0., 0., 1.],
+                 [1., 1., 1., 0., 1.]]])
     """
 
     def __init__(
@@ -156,43 +183,62 @@ class RandomTransplantation(MixAugmentationBaseV2):
         acceptor[selection] = donor[selection]
         return acceptor
 
-    def forward(  # type: ignore[override]
+    def params_from_input(
         self,
         *input: Tensor,
-        params: dict[str, Tensor] | None = None,
-        data_keys: list[str | int | DataKey] | None = None,
-    ) -> Tensor | list[Tensor]:
-        keys: list[DataKey]
-        if data_keys is None:
-            keys = self.data_keys
-        else:
-            keys = [DataKey.get(inp) for inp in data_keys]
+        data_keys: list[DataKey],
+        params: dict[str, Tensor],
+        extra_args: dict[DataKey, dict[str, Any]] | None = None,
+    ) -> dict[str, Tensor]:
+        """Compute parameters for the transformation which are based on one or more input tensors.
 
+        This function is, for example, called by :class:`kornia.augmentation.container.ops.AugmentationSequentialOps`
+        before the augmentation is applied on the individual input tensors.
+
+        Args:
+            *input: All input tensors passed to the augmentation pipeline.
+            data_keys: Associated data key for every input tensor.
+            params: Dictionary of parameters computed so far by the augmentation pipeline (e.g. including the
+                    `batch_prob`).
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
+
+        Returns: Updated dictionary of parameters with the necessary information to apply the augmentation on all input
+                 tensors separately.
+        """
         KORNIA_CHECK(
-            len(keys) == len(input), f"Length of keys ({len(keys)}) does not match number of inputs ({len(input)})."
+            len(data_keys) == len(input),
+            f"Length of keys ({len(data_keys)}) does not match number of inputs ({len(input)}).",
         )
 
         # The first mask key will be used for the transplantation
-        mask: Tensor = input[keys.index(DataKey.MASK)]
+        mask: Tensor = input[data_keys.index(DataKey.MASK)]
+        for _input, key in zip(input, data_keys):
+            if key == DataKey.INPUT:
+                KORNIA_CHECK(
+                    _input.ndim == mask.ndim + 1,
+                    f"Every image input must have one additional dimension (channel dimension) than the segmentation "
+                    f"mask, but got {_input.ndim} for the input image and {mask.ndim} for the segmentation mask.",
+                )
+                KORNIA_CHECK(
+                    mask.size() == torch.Size([s for i, s in enumerate(_input.size()) if i != self._channel_dim]),
+                    f"The dimensions of the input image and segmentation mask must match except for the channel "
+                    f"dimension, but got {_input.size()} for the input image and {mask.size()} for the segmentation "
+                    "mask.",
+                )
 
-        if params is None:
-            self._params = self.forward_parameters(mask.shape)
-        else:
-            self._params = params
+        if "acceptor_indices" not in params:
+            params["acceptor_indices"] = torch.where(params["batch_prob"] > 0.5)[0]
+        if "donor_indices" not in params:
+            params["donor_indices"] = (params["acceptor_indices"] - 1) % len(params["batch_prob"])
 
-        if self.excluded_labels.device != mask.device:
-            self.excluded_labels = self.excluded_labels.to(mask.device)
+        if "selected_labels" not in params:
+            if self.excluded_labels.device != mask.device:
+                self.excluded_labels = self.excluded_labels.to(mask.device)
 
-        # Image below are the donors
-        acceptor_indices = torch.where(self._params["batch_prob"] > 0.5)[0]
-        donor_indices = (acceptor_indices - 1) % len(self._params["batch_prob"])
-        selection = torch.zeros((len(acceptor_indices), *mask.shape[1:]), dtype=torch.bool, device=mask.device)
-
-        if "selected_labels" not in self._params:
             donor_labels: list[Tensor] = []
-            for d in range(len(donor_indices)):
+            for d in range(len(params["donor_indices"])):
                 # Select a random label from the donor image
-                current_mask = mask[donor_indices[d]]
+                current_mask = mask[params["donor_indices"][d]]
                 labels = current_mask.unique()
 
                 # Remove any label which is part of the excluded labels
@@ -200,57 +246,76 @@ class RandomTransplantation(MixAugmentationBaseV2):
 
                 if len(labels) > 0:
                     selected_label = labels[torch.randperm(len(labels))[0]]
-
-                    selection[d].masked_fill_(current_mask == selected_label, True)
                     donor_labels.append(selected_label)
 
-            self._params["selected_labels"] = torch.stack(donor_labels) if len(donor_labels) > 0 else torch.empty(0)
-        else:
-            selected_labels: Tensor = self._params["selected_labels"]
+            params["selected_labels"] = torch.stack(donor_labels) if len(donor_labels) > 0 else torch.empty(0)
+
+        if "selection" not in params:
+            selection = torch.zeros(
+                (len(params["acceptor_indices"]), *mask.shape[1:]), dtype=torch.bool, device=mask.device
+            )
+            selected_labels: Tensor = params["selected_labels"]
             KORNIA_CHECK(
                 selected_labels.ndim == 1,
                 f"selected_labels must be a 1-dimensional tensor, but got {selected_labels.ndim} dimensions.",
             )
             KORNIA_CHECK(
-                len(selected_labels) == len(acceptor_indices),
-                f"Length of selected_labels ({len(selected_labels)}) in the parameters does not match the number of "
-                f"images where this augmentation should be applied ({len(acceptor_indices)}).",
+                len(selected_labels) <= len(params["acceptor_indices"]),
+                f"There cannot be more selected labels ({len(selected_labels)}) than images where this augmentation "
+                f"should be applied ({len(params['acceptor_indices'])}).",
             )
 
-            for d, selected_label in zip(range(len(donor_indices)), selected_labels):
-                current_mask = mask[donor_indices[d]]
+            for d, selected_label in zip(range(len(params["donor_indices"])), selected_labels):
+                current_mask = mask[params["donor_indices"][d]]
                 selection[d].masked_fill_(current_mask == selected_label, True)
+
+            params["selection"] = selection
+
+        return params
+
+    def forward(  # type: ignore[override]
+        self,
+        *input: Tensor,
+        params: dict[str, Tensor] | None = None,
+        data_keys: list[str | int | DataKey] | None = None,
+        **kwargs: dict[str, Any],
+    ) -> Tensor | list[Tensor]:
+        keys: list[DataKey]
+        if data_keys is None:
+            keys = self.data_keys
+        else:
+            keys = [DataKey.get(inp) for inp in data_keys]
+
+        if params is None:
+            mask: Tensor = input[keys.index(DataKey.MASK)]
+            self._params = self.forward_parameters(mask.shape)
+        else:
+            self._params = params
+
+        if any(k not in self._params for k in ["acceptor_indices", "donor_indices", "selection"]):
+            self._params.update(self.params_from_input(*input, data_keys=keys, params=self._params))
 
         outputs: list[Tensor] = []
         for dcate, _input in zip(keys, input):
-            acceptor = _input[acceptor_indices].clone()
-            donor = _input[donor_indices]
+            acceptor = _input[self._params["acceptor_indices"]].clone()
+            donor = _input[self._params["donor_indices"]]
 
             output: Tensor
             if dcate == DataKey.INPUT:
                 _validate_input_dtype(_input, accepted_dtypes=[torch.float16, torch.float32, torch.float64])
-                KORNIA_CHECK(
-                    _input.ndim == mask.ndim + 1,
-                    f"Every image input must have one additional dimension (channel dimension) than the segmentation"
-                    f" mask, but got {_input.ndim} for the input image and {mask.ndim} for the segmentation mask.",
-                )
-                KORNIA_CHECK(
-                    mask.size() == torch.Size([s for i, s in enumerate(_input.size()) if i != self._channel_dim]),
-                    f"The dimensions of the input image and segmentation mask must match except for the channel"
-                    f" dimension, but got {_input.size()} for the input image and {mask.size()} for the segmentation"
-                    " mask.",
-                )
 
-                applied = self.transform_input(acceptor, donor, selection)
+                applied = self.transform_input(acceptor, donor, self._params["selection"])
                 output = self.apply_non_transform(_input, self._params, self.flags)
                 output = output.index_put(
-                    (acceptor_indices,), self.apply_non_transform_mask(applied, self._params, self.flags)
+                    (self._params["acceptor_indices"],),
+                    self.apply_non_transform_mask(applied, self._params, self.flags),
                 )
             elif dcate == DataKey.MASK:
-                applied = self.transform_mask(acceptor, donor, selection)
+                applied = self.transform_mask(acceptor, donor, self._params["selection"])
                 output = self.apply_non_transform_mask(_input, self._params, self.flags)
                 output = output.index_put(
-                    (acceptor_indices,), self.apply_non_transform_mask(applied, self._params, self.flags)
+                    (self._params["acceptor_indices"],),
+                    self.apply_non_transform_mask(applied, self._params, self.flags),
                 )
             else:
                 raise NotImplementedError

--- a/kornia/augmentation/_2d/mix/transplantation.py
+++ b/kornia/augmentation/_2d/mix/transplantation.py
@@ -202,8 +202,9 @@ class RandomTransplantation(MixAugmentationBaseV2):
                     `batch_prob`).
             extra_args: Optional dictionary of extra arguments with specific options for different input types.
 
-        Returns: Updated dictionary of parameters with the necessary information to apply the augmentation on all input
-                 tensors separately.
+        Returns:
+             Updated dictionary of parameters with the necessary information to apply the augmentation on all input
+             tensors separately.
         """
         KORNIA_CHECK(
             len(data_keys) == len(input),

--- a/kornia/augmentation/_2d/mix/transplantation.py
+++ b/kornia/augmentation/_2d/mix/transplantation.py
@@ -1,0 +1,261 @@
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import torch
+
+from kornia.augmentation._2d.mix.base import MixAugmentationBaseV2
+from kornia.augmentation.utils import _validate_input_dtype
+from kornia.constants import DataKey, DType
+from kornia.core import Tensor, tensor
+
+__all__ = ["RandomTransplantation"]
+
+
+class RandomTransplantation(MixAugmentationBaseV2):
+    r"""RandomTransplantation augmentation.
+
+    .. image:: _static/img/RandomTransplantation.png
+
+    Randomly transplant (copy and paste) image features and corresponding segmentation masks between images in a batch.
+    The transplantation transform works as follows:
+
+        1. Based on the parameter `p`, a certain number of images in the batch are selected as acceptor of a
+           transplantation.
+        2. For each acceptor, the image below in the batch is selected as donor (via circling: :math:`i - 1 \mod B`).
+        3. From the donor, a random label is selected and the corresponding image features and segmentation mask are
+           transplanted to the acceptor.
+
+    The augmentation is described in `Semantic segmentation of surgical hyperspectral images under geometric domain
+    shifts` :cite:`sellner2023semantic`.
+
+    Args:
+        excluded_labels: sequence of labels which should not be transplanted from a donor. This can be useful if only
+          parts of the image are annotated and the non-annotated regions (with a specific label index) should be
+          excluded from the augmentation. If no label is left in the donor image, nothing is transplanted.
+        p: probability for applying an augmentation to an image. This parameter controls how many images in a batch
+          receive a transplant.
+        p_batch: probability for applying an augmentation to a batch. This param controls the augmentation
+          probabilities batch-wise.
+        data_keys: the input type sequential for applying augmentations.
+          Accepts "input", "mask".
+
+    Note:
+        - This augmentation requires that segmentation masks are available for all images in the batch and that at
+          least some objects in the image are annotated.
+        - This implementation works for arbitrary spatial dimensions including 2D and 3D images.
+
+    Inputs:
+        - Input image tensors: :math:`(B, C, *)`.
+        - Segmentation mask tensors: :math:`(B, *)`.
+        - (optional) Additional image or mask tensors with are transformed in the same ways as the input image:
+          :math:`(B, C, *)` or :math:`(B, *)`.
+
+    Returns:
+        Union[Tuple[Tensor, Tensor], List[Tensor]]:
+
+        Tuple[Tensor, Tensor]:
+            - Augmented image tensors: :math:`(B, C, *)`.
+            - Augmented mask tensors: :math:`(B, *)`.
+        List[Tensor]:
+            - Augmented image tensors: :math:`(B, C, *)`.
+            - Augmented mask tensors: :math:`(B, *)`.
+            - Additional augmented image or mask tensors: :math:`(B, C, *)` or :math:`(B, *)`.
+
+    Examples:
+        >>> import torch
+        >>> rng = torch.manual_seed(0)
+        >>> aug = RandomTransplantation(p=1.)
+        >>> image = torch.randn(2, 3, 5, 5)
+        >>> mask = torch.randint(0, 3, (2, 5, 5))
+        >>> mask
+        tensor([[[0, 0, 1, 1, 0],
+                 [1, 2, 0, 0, 0],
+                 [1, 2, 1, 1, 0],
+                 [0, 0, 0, 0, 2],
+                 [2, 2, 2, 0, 2]],
+        <BLANKLINE>
+                [[2, 0, 0, 2, 1],
+                 [2, 1, 0, 2, 1],
+                 [2, 0, 1, 0, 2],
+                 [2, 2, 2, 0, 2],
+                 [2, 1, 0, 0, 0]]])
+        >>> image_out, mask_out = aug(image, mask)
+        >>> image_out.shape
+        torch.Size([2, 3, 5, 5])
+        >>> mask_out.shape
+        torch.Size([2, 5, 5])
+        >>> mask_out
+        tensor([[[2, 0, 1, 2, 0],
+                 [2, 2, 0, 2, 0],
+                 [2, 2, 1, 1, 2],
+                 [2, 2, 2, 0, 2],
+                 [2, 2, 2, 0, 2]],
+        <BLANKLINE>
+                [[0, 0, 0, 2, 0],
+                 [2, 1, 0, 0, 0],
+                 [2, 0, 1, 0, 0],
+                 [0, 0, 0, 0, 2],
+                 [2, 1, 0, 0, 0]]])
+
+    You can apply the same augmentation again, but the new mask should contain the same labels for the augmentation
+    to have an effect:
+
+        >>> aug._params["selected_labels"]  # Image 0 received label 2 from image 1 and image 1 label 0 from image 0
+        [tensor(2), tensor(0)]
+        >>> mask2 = torch.randint(0, 3, (2, 5, 5))
+        >>> image_out2, mask_out2 = aug(image, mask2, params=aug._params)
+        >>> mask_out2
+        tensor([[[2, 2, 2, 0, 1],
+                 [1, 2, 0, 1, 1],
+                 [0, 0, 1, 2, 2],
+                 [0, 0, 1, 2, 1],
+                 [1, 1, 1, 2, 0]],
+        <BLANKLINE>
+                [[0, 2, 2, 0, 0],
+                 [0, 0, 0, 0, 1],
+                 [0, 0, 0, 2, 0],
+                 [0, 0, 1, 0, 1],
+                 [1, 1, 1, 2, 0]]])
+    """
+
+    def __init__(
+        self,
+        excluded_labels: Optional[Sequence[int]] = None,
+        p: float = 0.5,
+        p_batch: float = 1.0,
+        data_keys: Optional[List[Union[str, int, DataKey]]] = None,
+    ) -> None:
+        super().__init__(p=p, p_batch=p_batch)
+
+        if excluded_labels is None:
+            excluded_labels = []
+        self.excluded_labels = tensor(excluded_labels)
+        if self.excluded_labels.ndim != 1:
+            raise ValueError(
+                f"excluded_labels must be a 1-dimensional sequence, but got {self.excluded_labels.ndim} dimensions."
+            )
+
+        if data_keys is None:
+            data_keys = [DataKey.INPUT, DataKey.MASK]
+        self.data_keys = [DataKey.get(inp) for inp in data_keys]
+        self._channel_dim = 1
+
+    def apply_non_transform_mask(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
+        return input
+
+    def transform_input(self, acceptor: Tensor, donor: Tensor, selection: Tensor) -> Tensor:
+        # Expand selection to the channel dimension
+        selection = selection.unsqueeze(dim=self._channel_dim).expand_as(donor)
+        acceptor[selection] = donor[selection]
+        return acceptor
+
+    def transform_mask(self, acceptor: Tensor, donor: Tensor, selection: Tensor) -> Tensor:
+        acceptor[selection] = donor[selection]
+        return acceptor
+
+    def forward(  # type: ignore[override]
+        self,
+        image: Tensor,
+        mask: Tensor,
+        *additional_inputs: Tensor,
+        params: Optional[Dict[str, Tensor]] = None,
+        data_keys: Optional[List[Union[str, int, DataKey]]] = None,
+    ) -> Union[Tuple[Tensor, Tensor], List[Tensor]]:
+        keys: List[DataKey]
+        if data_keys is None:
+            keys = self.data_keys
+        else:
+            keys = [DataKey.get(inp) for inp in data_keys]
+
+        inputs: List[Tensor] = [image, mask, *additional_inputs]
+        if len(keys) != len(inputs):
+            raise RuntimeError(f"Length of keys ({len(keys)}) does not match number of inputs ({len(inputs)}).")
+        if keys[:2] != [DataKey.INPUT, DataKey.MASK]:
+            raise RuntimeError(
+                f"The first two keys must be {DataKey.INPUT} (image) and {DataKey.MASK} (segmentation mask),"
+                f" but got {keys[:2]}."
+            )
+
+        _validate_input_dtype(image, accepted_dtypes=[torch.float16, torch.float32, torch.float64])
+
+        if image.ndim != mask.ndim + 1:
+            raise RuntimeError(
+                "image must have one additional dimension (channel dimension) than mask,"
+                f" but got {image.ndim} and {mask.ndim}."
+            )
+
+        if mask.size() != torch.Size([s for i, s in enumerate(image.size()) if i != self._channel_dim]):
+            raise RuntimeError(
+                "The dimensions of image and mask must match except for the channel dimension),"
+                f" but got {mask.size()} and {image.size()}."
+            )
+
+        if params is None:
+            self._params = self.forward_parameters(image.shape)
+            self._params.update({"dtype": tensor(DType.get(image.dtype).value)})
+        else:
+            self._params = params
+
+        if self.excluded_labels.device != mask.device:
+            self.excluded_labels = self.excluded_labels.to(mask.device)
+
+        # Image below are the donors
+        acceptor_indices = torch.where(self._params["batch_prob"] > 0.5)[0]
+        donor_indices = (acceptor_indices - 1) % len(self._params["batch_prob"])
+        selection = torch.zeros((len(acceptor_indices), *mask.shape[1:]), dtype=torch.bool, device=mask.device)
+
+        if "selected_labels" not in self._params:
+            selected_labels: List[Tensor] = []
+            for d in range(len(donor_indices)):
+                # Select a random label from the donor image
+                current_mask = mask[donor_indices[d]]
+                labels = current_mask.unique()
+
+                # Remove any label which is part of the excluded labels
+                labels = labels[(labels.view(1, -1) != self.excluded_labels.view(-1, 1)).all(dim=0)]
+
+                if len(labels) > 0:
+                    selected_label = labels[torch.randperm(len(labels))[0]]
+
+                    selection[d].masked_fill_(current_mask == selected_label, True)
+                    selected_labels.append(selected_label)
+
+            self._params["selected_labels"] = selected_labels
+        else:
+            selected_labels = self._params["selected_labels"]
+            if len(selected_labels) != len(acceptor_indices):
+                raise RuntimeError(
+                    f"Length of selected_labels ({len(selected_labels)}) in the parameters does not match the number"
+                    f" of images where this augmentation should be applied ({len(acceptor_indices)})."
+                )
+
+            for d, selected_label in zip(range(len(donor_indices)), selected_labels):
+                current_mask = mask[donor_indices[d]]
+                selection[d].masked_fill_(current_mask == selected_label, True)
+
+        outputs: List[Tensor] = []
+        for dcate, _input in zip(keys, inputs):
+            acceptor = _input[acceptor_indices].clone()
+            donor = _input[donor_indices]
+
+            output: Tensor
+            if dcate == DataKey.INPUT:
+                applied = self.transform_input(acceptor, donor, selection)
+                output = self.apply_non_transform(_input, params, self.flags)
+                output = output.index_put(
+                    (acceptor_indices,), self.apply_non_transform_mask(applied, params, self.flags)
+                )
+            elif dcate == DataKey.MASK:
+                applied = self.transform_mask(acceptor, donor, selection)
+                output = self.apply_non_transform_mask(_input, params, self.flags)
+                output = output.index_put(
+                    (acceptor_indices,), self.apply_non_transform_mask(applied, params, self.flags)
+                )
+            else:
+                raise NotImplementedError
+
+            outputs.append(output)
+
+        if len(outputs) == 2:
+            return outputs[0], outputs[1]
+        else:
+            return outputs

--- a/kornia/augmentation/_3d/__init__.py
+++ b/kornia/augmentation/_3d/__init__.py
@@ -1,2 +1,3 @@
 from kornia.augmentation._3d.geometric import *
 from kornia.augmentation._3d.intensity import *
+from kornia.augmentation._3d.mix import *

--- a/kornia/augmentation/_3d/mix/__init__.py
+++ b/kornia/augmentation/_3d/mix/__init__.py
@@ -1,0 +1,1 @@
+from kornia.augmentation._3d.mix.transplantation import RandomTransplantation3D

--- a/kornia/augmentation/_3d/mix/transplantation.py
+++ b/kornia/augmentation/_3d/mix/transplantation.py
@@ -1,0 +1,14 @@
+from kornia.augmentation._2d.mix.transplantation import RandomTransplantation
+from kornia.augmentation._3d.base import AugmentationBase3D
+
+__all__ = ["RandomTransplantation3D"]
+
+
+class RandomTransplantation3D(RandomTransplantation, AugmentationBase3D):  # type: ignore
+    """RandomTransplantation3D augmentation.
+
+    3D version of the :class:`kornia.augmentation.RandomTransplantation` augmentation intended to be used with
+    :class:`kornia.augmentation.AugmentationSequential`. The interface is identical to the 2D version.
+    """
+
+    pass

--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -68,6 +68,7 @@ from kornia.augmentation._3d import (
     RandomMotionBlur3D,
     RandomPerspective3D,
     RandomRotation3D,
+    RandomTransplantation3D,
     RandomVerticalFlip3D,
 )
 from kornia.augmentation._3d.base import AugmentationBase3D, RigidAffineAugmentationBase3D

--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -49,6 +49,7 @@ from kornia.augmentation._2d import (
     RandomSolarize,
     RandomThinPlateSpline,
     RandomTranslate,
+    RandomTransplantation,
     RandomVerticalFlip,
     Resize,
     SmallestMaxSize,

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -102,6 +102,16 @@ class AugmentationSequentialOps:
         data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None,
     ) -> Union[DataType, List[DataType]]:
         _data_keys = self.preproc_datakeys(data_keys)
+
+        if hasattr(module, "params_from_input"):
+            # For transforms which require the full input to calculate the parameters (e.g. RandomTransplantation)
+            param = ParamItem(
+                name=param.name,
+                data=module.params_from_input(  # type: ignore
+                    *arg, data_keys=_data_keys, params=param.data, extra_args=extra_args
+                ),
+            )
+
         outputs = []
         for inp, dcate in zip(arg, _data_keys):
             op = self._get_op(dcate)
@@ -156,7 +166,7 @@ class InputSequentialOps(SequentialOpsInterface[Tensor]):
     @classmethod
     def transform(cls, input: Tensor, module: Module, param: ParamItem, extra_args: Dict[str, Any] = {}) -> Tensor:
         if isinstance(module, (_AugmentationBase, K.MixAugmentationBaseV2)):
-            input = module(input, params=cls.get_instance_module_param(param), **extra_args)
+            input = module(input, params=cls.get_instance_module_param(param), data_keys=[DataKey.INPUT], **extra_args)
         elif isinstance(module, (K.container.ImageSequentialBase,)):
             input = module.transform_inputs(input, params=cls.get_sequential_module_param(param), extra_args=extra_args)
         elif isinstance(module, (K.auto.operations.OperationBase,)):
@@ -211,6 +221,9 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
             raise NotImplementedError(
                 "The support for 3d mask operations are not yet supported. You are welcome to file a PR in our repo."
             )
+
+        elif isinstance(module, K.MixAugmentationBaseV2):
+            input = module(input, params=cls.get_instance_module_param(param), data_keys=[DataKey.MASK], **extra_args)
 
         elif isinstance(module, (_AugmentationBase)):
             input = module.transform_masks(

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -103,12 +103,12 @@ class AugmentationSequentialOps:
     ) -> Union[DataType, List[DataType]]:
         _data_keys = self.preproc_datakeys(data_keys)
 
-        if hasattr(module, "params_from_input"):
+        if isinstance(module, K.RandomTransplantation):
             # For transforms which require the full input to calculate the parameters (e.g. RandomTransplantation)
             param = ParamItem(
                 name=param.name,
-                data=module.params_from_input(  # type: ignore
-                    *arg, data_keys=_data_keys, params=param.data, extra_args=extra_args
+                data=module.params_from_input(
+                    *arg, data_keys=_data_keys, params=param.data, extra_args=extra_args  # type: ignore
                 ),
             )
 

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -222,7 +222,7 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
                 "The support for 3d mask operations are not yet supported. You are welcome to file a PR in our repo."
             )
 
-        elif isinstance(module, K.MixAugmentationBaseV2):
+        elif isinstance(module, K.RandomTransplantation):
             input = module(input, params=cls.get_instance_module_param(param), data_keys=[DataKey.MASK], **extra_args)
 
         elif isinstance(module, (_AugmentationBase)):

--- a/test/augmentation/test_augmentation_mix.py
+++ b/test/augmentation/test_augmentation_mix.py
@@ -1,8 +1,10 @@
+import copy
+
 import pytest
 import torch
 
 from kornia.augmentation import RandomCutMixV2, RandomJigsaw, RandomMixUpV2, RandomMosaic, RandomTransplantation
-from kornia.testing import assert_close
+from kornia.testing import BaseTester, assert_close, tensor_to_gradcheck_var
 
 
 class TestRandomMixUpV2:
@@ -389,64 +391,8 @@ class TestRandomJigsaw:
         f(input)
 
 
-class TestRandomTransplantation:
-    @pytest.mark.parametrize("input_3D", [False, True])
-    def test_apply_all(self, input_3D, device, dtype):
-        torch.manual_seed(22)
-
-        if input_3D:
-            image = torch.rand(4, 3, 2, 10, 10, device=device, dtype=dtype)
-            mask = torch.zeros(4, 2, 10, 10, device=device, dtype=dtype)
-            mask_additional = torch.randint(0, 2, (4, 2, 10, 10), device=device, dtype=dtype)
-
-            selection = torch.zeros(2, 10, 10, device=device, dtype=torch.bool)
-            selection[0:1, 0:5, 0:5] = True
-        else:
-            image = torch.rand(4, 3, 10, 10, device=device, dtype=dtype)
-            mask = torch.zeros(4, 10, 10, device=device, dtype=dtype)
-            mask_additional = torch.randint(0, 2, (4, 10, 10), device=device, dtype=dtype)
-
-            selection = torch.zeros(10, 10, device=device, dtype=torch.bool)
-            selection[0:5, 0:5] = True
-
-        # Transplant rectangle from the (i - 1)-th to the i-th image
-        for i in range(4):
-            mask[i, selection] = i + 1
-
-        image_copy = image.clone()
-        mask_copy = mask.clone()
-        mask_additional_copy = mask_additional.clone()
-
-        f = RandomTransplantation(p=1, excluded_labels=[0])
-        image_out, mask_out, mask_additional_out = f(image, mask, mask_additional, data_keys=["input", "mask", "mask"])
-
-        assert torch.allclose(image, image_copy)
-        assert torch.allclose(mask, mask_copy)
-        assert torch.allclose(mask_additional, mask_additional_copy)
-
-        for i in range(4):
-            assert torch.allclose(mask_out[i, selection], torch.tensor((i - 1) % 4 + 1, device=device, dtype=dtype))
-            assert torch.allclose(mask_out[i, ~selection], torch.tensor(0, device=device, dtype=dtype))
-            assert torch.allclose(image_out[i, :, selection], image[(i - 1) % 4, :, selection])
-            assert torch.allclose(image_out[i, :, ~selection], image[i, :, ~selection])
-            assert torch.allclose(mask_additional_out[i, selection], mask_additional[(i - 1) % 4, selection])
-            assert torch.allclose(mask_additional_out[i, ~selection], mask_additional[i, ~selection])
-
-    def test_apply_none(self, device, dtype):
-        torch.manual_seed(22)
-        image = torch.rand(4, 3, 10, 10, device=device, dtype=dtype)
-        mask = torch.randint(0, 2, (4, 10, 10), device=device, dtype=dtype)
-
-        f = RandomTransplantation(p=0)
-        image_out, mask_out = f(image, mask)
-
-        assert torch.all(f._params["batch_prob"] == 0)
-        assert len(f._params["selected_labels"]) == 0
-
-        assert torch.allclose(image_out, image)
-        assert torch.allclose(mask_out, mask)
-
-    def test_different_objects(self, device, dtype):
+class TestRandomTransplantation(BaseTester):
+    def test_smoke(self, device, dtype):
         torch.manual_seed(22)
 
         mask = torch.zeros(2, 3, 3, device=device, dtype=dtype)
@@ -461,8 +407,76 @@ class TestRandomTransplantation:
             [[[1, 1, 0], [1, 2, 0], [0, 0, 0]], [[1, 1, 0], [1, 1, 0], [0, 0, 0]]], device=device, dtype=dtype
         )
 
-        assert torch.allclose(mask_out, mask_out_expected)
-        assert torch.allclose(image_out, mask_out_expected.unsqueeze(dim=1))
+        self.assert_close(mask_out, mask_out_expected)
+        self.assert_close(image_out, mask_out_expected.unsqueeze(dim=1))
+
+    def test_mask_only(self, device, dtype):
+        torch.manual_seed(22)
+
+        mask = torch.zeros(2, 3, 3, device=device, dtype=dtype)
+        mask[0, 0:2, 0:2] = 1
+        mask[1, 1:2, 1:2] = 2
+
+        f = RandomTransplantation(p=1, excluded_labels=[0], data_keys=["mask"])
+        mask_out = f(mask)
+
+        mask_out_expected = torch.tensor(
+            [[[1, 1, 0], [1, 2, 0], [0, 0, 0]], [[1, 1, 0], [1, 1, 0], [0, 0, 0]]], device=device, dtype=dtype
+        )
+
+        self.assert_close(mask_out, mask_out_expected)
+
+    @pytest.mark.parametrize("n_spatial", [2, 3, 4])
+    def test_module(self, n_spatial, device, dtype):
+        torch.manual_seed(22)
+
+        spatial_dimensions = [10] * n_spatial
+        image = torch.rand(4, 3, *spatial_dimensions, device=device, dtype=dtype)
+        mask = torch.zeros(4, *spatial_dimensions, device=device, dtype=dtype)
+        mask_additional = torch.randint(0, 2, (4, *spatial_dimensions), device=device, dtype=dtype)
+
+        selection = torch.zeros(*spatial_dimensions, device=device, dtype=torch.bool)
+        selection[[slice(0, 5)] * n_spatial] = True
+        assert selection.sum() == 5**n_spatial
+
+        # Transplant rectangle from the (i - 1)-th to the i-th image
+        for i in range(4):
+            mask[i, selection] = i + 1
+
+        image_copy = image.clone()
+        mask_copy = mask.clone()
+        mask_additional_copy = mask_additional.clone()
+
+        f = RandomTransplantation(p=1, excluded_labels=[0])
+        image_out, mask_out, mask_additional_out = f(image, mask, mask_additional, data_keys=["input", "mask", "mask"])
+
+        self.assert_close(image, image_copy)
+        self.assert_close(mask, mask_copy)
+        self.assert_close(mask_additional, mask_additional_copy)
+
+        for i in range(4):
+            selection_moved = mask_out[i, selection]
+            selection_unchanged = mask_out[i, ~selection]
+            self.assert_close(selection_moved, torch.full_like(selection_moved, (i - 1) % 4 + 1))
+            self.assert_close(selection_unchanged, torch.full_like(selection_unchanged, 0))
+            self.assert_close(image_out[i, :, selection], image[(i - 1) % 4, :, selection])
+            self.assert_close(image_out[i, :, ~selection], image[i, :, ~selection])
+            self.assert_close(mask_additional_out[i, selection], mask_additional[(i - 1) % 4, selection])
+            self.assert_close(mask_additional_out[i, ~selection], mask_additional[i, ~selection])
+
+    def test_apply_none(self, device, dtype):
+        torch.manual_seed(22)
+        image = torch.rand(4, 3, 10, 10, device=device, dtype=dtype)
+        mask = torch.randint(0, 2, (4, 10, 10), device=device, dtype=dtype)
+
+        f = RandomTransplantation(p=0)
+        image_out, mask_out = f(image, mask)
+
+        assert torch.all(f._params["batch_prob"] == 0)
+        assert len(f._params["selected_labels"]) == 0
+
+        self.assert_close(image_out, image)
+        self.assert_close(mask_out, mask)
 
     def test_repeating(self, device, dtype):
         torch.manual_seed(22)
@@ -474,10 +488,26 @@ class TestRandomTransplantation:
         image_out_same, mask_out_same = f(image, mask, params=f._params)
         image_out_different, mask_out_different = f(image, mask)
 
-        assert torch.allclose(image_out, image_out_same)
-        assert torch.allclose(mask_out, mask_out_same)
-        assert not torch.allclose(image_out, image_out_different)
-        assert not torch.allclose(mask_out, mask_out_different)
+        self.assert_close(image_out, image_out_same)
+        self.assert_close(mask_out, mask_out_same)
+        with pytest.raises(AssertionError):
+            self.assert_close(image_out, image_out_different)
+        with pytest.raises(AssertionError):
+            self.assert_close(mask_out, mask_out_different)
+
+    def test_data_keys(self, device, dtype):
+        torch.manual_seed(22)
+        image = torch.rand(4, 3, 10, 10, device=device, dtype=dtype)
+        mask = torch.randint(0, 2, (4, 10, 10), device=device, dtype=dtype)
+
+        f = RandomTransplantation(p=1)
+        torch.manual_seed(22)
+        image_out, mask_out = f(image, mask, data_keys=["input", "mask"])
+        torch.manual_seed(22)
+        mask_out2, image_out2 = f(mask, image, data_keys=["mask", "input"])
+
+        self.assert_close(image_out, image_out2)
+        self.assert_close(mask_out, mask_out2)
 
     @pytest.mark.parametrize(
         "input_shape_image, input_shape_mask, target_shape_image",
@@ -487,7 +517,7 @@ class TestRandomTransplantation:
             [(1, 1, 1, 1), (1, 1, 1), (1, 1, 1, 1)],  # (B, C, H, W)
         ],
     )
-    def test_shapes(self, input_shape_image, input_shape_mask, target_shape_image, device, dtype):
+    def test_cardinality(self, input_shape_image, input_shape_mask, target_shape_image, device, dtype):
         torch.manual_seed(22)
         image = torch.rand(input_shape_image, device=device, dtype=dtype)
         mask = torch.randint(0, 2, input_shape_mask, device=device, dtype=dtype)
@@ -497,3 +527,45 @@ class TestRandomTransplantation:
 
         assert image_out.shape == target_shape_image
         assert mask_out.shape == torch.Size([s for i, s in enumerate(target_shape_image) if i != 1])
+
+    def test_gradcheck(self, device):
+        torch.manual_seed(22)
+        image = torch.rand(1, 3, 2, 2, device=device, dtype=torch.float64)
+        mask = torch.randint(0, 2, (1, 2, 2), device=device, dtype=torch.float64)
+
+        image = tensor_to_gradcheck_var(image)  # to var
+        mask = tensor_to_gradcheck_var(mask)  # to var
+
+        assert self.gradcheck(RandomTransplantation(p=1.0), (image, mask), raise_exception=True, fast_mode=True)
+
+    def test_exception(self, device, dtype):
+        torch.manual_seed(22)
+        image = torch.rand(1, 3, 2, 2, device=device, dtype=torch.float64)
+        mask = torch.randint(0, 2, (1, 2, 2), device=device, dtype=torch.float64)
+        f = RandomTransplantation(p=1.0)
+        f(image, mask)
+        params = f._params
+
+        with pytest.raises(Exception, match="excluded_labels must be a 1-dimensional"):
+            RandomTransplantation(p=1.0, excluded_labels=torch.tensor([[0, 1]], device=device, dtype=dtype))
+
+        with pytest.raises(Exception, match="Length of keys.*does not match number of inputs"):
+            f = RandomTransplantation(p=1.0)
+            f(image, mask, data_keys=["input", "mask", "mask"])
+
+        with pytest.raises(Exception, match="selected_labels must be a 1-dimensional tensor"):
+            params_copy = copy.deepcopy(params)
+            params_copy["selected_labels"] = torch.tensor([[0, 1]], device=device, dtype=dtype)
+            f(image, mask, params=params_copy)
+
+        with pytest.raises(Exception, match="Length of selected_labels.*does not match the number of images"):
+            params_copy = copy.deepcopy(params)
+            params_copy["selected_labels"] = torch.tensor([0, 1], device=device, dtype=dtype)
+            f(image, mask, params=params_copy)
+
+        with pytest.raises(Exception, match="Every image input must have one additional dimension"):
+            f(image.unsqueeze(dim=-1), mask)
+
+        with pytest.raises(Exception, match="The dimensions of the input image and segmentation mask must match"):
+            image = torch.rand(1, 3, 2, 5, device=device, dtype=torch.float64)
+            f(image, mask)


### PR DESCRIPTION
#### Changes
This PR adds the [transplantation augmentation](https://arxiv.org/abs/2303.10972) which copies object instances between images in a batch.
![image](https://github.com/kornia/kornia/assets/11442755/17717ed2-97cf-4ba1-97bb-26cde65ade20)

The paper was accepted at [MICCAI2023](https://conferences.miccai.org/2023/en/) and even though originally targeted at (hyperspectral) medical images, I think it could be of general interest to the community and hence it would be cool to see this in kornia :-) 
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?

#### TODO
- [x] If everything is fine, it would be great if someone could upload the image [https://files.jansellner.net/simba_mask.png](https://files.jansellner.net/simba_mask.png) which I used in the [generate_examples.py](docs/generate_examples.py) script to kornia/data, then I can change the link.