### PR TITLE
Fix improper `importlib.util` import

### DIFF
--- a/kornia/testing/__init__.py
+++ b/kornia/testing/__init__.py
@@ -1,5 +1,5 @@
 """The testing package contains testing-specific utilities."""
-import importlib
+import importlib.util
 import math
 from abc import ABC, abstractmethod
 from copy import deepcopy


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes an improper usage of `importlib.util` in tests.
See the discussion in, and up to https://github.com/python/typeshed/pull/10746#issuecomment-1730371768 as to why importing directly from `importlib` shouldn't be relied on for `importlib.machinery`, `importlib.util` and `importlib.abc`. Mypy & pyright will also catch this.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue) (typing issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (waiting for CI)
- [N/A] Did you update CHANGELOG in case of a major change?
