### PR TITLE
add deps info to tests header

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -103,6 +103,35 @@ def pytest_addoption(parser):
     parser.addoption('--dtype', action="store", default="float32")
 
 
+def pytest_report_header(config):
+    try:
+        import accelerate
+
+        accelerate_info = f'accelerate-{accelerate.__version__}'
+    except ImportError:
+        accelerate_info = '`accelerate` not found'
+
+    import cv2
+    import kornia_rs
+    import onnx
+    import scipy
+
+    return f"""
+main deps:
+    - kornia-{kornia.__version__}
+    - torch-{torch.__version__}
+        - commit: {torch.version.git_version}
+        - cuda: {torch.version.cuda}
+x deps:
+    - {accelerate_info}
+dev deps:
+    - kornia_rs-{kornia_rs.__version__}
+    - opencv (cv2)-{cv2.__version__}
+    - onnx-{onnx.__version__}
+    - scipy-{scipy.__version__}
+"""
+
+
 @pytest.fixture(autouse=True)
 def add_doctest_deps(doctest_namespace):
     doctest_namespace["np"] = np

--- a/conftest.py
+++ b/conftest.py
@@ -111,7 +111,6 @@ def pytest_report_header(config):
     except ImportError:
         accelerate_info = '`accelerate` not found'
 
-    import cv2
     import kornia_rs
     import onnx
     import scipy
@@ -126,7 +125,6 @@ x deps:
     - {accelerate_info}
 dev deps:
     - kornia_rs-{kornia_rs.__version__}
-    - opencv (cv2)-{cv2.__version__}
     - onnx-{onnx.__version__}
     - scipy-{scipy.__version__}
 """


### PR DESCRIPTION
with this patch we should see the kornia deps into the pytest header

example
```output
$ pytest 
============================= test session starts =============================
platform linux -- Python 3.10.10, pytest-7.4.2, pluggy-1.0.0

main deps:
    - kornia-0.7.0
    - torch-2.0.1
        - commit: e9ebda29d87ce0916ab08c06ab26fd3766a870e5
        - cuda: 11.7
x deps:
    - accelerate-0.19.0
dev deps:
    - kornia_rs-0.0.8
    - opencv (cv2)-4.7.0
    - onnx-1.14.1
    - scipy-1.10.1

...
```