### PR TITLE
Add alias 'average_endpoint_error' for aepe method

### DIFF
--- a/kornia/metrics/endpoint_error.py
+++ b/kornia/metrics/endpoint_error.py
@@ -90,4 +90,5 @@ class AEPE(nn.Module):
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         return aepe(input, target, self.reduction)
 
+
 average_endpoint_error = aepe

--- a/kornia/metrics/endpoint_error.py
+++ b/kornia/metrics/endpoint_error.py
@@ -54,6 +54,7 @@ def aepe(input: torch.Tensor, target: torch.Tensor, reduction: str = "mean") -> 
 
     return epe
 
+
 def average_endpoint_error(input: torch.Tensor, target: torch.Tensor, reduction: str = "mean") -> torch.Tensor:
     return aepe(input, target, reduction)
 

--- a/kornia/metrics/endpoint_error.py
+++ b/kornia/metrics/endpoint_error.py
@@ -55,10 +55,6 @@ def aepe(input: torch.Tensor, target: torch.Tensor, reduction: str = "mean") -> 
     return epe
 
 
-def average_endpoint_error(input: torch.Tensor, target: torch.Tensor, reduction: str = "mean") -> torch.Tensor:
-    return aepe(input, target, reduction)
-
-
 class AEPE(nn.Module):
     r"""Computes the average endpoint error (AEPE) between 2 flow maps.
 
@@ -93,3 +89,5 @@ class AEPE(nn.Module):
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         return aepe(input, target, self.reduction)
+
+average_endpoint_error = aepe

--- a/kornia/metrics/endpoint_error.py
+++ b/kornia/metrics/endpoint_error.py
@@ -54,6 +54,9 @@ def aepe(input: torch.Tensor, target: torch.Tensor, reduction: str = "mean") -> 
 
     return epe
 
+def average_endpoint_error(input: torch.Tensor, target: torch.Tensor, reduction: str = "mean") -> torch.Tensor:
+    return aepe(input, target, reduction)
+
 
 class AEPE(nn.Module):
     r"""Computes the average endpoint error (AEPE) between 2 flow maps.

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -220,8 +220,7 @@ class TestAepe:
         expected = torch.zeros(4, 4, device=device, dtype=dtype)
         actual = kornia.metrics.aepe(sample, sample, reduction="none")
         assert_close(actual, expected)
-        
-        
+
     def test_aepe_alias(self, device, dtype):
         sample = torch.ones(4, 4, 2, device=device, dtype=dtype)
         expected = torch.zeros(4, 4, device=device, dtype=dtype)

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -220,6 +220,16 @@ class TestAepe:
         expected = torch.zeros(4, 4, device=device, dtype=dtype)
         actual = kornia.metrics.aepe(sample, sample, reduction="none")
         assert_close(actual, expected)
+        
+        
+    def test_aepe_alias(self, device, dtype):
+        sample = torch.ones(4, 4, 2, device=device, dtype=dtype)
+        expected = torch.zeros(4, 4, device=device, dtype=dtype)
+        actual_aepe = kornia.metrics.aepe(sample, sample, reduction="none")
+        actual_alias = kornia.metrics.endpoint_error.average_endpoint_error(sample, sample, reduction="none")
+        assert_close(actual_aepe, expected)
+        assert_close(actual_alias, expected)
+        assert_close(actual_aepe, actual_alias)
 
     def test_exception(self, device, dtype):
         with pytest.raises(TypeError) as errinfo:


### PR DESCRIPTION
#### Changes
Add an alias `average_enpoint_error = aepe` to have more explicit name functions


Fixes [#2597](https://github.com/kornia/kornia/issues/2597) 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
