### PR TITLE
added skeletonize in morphology.py

### DIFF
--- a/docs/source/morphology.rst
+++ b/docs/source/morphology.rst
@@ -10,6 +10,7 @@ kornia.morphology
 .. autofunction:: gradient
 .. autofunction:: top_hat
 .. autofunction:: bottom_hat
+.. autofunction:: skeletonize
 
 Interactive Demo
 ~~~~~~~~~~~~~~~~

--- a/kornia/morphology/morphology.py
+++ b/kornia/morphology/morphology.py
@@ -564,12 +564,11 @@ def bottom_hat(
         - tensor
     )
 
-def skeletonize(
-    tensor: torch.Tensor,
-    kernel: Optional[torch.Tensor] = None,
-) -> torch.Tensor:
-    r"""Return the skeleton of a binary image. In morphological terms, it involves reducing foreground regions in a binary 
-    image while preserving the extent and connectivity of the original region and throwing away most of the foreground pixels.
+
+def skeletonize(tensor: torch.Tensor, kernel: Optional[torch.Tensor] = None) -> torch.Tensor:
+    r"""Return the skeleton of a binary image. In morphological terms, it involves reducing foreground regions in a
+    binary image while preserving the extent and connectivity of the original region and throwing away most of the
+    foreground pixels.
 
     The kernel must have 2 dimensions.
 
@@ -614,5 +613,5 @@ def skeletonize(
         tensor = eroded_img.clone()
         if torch.count_nonzero(tensor) == 0:
             break
-            
+
     return output.view_as(tensor)

--- a/kornia/morphology/morphology.py
+++ b/kornia/morphology/morphology.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Optional
-
 import torch
 import torch.nn.functional as F
 
@@ -16,11 +14,12 @@ def _neight2channels_like_kernel(kernel: torch.Tensor) -> torch.Tensor:
     kernel = torch.eye(h * w, dtype=kernel.dtype, device=kernel.device)
     return kernel.view(h * w, 1, h, w)
 
+
 def dilation(
     tensor: torch.Tensor,
     kernel: torch.Tensor,
-    structuring_element: Optional[torch.Tensor] = None,
-    origin: Optional[List[int]] = None,
+    structuring_element: torch.Tensor | None = None,
+    origin: list[int] | None = None,
     border_type: str = 'geodesic',
     border_value: float = 0.0,
     max_val: float = 1e4,
@@ -78,7 +77,7 @@ def dilation(
         origin = [se_h // 2, se_w // 2]
 
     # pad
-    pad_e: List[int] = [origin[1], se_w - origin[1] - 1, origin[0], se_h - origin[0] - 1]
+    pad_e: list[int] = [origin[1], se_w - origin[1] - 1, origin[0], se_h - origin[0] - 1]
     if border_type == 'geodesic':
         border_value = -max_val
         border_type = 'constant'
@@ -112,8 +111,8 @@ def dilation(
 def erosion(
     tensor: torch.Tensor,
     kernel: torch.Tensor,
-    structuring_element: Optional[torch.Tensor] = None,
-    origin: Optional[List[int]] = None,
+    structuring_element: torch.Tensor | None = None,
+    origin: list[int] | None = None,
     border_type: str = 'geodesic',
     border_value: float = 0.0,
     max_val: float = 1e4,
@@ -171,7 +170,7 @@ def erosion(
         origin = [se_h // 2, se_w // 2]
 
     # pad
-    pad_e: List[int] = [origin[1], se_w - origin[1] - 1, origin[0], se_h - origin[0] - 1]
+    pad_e: list[int] = [origin[1], se_w - origin[1] - 1, origin[0], se_h - origin[0] - 1]
     if border_type == 'geodesic':
         border_value = max_val
         border_type = 'constant'
@@ -206,8 +205,8 @@ def erosion(
 def opening(
     tensor: torch.Tensor,
     kernel: torch.Tensor,
-    structuring_element: Optional[torch.Tensor] = None,
-    origin: Optional[List[int]] = None,
+    structuring_element: torch.Tensor | None = None,
+    origin: list[int] | None = None,
     border_type: str = 'geodesic',
     border_value: float = 0.0,
     max_val: float = 1e4,
@@ -283,8 +282,8 @@ def opening(
 def closing(
     tensor: torch.Tensor,
     kernel: torch.Tensor,
-    structuring_element: Optional[torch.Tensor] = None,
-    origin: Optional[List[int]] = None,
+    structuring_element: torch.Tensor | None = None,
+    origin: list[int] | None = None,
     border_type: str = 'geodesic',
     border_value: float = 0.0,
     max_val: float = 1e4,
@@ -361,8 +360,8 @@ def closing(
 def gradient(
     tensor: torch.Tensor,
     kernel: torch.Tensor,
-    structuring_element: Optional[torch.Tensor] = None,
-    origin: Optional[List[int]] = None,
+    structuring_element: torch.Tensor | None = None,
+    origin: list[int] | None = None,
     border_type: str = 'geodesic',
     border_value: float = 0.0,
     max_val: float = 1e4,
@@ -427,8 +426,8 @@ def gradient(
 def top_hat(
     tensor: torch.Tensor,
     kernel: torch.Tensor,
-    structuring_element: Optional[torch.Tensor] = None,
-    origin: Optional[List[int]] = None,
+    structuring_element: torch.Tensor | None = None,
+    origin: list[int] | None = None,
     border_type: str = 'geodesic',
     border_value: float = 0.0,
     max_val: float = 1e4,
@@ -498,8 +497,8 @@ def top_hat(
 def bottom_hat(
     tensor: torch.Tensor,
     kernel: torch.Tensor,
-    structuring_element: Optional[torch.Tensor] = None,
-    origin: Optional[List[int]] = None,
+    structuring_element: torch.Tensor | None = None,
+    origin: list[int] | None = None,
     border_type: str = 'geodesic',
     border_value: float = 0.0,
     max_val: float = 1e4,
@@ -570,18 +569,18 @@ def bottom_hat(
 
 
 def skeletonize(data: Tensor, kernel: Tensor | None = None) -> Tensor:
-    r"""Return the skeleton of a binary image. 
-    
+    r"""Return the skeleton of a binary image.
+
     In morphological terms, it involves reducing foreground regions in a
-    binary image while preserving the extent and connectivity of the original 
+    binary image while preserving the extent and connectivity of the original
     region and throwing away most of the foreground pixels.
 
     The kernel must have 2 dimensions.
 
     Args:
         data: Image with shape :math:`(B, 1, H, W)`. [C = 1]
-        kernel: Positions of non-infinite elements of a flat structuring element. 
-                Non-zero values give the set of neighbors of the center over which 
+        kernel: Positions of non-infinite elements of a flat structuring element.
+                Non-zero values give the set of neighbors of the center over which
                 the operation is applied. Its shape is :math:`(k_x, k_y)`.
                 For full structural elements use torch.ones_like(structural_element).
     Returns:
@@ -601,7 +600,7 @@ def skeletonize(data: Tensor, kernel: Tensor | None = None) -> Tensor:
 
     if kernel is None:
         kernel = torch.tensor([[0, 1, 0], [1, 1, 1], [0, 1, 0]], device=data.device, dtype=torch.int64)
-    
+
     KORNIA_CHECK_IS_TENSOR(kernel)
     KORNIA_CHECK(len(kernel.shape) == 2, "Kernel size must have 2 dimensions.")
 

--- a/test/morphology/test_skeletonize.py
+++ b/test/morphology/test_skeletonize.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+from torch.autograd import gradcheck
+
+from kornia.morphology import skeletonize
+from kornia.testing import assert_close
+
+class TestSkeletonize:
+    def test_smoke(self, device, dtype):
+        kernel = torch.rand(3, 3, device=device, dtype=dtype)
+        assert kernel is not None
+
+    @pytest.mark.parametrize("shape", [(1, 1, 4, 4), (2, 1, 2, 4), (3, 1, 4, 1), (3, 1, 5, 5)])
+    @pytest.mark.parametrize("kernel", [(3, 3), (5, 5)])
+    def test_cardinality(self, device, dtype, shape, kernel):
+        img = torch.ones(shape, device=device, dtype=dtype)
+        krnl = torch.ones(kernel, device=device, dtype=dtype)
+        assert skeletonize(img, krnl).shape == shape
+
+    def test_kernel(self, device, dtype):
+        tensor = torch.tensor([[0.5, 1.0, 0.3], [0.7, 0.3, 0.8], [0.4, 0.9, 0.2]], device=device, dtype=dtype)[
+            None, None, :, :
+        ]
+        kernel = torch.tensor([[0.0, 1.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 0.0]], device=device, dtype=dtype)
+        expected = torch.tensor([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], device=device, dtype=dtype)[
+            None, None, :, :
+        ]
+        assert_close(skeletonize(tensor, kernel), expected, atol=1e-4, rtol=1e-4)
+
+    def test_exception(self, device, dtype):
+        tensor = torch.ones(1, 1, 3, 4, device=device, dtype=dtype)
+        kernel = torch.ones(3, 3, device=device, dtype=dtype)
+
+        with pytest.raises(TypeError):
+            assert skeletonize([0.0], kernel)
+
+        with pytest.raises(TypeError):
+            assert skeletonize(tensor, [0.0])
+
+        with pytest.raises(ValueError):
+            test = torch.ones(2, 3, 4, device=device, dtype=dtype)
+            assert skeletonize(test, kernel)
+
+        with pytest.raises(ValueError):
+            test = torch.ones(2, 3, 4, device=device, dtype=dtype)
+            assert skeletonize(tensor, test)
+
+    @pytest.mark.grad()
+    def test_gradcheck(self, device, dtype):
+        tensor = torch.rand(2, 1, 4, 4, requires_grad=True, device=device, dtype=torch.float64)
+        kernel = torch.rand(3, 3, requires_grad=True, device=device, dtype=torch.float64)
+        assert gradcheck(skeletonize, (tensor, kernel), raise_exception=True, fast_mode=True)
+
+    @pytest.mark.jit()
+    def test_jit(self, device, dtype):
+        op = skeletonize
+        op_script = torch.jit.script(op)
+
+        tensor = torch.rand(1, 1, 7, 7, device=device, dtype=dtype)
+        kernel = torch.ones(3, 3, device=device, dtype=dtype)
+
+        actual = op_script(tensor, kernel)
+        expected = op(tensor, kernel)
+
+        assert_close(actual, expected)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2575

Added a vanilla implementation of skeletonization in morphology.py as described in Issue[#2575](https://github.com/kornia/kornia/issues/2575). No additional dependencies required, uses the functions `opening` and `erosion` from _morphology.py_ along with `torch`. 

#### Type of change
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
