### PR TITLE
Deprecated decorator added

### DIFF
--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -10,6 +10,7 @@ from kornia.core import Module, Tensor, tensor
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
 from kornia.filters.sobel import spatial_gradient
 from kornia.utils import create_meshgrid
+from kornia.utils.helpers import deprecated
 
 from .camera import PinholeCamera, cam2pixel, pixel2cam, project_points, unproject_points
 from .conversions import normalize_pixel_coordinates, normalize_points_with_intrinsics
@@ -109,7 +110,7 @@ def depth_to_3d_v2(
 
 # NOTE: this function should replace the old depth_to_3d
 
-
+@deprecated(replace_with="depth_to_3d_v2")
 def depth_to_3d(depth: Tensor, camera_matrix: Tensor, normalize_points: bool = False) -> Tensor:
     """Compute a 3d point per pixel given its depth value and the camera intrinsics.
 

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -110,6 +110,7 @@ def depth_to_3d_v2(
 
 # NOTE: this function should replace the old depth_to_3d
 
+
 @deprecated(replace_with="depth_to_3d_v2")
 def depth_to_3d(depth: Tensor, camera_matrix: Tensor, normalize_points: bool = False) -> Tensor:
     """Compute a 3d point per pixel given its depth value and the camera intrinsics.

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -111,7 +111,7 @@ def depth_to_3d_v2(
 # NOTE: this function should replace the old depth_to_3d
 
 
-@deprecated(replace_with="depth_to_3d_v2")
+@deprecated(replace_with="depth_to_3d_v2", version='0.7.0')
 def depth_to_3d(depth: Tensor, camera_matrix: Tensor, normalize_points: bool = False) -> Tensor:
     """Compute a 3d point per pixel given its depth value and the camera intrinsics.
 


### PR DESCRIPTION
#### Changes
Added the deprecated decorator in `depth_to_3d`

Fixes #2560 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🔬 New feature (non-breaking change which adds functionality)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
