### PR TITLE
Fix tutorials links to use the github page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ English | [简体中文](README_zh-CN.md)
 <a href="https://kornia.org">Website</a> •
 <a href="https://kornia.readthedocs.io">Docs</a> •
 <a href="https://colab.research.google.com/github/kornia/tutorials/blob/master/source/hello_world_tutorial.ipynb">Try it Now</a> •
-<a href="https://kornia-tutorials.readthedocs.io">Tutorials</a> •
+<a href="https://kornia.github.io/tutorials/">Tutorials</a> •
 <a href="https://github.com/kornia/kornia-examples">Examples</a> •
 <a href="https://kornia.github.io//kornia-blog">Blog</a> •
 <a href="https://join.slack.com/t/kornia/shared_invite/zt-csobk21g-CnydWe5fmvkcktIeRFGCEQ">Community</a>
@@ -103,7 +103,7 @@ At a granular level, Kornia is a library that consists of the following componen
 
 ## Examples
 
-Run our Jupyter notebooks [tutorials](https://kornia-tutorials.readthedocs.io/en/latest/) to learn to use the library.
+Run our Jupyter notebooks [tutorials](https://kornia.github.io/tutorials) to learn to use the library.
 
 <div align="center">
   <a href="https://colab.research.google.com/github/kornia/tutorials/blob/master/source/hello_world_tutorial.ipynb" target="_blank">

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -12,8 +12,8 @@
 <!-- prettier-ignore -->
 <a href="https://kornia.org">网站</a> •
 <a href="https://kornia.readthedocs.io">文档</a> •
-<a href="https://colab.research.google.com/github/kornia/tutorials/blob/master/source/hello_world_tutorial.ipynb">快速尝试</a> •
-<a href="https://kornia-tutorials.readthedocs.io">教程</a> •
+<a href="https://colab.sandbox.google.com/github/kornia/tutorials/blob/master/nbs/hello_world_tutorial.ipynb">快速尝试</a> •
+<a href="https://kornia.github.io/tutorials/">教程</a> •
 <a href="https://github.com/kornia/kornia-examples">例子</a> •
 <a href="https://kornia.github.io//kornia-blog">博客</a> •
 <a href="https://join.slack.com/t/kornia/shared_invite/zt-csobk21g-CnydWe5fmvkcktIeRFGCEQ">Slack社区</a>
@@ -105,10 +105,10 @@
 
 ## 例子
 
-可以尝试通过这些 [教程](https://kornia-tutorials.readthedocs.io/en/latest/) 来学习和使用这个库。
+可以尝试通过这些 [教程](https://kornia.github.io/tutorials/) 来学习和使用这个库。
 
 <div align="center">
-  <a href="https://colab.research.google.com/github/kornia/tutorials/blob/master/source/hello_world_tutorial.ipynb" target="_blank">
+  <a href="https://colab.sandbox.google.com/github/kornia/tutorials/blob/master/nbs/hello_world_tutorial.ipynb" target="_blank">
     <img src="https://raw.githubusercontent.com/kornia/data/main/hello_world_arturito.png" width="75%" height="75%">
   </a>
 </div>

--- a/docs/source/applications/face_detection.rst
+++ b/docs/source/applications/face_detection.rst
@@ -38,4 +38,4 @@ Using our API you easily detect faces in images as shown below:
     dets = [FaceDetectorResult(o) for o in dets[0]]
 
 
-Play yourself with the detector and generate new images with this `tutorial <https://kornia-tutorials.readthedocs.io/en/latest/_nbs/face_detection.html>`_.
+Play yourself with the detector and generate new images with this `tutorial <https://kornia.github.io/tutorials/nbs/face_detection.html>`_.

--- a/docs/source/applications/image_matching.rst
+++ b/docs/source/applications/image_matching.rst
@@ -21,4 +21,4 @@ However we recommend to start with high-level API, such as :py:class:`~kornia.fe
 
 .. image:: https://raw.githubusercontent.com/kornia/data/main/matching/matching_loftr.jpg
 
-You also can go through or full tutorial using Colab found `here <https://kornia-tutorials.readthedocs.io/en/latest/image_matching.html>`_.
+You also can go through or full tutorial using Colab found `here <https://kornia.github.io/tutorials/nbs/image_matching.html>`_.

--- a/docs/source/applications/image_registration.rst
+++ b/docs/source/applications/image_registration.rst
@@ -21,7 +21,7 @@ Then, if you want to perform a more sophisticated process:
 
 .. literalinclude:: ../_static/image_registration.py
 
-To reproduce the same results as in the showed video you can go through or full tutorial using Colab found `here <https://kornia-tutorials.readthedocs.io/en/latest/image_registration.html>`_ .
+To reproduce the same results as in the showed video you can go through or full tutorial using Colab found `here <https://kornia.github.io/tutorials/nbs/image_registration.html>`_ .
 
 Interactive Demo
 ----------------

--- a/docs/source/applications/visual_prompting.rst
+++ b/docs/source/applications/visual_prompting.rst
@@ -1,7 +1,7 @@
 Visual Prompting
 ================
 
-.. image:: https://kornia-tutorials.readthedocs.io/en/latest/_images/c5ec618b63c6118f00e6f29377cc2b50a1e1df2d247657eec531dfc5454272c7.png
+.. image:: https://kornia.github.io/tutorials/nbs/image_prompter_files/figure-html/cell-34-output-1.png
    :width: 20%
 
 Visual Prompting is the task of streamlining computer vision processes by harnessing the power of prompts,
@@ -50,7 +50,7 @@ How to use with Kornia
       multimask_output=True,
    )
 
-You also can go through or full tutorial using Colab found `here <https://kornia-tutorials.readthedocs.io/en/latest/_nbs/image_prompter.html>`_.
+You also can go through or full tutorial using Colab found `here <https://kornia.github.io/tutorials/nbs/image_prompter.html>`_.
 
 
 Integration with other libraries, fineturning and more examples soon.

--- a/docs/source/color.rst
+++ b/docs/source/color.rst
@@ -6,8 +6,7 @@ kornia.color
 The functions in this section perform various color space conversions.
 
 .. note::
-   Check a tutorial for color space conversions `here <https://kornia-tutorials.readthedocs.io/en/latest/
-   hello_world_tutorial.html>`__.
+   Check a tutorial for color space conversions `here <https://kornia.github.io/tutorials/nbs/hello_world_tutorial.html>`__.
 
 
 Grayscale

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,7 +44,7 @@ Join the community
    get-started/highlights
    get-started/installation
    get-started/about
-   Tutorials <https://kornia-tutorials.readthedocs.io/en/latest/>
+   Tutorials <https://kornia.github.io/tutorials/>
    get-started/training
    OpenCV AI Kit <https://docs.luxonis.com/en/latest/pages/tutorials/creating-custom-nn-models/#kornia>
    get-started/governance

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -64,8 +64,7 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         It is not clear how to deal with the conversions of masks, bounding boxes and keypoints.
 
     .. note::
-        See a working example `here <https://kornia-tutorials.readthedocs.io/en/
-        latest/data_augmentation_sequential.html>`__.
+        See a working example `here <https://kornia.github.io/tutorials/nbs/data_augmentation_sequential.html>`__.
 
     Examples:
         >>> import kornia

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -57,8 +57,7 @@ class PatchSequential(ImageSequential):
         Those transformations in ``kornia.geometry`` will not be taken into account.
 
     .. note::
-        See a working example `here <https://kornia-tutorials.readthedocs.io/en/
-        latest/data_patch_sequential.html>`__.
+        See a working example `here <https://kornia.github.io/tutorials/nbs/data_patch_sequential.html>`__.
 
     Examples:
         >>> import kornia.augmentation as K

--- a/kornia/color/gray.py
+++ b/kornia/color/gray.py
@@ -47,8 +47,7 @@ def rgb_to_grayscale(image: Tensor, rgb_weights: Tensor | None = None) -> Tensor
         grayscale version of the image with shape :math:`(*,1,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       color_conversions.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/color_conversions.html>`__.
 
     Example:
         >>> input = torch.rand(2, 3, 4, 5)

--- a/kornia/color/hsv.py
+++ b/kornia/color/hsv.py
@@ -20,8 +20,7 @@ def rgb_to_hsv(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
         The H channel values are in the range 0..2pi. S and V are in the range 0..1.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       color_conversions.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/color_conversions.html>`__.
 
     Example:
         >>> input = torch.rand(2, 3, 4, 5)

--- a/kornia/contrib/connected_components.py
+++ b/kornia/contrib/connected_components.py
@@ -15,8 +15,7 @@ def connected_components(image: torch.Tensor, num_iterations: int = 100) -> torc
         This is an experimental API subject to changes and optimization improvements.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       connected_components.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/connected_components.html>`__.
 
     Args:
         image: the binarized input image with shape :math:`(*, 1, H, W)`.

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -114,8 +114,7 @@ def adjust_saturation(image: Tensor, factor: Union[float, Tensor]) -> Tensor:
         Adjusted image in the shape of :math:`(*, 3, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       image_enhancement.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> x = torch.ones(1, 3, 3, 3)
@@ -190,8 +189,7 @@ def adjust_hue(image: Tensor, factor: Union[float, Tensor]) -> Tensor:
         Adjusted image in the shape of :math:`(*, 3, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       image_enhancement.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> x = torch.ones(1, 3, 2, 2)
@@ -233,8 +231,7 @@ def adjust_gamma(input: Tensor, gamma: Union[float, Tensor], gain: Union[float, 
         Adjusted image in the shape of :math:`(*, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       image_enhancement.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> x = torch.ones(1, 1, 2, 2)
@@ -315,8 +312,7 @@ def adjust_contrast(image: Tensor, factor: Union[float, Tensor], clip_output: bo
         Adjusted image in the shape of :math:`(*, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       image_enhancement.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> import torch
@@ -441,8 +437,7 @@ def adjust_brightness(image: Tensor, factor: Union[float, Tensor], clip_output: 
         Adjusted tensor in the shape of :math:`(*, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       image_enhancement.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> x = torch.ones(1, 1, 2, 2)

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -36,8 +36,7 @@ def box_blur(
         the blurred tensor with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       filtering_operators.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -158,8 +158,7 @@ def blur_pool2d(input: Tensor, kernel_size: tuple[int, int] | int, stride: int =
         This function is tested against https://github.com/adobe/antialiased-cnns.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       filtering_operators.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
 
     Examples:
         >>> input = torch.eye(5)[None, None]
@@ -193,8 +192,7 @@ def max_blur_pool2d(
         This function is tested against https://github.com/adobe/antialiased-cnns.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       filtering_operators.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
 
     Examples:
         >>> input = torch.eye(5)[None, None]

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -42,8 +42,7 @@ def canny(
         - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       canny.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
 
     Example:
         >>> input = torch.rand(5, 3, 4, 4)

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -37,8 +37,7 @@ def gaussian_blur2d(
         the blurred tensor with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       gaussian_blur.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/gaussian_blur.html>`__.
 
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -28,8 +28,7 @@ def laplacian(
         the blurred image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       filtering_edges.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_edges.html>`__.
 
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -27,8 +27,7 @@ def median_blur(input: Tensor, kernel_size: tuple[int, int] | int) -> Tensor:
         the blurred input tensor with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       filtering_operators.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -24,8 +24,7 @@ def spatial_gradient(input: Tensor, mode: str = 'sobel', order: int = 1, normali
         the derivatives of the input feature map. with shape :math:`(B, C, 2, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       filtering_edges.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_edges.html>`__.
 
     Examples:
         >>> input = torch.rand(1, 3, 4, 4)
@@ -128,8 +127,7 @@ def sobel(input: Tensor, normalized: bool = True, eps: float = 1e-6) -> Tensor:
         the sobel edge gradient magnitudes map with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       filtering_edges.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_edges.html>`__.
 
     Example:
         >>> input = torch.rand(1, 3, 4, 4)

--- a/kornia/filters/unsharp.py
+++ b/kornia/filters/unsharp.py
@@ -52,8 +52,7 @@ class UnsharpMask(Module):
         - Output: :math:`(B, C, H, W)`
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       unsharp_mask.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/unsharp_mask.html>`__.
 
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -251,8 +251,7 @@ def rotate(
         The rotated tensor with shape as input.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       rotate_affine.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/rotate_affine.html>`__.
 
     Example:
         >>> img = torch.rand(1, 3, 4, 4)

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -55,8 +55,6 @@ def warp_perspective(
 ) -> Tensor:
     r"""Apply a perspective transformation to an image.
 
-    .. image:: https://kornia-tutorials.readthedocs.io/en/latest/_images/warp_perspective_10_1.png
-
     The function warp_perspective transforms the source image using
     the specified matrix:
 
@@ -89,8 +87,7 @@ def warp_perspective(
         This function is often used in conjunction with :func:`get_perspective_transform`.
 
     .. note::
-        See a working example `here <https://kornia-tutorials.readthedocs.io/en/
-        latest/warp_perspective.html>`_.
+        See a working example `here <https://kornia.github.io/tutorials/nbs/warp_perspective.html>`_.
     """
     if not isinstance(src, Tensor):
         raise TypeError(f"Input src type is not a Tensor. Got {type(src)}")
@@ -167,8 +164,7 @@ def warp_affine(
         :func:`get_shear_matrix2d`, :func:`get_affine_matrix2d`, :func:`invert_affine_transform`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       rotate_affine.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/rotate_affine.html>`__.
 
     Example:
        >>> img = torch.rand(1, 4, 5, 6)

--- a/kornia/losses/total_variation.py
+++ b/kornia/losses/total_variation.py
@@ -23,8 +23,7 @@ def total_variation(img: Tensor, reduction: str = "sum") -> Tensor:
         torch.Size([2, 5, 3])
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       total_variation_denoising.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/total_variation_denoising.html>`__.
        Total Variation is formulated with summation, however this is not resolution invariant.
        Thus, `reduction='mean'` was added as an optional reduction method.
 

--- a/kornia/morphology/morphology.py
+++ b/kornia/morphology/morphology.py
@@ -48,8 +48,7 @@ def dilation(
         Dilated image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       morphology_101.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -142,8 +141,7 @@ def erosion(
         Eroded image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       morphology_101.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -237,8 +235,7 @@ def opening(
        torch.Tensor: Opened image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       morphology_101.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -315,8 +312,7 @@ def closing(
        Closed image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       morphology_101.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -395,8 +391,7 @@ def gradient(
        Gradient image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       morphology_101.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -464,8 +459,7 @@ def top_hat(
        Top hat transformed image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       morphology_101.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -536,8 +530,7 @@ def bottom_hat(
        Top hat transformed image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia-tutorials.readthedocs.io/en/latest/
-       morphology_101.html>`__.
+       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)


### PR DESCRIPTION
#### Changes
After we move the tutorials to use the quarto framework, we also move out from the readthedocs, to use the GitHub pages. https://kornia.github.io/tutorials

This patch updates the old links for the new one

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
