### PR TITLE
skip dynamo test for py311 torch 2.0.x

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 import kornia
+from kornia.utils._compat import torch_version
 
 
 def get_test_devices() -> Dict[str, torch.device]:
@@ -67,8 +68,9 @@ def dtype(dtype_name) -> torch.dtype:
 @pytest.fixture(scope='session')
 def torch_optimizer():
     if hasattr(torch, 'compile') and sys.platform == "linux":
-        # torch.set_float32_matmul_precision('high')
-        return torch.compile
+        if not (sys.version_info[:2] == (3, 11) and torch_version() in {'2.0.0', '2.0.1'}):
+            # torch compile just have support for python 3.11 after torch 2.1.0
+            return torch.compile
 
     pytest.skip(f"skipped because {torch.__version__} not have `compile` available! Failed to setup dynamo.")
 


### PR DESCRIPTION
**IN THE QUEST OF THE COMPLETELY GREEN CI**
![image](https://github.com/kornia/kornia/assets/20444345/2658fd0c-f0c1-40ae-8eef-13a72b8f3887)

torch compile has added support for python3.11 after the torch 2.1 release

this patch specific skip tests on py 3.11 with torch 2.0.0 and 2.0.1