### PR TITLE
replace deprecated prompter test and fix skiping dynamo test

### DIFF
--- a/test/contrib/test_prompter.py
+++ b/test/contrib/test_prompter.py
@@ -1,18 +1,16 @@
-import sys
-
 import pytest
 import torch
 
-from kornia.contrib.image_prompter import ImagePrompter
 from kornia.contrib.models.sam import SamConfig
+from kornia.contrib.visual_prompter import VisualPrompter
 from kornia.testing import BaseTester
 
 
-class TestImagePrompter(BaseTester):
+class TestVisualPrompter(BaseTester):
     @pytest.mark.slow
     def test_smoke(self, device, dtype):
         inpt = torch.rand(3, 77, 128, device=device, dtype=dtype)
-        prompter = ImagePrompter(SamConfig('vit_b'), device, dtype)
+        prompter = VisualPrompter(SamConfig('vit_b'), device, dtype)
 
         prompter.set_image(inpt)
         assert prompter.is_image_set
@@ -28,7 +26,7 @@ class TestImagePrompter(BaseTester):
         # SAM: don't supports float64
         dtype = torch.float32
         inpt = torch.rand(3, 77, 128, device=device, dtype=dtype)
-        prompter = ImagePrompter(SamConfig('vit_b'), device, dtype)
+        prompter = VisualPrompter(SamConfig('vit_b'), device, dtype)
 
         keypoints = torch.randint(0, min(inpt.shape[-2:]), (batch_size, N, 2), device=device).to(dtype=dtype)
         labels = torch.randint(0, 1, (batch_size, N), device=device).to(dtype=dtype)
@@ -42,7 +40,7 @@ class TestImagePrompter(BaseTester):
         assert out.scores.shape == (1, C)
 
     def test_exception(self):
-        prompter = ImagePrompter(SamConfig('vit_b'))
+        prompter = VisualPrompter(SamConfig('vit_b'))
 
         inpt = torch.rand(1, 3, 1, 2)
 
@@ -87,14 +85,11 @@ class TestImagePrompter(BaseTester):
     def test_module(self):
         ...
 
-    def test_dynamo(self, device):
-        if not (hasattr(torch, 'compile') and sys.platform == "linux"):
-            pytest.skip(f"skipped because {torch.__version__} not have `compile` available! Failed to setup dynamo.")
-
+    def test_dynamo(self, device, torch_optimizer):
         dtype = torch.float32
         img = torch.rand(3, 128, 75, device=device, dtype=dtype)
 
-        prompter = ImagePrompter(SamConfig('vit_b'), device, dtype)
+        prompter = VisualPrompter(SamConfig('vit_b'), device, dtype)
         prompter.set_image(img)
 
         expected = prompter.predict(img)


### PR DESCRIPTION
#### Changes
follow up on #2621 

The `TestImagePrompter` test dynamo isn't using the fixture, so it's wrong skipped. This patch also replaces the deprecated prompter on the test suite.

![image](https://github.com/kornia/kornia/assets/20444345/e1423391-18da-458b-a79a-7a77c4966be5)


#### Type of change
- [x] 🧪 Tests Cases