### PR TITLE
Update docs CI

### DIFF
--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -14,7 +14,11 @@ on:
         required: true
         default: '2.1.0'
         type: string
-
+      extra-dependencies:
+        description: "Kornia extra dependencies to be installed"
+        required: false
+        default: 'dev,x'
+        type: string
 runs:
   using: "composite"
   steps:
@@ -33,9 +37,9 @@ runs:
       shell: bash
       run: pip install torch==${{ inputs.pytorch-version }} --index-url https://download.pytorch.org/whl/cpu
 
-    - name: Install Kornia dev
+    - name: Install Kornia ${{ inputs.extra-dependencies }}
       shell: bash
-      run: pip install .[dev,x]
+      run: pip install .[${{ inputs.extra-dependencies }}]
 
     - name: Check dependencies and kornia version
       shell: bash

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -14,11 +14,7 @@ on:
         required: true
         default: "2.1.0"
         type: string
-      extra-dependencies:
-        description: "Kornia extra dependencies to be installed"
-        required: false
-        default: "dev,x"
-        type: string
+
 runs:
   using: "composite"
   steps:
@@ -37,9 +33,9 @@ runs:
       shell: bash
       run: pip install torch==${{ inputs.pytorch-version }} --index-url https://download.pytorch.org/whl/cpu
 
-    - name: Install Kornia ${{ inputs.extra-dependencies }}
+    - name: Install Kornia dev
       shell: bash
-      run: pip install .[${{ inputs.extra-dependencies }}]
+      run: pip install .[dev,x]
 
     - name: Check dependencies and kornia version
       shell: bash

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -6,18 +6,18 @@ on:
       python-version:
         description: "The python version desired."
         required: true
-        default: '3.11'
+        default: "3.11"
         type: string
 
       pytorch-version:
         description: "The pytorch version desired."
         required: true
-        default: '2.1.0'
+        default: "2.1.0"
         type: string
       extra-dependencies:
         description: "Kornia extra dependencies to be installed"
         required: false
-        default: 'dev,x'
+        default: "dev,x"
         type: string
 runs:
   using: "composite"

--- a/.github/actions_info.md
+++ b/.github/actions_info.md
@@ -45,6 +45,8 @@ Has the inputs:
   `continue-on-error` behavior on the test step.
 - `fail-fast`: (boolean, default: `false`) to set the `fail-fast` behavior on
   the matrix strategy.
+- `coverage`: (boolean, default: `false`) to run the tests suite using the
+  coverage mode, and report the results and upload it on codecov.
 
 A matrix strategy will be adopted from the list of python and pytorch version.
 
@@ -69,8 +71,25 @@ A matrix strategy will be adopted from the list of python and pytorch version.
 
 ### Tests typing
 This workflow ([.github/workflows/test_typing.yml](workflows/test_typing.yml)) will setup
-an environment using the [env](#Env) action, run the typing tests using mypy and
-uploading the coverage report to codecov.
+an environment using the [env](#Env) action, run the typing tests using mypy.
+
+Use the actions:
+- `actions/checkout`
+- `.github/actions/env`
+
+Has the inputs:
+- `os`: (string, default: `ubuntu-latest`) the OS name same as supported by [gha](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners).
+- `python-version`: (json list of strings, default: `'["3.11"]'`) a string with
+  format of a json list within strings for each python version desired.
+- `pytorch-version`: (json list of strings, default: `'["2.1.0"]'`) a string
+  with format of a json list within strings for each pytorch version desired.
+- `fail-fast`: (boolean, default: `false`) to set the `fail-fast` behavior on
+  the matrix strategy.
+
+### Docs
+This workflow ([.github/workflows/docs.yml](workflows/docs.yml)) will setup
+an environment using the [env](#Env) action, run the docstrings tests using pytest,
+install the docs dependencies and build the html docs within sphinxs.
 
 Use the actions:
 - `actions/checkout`

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,8 @@ on:
         default: false
 
 jobs:
-  docstrings-test:
-    name: python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
+  tests:
+    name: docstrings & doc builds - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout kornia
       uses: actions/checkout@v3
 
-    - name: Setting environment on ${{ inputs.os }} with python ${{ matrix.python-version }} and pytorch ${{ matrix.pytorch-ver»
+    - name: Setting environment on ${{ inputs.os }} with python ${{ matrix.python-version }} and pytorch ${{ matrix.pytorch-version }}
       uses: ./.github/actions/env
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,11 +52,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         pytorch-version: ${{ matrix.pytorch-version }}
-        extra-dependencies: 'docs'
 
     - name: Run doctest
       shell: bash -l {0}
       run: make doctest
+
+    - name: Install docs deps
+      shell: bash -l {0}
+      run: pip install -e .[docs]
 
     - name: Build Documentation
       shell: bash -l {0}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-      continue-on-error:
+      fail-fast:
         required: false
         type: boolean
         default: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,50 +1,63 @@
-name: Documentation
-
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - master
-  pull_request:
-  schedule:
-    - cron: "0 4 * * *"
+  workflow_call:
+    inputs:
+      python-version:
+        required: false
+        type: string
+        default: '["3.11"]'
+      pytorch-version:
+        required: false
+        type: string
+        default: '["2.1.0"]'
+      os:
+        required: false
+        type: string
+        default: ubuntu-latest
+      continue-on-error:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  test:
+  docstrings-test:
+    name: python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: ${{ inputs.fail-fast }}
+      matrix:
+        python-version: ${{ fromJSON(inputs.python-version) }}
+        pytorch-version: ${{ fromJSON(inputs.pytorch-version) }}
+        exclude:
+          - pytorch-version: '1.9.1'
+            python-version: '3.10'
+          - pytorch-version: '1.10.2'
+            python-version: '3.10'
+          - pytorch-version: '1.9.1'
+            python-version: '3.11'
+          - pytorch-version: '1.10.2'
+            python-version: '3.11'
+          - pytorch-version: '1.11.0'
+            python-version: '3.11'
+          - pytorch-version: '1.12.1'
+            python-version: '3.11'
+          - pytorch-version: '1.13.1'
+            python-version: '3.11'
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup conda dependencies
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Checkout kornia
+      uses: actions/checkout@v3
+
+    - name: Setting environment on ${{ inputs.os }} with python ${{ matrix.python-version }} and pytorch ${{ matrix.pytorch-ver»
+      uses: ./.github/actions/env
       with:
-        auto-update-conda: true
-        python-version: 3.11
-    - name: Install dependencies
-      shell: bash -l {0}
-      run: |
-        conda install curl -c conda-forge
-        conda install pytorch cpuonly -c pytorch
-        pip install .[dev,x]
+        python-version: ${{ matrix.python-version }}
+        pytorch-version: ${{ matrix.pytorch-version }}
+        extra-dependencies: 'docs'
+
     - name: Run doctest
       shell: bash -l {0}
       run: make doctest
 
-  build:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup conda dependencies
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        python-version: 3.11
-    - name: Install dependencies
-      shell: bash -l {0}
-      run: |
-        pip install .[docs]
     - name: Build Documentation
       shell: bash -l {0}
       run: make build-docs SPHINXOPTS="-W"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   tests:
-    name: docstrings & doc builds - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
+    name: docstests & sphinx-build - python-${{ matrix.python-version }}, torch-${{ matrix.pytorch-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: ${{ inputs.fail-fast }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,11 +48,3 @@ jobs:
     - name: Build Documentation
       shell: bash -l {0}
       run: make build-docs SPHINXOPTS="-W"
-    - name: Deploy to GitHub Pages
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh_pages # The branch the action should deploy to.
-        FOLDER: docs/build/html # The folder the action should deploy.
-        CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -50,8 +50,11 @@ jobs:
   test-tutorials:
     uses: ./.github/workflows/test_tutorials.yml
 
+  docs:
+    uses: ./.github/workflows/docs.yml
+
   collector:
-    needs: [tests-cpu, test-tutorials, test-typing, tests-coverage]
+    needs: [tests-cpu, test-tutorials, test-typing, tests-coverage, docs]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -21,7 +21,6 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       os: 'Ubuntu-latest'
-
       python-version: '["3.8", "3.9", "3.10", "3.11"]'
       pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.0"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
@@ -58,6 +57,9 @@ jobs:
 
   test-typing:
     uses: ./.github/workflows/test_typing.yml
+
+  docs:
+    uses: ./.github/workflows/docs.yml
 
   tests-coverage:
     uses: ./.github/workflows/tests.yml


### PR DESCRIPTION
#### Changes

As part of our plan to reduce the size of the kornia repository, we will delete the gh-pages branch, which isn't used anywhere, since we built our docs on read-the-docs. 

This patch, removes the docs deploy to gh pages branch, updates the docs CI to be a workflow dispatch, and add it to be executed as a job within the main actions

