### PR TITLE
implement grayscale_from_rgb

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        os: ['Ubuntu-latest', 'MacOS-latest']
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        os: ['Ubuntu-latest', 'MacOS-latest']
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        os: ['Ubuntu-latest', 'MacOS-latest']
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -43,13 +43,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        os: ['Ubuntu-latest', 'MacOS-latest']
     uses: ./.github/workflows/tests.yml
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.10"]'
       backend: '["tensorflow"]'
       backend-version: '["2.12.0", "2.13.0"]'
+      backend-dtype: 'float32'
+
+  tests-numpy:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: '["3.8", "3.10"]'
+      backend: '["numpy"]'
+      backend-version: '["1.24.3"]'
       backend-dtype: 'float32'
 
   # tests-cpu-fp64:

--- a/kornia/augmentation/_2d/intensity/grayscale.py
+++ b/kornia/augmentation/_2d/intensity/grayscale.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, Optional
+from __future__ import annotations
+
+from typing import Any
 
 import torch
 from torch import Tensor
@@ -52,13 +54,17 @@ class RandomGrayscale(IntensityAugmentationBase2D):
     """
 
     def __init__(
-        self, rgb_weights: Optional[Tensor] = None, same_on_batch: bool = False, p: float = 0.1, keepdim: bool = False
+        self,
+        rgb_weights: tuple[float, float, float] | None = None,
+        same_on_batch: bool = False,
+        p: float = 0.1,
+        keepdim: bool = False,
     ) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
         self.rgb_weights = rgb_weights
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self, input: Tensor, params: dict[str, Tensor], flags: dict[str, Any], transform: Tensor | None = None
     ) -> Tensor:
         # Make sure it returns (*, 3, H, W)
         grayscale = torch.ones_like(input)

--- a/kornia/color/gray.py
+++ b/kornia/color/gray.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import keras_core as keras
+import keras_core as keras  # type: ignore
+from keras_core import KerasTensor as kTensor
 
 from kornia.color.rgb import bgr_to_rgb
 from kornia.core import Module, Tensor, concatenate
 from kornia.core.check import KORNIA_CHECK_IS_TENSOR
 
 
-def _weighted_sum_channels_kernel(r, g, b, w_r, w_g, w_b) -> Tensor:
+def _weighted_sum_channels_kernel(r: kTensor, g: kTensor, b: kTensor, w_r: float, w_g: float, w_b: float) -> kTensor:
     return w_r * r + w_g * g + w_b * b
 
 
@@ -36,7 +37,9 @@ def grayscale_to_rgb(image: Tensor) -> Tensor:
     return concatenate([image, image, image], -3)
 
 
-def grayscale_from_rgb(image: Tensor, rgb_weights: Tensor | None = None, channels_axis: int = -3) -> Tensor:
+def grayscale_from_rgb(
+    image: Tensor, rgb_weights: tuple[float, float, float] | None = None, channels_axis: int = -3
+) -> Tensor:
     r"""Convert a RGB image to grayscale version of image.
 
     .. image:: _static/img/rgb_to_grayscale.png
@@ -62,10 +65,10 @@ def grayscale_from_rgb(image: Tensor, rgb_weights: Tensor | None = None, channel
     if rgb_weights is None:
         # floating point images
         if "float32" in str(image.dtype):
-            rgb_weights = [0.299, 0.587, 0.114]
+            rgb_weights = (0.299, 0.587, 0.114)
         # 8 bit images
         elif "uint8" in str(image.dtype):
-            rgb_weights = [76, 150, 29]
+            rgb_weights = (76, 150, 29)
         else:
             raise TypeError(f"Unknown data type: {image.dtype}")
 
@@ -142,11 +145,9 @@ class RgbToGrayscale(Module):
         >>> output = gray(input)  # 2x1x4x5
     """
 
-    def __init__(self, rgb_weights: Tensor | None = None) -> None:
+    def __init__(self, rgb_weights: tuple[float, float, float] | None = None) -> None:
         super().__init__()
-        if rgb_weights is None:
-            rgb_weights = Tensor([0.299, 0.587, 0.114])
-        self.rgb_weights = rgb_weights
+        self.rgb_weights = rgb_weights or (0.299, 0.587, 0.114)
 
     def forward(self, image: Tensor) -> Tensor:
         return rgb_to_grayscale(image, rgb_weights=self.rgb_weights)

--- a/kornia/color/gray.py
+++ b/kornia/color/gray.py
@@ -69,7 +69,7 @@ def grayscale_from_rgb(
 
     if rgb_weights is None:
         # floating point images
-        if "float32" in str(image.dtype):
+        if "float" in str(image.dtype):
             rgb_weights = (0.299, 0.587, 0.114)
         # 8 bit images
         elif "uint8" in str(image.dtype):

--- a/kornia/core/__init__.py
+++ b/kornia/core/__init__.py
@@ -25,6 +25,7 @@ from ._backend import (
     zeros,
     zeros_like,
 )
+from .ops import *
 from .tensor_wrapper import TensorWrapper  # type: ignore
 
 __all__ = [

--- a/kornia/core/ops.py
+++ b/kornia/core/ops.py
@@ -1,0 +1,3 @@
+import keras_core as keras  # type: ignore
+
+split = keras.ops.split

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,3 +1,4 @@
+keras-core==0.1.3
 kornia-rs==0.0.8
 mypy[reports]
 numpy

--- a/tests/color/test_grayscale.py
+++ b/tests/color/test_grayscale.py
@@ -1,0 +1,37 @@
+import keras_core as keras
+import numpy as np
+import pytest
+import torch
+from jax import random
+
+from kornia.color.gray import grayscale_from_rgb
+
+
+# TODO: make this a fixture
+def genrate_image_data(channel_first: bool = False):
+    if channel_first:
+        shape = (3, 4, 5)
+    else:
+        shape = (4, 5, 3)
+
+    backend = keras.backend.backend()
+
+    if backend == "torch":
+        return torch.randint(0, 1, shape, dtype=torch.float32)
+    if backend == "numpy":
+        key = np.random.RandomState(42)
+        return key.uniform(size=shape).astype(np.float32)
+    if backend == "jax":
+        key = random.PRNGKey(42)
+        return random.uniform(key, shape)
+
+    return None
+
+
+class TestColorGray:
+    @pytest.mark.parametrize("channel_first", [False, True])
+    def test_channels(self, channel_first):
+        image_rgb = genrate_image_data(channel_first)
+        channels_axis = -3 if channel_first else -1
+        image_gray = grayscale_from_rgb(image_rgb, channels_axis=channels_axis)
+        assert image_gray.shape == (1, 4, 5) if channel_first else (4, 5, 1)

--- a/tests/color/test_grayscale.py
+++ b/tests/color/test_grayscale.py
@@ -1,8 +1,9 @@
+import jax
 import keras_core as keras
 import numpy as np
 import pytest
+import tensorflow as tf
 import torch
-from jax import random
 
 from kornia.color.gray import grayscale_from_rgb
 
@@ -22,8 +23,10 @@ def genrate_image_data(channel_first: bool = False):
         key = np.random.RandomState(42)
         return key.uniform(size=shape).astype(np.float32)
     if backend == "jax":
-        key = random.PRNGKey(42)
-        return random.uniform(key, shape)
+        key = jax.random.PRNGKey(42)
+        return jax.random.uniform(key, shape).astype(jax.numpy.float32)
+    if backend == "tensorflow":
+        return tf.random.uniform(shape, dtype=tf.float32)
 
     return None
 


### PR DESCRIPTION
#### Changes

- proves that we can just use raw tensor within keras_core
- implement `grayscale_from_rgb`
- add alias for temporal backward compatibility

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [x] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
