### PR TITLE
Allow CombineTensorPatches to work with overlapping patches

### DIFF
--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -249,8 +249,11 @@ def combine_tensor_patches(
     ones = torch.ones(patches.shape[0], patches.shape[2], original_size[0], original_size[1])
     patches = patches.permute(0, 2, 3, 4, 1)
     patches = patches.reshape(patches.shape[0], -1, patches.shape[-1])
-    dtype = patches.dtype
-    patches = patches.double()
+    int_flag = 0
+    if not torch.is_floating_point(patches):
+        int_flag = 1
+        dtype = patches.dtype
+        patches = patches.float()
 
     # Calculate normalization map
     unfold_ones = F.unfold(ones, kernel_size=window_size, stride=stride, padding=unpadding)
@@ -263,7 +266,8 @@ def combine_tensor_patches(
     )
     # Remove satuation effect due to multiple summations
     restored_tensor = saturated_restored_tensor / (norm_map + eps)
-    restored_tensor = restored_tensor.to(dtype)
+    if int_flag:
+        restored_tensor = restored_tensor.to(dtype)
     return restored_tensor
 
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -38,8 +38,14 @@ def compute_padding(
     original_size = cast(Tuple[int, int], _pair(original_size))
     window_size = cast(Tuple[int, int], _pair(window_size))
 
-    padh = math.ceil((window_size[0] - original_size[0] % window_size[0]) / 2)
-    padw = math.ceil((window_size[1] - original_size[1] % window_size[1]) / 2)
+    if original_size[0] % window_size[0] != 0:
+        padh = math.ceil((window_size[0] - original_size[0] % window_size[0]) / 2)
+    else:
+        padh = 0
+    if original_size[1] % window_size[1] != 0:
+        padw = math.ceil((window_size[1] - original_size[1] % window_size[1]) / 2)
+    else:
+        padw = 0
 
     return (padh, padw)
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -246,7 +246,14 @@ def combine_tensor_patches(
     if len(unpadding) != 2:
         raise AssertionError("Unpadding must be either an int or a tuple of two ints")
 
-    ones = torch.ones(patches.shape[0], patches.shape[2], original_size[0], original_size[1])
+    ones = torch.ones(
+        patches.shape[0],
+        patches.shape[2],
+        original_size[0],
+        original_size[1],
+        device=patches.device,
+        dtype=patches.dtype,
+    )
     patches = patches.permute(0, 2, 3, 4, 1)
     patches = patches.reshape(patches.shape[0], -1, patches.shape[-1])
     int_flag = 0
@@ -254,6 +261,7 @@ def combine_tensor_patches(
         int_flag = 1
         dtype = patches.dtype
         patches = patches.float()
+        ones = ones.float()
 
     # Calculate normalization map
     unfold_ones = F.unfold(ones, kernel_size=window_size, stride=stride, padding=unpadding)

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -207,7 +207,7 @@ def combine_tensor_patches(
     window_size: Union[int, Tuple[int, int]],
     stride: Union[int, Tuple[int, int]],
     unpadding: Union[int, Tuple[int, int]] = 0,
-    eps: float = 1e-8
+    eps: float = 1e-8,
 ) -> Tensor:
     r"""Restore input from patches.
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -248,6 +248,8 @@ def combine_tensor_patches(
     ones = torch.ones(patches.shape[0], patches.shape[2], original_size[0], original_size[1])
     patches = patches.permute(0, 2, 3, 4, 1)
     patches = patches.reshape(patches.shape[0], -1, patches.shape[-1])
+    dtype = patches.dtype
+    patches = patches.double()
 
     # Calculate normalization map
     unfold_ones = F.unfold(ones, kernel_size=window_size, stride=stride, padding=unpadding)
@@ -260,6 +262,7 @@ def combine_tensor_patches(
     )
     # Remove satuation effect due to multiple summations
     restored_tensor = saturated_restored_tensor / (norm_map + 1e-8)
+    restored_tensor = restored_tensor.to(dtype)
     return restored_tensor
 
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -260,10 +260,12 @@ def combine_tensor_patches(
     norm_map = F.fold(
         input=unfold_ones, output_size=original_size, kernel_size=window_size, stride=stride, padding=unpadding
     )
+
     # Restored tensor
     saturated_restored_tensor = F.fold(
         input=patches, output_size=original_size, kernel_size=window_size, stride=stride, padding=unpadding
     )
+
     # Remove satuation effect due to multiple summations
     restored_tensor = saturated_restored_tensor / (norm_map + eps)
     if int_flag:

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -251,12 +251,15 @@ def combine_tensor_patches(
     # Assuming BNCHW
     patches = patches.permute(0, 2, 3, 4, 1)
     patches = patches.reshape(patches.shape[0], -1, patches.shape[-1])
+    dtype = patches.dtype
+    patches = patches.double()
 
     # Calculate normalization map
     norm_map = fold(unfold(ones))
     saturated_restored_tensor = fold(patches)
     # Remove satuation effect due to multiple summations
     restored_tensor = saturated_restored_tensor / (norm_map)
+    restored_tensor = restored_tensor.to(dtype)
     return restored_tensor
 
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -1,16 +1,16 @@
+import math
 from typing import Optional, Tuple, Union, cast
 
 import torch
+from torch import nn
 from torch.nn.modules.utils import _pair
 
-from kornia.core import Module, Tensor, concatenate, pad
-
-PadType = Union[Tuple[int, int], Tuple[int, int, int, int]]
+from kornia.core import Module, Tensor, pad
 
 
 def compute_padding(
     original_size: Union[int, Tuple[int, int]], window_size: Union[int, Tuple[int, int]]
-) -> Tuple[int, int, int, int]:
+) -> Tuple[int, int]:
     r"""Compute required padding to ensure chaining of :func:`extract_tensor_patches` and
     :func:`combine_tensor_patches` produces expected result.
 
@@ -19,7 +19,7 @@ def compute_padding(
         window_size: the size of the sliding window used while extracting patches.
 
     Return:
-        The required padding for `(top, bottom, left, right)` as a tuple of 4 ints.
+        The required padding for `(vertical, horizontal)` as a tuple of 2 ints.
 
     Example:
         >>> image = torch.arange(12).view(1, 1, 4, 3)
@@ -38,23 +38,10 @@ def compute_padding(
     original_size = cast(Tuple[int, int], _pair(original_size))
     window_size = cast(Tuple[int, int], _pair(window_size))
 
-    def paddim(dim1: int, dim2: int) -> Tuple[int, int]:
-        if dim1 % dim2 == 0:
-            p1 = 0
-            p2 = 0
-        else:
-            tmp = dim2 - (dim1 % dim2)
-            if tmp % 2 == 0:
-                p1 = p2 = tmp // 2
-            else:
-                p1 = tmp
-                p2 = 0
-        return p1, p2
+    padh = math.ceil((window_size[0] - original_size[0] % window_size[0]) / 2)
+    padw = math.ceil((window_size[1] - original_size[1] % window_size[1]) / 2)
 
-    padt, padb = paddim(original_size[0], window_size[0])
-    padl, padr = paddim(original_size[1], window_size[1])
-
-    return (padt, padb, padl, padr)
+    return (padh, padw)
 
 
 class ExtractTensorPatches(Module):
@@ -119,12 +106,12 @@ class ExtractTensorPatches(Module):
         self,
         window_size: Union[int, Tuple[int, int]],
         stride: Optional[Union[int, Tuple[int, int]]] = 1,
-        padding: Optional[Union[int, PadType]] = 0,
+        padding: Optional[Union[int, Tuple[int, int]]] = 0,
     ) -> None:
         super().__init__()
         self.window_size: Tuple[int, int] = _pair(window_size)
         self.stride: Tuple[int, int] = _pair(stride)
-        self.padding: PadType = _pair(padding)
+        self.padding: Tuple[int, int] = _pair(padding)
 
     def forward(self, input: Tensor) -> Tensor:
         return extract_tensor_patches(input, self.window_size, stride=self.stride, padding=self.padding)
@@ -149,10 +136,12 @@ class CombineTensorPatches(Module):
       extracting tensor patches and defines the shape of the output patch.
     * :attr:`window_size` is the size of the sliding window used while
       extracting tensor patches.
+    * :attr:`stride` controls the stride to apply to the sliding window and
+      regulates the overlapping between the extracted patches.
     * :attr:`unpadding` is the amount of padding to be removed. This value
       must be the same as padding used while extracting tensor patches.
 
-    The parameters :attr:`original_size`, :attr:`window_size`, and :attr:`unpadding` can
+    The parameters :attr:`original_size`, :attr:`window_size`, :attr:`stride`, and :attr:`unpadding` can
     be either:
 
         - a single ``int`` -- in which case the same value is used for the
@@ -168,6 +157,7 @@ class CombineTensorPatches(Module):
         patches: patched tensor.
         original_size: the size of the original tensor and the output patch size.
         window_size: the size of the sliding window used.
+        stride: stride of the sliding window.
         unpadding: remove the padding added to both side of the input.
 
     Shape:
@@ -190,16 +180,18 @@ class CombineTensorPatches(Module):
         self,
         original_size: Union[int, Tuple[int, int]],
         window_size: Union[int, Tuple[int, int]],
-        unpadding: Union[int, PadType] = 0,
+        stride: Union[int, Tuple[int, int]],
+        unpadding: Union[int, Tuple[int, int]] = 0,
     ) -> None:
         super().__init__()
         self.original_size: Tuple[int, int] = _pair(original_size)
         self.window_size: Tuple[int, int] = _pair(window_size)
-        self.unpadding: PadType = _pair(unpadding)
+        self.stride: Tuple[int, int] = _pair(stride)
+        self.unpadding: Tuple[int, int] = _pair(unpadding)
 
     def forward(self, input: Tensor) -> Tensor:
         return combine_tensor_patches(
-            input, self.original_size, self.window_size, stride=self.window_size, unpadding=self.unpadding
+            input, self.original_size, self.window_size, stride=self.stride, unpadding=self.unpadding
         )
 
 
@@ -208,7 +200,7 @@ def combine_tensor_patches(
     original_size: Union[int, Tuple[int, int]],
     window_size: Union[int, Tuple[int, int]],
     stride: Union[int, Tuple[int, int]],
-    unpadding: Union[int, PadType] = 0,
+    unpadding: Union[int, Tuple[int, int]] = 0,
 ) -> Tensor:
     r"""Restore input from patches.
 
@@ -242,45 +234,23 @@ def combine_tensor_patches(
     original_size = cast(Tuple[int, int], _pair(original_size))
     window_size = cast(Tuple[int, int], _pair(window_size))
     stride = cast(Tuple[int, int], _pair(stride))
+    unpadding = cast(Tuple[int, int], _pair(unpadding))
 
-    if stride[0] != window_size[0] or stride[1] != window_size[1]:
-        raise NotImplementedError(
-            f"Only stride == window_size is supported. Got {stride} and {window_size}."
-            "Please feel free to drop a PR to Kornia Github."
-        )
+    if len(unpadding) != 2:
+        raise AssertionError("Unpadding must be either an int or a tuple of two ints")
 
-    if unpadding:
-        unpadding = cast(PadType, _pair(unpadding))
+    fold = nn.Fold(output_size=original_size, kernel_size=window_size, stride=stride, padding=unpadding)
+    unfold = nn.Unfold(kernel_size=window_size, stride=stride, padding=unpadding)
+    ones = torch.ones(patches.shape[0], patches.shape[2], original_size[0], original_size[1])
+    # Assuming BNCHW
+    patches = patches.permute(0, 2, 3, 4, 1)
+    patches = patches.reshape(patches.shape[0], -1, patches.shape[-1])
 
-        if len(unpadding) not in [2, 4]:
-            raise AssertionError("Unpadding must be either an int, tuple of two ints or tuple of four ints")
-
-        if len(unpadding) == 2:
-            pad_vert = _pair(unpadding[0])
-            pad_horz = _pair(unpadding[1])
-        else:
-            pad_vert = unpadding[:2]
-            pad_horz = unpadding[2:]
-        unpadding = cast(Tuple[int, int, int, int], pad_horz + pad_vert)
-
-        hpad_check = (original_size[0] + unpadding[2] + unpadding[3]) % window_size[0] == 0
-        wpad_check = (original_size[1] + unpadding[0] + unpadding[1]) % window_size[1] == 0
-
-        if not hpad_check or not wpad_check:
-            raise NotImplementedError("Insufficient padding")
-
-        window_size = (
-            (original_size[0] + (unpadding[2] + unpadding[3])) // window_size[0],
-            (original_size[1] + (unpadding[0] + unpadding[1])) // window_size[1],
-        )
-
-    patches_tensor = patches.view(-1, window_size[0], window_size[1], *patches.shape[-3:])
-    restored_tensor = concatenate(torch.chunk(patches_tensor, window_size[0], 1), -2).squeeze(1)
-    restored_tensor = concatenate(torch.chunk(restored_tensor, window_size[1], 1), -1).squeeze(1)
-
-    if unpadding:
-        unpadding = cast(Tuple[int, int, int, int], unpadding)
-        restored_tensor = pad(restored_tensor, [-i for i in unpadding])
+    # Calculate normalization map
+    norm_map = fold(unfold(ones))
+    saturated_restored_tensor = fold(patches)
+    # Remove satuation effect due to multiple summations
+    restored_tensor = saturated_restored_tensor / (norm_map)
     return restored_tensor
 
 
@@ -297,7 +267,7 @@ def extract_tensor_patches(
     input: Tensor,
     window_size: Union[int, Tuple[int, int]],
     stride: Union[int, Tuple[int, int]] = 1,
-    padding: Union[int, PadType] = 0,
+    padding: Union[int, Tuple[int, int]] = 0,
 ) -> Tensor:
     r"""Function that extract patches from tensors and stack them.
 
@@ -330,7 +300,7 @@ def extract_tensor_patches(
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
 
     if padding:
-        padding = cast(PadType, _pair(padding))
+        padding = cast(Tuple[int, int], _pair(padding))
 
         if len(padding) not in [2, 4]:
             raise AssertionError("Padding must be either an int, tuple of two ints or tuple of four ints")

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -313,7 +313,7 @@ def extract_tensor_patches(
 
         pad_vert = _pair(padding[0])
         pad_horz = _pair(padding[1])
-        padding = cast(Tuple[int, int, int, int], pad_horz + pad_vert)
-        input = pad(input, padding)
+        padding4 = cast(Tuple[int, int, int, int], pad_horz + pad_vert)
+        input = pad(input, padding4)
 
     return _extract_tensor_patchesnd(input, _pair(window_size), _pair(stride))

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -302,15 +302,11 @@ def extract_tensor_patches(
     if padding:
         padding = cast(Tuple[int, int], _pair(padding))
 
-        if len(padding) not in [2, 4]:
-            raise AssertionError("Padding must be either an int, tuple of two ints or tuple of four ints")
+        if len(padding) != 2:
+            raise AssertionError("Padding must be either an int or a tuple of two ints")
 
-        if len(padding) == 2:
-            pad_vert = _pair(padding[0])
-            pad_horz = _pair(padding[1])
-        else:
-            pad_vert = padding[:2]
-            pad_horz = padding[2:]
+        pad_vert = _pair(padding[0])
+        pad_horz = _pair(padding[1])
         padding = cast(Tuple[int, int, int, int], pad_horz + pad_vert)
         input = pad(input, padding)
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -326,8 +326,8 @@ def extract_tensor_patches(
     if len(input.shape) != 4:
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
 
-    window_size = _pair(window_size)
-    stride = _pair(stride)
+    window_size = cast(Tuple[int, int], _pair(window_size))
+    stride = cast(Tuple[int, int], _pair(stride))
 
     if (stride[0] > window_size[0]) | (stride[1] > window_size[1]):
         raise AssertionError(f"Stride={stride} should be less than or equal to Window size={window_size}")

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -207,6 +207,7 @@ def combine_tensor_patches(
     window_size: Union[int, Tuple[int, int]],
     stride: Union[int, Tuple[int, int]],
     unpadding: Union[int, Tuple[int, int]] = 0,
+    eps: float = 1e-8
 ) -> Tensor:
     r"""Restore input from patches.
 
@@ -261,7 +262,7 @@ def combine_tensor_patches(
         input=patches, output_size=original_size, kernel_size=window_size, stride=stride, padding=unpadding
     )
     # Remove satuation effect due to multiple summations
-    restored_tensor = saturated_restored_tensor / (norm_map + 1e-8)
+    restored_tensor = saturated_restored_tensor / (norm_map + eps)
     restored_tensor = restored_tensor.to(dtype)
     return restored_tensor
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -248,8 +248,6 @@ def combine_tensor_patches(
     ones = torch.ones(patches.shape[0], patches.shape[2], original_size[0], original_size[1])
     patches = patches.permute(0, 2, 3, 4, 1)
     patches = patches.reshape(patches.shape[0], -1, patches.shape[-1])
-    dtype = patches.dtype
-    patches = patches.double()
 
     # Calculate normalization map
     unfold_ones = F.unfold(ones, kernel_size=window_size, stride=stride, padding=unpadding)
@@ -261,8 +259,7 @@ def combine_tensor_patches(
         input=patches, output_size=original_size, kernel_size=window_size, stride=stride, padding=unpadding
     )
     # Remove satuation effect due to multiple summations
-    restored_tensor = saturated_restored_tensor / (norm_map)
-    restored_tensor = restored_tensor.to(dtype)
+    restored_tensor = saturated_restored_tensor / (norm_map + 1e-8)
     return restored_tensor
 
 

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -326,6 +326,12 @@ def extract_tensor_patches(
     if len(input.shape) != 4:
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
 
+    window_size = _pair(window_size)
+    stride = _pair(stride)
+
+    if (stride[0] > window_size[0]) | (stride[1] > window_size[1]):
+        raise AssertionError(f"Stride={stride} should be less than or equal to Window size={window_size}")
+
     if padding:
         padding = cast(Tuple[int, int], _pair(padding))
 
@@ -337,4 +343,4 @@ def extract_tensor_patches(
         padding4 = cast(Tuple[int, int, int, int], pad_horz + pad_vert)
         input = pad(input, padding4)
 
-    return _extract_tensor_patchesnd(input, _pair(window_size), _pair(stride))
+    return _extract_tensor_patchesnd(input, window_size, stride)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2513

Previously `CombineTensorPatches` only worked if stride == window_size. This PR lifts this restriction and allows users to combine overlapping patches. 

Breaking changes:
1. Padding can no longer be a tuple of 4 ints. It can only be an int or a tuple of 2 ints.
2. Stride is a required argument for `CombineTensorPatches`

Corresponding tutorial has been updated in kornia/tutorials#69

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [x] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
