### PR TITLE
Fix TestEqualization

### DIFF
--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -218,7 +218,7 @@ def perform_keep_shape_image(f: Callable[..., Tensor]) -> Callable[..., Tensor]:
         if not isinstance(input, Tensor):
             raise TypeError(f"Input input type is not a Tensor. Got {type(input)}")
 
-        if len(input.shape) == 0:
+        if input.numel() == 0:
             raise ValueError("Invalid input tensor, it is empty.")
 
         input_shape = input.shape

--- a/test/enhance/test_equalization.py
+++ b/test/enhance/test_equalization.py
@@ -43,21 +43,22 @@ class TestEqualization(BaseTester):
         assert res.shape == img.shape
 
     @pytest.mark.parametrize(
-        "B, clip, grid, exception_type",
+        "B, clip, grid, exception_type, expected_error_msg",
         [
-            (0, 1.0, (2, 2), ValueError),
-            (1, 1, (2, 2), TypeError),
-            (1, 2.0, 2, TypeError),
-            (1, 2.0, (2, 2, 2), TypeError),
-            (1, 2.0, (2, 2.0), TypeError),
-            (1, 2.0, (2.0, 0.0), ValueError),
+            (0, 1.0, (2, 2), ValueError, 'Invalid input tensor, it is empty.'),  # from perform_keep_shape_image
+            (1, 1, (2, 2), TypeError, 'Input clip_limit type is not float. Got'),
+            (1, 2.0, 2, TypeError, 'Input grid_size type is not Tuple. Got'),
+            (1, 2.0, (2, 2, 2), TypeError, 'Input grid_size is not a Tuple with 2 elements. Got 3'),
+            (1, 2.0, (2, 2.0), TypeError, 'Input grid_size type is not valid, must be a Tuple[int, int]'),
+            (1, 2.0, (2, 0), ValueError, 'Input grid_size elements must be positive. Got'),
         ],
     )
-    def test_exception(self, B, clip, grid, exception_type):
+    def test_exception(self, B, clip, grid, exception_type, expected_error_msg):
         C, H, W = 1, 10, 20
         img = torch.rand(B, C, H, W)
-        with pytest.raises(exception_type):
+        with pytest.raises(exception_type) as errinfo:
             enhance.equalize_clahe(img, clip, grid)
+        assert expected_error_msg in str(errinfo)
 
     @pytest.mark.parametrize("dims", [(1, 1, 1, 1, 1), (1, 1)])
     def test_exception_tensor_dims(self, dims):

--- a/test/enhance/test_equalization.py
+++ b/test/enhance/test_equalization.py
@@ -45,6 +45,7 @@ class TestEqualization(BaseTester):
     @pytest.mark.parametrize(
         "B, clip, grid, exception_type",
         [
+            (0, 1.0, (2, 2), ValueError),
             (1, 1, (2, 2), TypeError),
             (1, 2.0, 2, TypeError),
             (1, 2.0, (2, 2, 2), TypeError),

--- a/test/enhance/test_equalization.py
+++ b/test/enhance/test_equalization.py
@@ -45,12 +45,11 @@ class TestEqualization(BaseTester):
     @pytest.mark.parametrize(
         "B, clip, grid, exception_type",
         [
-            (0, 1.0, (2, 2), ValueError),
             (1, 1, (2, 2), TypeError),
             (1, 2.0, 2, TypeError),
             (1, 2.0, (2, 2, 2), TypeError),
             (1, 2.0, (2, 2.0), TypeError),
-            (1, 2.0, (2, 0), ValueError),
+            (1, 2.0, (2.0, 0.0), ValueError),
         ],
     )
     def test_exception(self, B, clip, grid, exception_type):


### PR DESCRIPTION
~I'm not sure why this is passing before, but if the Batch size is 0, the `torch.rand` will return an empty tensor, so it will raise an internal error at torch when trying to do some computation. Maybe the internal error changed from ValueError to RunTime error?~

~I couldn't reproduce the error locally, but I also couldn't find the reason for this particular test, since we don't have a raise for this case too. And we already have a specific test for the tensor dimensions exception `test_exception_tensor_dims`~

The issue is: https://github.com/kornia/kornia/pull/2548#discussion_r1331975478

The falling case is from the decorator `perform_keep_shape_image` which isn't true when having an empty tensor with more than one dimension like: `tensor([], size=(0, 1, 10, 20))` from `torch.rand(0, 1, 10, 20)