### PR TITLE
ExtractTensorPatches augmentation

### DIFF
--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -1,12 +1,12 @@
 import math
-from typing import Optional, Tuple, Union, cast, Dict, Any
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import torch
 import torch.nn.functional as F
 from torch.nn.modules.utils import _pair
 
-from kornia.core import Module, Tensor, pad
 from kornia.augmentation import GeometricAugmentationBase2D
+from kornia.core import Module, Tensor, pad
 
 
 def compute_padding(
@@ -125,13 +125,13 @@ class ExtractTensorPatches(GeometricAugmentationBase2D):
             "keepdim": keepdim,
         }
 
-    def compute_transformation(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]
-    ) -> Tensor:
+    def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         transform: Tensor = self.identity_matrix(input)
         return transform
 
-    def apply_transform(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None) -> Tensor:
+    def apply_transform(
+        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+    ) -> Tensor:
         out = extract_tensor_patches(
             input,
             window_size=flags["window_size"],

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -117,14 +117,6 @@ class ExtractTensorPatches(GeometricAugmentationBase2D):
         padding: Optional[Union[int, tuple[int, int]]] = 0,
         keepdim: bool = False,
     ) -> None:
-        """Initialize a new _ExtractPatches instance.
-
-        Args:
-            window_size: desired output size (out_h, out_w) of the crop
-            stride: stride of window to extract patches. Defaults to non-overlapping
-                patches (stride=window_size)
-            padding: zero padding added to the height and width dimensions
-        """
         super().__init__()
         self.flags = {
             "window_size": window_size,

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -115,7 +115,7 @@ class ExtractTensorPatches(GeometricAugmentationBase2D):
         window_size: Union[int, tuple[int, int]],
         stride: Optional[Union[int, tuple[int, int]]] = None,
         padding: Optional[Union[int, tuple[int, int]]] = 0,
-        keepdim: bool = True,
+        keepdim: bool = False,
     ) -> None:
         """Initialize a new _ExtractPatches instance.
 


### PR DESCRIPTION
#### Changes

Previously `kornia.contrib.ExtractTensorPatches` is just a `nn.Module`. This means when it's used inside a container like `AugmentationSequential` and the input has an `image` and a `mask`, only the `image` is transformed. To get around this I've refactored `ExtractTensorPatches` to a geometric augmentation.

The ideal case would be that if I'm training using a cropping augmentation like `K.RandomCrop(256)` and I want to evaluate on my larger images in the val or test sets with non-overlapping patches of the same size, one could use this to do this evaluation.

Fixes # (issue)


#### Type of change
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [] 🔬 New feature (non-breaking change which adds functionality)
- [X] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
