### PR TITLE
Replace docs source link from `viewcode` to github 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,5 @@
 import importlib.util
+import inspect
 import os
 import sys
 
@@ -39,7 +40,8 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_autodoc_defaultargs",
     "sphinx_copybutton",
-    "sphinx.ext.viewcode",
+    # "sphinx.ext.viewcode",
+    "sphinx.ext.linkcode",
     "sphinx.ext.githubpages",
     "sphinxcontrib.bibtex",
     "sphinxcontrib.gtagjs",
@@ -159,6 +161,47 @@ html_extra_path = ["_extra"]
 htmlhelp_basename = "Kornia"
 html_css_files = ["css/main.css"]
 html_js_files = ["js/custom.js"]
+
+
+# Configure viewcode extension.
+code_url = "https://github.com/kornia/kornia/blob/main"
+
+
+def linkcode_resolve(domain, info):
+    # Non-linkable objects from the starter kit in the tutorial.
+    if domain == "js" or info["module"] == "connect4":
+        return
+
+    assert domain == "py", "expected only Python objects"
+
+    mod = importlib.import_module(info["module"])
+    if "." in info["fullname"]:
+        objname, attrname = info["fullname"].split(".")
+        obj = getattr(mod, objname)
+        try:
+            # object is a method of a class
+            obj = getattr(obj, attrname)
+        except AttributeError:
+            # object is an attribute of a class
+            return None
+    else:
+        obj = getattr(mod, info["fullname"])
+
+    obj = inspect.unwrap(obj)
+
+    try:
+        file = inspect.getsourcefile(obj)
+        lines = inspect.getsourcelines(obj)
+    except TypeError:
+        # e.g. object is a typing.Union
+        return None
+    file = os.path.relpath(file, os.path.abspath(".."))
+    if not file.startswith("kornia/"):
+        # e.g. object is a typing.NewType
+        return None
+    start, end = lines[1], lines[1] + len(lines[0]) - 1
+
+    return f"{code_url}/{file}#L{start}-L{end}"
 
 
 # -- Options for LaTeX output ---------------------------------------------


### PR DESCRIPTION
#### Changes

This replaces the viewcode extension to use the linkcode extension.

Instead of showing the code on the docs, the `source` link will redirect to the github code.

Based on https://github.com/readthedocs/sphinx-autoapi/issues/202

I also believe that this should improve searches on the docs page, which sometimes returned pages containing the source code instead of the documentation.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
