### PR TITLE
Bump readthedocs python version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_autodoc_defaultargs",
     "sphinx_copybutton",
-    # "sphinx.ext.viewcode",
     "sphinx.ext.linkcode",
     "sphinx.ext.githubpages",
     "sphinxcontrib.bibtex",
@@ -164,6 +163,7 @@ html_js_files = ["js/custom.js"]
 
 
 # Configure viewcode extension.
+# based on https://github.com/readthedocs/sphinx-autoapi/issues/202
 code_url = "https://github.com/kornia/kornia/blob/main"
 
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
#### Changes
This updates the python version used to compile the docs on readthedocs. I realized that the PR #2727 modifications didn't work, and I got some errors/warnings in the documentation compilation that don't appear in the CI. Anyway, it makes more sense (for performance) to use the latest python to compile the documentation. Let's see if this makes the #2727 works too,

[![image](https://github.com/kornia/kornia/assets/20444345/a63204db-c99c-4789-a827-0b4c0f2f803d)](https://readthedocs.org/projects/kornia/builds/23106016/)

Also, address comments from linkcode pr (#2727) -- anyway, I tested it locally and looks working the `link to github` 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
