### PR TITLE
Multiplication with `torch.ones` not needed for kernel_values

### DIFF
--- a/kornia/enhance/histogram.py
+++ b/kornia/enhance/histogram.py
@@ -227,7 +227,7 @@ def image_histogram2d(
         if kernel == "triangular":
             kernel_values = (1.0 - u) * mask
         elif kernel == "uniform":
-            kernel_values = torch.ones_like(u) * mask
+            kernel_values = mask
         else:  # kernel == "epanechnikov"
             kernel_values = (1.0 - u**2) * mask
     else:


### PR DESCRIPTION
#### Changes
Mask is already of the same shape and dtype as `u`

This removes a alloc, set_values and multiplication call

#### Type of change
<!-- Please delete options that are not relevant. -->


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
