### PR TITLE
Fix visual prompter bug (#2627)

### DIFF
--- a/kornia/contrib/models/structures.py
+++ b/kornia/contrib/models/structures.py
@@ -14,7 +14,7 @@ class SegmentationResults:
 
     Args:
         logits: Results logits with shape :math:`(B, C, H, W)`, where :math:`C` refers to the number of predicted masks
-        scores: The scores from the logits. Shape :math:`(B,)`
+        scores: The scores from the logits. Shape :math:`(B, C)`
         mask_threshold: The threshold value to generate the `binary_masks` from the `logits`
     """
 

--- a/kornia/contrib/visual_prompter.py
+++ b/kornia/contrib/visual_prompter.py
@@ -166,6 +166,10 @@ class VisualPrompter:
         self, *prompts: Tensor | Boxes | Keypoints, data_keys: list[str] = []
     ) -> dict[str, Tensor | Boxes | Keypoints]:
         transformed_prompts = self.transforms(*prompts, data_keys=data_keys, params=self._tfs_params)
+
+        # prevent unpacking tensor when creating the output dict (issue #2627)
+        if not isinstance(transformed_prompts, (list, tuple)):
+            transformed_prompts = [transformed_prompts]
         return {key: transformed_prompts[idx] for idx, key in enumerate(data_keys)}
 
     def preprocess_prompts(
@@ -197,7 +201,7 @@ class VisualPrompter:
         if 'keypoints' in data and isinstance(data['keypoints'], Keypoints):
             kpts_tensor = data['keypoints'].to_tensor()
             if KORNIA_CHECK_IS_TENSOR(kpts_tensor) and KORNIA_CHECK_IS_TENSOR(keypoints_labels):
-                points = (kpts_tensor[None, ...], keypoints_labels)
+                points = (kpts_tensor, keypoints_labels)
         else:
             points = None
 

--- a/test/contrib/test_prompter.py
+++ b/test/contrib/test_prompter.py
@@ -33,11 +33,11 @@ class TestVisualPrompter(BaseTester):
 
         prompter.set_image(inpt)
 
-        out = prompter.predict((keypoints, labels), multimask_output=multimask_output)
+        out = prompter.predict(keypoints, labels, multimask_output=multimask_output)
 
         C = 3 if multimask_output else 1
-        assert out.logits.shape == (1, C, 256, 256)
-        assert out.scores.shape == (1, C)
+        assert out.logits.shape == (batch_size, C, 256, 256)
+        assert out.scores.shape == (batch_size, C)
 
     def test_exception(self):
         prompter = VisualPrompter(SamConfig('vit_b'))


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2627.
Also changed the tests for the VisualPrompter (test_cardinality) to reflect the intended functionality and the updated interface.
Lastly, edited the documentation of SegmentationResults.scores, which previously did not account for multi-mask output.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
