### PR TITLE
feat: `connected_components` metric stop case when `num_iterations=0`

### DIFF
--- a/kornia/contrib/connected_components.py
+++ b/kornia/contrib/connected_components.py
@@ -36,9 +36,7 @@ def connected_components(image: Tensor, num_iterations: int = 100) -> Tensor:
         raise TypeError(f"Input imagetype is not a Tensor. Got: {type(image)}")
 
     if not isinstance(num_iterations, int) or num_iterations < 0:
-        raise TypeError(
-            "Input num_iterations must be an integer greater or equal to zero."
-        )
+        raise TypeError("Input num_iterations must be an integer greater or equal to zero.")
 
     if len(image.shape) < 3 or image.shape[-3] != 1:
         raise ValueError(f"Input image shape must be (*,1,H,W). Got: {image.shape}")

--- a/test/contrib/test_contrib.py
+++ b/test/contrib/test_contrib.py
@@ -177,7 +177,7 @@ class TestConnectedComponents:
         img[..., 1:, 1:] = 1.0
 
         expected = torch.zeros((1, 1, N, N), device=device, dtype=dtype)
-        expected[..., 1:, 1:] = N * N 
+        expected[..., 1:, 1:] = N * N
 
         out = kornia.contrib.connected_components(img, num_iterations=0)
         assert_close(out, expected)

--- a/test/contrib/test_contrib.py
+++ b/test/contrib/test_contrib.py
@@ -121,14 +121,14 @@ class TestConnectedComponents:
 
         with pytest.raises(TypeError) as errinf:
             assert kornia.contrib.connected_components(img, 1.0)
-        assert "Input num_iterations must be integer greater or equal to zero." in str(errinf)
+        assert "Input num_iterations must be an integer greater or equal to zero." in str(errinf)
         with pytest.raises(TypeError) as errinf:
             assert kornia.contrib.connected_components("not a tensor", 0)
         assert "Input imagetype is not a Tensor. Got:" in str(errinf)
 
         with pytest.raises(TypeError) as errinf:
             assert kornia.contrib.connected_components(img, -1)
-        assert "Input num_iterations must be integer greater or equal to zero." in str(errinf)
+        assert "Input num_iterations must be an integer greater or equal to zero." in str(errinf)
         with pytest.raises(ValueError) as errinf:
             img = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)
             assert kornia.contrib.connected_components(img, 2)
@@ -139,8 +139,8 @@ class TestConnectedComponents:
             [
                 [
                     [
-                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
                         [0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
                         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
                         [0.0, 0.0, 0.0, 1.0, 1.0, 0.0],
@@ -156,12 +156,12 @@ class TestConnectedComponents:
             [
                 [
                     [
+                        [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 15.0, 0.0, 0.0, 12.0],
+                        [0.0, 15.0, 15.0, 0.0, 0.0, 0.0],
                         [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, 14.0, 14.0, 0.0, 0.0, 11.0],
-                        [0.0, 14.0, 14.0, 0.0, 0.0, 0.0],
-                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                        [0.0, 0.0, 0.0, 34.0, 34.0, 0.0],
-                        [0.0, 0.0, 0.0, 34.0, 34.0, 0.0],
+                        [0.0, 0.0, 0.0, 35.0, 35.0, 0.0],
+                        [0.0, 0.0, 0.0, 35.0, 35.0, 0.0],
                     ]
                 ]
             ],
@@ -177,7 +177,7 @@ class TestConnectedComponents:
         img[..., 1:, 1:] = 1.0
 
         expected = torch.zeros((1, 1, N, N), device=device, dtype=dtype)
-        expected[..., 1:, 1:] = N * N - 1
+        expected[..., 1:, 1:] = N * N 
 
         out = kornia.contrib.connected_components(img, num_iterations=0)
         assert_close(out, expected)

--- a/test/contrib/test_contrib.py
+++ b/test/contrib/test_contrib.py
@@ -172,7 +172,7 @@ class TestConnectedComponents:
         out = kornia.contrib.connected_components(img, num_iterations=10)
         assert_close(out, expected)
 
-        N = 1000
+        N = 100
         img = torch.zeros((1, 1, N, N), device=device, dtype=dtype)
         img[..., 1:, 1:] = 1.0
 


### PR DESCRIPTION
#### Changes
The function `connected_components` now supports `num_iterations` equals to zero, in this case the algorithm runs until convergence.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
