### PR TITLE
feat: LightGlue-ONNX

### DIFF
--- a/docs/source/feature.rst
+++ b/docs/source/feature.rst
@@ -112,6 +112,9 @@ Matching
 .. autoclass:: LoFTR
    :members: forward
 
+.. autoclass:: OnnxLightGlue
+   :members: forward
+
 
 Local Affine Frames (LAF)
 -------------------------

--- a/kornia/feature/__init__.py
+++ b/kornia/feature/__init__.py
@@ -39,6 +39,7 @@ from .laf import (
     set_laf_orientation,
 )
 from .lightglue import LightGlue
+from .lightglue_onnx import OnnxLightGlue
 from .loftr import LoFTR
 from .matching import (
     DescriptorMatcher,
@@ -159,4 +160,5 @@ __all__ = [
     "DISKFeatures",
     "LightGlue",
     "LightGlueMatcher",
+    "OnnxLightGlue",
 ]

--- a/kornia/feature/lightglue_onnx/__init__.py
+++ b/kornia/feature/lightglue_onnx/__init__.py
@@ -1,0 +1,1 @@
+from .lightglue import OnnxLightGlue

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -107,8 +107,8 @@ class OnnxLightGlue:
         size0 = size0 if size0 is not None else data0['image'].shape[-2:][::-1]  # type: ignore
         size1 = size1 if size1 is not None else data1['image'].shape[-2:][::-1]  # type: ignore
 
-        kpts0 = normalize_keypoints(kpts0_, size=size0)
-        kpts1 = normalize_keypoints(kpts1_, size=size1)
+        kpts0 = normalize_keypoints(kpts0_, size=size0)  # type: ignore
+        kpts1 = normalize_keypoints(kpts1_, size=size1)  # type: ignore
 
         KORNIA_CHECK(torch.all(kpts0 >= -1).item() and torch.all(kpts0 <= 1).item(), "")  # type: ignore
         KORNIA_CHECK(torch.all(kpts1 >= -1).item() and torch.all(kpts1 <= 1).item(), "")  # type: ignore

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+import numpy as np
+import torch
+
+from kornia.core import Device, Tensor
+from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SAME_DEVICES, KORNIA_CHECK_SHAPE
+
+from .utils import download_onnx_from_url, normalize_keypoints
+
+try:
+    import onnxruntime as ort
+except ImportError:
+    ort = None
+
+__all__ = ["OnnxLightGlue"]
+
+
+class OnnxLightGlue(object):
+    r"""Wrapper for loading LightGlue-ONNX models and running inference via ONNXRuntime.
+
+    LightGlue :cite:`LightGlue2023` performs fast descriptor-based deep keypoint matching.
+    This module requires `onnxruntime` to be installed.
+
+    If you have trained your own LightGlue model, see https://github.com/fabio-sim/LightGlue-ONNX for how to export the model to ONNX and optimize it.
+
+    Args:
+        weights: Pretrained weights, or a path to your own exported ONNX model. Available pretrained weights are: `disk`, `superpoint`, `disk_fp16`, and `superpoint_fp16`. Defaults to `disk_fp16`.
+        device: Device to run inference on. Currently, only `cuda` is supported. Defaults to `cuda`.
+    """
+    MODEL_URLS: ClassVar[dict[str, str]] = {
+        "disk": "https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/disk_lightglue_fused.onnx",
+        "superpoint": "https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/superpoint_lightglue_fused.onnx",
+        "disk_fp16": "https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/disk_lightglue_fused_fp16.onnx",
+        "superpoint_fp16": "https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/superpoint_lightglue_fused_fp16.onnx",
+    }
+
+    required_data_keys: ClassVar[list[str]] = ["image0", "image1"]
+
+    def __init__(self, weights: str = "disk_fp16", device: Device = None) -> None:
+        KORNIA_CHECK(ort is not None, "onnxruntime is not installed.")
+
+        if device is None:
+            device = torch.device("cuda")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        self.device = device
+
+        if device.type == "cpu":
+            raise NotImplementedError("CPUExecutionProvider is not supported yet for Multihead-Attention op.")
+        elif device.type == "cuda":
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        else:
+            raise ValueError(f"Unsupported device {device}")
+
+        if weights in self.MODEL_URLS:
+            weights = download_onnx_from_url(self.MODEL_URLS[weights])
+
+        self.session = ort.InferenceSession(weights, providers=providers)
+
+    def __call__(self, data: dict[str, Tensor]) -> dict[str, Tensor]:
+        return self.forward(data)
+
+    def forward(self, data: dict[str, Tensor]) -> dict[str, Tensor]:
+        r"""Match keypoints and descriptors between two images.
+
+        The output contains the matches (i.e., indices of the matching keypoint pairs between the first and second image) and the corresponding confidence scores.
+        Only a batch size of 1 is supported.
+
+        Args:
+            data: Dictionary containing the following keys:
+                image0: dict
+                    keypoints (`float32`): [1 x M x 2]
+                    descriptors (`float32`): [1 x M x D]
+                    image: [1 x C x H x W] or image_size: [1 x 2]
+                image1: dict
+                    keypoints (`float32`): [1 x N x 2]
+                    descriptors (`float32`): [1 x N x D]
+                    image: [1 x C x H x W] or image_size: [1 x 2]
+
+        Returns:
+            output: Dictionary containing the following keys:
+                matches (`int64`): [S x 2]
+                scores (`float32`): [S]
+        """
+        # Input validation.
+        for key in self.required_data_keys:
+            KORNIA_CHECK(key in data, f'Missing key {key} in data')
+        data0, data1 = data['image0'], data['image1']
+        kpts0_, kpts1_ = data0['keypoints'].contiguous(), data1['keypoints'].contiguous()
+        desc0, desc1 = data0['descriptors'].contiguous(), data1['descriptors'].contiguous()
+        KORNIA_CHECK_SAME_DEVICES([kpts0_, desc0, kpts1_, desc1])
+        KORNIA_CHECK(kpts0_.device.type == self.device.type)
+        KORNIA_CHECK(torch.float32 == kpts0_.dtype == kpts1_.dtype == desc0.dtype == desc1.dtype)
+        KORNIA_CHECK_SHAPE(kpts0_, ["1", "M", "2"])
+        KORNIA_CHECK_SHAPE(kpts1_, ["1", "N", "2"])
+        KORNIA_CHECK_SHAPE(desc0, ["1", "M", "D"])
+        KORNIA_CHECK_SHAPE(desc1, ["1", "N", "D"])
+        KORNIA_CHECK(kpts0_.shape[1] == desc0.shape[1])
+        KORNIA_CHECK(kpts1_.shape[1] == desc1.shape[1])
+        KORNIA_CHECK(desc0.shape[2] == desc1.shape[2])
+
+        # Normalize keypoints.
+        size0, size1 = data0.get('image_size'), data1.get('image_size')
+        size0 = size0 if size0 is not None else data0['image'].shape[-2:][::-1]  # type: ignore
+        size1 = size1 if size1 is not None else data1['image'].shape[-2:][::-1]  # type: ignore
+
+        kpts0 = normalize_keypoints(kpts0_, size=size0)
+        kpts1 = normalize_keypoints(kpts1_, size=size1)
+
+        KORNIA_CHECK(torch.all(kpts0 >= -1).item() and torch.all(kpts0 <= 1).item(), "")  # type: ignore
+        KORNIA_CHECK(torch.all(kpts1 >= -1).item() and torch.all(kpts1 <= 1).item(), "")  # type: ignore
+
+        # Inference.
+        lightglue_inputs = {"kpts0": kpts0, "kpts1": kpts1, "desc0": desc0, "desc1": desc1}
+        lightglue_outputs = ["matches0", "mscores0"]
+        binding = self.session.io_binding()
+
+        for name, tensor in lightglue_inputs.items():
+            binding.bind_input(
+                name,
+                device_type=self.device.type,
+                device_id=0,
+                element_type=np.float32,
+                shape=tuple(tensor.shape),
+                buffer_ptr=tensor.data_ptr(),
+            )
+
+        for name in lightglue_outputs:
+            binding.bind_output(name, device_type=self.device.type, device_id=0)
+
+        self.session.run_with_iobinding(binding)
+
+        matches, mscores = binding.get_outputs()
+
+        # TODO: The following is an unnecessary copy. Replace with a better solution when torch supports
+        # constructing a tensor from a data pointer, or when ORT supports converting to torch tensor.
+        # https://github.com/microsoft/onnxruntime/issues/15963
+        outputs = {
+            "matches": torch.from_numpy(matches.numpy()).to(self.device),
+            "scores": torch.from_numpy(mscores.numpy()).to(self.device),
+        }
+        return outputs

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -70,18 +70,22 @@ class OnnxLightGlue:
         Only a batch size of 1 is supported.
 
         Args:
-            data: Dictionary containing the following keys:
-                image0: dict
-                    keypoints (`float32`): [1 x M x 2]
-                    descriptors (`float32`): [1 x M x D]
-                    image: [1 x C x H x W] or image_size: [1 x 2]
-                image1: dict
-                    keypoints (`float32`): [1 x N x 2]
-                    descriptors (`float32`): [1 x N x D]
-                    image: [1 x C x H x W] or image_size: [1 x 2]
+            data: Dictionary containing both images and the keypoints and descriptors thereof.
 
         Returns:
-            output: Dictionary containing the following keys:
+            output: Dictionary containing the following matches and scores.
+
+        `data`:
+            image0: dict
+                keypoints (`float32`): [1 x M x 2]
+                descriptors (`float32`): [1 x M x D]
+                image: [1 x C x H x W] or image_size: [1 x 2]
+            image1: dict
+                keypoints (`float32`): [1 x N x 2]
+                descriptors (`float32`): [1 x N x D]
+                image: [1 x C x H x W] or image_size: [1 x 2]
+
+        `output`:
                 matches (`int64`): [S x 2]
                 scores (`float32`): [S]
         """

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -18,7 +18,7 @@ except ImportError:
 __all__ = ["OnnxLightGlue"]
 
 
-class OnnxLightGlue(object):
+class OnnxLightGlue:
     r"""Wrapper for loading LightGlue-ONNX models and running inference via ONNXRuntime.
 
     LightGlue :cite:`LightGlue2023` performs fast descriptor-based deep keypoint matching.

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -25,10 +25,12 @@ class OnnxLightGlue:
     LightGlue :cite:`LightGlue2023` performs fast descriptor-based deep keypoint matching.
     This module requires `onnxruntime` to be installed.
 
-    If you have trained your own LightGlue model, see https://github.com/fabio-sim/LightGlue-ONNX for how to export the model to ONNX and optimize it.
+    If you have trained your own LightGlue model, see https://github.com/fabio-sim/LightGlue-ONNX
+    for how to export the model to ONNX and optimize it.
 
     Args:
-        weights: Pretrained weights, or a path to your own exported ONNX model. Available pretrained weights are: `disk`, `superpoint`, `disk_fp16`, and `superpoint_fp16`. Defaults to `disk_fp16`.
+        weights: Pretrained weights, or a path to your own exported ONNX model. Available pretrained weights are:
+        `disk`, `superpoint`, `disk_fp16`, and `superpoint_fp16`. Defaults to `disk_fp16`.
         device: Device to run inference on. Currently, only `cuda` is supported. Defaults to `cuda`.
     """
     MODEL_URLS: ClassVar[dict[str, str]] = {
@@ -68,7 +70,8 @@ class OnnxLightGlue:
     def forward(self, data: dict[str, dict[str, Tensor]]) -> dict[str, Tensor]:
         r"""Match keypoints and descriptors between two images.
 
-        The output contains the matches (i.e., indices of the matching keypoint pairs between the first and second image) and the corresponding confidence scores.
+        The output contains the matches (the indices of the matching keypoint pairs between the first and second image)
+        and the corresponding confidence scores.
         Only a batch size of 1 is supported.
 
         Args:

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -60,10 +60,10 @@ class OnnxLightGlue:
 
         self.session = ort.InferenceSession(weights, providers=providers)
 
-    def __call__(self, data: dict[str, Tensor]) -> dict[str, Tensor]:
+    def __call__(self, data: dict[str, dict[str, Tensor]]) -> dict[str, Tensor]:
         return self.forward(data)
 
-    def forward(self, data: dict[str, Tensor]) -> dict[str, Tensor]:
+    def forward(self, data: dict[str, dict[str, Tensor]]) -> dict[str, Tensor]:
         r"""Match keypoints and descriptors between two images.
 
         The output contains the matches (i.e., indices of the matching keypoint pairs between the first and second image) and the corresponding confidence scores.

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -148,7 +148,7 @@ class OnnxLightGlue:
         # constructing a tensor from a data pointer, or when ORT supports converting to torch tensor.
         # https://github.com/microsoft/onnxruntime/issues/15963
         outputs = {
-            "matches": torch.from_numpy(matches.numpy()).to(self.device),
-            "scores": torch.from_numpy(mscores.numpy()).to(self.device),
+            "matches": torch.from_dlpack(matches.numpy()).to(self.device),
+            "scores": torch.from_dlpack(mscores.numpy()).to(self.device),
         }
         return outputs

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -13,8 +13,8 @@ try:
     import numpy as np
     import onnxruntime as ort
 except ImportError:
-    np = None
-    ort = None
+    np = None  # type: ignore
+    ort = None  # type: ignore
 
 __all__ = ["OnnxLightGlue"]
 

--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -14,7 +14,7 @@ try:
     import onnxruntime as ort
 except ImportError:
     np = None  # type: ignore
-    ort = None  # type: ignore
+    ort = None
 
 __all__ = ["OnnxLightGlue"]
 

--- a/kornia/feature/lightglue_onnx/utils/__init__.py
+++ b/kornia/feature/lightglue_onnx/utils/__init__.py
@@ -1,0 +1,2 @@
+from .download import download_onnx_from_url
+from .keypoints import normalize_keypoints

--- a/kornia/feature/lightglue_onnx/utils/download.py
+++ b/kornia/feature/lightglue_onnx/utils/download.py
@@ -39,7 +39,7 @@ def download_onnx_from_url(
         file_name (str, optional): name for the downloaded file. Filename from ``url`` will be used if not set.
 
     Example:
-        >>> model = load_onnx_from_url('https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/disk_lightglue_fused_fp16.onnx')
+        >>> model = download_onnx_from_url('https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/disk_lightglue_fused_fp16.onnx')
     """
     if model_dir is None:
         hub_dir = get_dir()

--- a/kornia/feature/lightglue_onnx/utils/download.py
+++ b/kornia/feature/lightglue_onnx/utils/download.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import errno
 import os
 import sys
 from typing import Optional
@@ -45,15 +44,7 @@ def download_onnx_from_url(
         hub_dir = get_dir()
         model_dir = os.path.join(hub_dir, 'checkpoints')
 
-    try:
-        os.makedirs(model_dir)
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            # Directory already exists, ignore.
-            pass
-        else:
-            # Unexpected OSError, re-raise.
-            raise
+    os.makedirs(model_dir, exist_ok=True)
 
     parts = urlparse(url)
     filename = os.path.basename(parts.path)

--- a/kornia/feature/lightglue_onnx/utils/download.py
+++ b/kornia/feature/lightglue_onnx/utils/download.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import errno
+import os
+import sys
+from typing import Optional
+from urllib.parse import urlparse  # noqa: F401
+
+from torch.hub import HASH_REGEX, download_url_to_file, get_dir
+
+
+def download_onnx_from_url(
+    url: str,
+    model_dir: Optional[str] = None,
+    progress: bool = True,
+    check_hash: bool = False,
+    file_name: Optional[str] = None,
+) -> str:
+    r"""Loads the ONNX model at the given URL.
+
+    If downloaded file is a zip file, it will be automatically
+    decompressed.
+
+    If the object is already present in `model_dir`, it's deserialized and
+    returned.
+    The default value of ``model_dir`` is ``<hub_dir>/checkpoints`` where
+    ``hub_dir`` is the directory returned by :func:`~torch.hub.get_dir`.
+
+    Args:
+        url (str): URL of the object to download
+        model_dir (str, optional): directory in which to save the object
+        progress (bool, optional): whether or not to display a progress bar to stderr.
+            Default: True
+        check_hash(bool, optional): If True, the filename part of the URL should follow the naming convention
+            ``filename-<sha256>.ext`` where ``<sha256>`` is the first eight or more
+            digits of the SHA256 hash of the contents of the file. The hash is used to
+            ensure unique names and to verify the contents of the file.
+            Default: False
+        file_name (str, optional): name for the downloaded file. Filename from ``url`` will be used if not set.
+
+    Example:
+        >>> model = load_onnx_from_url('https://s3.amazonaws.com/pytorch/models/resnet18-5c106cde.pth')
+
+    """
+    if model_dir is None:
+        hub_dir = get_dir()
+        model_dir = os.path.join(hub_dir, 'checkpoints')
+
+    try:
+        os.makedirs(model_dir)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            # Directory already exists, ignore.
+            pass
+        else:
+            # Unexpected OSError, re-raise.
+            raise
+
+    parts = urlparse(url)
+    filename = os.path.basename(parts.path)
+    if file_name is not None:
+        filename = file_name
+    cached_file = os.path.join(model_dir, filename)
+    if not os.path.exists(cached_file):
+        sys.stderr.write(f'Downloading: "{url}" to {cached_file}\n')
+        hash_prefix = None
+        if check_hash:
+            r = HASH_REGEX.search(filename)  # r is Optional[Match[str]]
+            hash_prefix = r.group(1) if r else None
+        download_url_to_file(url, cached_file, hash_prefix, progress=progress)
+
+    return cached_file

--- a/kornia/feature/lightglue_onnx/utils/download.py
+++ b/kornia/feature/lightglue_onnx/utils/download.py
@@ -39,7 +39,7 @@ def download_onnx_from_url(
         file_name (str, optional): name for the downloaded file. Filename from ``url`` will be used if not set.
 
     Example:
-        >>> model = load_onnx_from_url('https://s3.amazonaws.com/pytorch/models/resnet18-5c106cde.pth')
+        >>> model = load_onnx_from_url('https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/disk_lightglue_fused_fp16.onnx')
 
     """
     if model_dir is None:

--- a/kornia/feature/lightglue_onnx/utils/download.py
+++ b/kornia/feature/lightglue_onnx/utils/download.py
@@ -4,7 +4,7 @@ import errno
 import os
 import sys
 from typing import Optional
-from urllib.parse import urlparse  # noqa: F401
+from urllib.parse import urlparse
 
 from torch.hub import HASH_REGEX, download_url_to_file, get_dir
 
@@ -40,7 +40,6 @@ def download_onnx_from_url(
 
     Example:
         >>> model = load_onnx_from_url('https://github.com/fabio-sim/LightGlue-ONNX/releases/download/v1.0.0/disk_lightglue_fused_fp16.onnx')
-
     """
     if model_dir is None:
         hub_dir = get_dir()

--- a/kornia/feature/lightglue_onnx/utils/keypoints.py
+++ b/kornia/feature/lightglue_onnx/utils/keypoints.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import torch
+
+from kornia.core import Tensor, tensor
+
+
+def normalize_keypoints(kpts: Tensor, size: Tensor) -> Tensor:
+    if isinstance(size, torch.Size):
+        size = tensor(size)[None]
+    shift = size.float().to(kpts) / 2
+    scale = size.max(1).values.float().to(kpts) / 2
+    kpts = (kpts - shift[:, None]) / scale[:, None, None]
+    return kpts

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -3,6 +3,7 @@ kornia-rs==0.0.8
 mypy[reports]
 numpy
 onnx
+onnxruntime-gpu>=1.16
 pre-commit>=2
 pydocstyle
 pytest==7.4.2

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -3,7 +3,7 @@ kornia-rs==0.0.8
 mypy[reports]
 numpy
 onnx
-onnxruntime-gpu>=1.16
+onnxruntime-gpu>=1.16; sys_platform != 'darwin'
 pre-commit>=2
 pydocstyle
 pytest==7.4.2

--- a/test/feature/test_lightglue_onnx.py
+++ b/test/feature/test_lightglue_onnx.py
@@ -2,8 +2,15 @@ import pytest
 import torch
 
 from kornia.feature import OnnxLightGlue
+from kornia.feature.lightglue_onnx.utils import normalize_keypoints
+
+try:
+    import onnxruntime as ort
+except ImportError:
+    ort = None
 
 
+@pytest.mark.skipif(ort is None, reason="OnnxLightGlue requires onnxruntime-gpu")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="OnnxLightGlue requires CUDA")
 class TestOnnxLightGlue:
     @pytest.mark.slow
@@ -30,10 +37,17 @@ class TestOnnxLightGlue:
         assert "matches" in outputs
         assert "scores" in outputs
 
+    def test_normalize_keypoints(self):
+        kpts = torch.randint(0, 100, (1, 5, 2))
+        size = torch.tensor([[100, 100]])
+        kpts = normalize_keypoints(kpts, size)
+        assert torch.all(torch.abs(kpts) <= 1).item()
+
     @pytest.mark.slow
     def test_exception(self):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as e:
             OnnxLightGlue(device="invalid device")
+        assert "Invalid device string: 'invalid device'" in str(e)
 
         model = OnnxLightGlue()
 
@@ -43,11 +57,12 @@ class TestOnnxLightGlue:
         image = torch.zeros(1, 3, 10, 10)
 
         # Missing input
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as e:
             model({"image0": {"keypoints": kpts, "descriptors": desc, "image": image}})
+        assert "Missing key image1 in data" in str(e)
 
         # Wrong dtype
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as e:
             model(
                 {
                     "image0": {
@@ -58,28 +73,33 @@ class TestOnnxLightGlue:
                     "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
                 }
             )
+        assert "Wrong dtype" in str(e)
 
         # Wrong device
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as e:
             model(
                 {
                     "image0": {"keypoints": torch.zeros(1, 5, 2, device="cpu"), "descriptors": desc, "image": image},
                     "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
                 }
             )
+        assert "Wrong device" in str(e)
 
         # Wrong shapes
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as e:
             model(
                 {
                     "image0": {"keypoints": torch.zeros(1, 4, 2, device=device), "descriptors": desc, "image": image},
                     "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
                 }
             )
-        with pytest.raises(Exception):
+        assert "Number of keypoints does not match number of descriptors" in str(e)
+
+        with pytest.raises(Exception) as e:
             model(
                 {
                     "image0": {"keypoints": kpts, "descriptors": torch.zeros(1, 5, 127, device=device), "image": image},
                     "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
                 }
             )
+        assert "Descriptors' dimensions do not match" in str(e)

--- a/test/feature/test_lightglue_onnx.py
+++ b/test/feature/test_lightglue_onnx.py
@@ -1,0 +1,85 @@
+import pytest
+import torch
+
+from kornia.feature import OnnxLightGlue
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="OnnxLightGlue requires CUDA")
+class TestOnnxLightGlue:
+    @pytest.mark.slow
+    @pytest.mark.parametrize("weights", OnnxLightGlue.MODEL_URLS.keys())
+    def test_pretrained_weights(self, weights):
+        model = OnnxLightGlue(weights)
+        assert model is not None
+
+    @pytest.mark.slow
+    def test_forward(self):
+        model = OnnxLightGlue()
+
+        device = torch.device("cuda")
+        kpts = torch.zeros(1, 5, 2, device=device)
+        desc = torch.zeros(1, 5, 128, device=device)
+        image = torch.zeros(1, 3, 10, 10)
+        outputs = model(
+            {
+                "image0": {"keypoints": kpts, "descriptors": desc, "image": image},
+                "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
+            }
+        )
+
+        assert "matches" in outputs
+        assert "scores" in outputs
+
+    @pytest.mark.slow
+    def test_exception(self):
+        with pytest.raises(RuntimeError):
+            OnnxLightGlue(device="invalid device")
+
+        model = OnnxLightGlue()
+
+        device = torch.device("cuda")
+        kpts = torch.zeros(1, 5, 2, device=device)
+        desc = torch.zeros(1, 5, 128, device=device)
+        image = torch.zeros(1, 3, 10, 10)
+
+        # Missing input
+        with pytest.raises(Exception):
+            model({"image0": {"keypoints": kpts, "descriptors": desc, "image": image}})
+
+        # Wrong dtype
+        with pytest.raises(Exception):
+            model(
+                {
+                    "image0": {
+                        "keypoints": torch.zeros(1, 5, 2, dtype=torch.int32, device=device),
+                        "descriptors": desc,
+                        "image": image,
+                    },
+                    "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
+                }
+            )
+
+        # Wrong device
+        with pytest.raises(Exception):
+            model(
+                {
+                    "image0": {"keypoints": torch.zeros(1, 5, 2, device="cpu"), "descriptors": desc, "image": image},
+                    "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
+                }
+            )
+
+        # Wrong shapes
+        with pytest.raises(Exception):
+            model(
+                {
+                    "image0": {"keypoints": torch.zeros(1, 4, 2, device=device), "descriptors": desc, "image": image},
+                    "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
+                }
+            )
+        with pytest.raises(Exception):
+            model(
+                {
+                    "image0": {"keypoints": kpts, "descriptors": torch.zeros(1, 5, 127, device=device), "image": image},
+                    "image1": {"keypoints": kpts, "descriptors": desc, "image": image},
+                }
+            )


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
This PR adds a wrapper class for loading and running LightGlue-ONNX models via ONNXRuntime.
<!-- Please also include relevant motivation and context. -->
Re: https://github.com/fabio-sim/LightGlue-ONNX/issues/40
<!-- List any dependencies that are required for this change. -->
`onnxruntime-gpu>=1.16` is required as a dependency to instantiate the new `OnnxLightGlue` class. (Importing it will still work without installing).
related to #2559 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?

#### Example Usage
Sample images can be found [here](https://github.com/fabio-sim/LightGlue-ONNX/tree/main/assets).
```python
import torch

from kornia.feature import DISK, OnnxLightGlue
from kornia.io import ImageLoadType, load_image

device = torch.device("cuda")

img0 = load_image("sacre_coeur1.jpg", ImageLoadType.RGB32, device=device)[None]
img1 = load_image("sacre_coeur2.jpg", ImageLoadType.RGB32, device=device)[None]

extractor = DISK.from_pretrained("depth", device=device).eval().to(device)

data = {}
with torch.no_grad():
    for key, img in [("image0", img0), ("image1", img1)]:
        features = extractor(img, n=None, window_size=5, score_threshold=0.0, pad_if_not_divisible=True)
        data[key] = {
            "image": img,
            "keypoints": features[0].keypoints[None],
            "keypoint_scores": features[0].detection_scores[None],
            "descriptors": features[0].descriptors[None],
        }

matcher = OnnxLightGlue(weights="disk_fp16", device=device)
result = matcher(data)
print(result)
```
