### PR TITLE
Doc Fix: lafs2 shape in matchers

### DIFF
--- a/kornia/feature/adalam/adalam.py
+++ b/kornia/feature/adalam/adalam.py
@@ -49,7 +49,7 @@ def match_adalam(
         desc1: Batch of descriptors of a shape :math:`(B1, D)`.
         desc2: Batch of descriptors of a shape :math:`(B2, D)`.
         lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`.
-        lafs2: LAFs of a shape :math:`(1, B1, 2, 3)`.
+        lafs2: LAFs of a shape :math:`(1, B2, 2, 3)`.
         config: dict with AdaLAM config
         dm: Tensor containing the distances from each descriptor in desc1
           to each descriptor in desc2, shape of :math:`(B1, B2)`.

--- a/kornia/feature/integrated.py
+++ b/kornia/feature/integrated.py
@@ -431,7 +431,7 @@ class LightGlueMatcher(GeometryAwareDescriptorMatcher):
             desc1: Batch of descriptors of a shape :math:`(B1, D)`.
             desc2: Batch of descriptors of a shape :math:`(B2, D)`.
             lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`.
-            lafs2: LAFs of a shape :math:`(1, B1, 2, 3)`.
+            lafs2: LAFs of a shape :math:`(1, B2, 2, 3)`.
 
         Return:
             - Descriptor distance of matching descriptors, shape of :math:`(B3, 1)`.

--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -232,7 +232,7 @@ def match_fginn(
         desc1: Batch of descriptors of a shape :math:`(B1, D)`.
         desc2: Batch of descriptors of a shape :math:`(B2, D)`.
         lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`.
-        lafs2: LAFs of a shape :math:`(1, B1, 2, 3)`.
+        lafs2: LAFs of a shape :math:`(1, B2, 2, 3)`.
 
         th: distance ratio threshold.
         spatial_th: minimal distance in pixels to 2nd nearest neighbor.
@@ -313,7 +313,7 @@ class DescriptorMatcher(Module):
             desc1: Batch of descriptors of a shape :math:`(B1, D)`.
             desc2: Batch of descriptors of a shape :math:`(B2, D)`.
             lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`.
-            lafs2: LAFs of a shape :math:`(1, B1, 2, 3)`.
+            lafs2: LAFs of a shape :math:`(1, B2, 2, 3)`.
 
         Return:
             - Descriptor distance of matching descriptors, shape of :math:`(B3, 1)`.
@@ -360,7 +360,7 @@ class GeometryAwareDescriptorMatcher(Module):
             desc1: Batch of descriptors of a shape :math:`(B1, D)`.
             desc2: Batch of descriptors of a shape :math:`(B2, D)`.
             lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`.
-            lafs2: LAFs of a shape :math:`(1, B1, 2, 3)`.
+            lafs2: LAFs of a shape :math:`(1, B2, 2, 3)`.
 
         Return:
             - Descriptor distance of matching descriptors, shape of :math:`(B3, 1)`.


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->

Update the shape of `lafs2` to match the shape of `desc2` in the matchers doc. 
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
