### PR TITLE
xfail TestRandAugment::test_transform_mat based in torch version

### DIFF
--- a/test/augmentation/test_auto_operation.py
+++ b/test/augmentation/test_auto_operation.py
@@ -12,6 +12,7 @@ from kornia.augmentation.auto.trivial_augment import TrivialAugment
 from kornia.augmentation.container import AugmentationSequential
 from kornia.geometry.bbox import bbox_to_mask
 from kornia.testing import assert_close
+from kornia.utils._helpers import torch_version
 from test.augmentation.test_container import reproducibility_test
 
 
@@ -109,6 +110,9 @@ class TestRandAugment:
         in_tensor = torch.rand(10, 3, 50, 50, requires_grad=True)
         aug(in_tensor)
 
+    @pytest.mark.xfail(
+        torch_version() in {'1.10.2', '1.11.0', '1.12.1', '1.13.1'}, 'randomness failing into some torch versions'
+    )
     def test_transform_mat(self, device, dtype):
         aug = RandAugment(n=3, m=15)
         in_tensor = torch.rand(10, 3, 50, 50, device=device, dtype=dtype, requires_grad=True)

--- a/test/augmentation/test_auto_operation.py
+++ b/test/augmentation/test_auto_operation.py
@@ -12,7 +12,7 @@ from kornia.augmentation.auto.trivial_augment import TrivialAugment
 from kornia.augmentation.container import AugmentationSequential
 from kornia.geometry.bbox import bbox_to_mask
 from kornia.testing import assert_close
-from kornia.utils._helpers import torch_version
+from kornia.utils._compat import torch_version
 from test.augmentation.test_container import reproducibility_test
 
 

--- a/test/augmentation/test_auto_operation.py
+++ b/test/augmentation/test_auto_operation.py
@@ -111,7 +111,8 @@ class TestRandAugment:
         aug(in_tensor)
 
     @pytest.mark.xfail(
-        torch_version() in {'1.10.2', '1.11.0', '1.12.1', '1.13.1'}, 'randomness failing into some torch versions'
+        torch_version() in {'1.10.2', '1.11.0', '1.12.1', '1.13.1'},
+        reason='randomness failing into some torch versions',
     )
     def test_transform_mat(self, device, dtype):
         aug = RandAugment(n=3, m=15)


### PR DESCRIPTION
This test looks like randomness failing on the scheduled CI for some torch versions

![image](https://github.com/kornia/kornia/assets/20444345/e8f295d8-237b-43d2-9fef-70c98feb8b11)
