### PR TITLE
random rain augmentation: Add draw_line method

### DIFF
--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -75,9 +75,8 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-    def draw_line(self, img: torch.Tensor, intensity: float = 0.3) -> torch.Tensor:
+    def draw_line(self, image: torch.Tensor, intensity: float = 0.3) -> torch.Tensor:
         """Draws the drops on the image by changing its pixels' intensity."""
-        image = img.copy()
         if len(image.shape) != 4:
             raise ValueError("Input image tensor should have shape (B, C, H, W)")
         B, C, H, W = image.shape

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -76,7 +76,7 @@ class RainGenerator(RandomGeneratorBase):
         }
 
     def draw_line(self, img: torch.Tensor, intensity: float = 0.3) -> torch.Tensor:
-        """ Draws the drops on the image by changing its pixels' intensity."""
+        """Draws the drops on the image by changing its pixels' intensity."""
         image = img.clone()
         if len(image.shape) != 4:
             raise ValueError("Input image tensor should have shape (B, C, H, W)")

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -75,11 +75,8 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-    
     def draw_line(self, img: torch.Tensor, intensity: float = 0.3) -> torch.Tensor:
-        """
-        Draws the drops on the image by changing its pixels' intensity
-        """
+        """Draws the drops on the image by changing its pixels' intensity."""
         image = img.copy()
         if len(image.shape) != 4:
             raise ValueError("Input image tensor should have shape (B, C, H, W)")
@@ -102,4 +99,3 @@ class RainGenerator(RandomGeneratorBase):
                 image[b, :, y_start:y_end, x_start:x_end] -= intensity  # darken the image where the raindrop is
         image = torch.clamp(image, 0, 1)  # clip values to ensure they're within [0, 1]
         return image
-

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -75,23 +75,24 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-    def draw_line(self, image: torch.Tensor, intensity: float = 0.3) -> torch.Tensor:
-        """Draws the drops on the image by changing its pixels' intensity."""
+    def draw_line(self, img: torch.Tensor, intensity: float = 0.3) -> torch.Tensor:
+        """ Draws the drops on the image by changing its pixels' intensity."""
+        image = img.clone()
         if len(image.shape) != 4:
             raise ValueError("Input image tensor should have shape (B, C, H, W)")
         B, C, H, W = image.shape
         # generate rain parameters
         rain_params = self.forward((B,), same_on_batch=False)
         num_drops = rain_params['number_of_drops_factor'].item()
-        drop_heights = rain_params['drop_height_factor']
-        drop_widths = rain_params['drop_width_factor']
+        drop_heights = rain_params['drop_height_factor'].item()
+        drop_widths = rain_params['drop_width_factor'].item()
         coordinates = rain_params['coordinates_factor']
         for b in range(B):
-            for drop in range(num_drops):
+            for drop in range(int(num_drops)):
                 x_start = int(coordinates[b, drop, 0].item() * W)
                 y_start = int(coordinates[b, drop, 1].item() * H)
-                x_end = x_start + drop_widths[b].item()
-                y_end = y_start + drop_heights[b].item()
+                x_end = x_start + drop_widths
+                y_end = y_start + drop_heights
                 # ensure the raindrop is within the image boundaries
                 x_end = min(x_end, W)
                 y_end = min(y_end, H)

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -94,8 +94,8 @@ class RainGenerator(RandomGeneratorBase):
                 x_end = x_start + drop_widths
                 y_end = y_start + drop_heights
                 # ensure the raindrop is within the image boundaries
-                x_end = min(x_end, W)
-                y_end = min(y_end, H)
+                x_end = int(min(x_end, W))
+                y_end = int(min(y_end, H))
                 image[b, :, y_start:y_end, x_start:x_end] -= intensity  # darken the image where the raindrop is
         image = torch.clamp(image, 0, 1)  # clip values to ensure they're within [0, 1]
         return image

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
-import random
-import torch
+
 import math
+import random
+
+import torch
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
-
 import torch
-
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -75,12 +73,6 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-    import torch
-
-
-import math
-import random
-
 
 def random_rain_augmentation(
     image: torch.Tensor,
@@ -99,7 +91,23 @@ def random_rain_augmentation(
         color: the color of the raindrops.
 
     Return:
-        the image with raindrops.
+        The image with raindrops.
+    Doctests:
+    >>> import torch
+    >>> image = torch.zeros(3, 10, 10) # A black 10x10 image with 3 channels
+    >>> output = random_rain_augmentation(image, 0) # No raindrops
+    >>> torch.equal(output, image) # Expect True since no raindrops were added
+    True
+
+    >>> output_with_rain = random_rain_augmentation(image, 1000) # Lots of raindrops
+    >>> torch.equal(output_with_rain, image) # Expect False since raindrops were added
+    False
+
+    >>> # Test with custom color
+    >>> custom_color = torch.tensor([50])
+    >>> output_custom_color = random_rain_augmentation(image, 1000, color=custom_color)
+    >>> torch.any(output_custom_color == 50) # Expect True since raindrops of color 50 were added
+    True
     """
     H, W = image.shape[1], image.shape[2]
 

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -51,7 +51,7 @@ class RainGenerator(RandomGeneratorBase):
         self.drop_height_sampler = UniformDistribution(drop_height[0], drop_height[1], validate_args=False)
         self.drop_width_sampler = UniformDistribution(drop_width[0], drop_width[1], validate_args=False)
         self.coordinates_sampler = UniformDistribution(drop_coordinates[0], drop_coordinates[1], validate_args=False)
-
+        
     def forward(self, batch_shape: tuple[int, ...], same_on_batch: bool = False) -> dict[str, Tensor]:
         batch_size = batch_shape[0]
         _common_param_check(batch_size, same_on_batch)
@@ -78,14 +78,8 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-
-     def random_rain_augmentation(
-        self,
-        image_val: torch.Tensor,
-        num_raindrops: int = 100,
-        min_length: int = 5,
-        max_length: int = 15,
-        color: torch.Tensor = None)-> torch.Tensor:
+   def random_rain_augmentation(
+        self,image_val: torch.Tensor,num_raindrops: int = 100,min_length: int = 5,max_length: int = 15, color: torch.Tensor = None)-> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+
 import torch
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -76,62 +76,58 @@ class RainGenerator(RandomGeneratorBase):
         }
 
 
-def random_rain_augmentation(
-    image: torch.Tensor,
-    num_raindrops: int = 100,
-    min_length: int = 5,
-    max_length: int = 15,
-    color: torch.Tensor = torch.tensor([255]),
-) -> torch.Tensor:
+    def random_rain_augmentation(
+        image: torch.Tensor,
+        num_raindrops: int = 100,
+        min_length: int = 5,
+        max_length: int = 15,
+        color: torch.Tensor = torch.tensor([255]),
+    ) -> torch.Tensor:
+        """Apply random rain augmentation to the input image.
+        Args:
+            image (torch.Tensor): the input image with shape :math:`(C,H,W)`.
+            num_raindrops (int, optional): number of raindrops to draw. Defaults to 100.
+            min_length (int, optional): minimum length of a raindrop. Defaults to 5.
+            max_length (int, optional): maximum length of a raindrop. Defaults to 15.
+            color (torch.Tensor, optional): the color of the raindrops. Defaults to torch.tensor([255]).
+    
+        Returns:
+            torch.Tensor: The image with raindrops.
+        Doctests:
+        >>> import torch
+        >>> image = torch.zeros(3, 10, 10)  # A 10x10 black image with 3 channels
+        >>> no_rain = random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
+        >>> torch.equal(no_rain, image)
+        True
+    
+        >>> rain_img = random_rain_augmentation(image, 1000)  # Applying augmentation with 1000 raindrops
+        >>> torch.equal(rain_img, image)
+        False
+    
+        >>> # Applying augmentation with custom raindrop color
+        >>> custom_color = torch.tensor([50, 50, 50])
+        >>> colored_rain_img = random_rain_augmentation(image, 1000, color=custom_color)
+        >>> torch.any(colored_rain_img == 50)
+        True
         """
-    Apply random rain augmentation to the input image.
-    Args:
-        image (torch.Tensor): the input image with shape :math:`(C,H,W)`.
-        num_raindrops (int, optional): number of raindrops to draw. Defaults to 100.
-        min_length (int, optional): minimum length of a raindrop. Defaults to 5.
-        max_length (int, optional): maximum length of a raindrop. Defaults to 15.
-        color (torch.Tensor, optional): the color of the raindrops. Defaults to torch.tensor([255]).
-
-    Returns:
-        torch.Tensor: The image with raindrops.
-
-    Doctests:
-    >>> import torch
-    >>> image = torch.zeros(3, 10, 10)  # A 10x10 black image with 3 channels
-    >>> no_rain = random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
-    >>> torch.equal(no_rain, image)
-    True
-
-    >>> rain_img = random_rain_augmentation(image, 1000)  # Applying augmentation with 1000 raindrops
-    >>> torch.equal(rain_img, image)
-    False
-
-    >>> # Applying augmentation with custom raindrop color
-    >>> custom_color = torch.tensor([50])
-    >>> colored_rain_img = random_rain_augmentation(image, 1000, color=custom_color)
-    >>> torch.any(colored_rain_img == 50)
-    True
-    """
-
-    H, W = image.shape[1], image.shape[2]
-
-    for _ in range(num_raindrops):
-        # Randomly select the starting point
-        start_x = random.randint(0, W - 1)
-        start_y = random.randint(0, H - 1)
-        # Randomly select the length and angle of the raindrop
-        length = random.uniform(min_length, max_length)
-        angle = random.uniform(math.pi / 4, 3 * math.pi / 4)  # Rain typically falls at angles between 45 to 135 degrees
-        # Compute end point using trigonometry
-        end_x = start_x + length * math.cos(angle)
-        end_y = start_y + length * math.sin(angle)
-        # Clip the coordinates to be within the image boundaries
-        end_x = min(max(0, end_x), W - 1)
-        end_y = min(max(0, end_y), H - 1)
-        # Convert the start and end points to torch tensors
-        p1 = torch.tensor([start_x, start_y])
-        p2 = torch.tensor([end_x, end_y])
-        # Draw the raindrop
-        image = draw_line(image, p1, p2, color)
-
-    return image
+        H, W = image.shape[1], image.shape[2]
+        for _ in range(num_raindrops):
+            # Randomly select the starting point
+            start_x = random.randint(0, W - 1)
+            start_y = random.randint(0, H - 1)
+            # Randomly select the length and angle of the raindrop
+            length = random.uniform(min_length, max_length)
+            angle = random.uniform(math.pi / 4, 3 * math.pi / 4)  # Rain typically falls at angles between 45 to 135 degrees
+            # Compute end point using trigonometry
+            end_x = start_x + length * math.cos(angle)
+            end_y = start_y + length * math.sin(angle)
+            # Clip the coordinates to be within the image boundaries
+            end_x = min(max(0, end_x), W - 1)
+            end_y = min(max(0, end_y), H - 1)
+            # Convert the start and end points to torch tensors
+            p1 = torch.tensor([start_x, start_y])
+            p2 = torch.tensor([end_x, end_y])
+            # Draw the raindrop
+            image = draw_line(image, p1, p2, color)
+    
+        return image

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
-
 import math
 import random
-
 import torch
-
+from typing import Optional
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -84,8 +82,7 @@ class RainGenerator(RandomGeneratorBase):
         num_raindrops: int = 100,
         min_length: int = 5,
         max_length: int = 15,
-        color: torch.Tensor = None,
-    ) -> torch.Tensor:
+        color: Optional[torch.Tensor] = None) -> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -79,7 +79,7 @@ class RainGenerator(RandomGeneratorBase):
         }
 
     def random_rain_augmentation(
-        self, image: torch.Tensor, num_raindrops: int = 100, min_length: int = 5, max_length: int = 15, color: torch.Tensor = torch.tensor([255]))) -> torch.Tensor:
+        self, image: torch.Tensor, num_raindrops: int = 100, min_length: int = 5, max_length: int = 15, color: torch.Tensor = torch.tensor([255])) -> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -51,7 +51,7 @@ class RainGenerator(RandomGeneratorBase):
         self.drop_height_sampler = UniformDistribution(drop_height[0], drop_height[1], validate_args=False)
         self.drop_width_sampler = UniformDistribution(drop_width[0], drop_width[1], validate_args=False)
         self.coordinates_sampler = UniformDistribution(drop_coordinates[0], drop_coordinates[1], validate_args=False)
-        
+
     def forward(self, batch_shape: tuple[int, ...], same_on_batch: bool = False) -> dict[str, Tensor]:
         batch_size = batch_shape[0]
         _common_param_check(batch_size, same_on_batch)

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+
 import math
 import random
+
 import torch
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -76,7 +79,13 @@ class RainGenerator(RandomGeneratorBase):
         }
 
     def random_rain_augmentation(
-        self,image_val: torch.Tensor,num_raindrops: int = 100,min_length: int = 5,max_length: int = 15, color: torch.Tensor = None)-> torch.Tensor:
+        self,
+        image_val: torch.Tensor,
+        num_raindrops: int = 100,
+        min_length: int = 5,
+        max_length: int = 15,
+        color: torch.Tensor = None,
+    ) -> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -79,13 +79,7 @@ class RainGenerator(RandomGeneratorBase):
         }
 
     def random_rain_augmentation(
-        self,
-        image: torch.Tensor,
-        num_raindrops: int = 100,
-        min_length: int = 5,
-        max_length: int = 15,
-        color: torch.Tensor = torch.tensor([255]),
-    ) -> torch.Tensor:
+        self, image: torch.Tensor, num_raindrops: int = 100, min_length: int = 5, max_length: int = 15, color: torch.Tensor = torch.tensor([255]))) -> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.
@@ -98,15 +92,16 @@ class RainGenerator(RandomGeneratorBase):
             torch.Tensor: The image with raindrops.
         Doctests:
         >>> import torch
-        >>> aug = RainGenerator(100, 5, 15)
-        >>> image = torch.zeros(3, 10, 10)
-        >>> no_rain = aug.random_rain_augmentation(image, 0)
+        >>> aug = RainGenerator((50, 150), (3, 7), (1, 3))  # Initialize the RainGenerator
+        >>> image = torch.zeros(3, 10, 10)  # A 10x10 black image with 3 channels
+        >>> no_rain = aug.random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
         >>> torch.equal(no_rain, image)
         True
         >>> rain_img = aug.random_rain_augmentation(image, 1000)
         >>> torch.equal(rain_img, image)
         False
-        >>> custom_color = torch.tensor([50, 50, 50])
+
+        >>> custom_color = torch.tensor([50, 50, 50])  # Custom color for the raindrops
         >>> colored_rain_img = aug.random_rain_augmentation(image, 1000, color=custom_color)
         >>> torch.any(colored_rain_img == 50)
         True

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-
+import random
 import torch
-
+import math
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -117,23 +117,18 @@ def random_rain_augmentation(
         # Randomly select the starting point
         start_x = random.randint(0, W - 1)
         start_y = random.randint(0, H - 1)
-
         # Randomly select the length and angle of the raindrop
         length = random.uniform(min_length, max_length)
         angle = random.uniform(math.pi / 4, 3 * math.pi / 4)  # Rain typically falls at angles between 45 to 135 degrees
-
         # Compute end point using trigonometry
         end_x = start_x + length * math.cos(angle)
         end_y = start_y + length * math.sin(angle)
-
         # Clip the coordinates to be within the image boundaries
         end_x = min(max(0, end_x), W - 1)
         end_y = min(max(0, end_y), H - 1)
-
         # Convert the start and end points to torch tensors
         p1 = torch.tensor([start_x, start_y])
         p2 = torch.tensor([end_x, end_y])
-
         # Draw the raindrop
         image = draw_line(image, p1, p2, color)
 

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -99,7 +99,7 @@ def random_rain_augmentation(
     >>> import torch
     >>> image = torch.zeros(3, 10, 10)  # A 10x10 black image with 3 channels
     >>> no_rain = random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
-    >>> torch.equal(no_rain, image)  
+    >>> torch.equal(no_rain, image)
     True
 
     >>> rain_img = random_rain_augmentation(image, 1000)  # Applying augmentation with 1000 raindrops

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
+
 import math
 import random
-import torch
 from typing import Optional
+
+import torch
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -82,7 +85,8 @@ class RainGenerator(RandomGeneratorBase):
         num_raindrops: int = 100,
         min_length: int = 5,
         max_length: int = 15,
-        color: Optional[torch.Tensor] = None) -> torch.Tensor:
+        color: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import math
 import random
-
 import torch
-
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -78,7 +75,8 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-    def random_rain_augmentation(
+    
+    def random_rain_augmentation(self,
         image: torch.Tensor,
         num_raindrops: int = 100,
         min_length: int = 5,
@@ -97,18 +95,16 @@ class RainGenerator(RandomGeneratorBase):
             torch.Tensor: The image with raindrops.
         Doctests:
         >>> import torch
-        >>> image = torch.zeros(3, 10, 10)  # A 10x10 black image with 3 channels
-        >>> no_rain = random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
+        >>> aug = RainGenerator(100, 5, 15)
+        >>> image = torch.zeros(3, 10, 10)
+        >>> no_rain = aug.random_rain_augmentation(image, 0)
         >>> torch.equal(no_rain, image)
         True
-
-        >>> rain_img = random_rain_augmentation(image, 1000)  # Applying augmentation with 1000 raindrops
+        >>> rain_img = aug.random_rain_augmentation(image, 1000)
         >>> torch.equal(rain_img, image)
         False
-
-        >>> # Applying augmentation with custom raindrop color
         >>> custom_color = torch.tensor([50, 50, 50])
-        >>> colored_rain_img = random_rain_augmentation(image, 1000, color=custom_color)
+        >>> colored_rain_img = aug.random_rain_augmentation(image, 1000, color=custom_color)
         >>> torch.any(colored_rain_img == 50)
         True
         """

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -79,7 +79,13 @@ class RainGenerator(RandomGeneratorBase):
         }
 
     def random_rain_augmentation(
-        self, image: torch.Tensor, num_raindrops: int = 100, min_length: int = 5, max_length: int = 15, color: torch.Tensor = torch.tensor([255])) -> torch.Tensor:
+        self,
+        image: torch.Tensor,
+        num_raindrops: int = 100,
+        min_length: int = 5,
+        max_length: int = 15,
+        color: torch.Tensor = torch.tensor([255]),
+    ) -> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+
 import math
 import random
+
 import torch
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -75,8 +78,8 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-    
-    def random_rain_augmentation(self,
+    def random_rain_augmentation(
+        self,
         image: torch.Tensor,
         num_raindrops: int = 100,
         min_length: int = 5,

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import torch
-import randint
-from kornia.utils import draw_line
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
-from kornia.utils import _extract_device_dtype
+from kornia.utils import _extract_device_dtype, draw_line
 
 
 class RainGenerator(RandomGeneratorBase):
@@ -77,10 +76,19 @@ class RainGenerator(RandomGeneratorBase):
         }
 
     import torch
-import random
-import math
 
-def random_rain_augmentation(image: torch.Tensor, num_raindrops: int = 100, min_length: int = 5, max_length: int = 15, color: torch.Tensor = torch.tensor([255])) -> torch.Tensor:
+
+import math
+import random
+
+
+def random_rain_augmentation(
+    image: torch.Tensor,
+    num_raindrops: int = 100,
+    min_length: int = 5,
+    max_length: int = 15,
+    color: torch.Tensor = torch.tensor([255]),
+) -> torch.Tensor:
     r"""Apply random rain augmentation to the input image.
 
     Args:
@@ -97,20 +105,20 @@ def random_rain_augmentation(image: torch.Tensor, num_raindrops: int = 100, min_
 
     for _ in range(num_raindrops):
         # Randomly select the starting point
-        start_x = random.randint(0, W-1)
-        start_y = random.randint(0, H-1)
+        start_x = random.randint(0, W - 1)
+        start_y = random.randint(0, H - 1)
 
         # Randomly select the length and angle of the raindrop
         length = random.uniform(min_length, max_length)
-        angle = random.uniform(math.pi/4, 3*math.pi/4)  # Rain typically falls at angles between 45 to 135 degrees
+        angle = random.uniform(math.pi / 4, 3 * math.pi / 4)  # Rain typically falls at angles between 45 to 135 degrees
 
         # Compute end point using trigonometry
         end_x = start_x + length * math.cos(angle)
         end_y = start_y + length * math.sin(angle)
 
         # Clip the coordinates to be within the image boundaries
-        end_x = min(max(0, end_x), W-1)
-        end_y = min(max(0, end_y), H-1)
+        end_x = min(max(0, end_x), W - 1)
+        end_y = min(max(0, end_y), H - 1)
 
         # Convert the start and end points to torch tensors
         p1 = torch.tensor([start_x, start_y])
@@ -120,4 +128,3 @@ def random_rain_augmentation(image: torch.Tensor, num_raindrops: int = 100, min_
         image = draw_line(image, p1, p2, color)
 
     return image
-

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import math
 import random
-
 import torch
-
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -86,34 +83,36 @@ def random_rain_augmentation(
     max_length: int = 15,
     color: torch.Tensor = torch.tensor([255]),
 ) -> torch.Tensor:
-    r"""Apply random rain augmentation to the input image.
-
+        """
+    Apply random rain augmentation to the input image.
     Args:
-        image: the input image with shape :math`(C,H,W)`.
-        num_raindrops: number of raindrops to draw.
-        min_length: minimum length of a raindrop.
-        max_length: maximum length of a raindrop.
-        color: the color of the raindrops.
+        image (torch.Tensor): the input image with shape :math:`(C,H,W)`.
+        num_raindrops (int, optional): number of raindrops to draw. Defaults to 100.
+        min_length (int, optional): minimum length of a raindrop. Defaults to 5.
+        max_length (int, optional): maximum length of a raindrop. Defaults to 15.
+        color (torch.Tensor, optional): the color of the raindrops. Defaults to torch.tensor([255]).
 
-    Return:
-        The image with raindrops.
+    Returns:
+        torch.Tensor: The image with raindrops.
+
     Doctests:
     >>> import torch
-    >>> image = torch.zeros(3, 10, 10) # A black 10x10 image with 3 channels
-    >>> output = random_rain_augmentation(image, 0) # No raindrops
-    >>> torch.equal(output, image) # Expect True since no raindrops were added
+    >>> image = torch.zeros(3, 10, 10)  # A 10x10 black image with 3 channels
+    >>> no_rain = random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
+    >>> torch.equal(no_rain, image)  
     True
 
-    >>> output_with_rain = random_rain_augmentation(image, 1000) # Lots of raindrops
-    >>> torch.equal(output_with_rain, image) # Expect False since raindrops were added
+    >>> rain_img = random_rain_augmentation(image, 1000)  # Applying augmentation with 1000 raindrops
+    >>> torch.equal(rain_img, image)
     False
 
-    >>> # Test with custom color
+    >>> # Applying augmentation with custom raindrop color
     >>> custom_color = torch.tensor([50])
-    >>> output_custom_color = random_rain_augmentation(image, 1000, color=custom_color)
-    >>> torch.any(output_custom_color == 50) # Expect True since raindrops of color 50 were added
+    >>> colored_rain_img = random_rain_augmentation(image, 1000, color=custom_color)
+    >>> torch.any(colored_rain_img == 50)
     True
     """
+
     H, W = image.shape[1], image.shape[2]
 
     for _ in range(num_raindrops):

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import math
 import random
-
 import torch
-
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -78,7 +75,7 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-   def random_rain_augmentation(
+    def random_rain_augmentation(
         self,image_val: torch.Tensor,num_raindrops: int = 100,min_length: int = 5,max_length: int = 15, color: torch.Tensor = None)-> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -78,14 +78,14 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-    def random_rain_augmentation(
+
+     def random_rain_augmentation(
         self,
-        image: torch.Tensor,
+        image_val: torch.Tensor,
         num_raindrops: int = 100,
         min_length: int = 5,
         max_length: int = 15,
-        color: torch.Tensor = None),
-    ) -> torch.Tensor:
+        color: torch.Tensor = None)-> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
             image (torch.Tensor): the input image with shape :math:`(C,H,W)`.
@@ -103,15 +103,16 @@ class RainGenerator(RandomGeneratorBase):
         >>> no_rain = aug.random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
         >>> torch.equal(no_rain, image)
         True
-        >>> rain_img = aug.random_rain_augmentation(image, 1000)
+        >>> rain_img = aug.random_rain_augmentation(image, 100)
         >>> torch.equal(rain_img, image)
         False
 
         >>> custom_color = torch.tensor([50, 50, 50])  # Custom color for the raindrops
         >>> colored_rain_img = aug.random_rain_augmentation(image, 1000, color=custom_color)
-        >>> torch.any(colored_rain_img == 50)
+        >>> bool(torch.any(colored_rain_img == 50))
         True
         """
+        image = image_val.clone()
         if color is None:
             num_channels = image.shape[0]
             color = torch.tensor([255] * num_channels).to(image.device)

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+
 import math
 import random
+
 import torch
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor
@@ -75,7 +78,6 @@ class RainGenerator(RandomGeneratorBase):
             'drop_width_factor': drop_width_factor,
         }
 
-
     def random_rain_augmentation(
         image: torch.Tensor,
         num_raindrops: int = 100,
@@ -90,7 +92,7 @@ class RainGenerator(RandomGeneratorBase):
             min_length (int, optional): minimum length of a raindrop. Defaults to 5.
             max_length (int, optional): maximum length of a raindrop. Defaults to 15.
             color (torch.Tensor, optional): the color of the raindrops. Defaults to torch.tensor([255]).
-    
+
         Returns:
             torch.Tensor: The image with raindrops.
         Doctests:
@@ -99,11 +101,11 @@ class RainGenerator(RandomGeneratorBase):
         >>> no_rain = random_rain_augmentation(image, 0)  # Applying augmentation with 0 raindrops
         >>> torch.equal(no_rain, image)
         True
-    
+
         >>> rain_img = random_rain_augmentation(image, 1000)  # Applying augmentation with 1000 raindrops
         >>> torch.equal(rain_img, image)
         False
-    
+
         >>> # Applying augmentation with custom raindrop color
         >>> custom_color = torch.tensor([50, 50, 50])
         >>> colored_rain_img = random_rain_augmentation(image, 1000, color=custom_color)
@@ -117,7 +119,9 @@ class RainGenerator(RandomGeneratorBase):
             start_y = random.randint(0, H - 1)
             # Randomly select the length and angle of the raindrop
             length = random.uniform(min_length, max_length)
-            angle = random.uniform(math.pi / 4, 3 * math.pi / 4)  # Rain typically falls at angles between 45 to 135 degrees
+            angle = random.uniform(
+                math.pi / 4, 3 * math.pi / 4
+            )  # Rain typically falls at angles between 45 to 135 degrees
             # Compute end point using trigonometry
             end_x = start_x + length * math.cos(angle)
             end_y = start_y + length * math.sin(angle)
@@ -129,5 +133,5 @@ class RainGenerator(RandomGeneratorBase):
             p2 = torch.tensor([end_x, end_y])
             # Draw the raindrop
             image = draw_line(image, p1, p2, color)
-    
+
         return image

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+
 import math
 import random
+
 import torch
+
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -84,7 +84,7 @@ class RainGenerator(RandomGeneratorBase):
         num_raindrops: int = 100,
         min_length: int = 5,
         max_length: int = 15,
-        color: torch.Tensor = torch.tensor([255]),
+        color: torch.Tensor = None),
     ) -> torch.Tensor:
         """Apply random rain augmentation to the input image.
         Args:
@@ -112,6 +112,9 @@ class RainGenerator(RandomGeneratorBase):
         >>> torch.any(colored_rain_img == 50)
         True
         """
+        if color is None:
+            num_channels = image.shape[0]
+            color = torch.tensor([255] * num_channels).to(image.device)
         H, W = image.shape[1], image.shape[2]
         for _ in range(num_raindrops):
             # Randomly select the starting point

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 import math
 import random
-
 import torch
-
 from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
 from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _range_bound
 from kornia.core import Tensor


### PR DESCRIPTION
Added # draw_line method to Random Rain class

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

The implemented method takes the generated coordinates of raindrops (lines in our case)  and changes their pixels' intensity accordingly. I made it with decreasing intensity, but increasing intensity also can be considered. For calling this method, user should give image and intensity arguments. It returns the edited image.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🔬 New feature (implemented method which draws rain)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
