### PR TITLE
fix: same_on_batch behavior in _adapted_rsampling for shapes of size 1

### DIFF
--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -204,7 +204,9 @@ def _adapted_rsampling(
         shape = torch.Size(shape)
 
     if same_on_batch:
-        return dist.rsample(torch.Size((1, *shape[1:]))).repeat(shape[0], *[1] * (len(shape) - 1))
+        rsample_size = torch.Size((1, *shape[1:]))
+        rsample = dist.rsample(rsample_size)
+        return rsample.repeat(shape[0], *[1] * (len(rsample.shape) - 1))
     return dist.rsample(shape)
 
 

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -3726,6 +3726,15 @@ class TestRandomFisheye:
         aug = RandomFisheye(center_x, center_y, gamma, p=1.0)
         assert img.shape == aug(img).shape
 
+    def test_same_on_batch(self, device, dtype):
+        torch.manual_seed(0)
+        center_x = torch.tensor([-0.3, 0.3])
+        center_y = torch.tensor([-0.3, 0.3])
+        gamma = torch.tensor([-1.0, 1.0])
+        img = torch.rand(1, 1, 2, 2, device=device, dtype=dtype)
+        aug = RandomFisheye(center_x, center_y, gamma, same_on_batch=True, p=1.0)
+        assert img.shape == aug(img).shape
+
     @pytest.mark.skip(reason="RuntimeError: Jacobian mismatch for output 0 with respect to input 0")
     def test_gradcheck(self, device, dtype):
         img = torch.rand(1, 1, 3, 3, device=device, dtype=dtype)

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -3728,8 +3728,8 @@ class TestRandomFisheye:
 
     def test_same_on_batch(self, device, dtype):
         torch.manual_seed(0)
-        center_x = torch.tensor([-0.3, 0.3])
-        center_y = torch.tensor([-0.3, 0.3])
+        center_x = torch.tensor([-0.3, 0.3], device=device, dtype=dtype)
+        center_y = torch.tensor([-0.3, 0.3], device=device, dtype=dtype)
         gamma = torch.tensor([-1.0, 1.0])
         img = torch.rand(1, 1, 2, 2, device=device, dtype=dtype)
         aug = RandomFisheye(center_x, center_y, gamma, same_on_batch=True, p=1.0)

--- a/test/augmentation/test_augmentation.py
+++ b/test/augmentation/test_augmentation.py
@@ -3730,7 +3730,7 @@ class TestRandomFisheye:
         torch.manual_seed(0)
         center_x = torch.tensor([-0.3, 0.3], device=device, dtype=dtype)
         center_y = torch.tensor([-0.3, 0.3], device=device, dtype=dtype)
-        gamma = torch.tensor([-1.0, 1.0])
+        gamma = torch.tensor([-1.0, 1.0], device=device, dtype=dtype)
         img = torch.rand(1, 1, 2, 2, device=device, dtype=dtype)
         aug = RandomFisheye(center_x, center_y, gamma, same_on_batch=True, p=1.0)
         assert img.shape == aug(img).shape


### PR DESCRIPTION
#### Changes

`torch.repeat` is called on the final rsampled tensor, repeating only the batch dimension and just copying the rest

Fixes https://github.com/kornia/kornia/issues/2698

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
