### PR TITLE
Add support for class data keys in AugmentationSequential

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -275,6 +275,8 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
                 inp.append(self._preproc_keypoints(arg, dcate))
             elif DataKey.get(dcate) in _BOXES_OPTIONS:
                 inp.append(self._preproc_boxes(arg, dcate))
+            elif DataKey.get(dcate) is DataKey.CLASS:
+                inp.append(arg)
             else:
                 raise NotImplementedError(f"input type of {dcate} is not implemented.")
         return inp
@@ -306,6 +308,9 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
                     else:
                         _out_b = _out_b.type(in_arg.dtype)
                 out.append(_out_b)
+
+            elif DataKey.get(dcate) is DataKey.CLASS:
+                out.append(out_arg)
 
             else:
                 raise NotImplementedError(f"input type of {dcate} is not implemented.")

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -91,6 +91,8 @@ class AugmentationSequentialOps:
             return BoxSequentialOps
         if data_key == DataKey.KEYPOINTS:
             return KeypointSequentialOps
+        if data_key == DataKey.CLASS:
+            return NoOps
         raise RuntimeError(f"Operation for `{data_key.name}` is not found.")
 
     def transform(
@@ -192,6 +194,18 @@ class InputSequentialOps(SequentialOpsInterface[Tensor]):
             input = module.inverse_inputs(input, params=cls.get_sequential_module_param(param), extra_args=extra_args)
         elif isinstance(module, K.container.ImageSequentialBase):
             input = module.inverse_inputs(input, params=cls.get_sequential_module_param(param), extra_args=extra_args)
+        return input
+
+
+class NoOps(SequentialOpsInterface[Tensor]):
+    """A no-op operation for class labels."""
+
+    @classmethod
+    def transform(cls, input: Tensor, module: Module, param: ParamItem, extra_args: Dict[str, Any] = {}) -> Tensor:
+        return input
+
+    @classmethod
+    def inverse(cls, input: Tensor, module: Module, param: ParamItem, extra_args: Dict[str, Any] = {}) -> Tensor:
         return input
 
 

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -92,7 +92,7 @@ class AugmentationSequentialOps:
         if data_key == DataKey.KEYPOINTS:
             return KeypointSequentialOps
         if data_key == DataKey.CLASS:
-            return NoOps
+            return ClassSequentialOps
         raise RuntimeError(f"Operation for `{data_key.name}` is not found.")
 
     def transform(
@@ -197,11 +197,15 @@ class InputSequentialOps(SequentialOpsInterface[Tensor]):
         return input
 
 
-class NoOps(SequentialOpsInterface[Tensor]):
+class ClassSequentialOps(SequentialOpsInterface[Tensor]):
     """A no-op operation for class labels."""
 
     @classmethod
     def transform(cls, input: Tensor, module: Module, param: ParamItem, extra_args: Dict[str, Any] = {}) -> Tensor:
+        if isinstance(module, K.MixAugmentationBaseV2):
+            raise NotImplementedError(
+                "The support for class labels for mix augmentations that change the class label is not yet supported."
+            )
         return input
 
     @classmethod

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -198,7 +198,7 @@ class InputSequentialOps(SequentialOpsInterface[Tensor]):
 
 
 class ClassSequentialOps(SequentialOpsInterface[Tensor]):
-    """A no-op operation for class labels."""
+    """Apply and inverse transformations for class labels if needed."""
 
     @classmethod
     def transform(cls, input: Tensor, module: Module, param: ParamItem, extra_args: Dict[str, Any] = {}) -> Tensor:

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -505,6 +505,16 @@ class TestAugmentationSequential:
         for i in range(len(bbox)):
             assert len(bboxes_transformed[i]) == len(bbox[i])
 
+    def test_class(self, device, dtype):
+        img = torch.zeros((5, 1, 5, 5))
+        labels = torch.randint(0, 10, size=(5, 1))
+        aug = K.AugmentationSequential(
+            K.RandomCrop((3,3), pad_if_needed=True),
+            data_keys=['input', 'class'])
+
+        _, out_labels = aug(img, labels)
+        assert labels is out_labels
+
     @pytest.mark.parametrize('random_apply', [1, (2, 2), (1, 2), (2,), 10, True, False])
     def test_forward_and_inverse(self, random_apply, device, dtype):
         inp = torch.randn(1, 3, 1000, 500, device=device, dtype=dtype)

--- a/test/augmentation/test_container.py
+++ b/test/augmentation/test_container.py
@@ -508,9 +508,7 @@ class TestAugmentationSequential:
     def test_class(self, device, dtype):
         img = torch.zeros((5, 1, 5, 5))
         labels = torch.randint(0, 10, size=(5, 1))
-        aug = K.AugmentationSequential(
-            K.RandomCrop((3,3), pad_if_needed=True),
-            data_keys=['input', 'class'])
+        aug = K.AugmentationSequential(K.RandomCrop((3, 3), pad_if_needed=True), data_keys=['input', 'class'])
 
         _, out_labels = aug(img, labels)
         assert labels is out_labels


### PR DESCRIPTION
#### Changes
Add a no-op op class to do nothing when data key is CLASS. Assumes that any augmentation that can be done will not change the class which would fail with MixUp and so on but I really don't know how to tackle that because it changes the very nature of the class labels.

Fixes #2535 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
