### PR TITLE
Make use of composition for augmentation multiprocessing friendliness

### DIFF
--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -1,6 +1,5 @@
 # Lazy loading auto module
 from kornia.augmentation import auto, container
-from kornia.augmentation._multiprocessing import MultiprocessWrapper
 from kornia.augmentation._2d import (
     CenterCrop,
     ColorJiggle,
@@ -75,6 +74,7 @@ from kornia.augmentation._3d import (
 from kornia.augmentation._3d.base import AugmentationBase3D, RigidAffineAugmentationBase3D
 from kornia.augmentation._3d.geometric.base import GeometricAugmentationBase3D
 from kornia.augmentation._3d.intensity.base import IntensityAugmentationBase3D
+from kornia.augmentation._multiprocessing import MultiprocessWrapper
 from kornia.augmentation.container import (
     AugmentationSequential,
     ImageSequential,

--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -1,5 +1,6 @@
 # Lazy loading auto module
 from kornia.augmentation import auto, container
+from kornia.augmentation._multiprocessing import MultiprocessWrapper
 from kornia.augmentation._2d import (
     CenterCrop,
     ColorJiggle,

--- a/kornia/augmentation/_multiprocessing.py
+++ b/kornia/augmentation/_multiprocessing.py
@@ -6,7 +6,7 @@ class MultiprocessWrapper:
     context."""
 
     def __init__(self, *args, **kwargs) -> None:
-        args = [arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args]
+        args = (arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args)
         kwargs = {key: val.clone() if isinstance(val, torch.Tensor) else val for key, val in kwargs.items()}
 
         super().__init__(*args, **kwargs)

--- a/kornia/augmentation/_multiprocessing.py
+++ b/kornia/augmentation/_multiprocessing.py
@@ -1,11 +1,12 @@
 import torch
 
+
 class MultiprocessWrapper:
-    """Utility class which when used as a base class, makes the class work with the 'spawn' multiprocessing context."""
+    """Utility class which when used as a base class, makes the class work with the 'spawn' multiprocessing
+    context."""
+
     def __init__(self, *args, **kwargs) -> None:
-        args = [arg.clone() if isinstance(arg, torch.Tensor) else arg
-                for arg in args]
-        kwargs = {key: val.clone() if isinstance(val, torch.Tensor) else val
-                  for key, val in kwargs.items()}
+        args = [arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args]
+        kwargs = {key: val.clone() if isinstance(val, torch.Tensor) else val for key, val in kwargs.items()}
 
         super().__init__(*args, **kwargs)

--- a/kornia/augmentation/_multiprocessing.py
+++ b/kornia/augmentation/_multiprocessing.py
@@ -1,0 +1,11 @@
+import torch
+
+class MultiprocessWrapper:
+    """Utility class which when used as a base class, makes the class work with the 'spawn' multiprocessing context."""
+    def __init__(self, *args, **kwargs) -> None:
+        args = [arg.clone() if isinstance(arg, torch.Tensor) else arg
+                for arg in args]
+        kwargs = {key: val.clone() if isinstance(val, torch.Tensor) else val
+                  for key, val in kwargs.items()}
+
+        super().__init__(*args, **kwargs)

--- a/kornia/augmentation/_multiprocessing.py
+++ b/kornia/augmentation/_multiprocessing.py
@@ -5,7 +5,7 @@ class MultiprocessWrapper:
     """Utility class which when used as a base class, makes the class work with the 'spawn' multiprocessing
     context."""
 
-    def __init__(self, *args, **kwargs) -> None: # type: ignore
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore
         args = (arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args)
         kwargs = {key: val.clone() if isinstance(val, torch.Tensor) else val for key, val in kwargs.items()}
 

--- a/kornia/augmentation/_multiprocessing.py
+++ b/kornia/augmentation/_multiprocessing.py
@@ -5,7 +5,7 @@ class MultiprocessWrapper:
     """Utility class which when used as a base class, makes the class work with the 'spawn' multiprocessing
     context."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None: # type: ignore
         args = (arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args)
         kwargs = {key: val.clone() if isinstance(val, torch.Tensor) else val for key, val in kwargs.items()}
 

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar
 
 import torch
 from torch.distributions import Distribution, Uniform

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union
 import torch
 from torch.distributions import Distribution, Uniform
 
+from kornia.augmentation._multiprocessing import MultiprocessWrapper
 from kornia.core import Device, Module, Tensor
 
 T = TypeVar('T')
@@ -109,15 +110,5 @@ class DistributionWithMapper(Distribution):
             return getattr(self.dist, attr)
 
 
-class UniformDistribution(Uniform):
+class UniformDistribution(MultiprocessWrapper, Uniform):
     """Wrapper around torch Uniform distribution which makes it work with the 'spawn' multiprocessing context."""
-
-    def __init__(self, low: Union[Tensor, float], high: Union[Tensor, float], validate_args: Optional[bool] = None):
-        if isinstance(low, torch.Tensor):
-            low = low.clone()
-        if isinstance(high, torch.Tensor):
-            high = high.clone()
-        # we could clone self.low and self.high after the init but given the
-        # tensors are broadcast in the init this would mean copying more data
-        # which would be slower
-        super().__init__(low, high, validate_args)


### PR DESCRIPTION
#### Changes

Modifies the UniformDistributed augmentation such that it uses composition. This would ultimately allow to make any other transform multiprocessing easy. 

Design note: I initially wanted to override `__setattr__` but then came back on my decision as this could result in unwanted copies during operations beyond  the initialization. Instead I simply clone input tensors upon initialization.

Addresses [this comment](https://github.com/kornia/kornia/pull/2499#discussion_r1308401158) from @edgarriba in my previous PR

#### Type of change

Small Refactor


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
