### PR TITLE
Introduce Tikhonov Regularization to get_tps_transform

### DIFF
--- a/kornia/geometry/transform/thin_plate_spline.py
+++ b/kornia/geometry/transform/thin_plate_spline.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from kornia.core import ones, zeros
 from kornia.utils import create_meshgrid
 from kornia.utils.helpers import _torch_solve_cast
 
@@ -35,7 +34,9 @@ def _kernel_distance(squared_distances: torch.Tensor, eps: float = 1e-8) -> torc
     return 0.5 * squared_distances * squared_distances.add(eps).log()
 
 
-def get_tps_transform(points_src: torch.Tensor, points_dst: torch.Tensor, lambda_reg: float = None) -> Tuple[torch.Tensor, torch.Tensor]:
+def get_tps_transform(
+    points_src: torch.Tensor, points_dst: torch.Tensor, lambda_reg: float = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Compute the TPS transform parameters that warp source points to target points.
 
     The input to this function is a tensor of :math:`(x, y)` source points :math:`(B, N, 2)` and a corresponding
@@ -60,7 +61,7 @@ def get_tps_transform(points_src: torch.Tensor, points_dst: torch.Tensor, lambda
         >>> lambda_reg = 0.01
         >>> kernel_weights, affine_weights = get_tps_transform(points_src, points_dst, lambda_reg)
 
-        
+
     Regularization:
         When lambda_reg is not None, Tikhonov regularization (also known as ridge regression) is applied.
         This adds a term lambda_reg * I to the kernel matrix K, where I is the identity matrix. This regularization
@@ -112,7 +113,8 @@ def get_tps_transform(points_src: torch.Tensor, points_dst: torch.Tensor, lambda
     affine_weights: torch.Tensor = weights[:, -3:]
 
     return (kernel_weights, affine_weights)
-    
+
+
 def warp_points_tps(
     points_src: torch.Tensor, kernel_centers: torch.Tensor, kernel_weights: torch.Tensor, affine_weights: torch.Tensor
 ) -> torch.Tensor:

--- a/kornia/geometry/transform/thin_plate_spline.py
+++ b/kornia/geometry/transform/thin_plate_spline.py
@@ -105,7 +105,7 @@ def get_tps_transform(
         k_matrix = k_matrix + lambda_reg * identity_matrix
 
     # Rest of the code remains the same, replace k_matrix with k_matrix_reg in the linear system
-    l_matrix = torch.cat((k_matrix, p_matrix), -1)
+    l_matrix = concatenate((k_matrix, p_matrix), -1)
     l_matrix = torch.cat((l_matrix, p_matrix_t), 1)
 
     weights = _torch_solve_cast(l_matrix, dest_with_zeros)

--- a/kornia/geometry/transform/thin_plate_spline.py
+++ b/kornia/geometry/transform/thin_plate_spline.py
@@ -94,7 +94,7 @@ def get_tps_transform(
     pair_distance: torch.Tensor = _pair_square_euclidean(points_src, points_dst)
     k_matrix: torch.Tensor = _kernel_distance(pair_distance)
 
-    zero_mat: torch.Tensor = torch.zeros(batch_size, 3, 3, device=device, dtype=dtype)
+    zero_mat: torch.Tensor = zeros(batch_size, 3, 3, device=device, dtype=dtype)
     one_mat: torch.Tensor = torch.ones(batch_size, num_points, 1, device=device, dtype=dtype)
     dest_with_zeros: torch.Tensor = torch.cat((points_dst, zero_mat[:, :, :2]), 1)
     p_matrix: torch.Tensor = torch.cat((one_mat, points_src), -1)


### PR DESCRIPTION
During testing, I observed that the TPS transformation could produce erratic warping effects when dealing with misaligned control points ( e.g. a translation and a scale).

To address this, we've added an optional Tikhonov regularization parameter (lambda_reg) to the get_tps_transform function. This regularization significantly improves the stability and smoothness of the warp.

- Introduced lambda_reg for optional regularization to improve warp smoothness
- Expanded documentation with practical insights on regularization benefits
- Maintained backward compatibility with lambda_reg defaulting to None