### PR TITLE
drop `torchvision` from docs deps

### DIFF
--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -11,4 +11,3 @@ sphinx-design
 sphinxcontrib-bibtex
 sphinxcontrib-gtagjs
 sphinxcontrib-youtube
-torchvision


### PR DESCRIPTION
Looks like this isn't used anywhere on docs, or in kornia