### PR TITLE
Feat/salt and pepper noise

### DIFF
--- a/kornia/augmentation/_2d/intensity/salt_pepper_noise.py
+++ b/kornia/augmentation/_2d/intensity/salt_pepper_noise.py
@@ -1,0 +1,131 @@
+from typing import Any, Dict, Optional, Tuple, Union
+
+import torch
+
+from kornia.augmentation import random_generator as rg
+from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
+from kornia.core import Tensor
+from kornia.core.check import KORNIA_CHECK
+
+
+class SaltAndPepperNoise(IntensityAugmentationBase2D):
+    """
+    Apply salt-and-pepper noise to the input image.
+
+    Args:
+        amount (float or Tuple[float, float]): Range of noise values to be added. Default is (0.01, 0.06).
+            The valid range is [0, 1], where 0 represents no noise and 1 represents full noise.
+        salt_vs_pepper (float or Tuple[float, float]): Range of salt vs. pepper ratio. Default is (0.4, 0.6).
+            The valid range is [0, 1], where 0 represents only pepper noise, 1 represents only salt noise,
+            and 0.5 represents an equal mix.
+        p (float): Probability of applying the transformation. Default is 0.5.
+        same_on_batch (bool): Apply the same transformation across the batch. Default is False.
+        keepdim (bool): Keep the same dimensions after transformation. Default is False.
+
+    Attributes:
+        _param_generator (PlainUniformGenerator): Parameter generator for random parameter generation.
+
+    Raises:
+        ValueError: If `salt_vs_pepper` or `amount` are not in the valid range.
+
+    Note:
+        The `amount` and `salt_vs_pepper` parameters control the intensity of the salt-and-pepper noise.
+        `amount` determines the range of noise values to be added, and `salt_vs_pepper` determines the
+        range of the salt vs. pepper ratio.
+
+    Example:
+        >>> transform = SaltAndPepperNoise(amount=(0.02, 0.1), salt_vs_pepper=(0.3, 0.7), p=0.8)
+        >>> noisy_image = transform(input_image)
+    """
+
+    def __init__(
+        self,
+        amount: Optional[Union[float, Tuple[float, float]]] = (0.01, 0.06),
+        salt_vs_pepper: Optional[Union[float, Tuple[float, float]]] = (0.4, 0.6),
+        p: float = 0.5,
+        same_on_batch: bool = False,
+        keepdim: bool = False,
+    ) -> None:
+        super().__init__(p=p, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim)
+
+        if isinstance(salt_vs_pepper, (int, float)):
+            salt_vs_pepper = (salt_vs_pepper, salt_vs_pepper)
+        else:
+            raise ValueError("salt_vs_pepper must be a tuple or a float")
+        KORNIA_CHECK(
+            all(0 <= el <= 1 for el in salt_vs_pepper),
+            "Salt vs pepper values must be between 0 and 1. Recommended value 0.5.",
+        )
+
+        if isinstance(amount, (int, float)):
+            amount = (amount, amount)
+        else:
+            raise ValueError("amount must be a tuple or a float")
+        KORNIA_CHECK(
+            all(0 <= el <= 1 for el in amount),
+            "amount of noise values must be between 0 and 1. Recommended values less than 0.2.",
+        )
+
+        self._param_generator = rg.PlainUniformGenerator(
+            (amount, "amount", None, None), (salt_vs_pepper, "salt_vs_pepper", None, None)
+        )
+
+    def _generate_params(self, input: Tensor) -> Tuple[Tensor, Tensor]:
+        """
+        Generate salt and pepper noise masks.
+
+        Args:
+            input (Tensor): Input tensor.
+
+        Returns:
+            Tuple of salt and pepper masks.
+        """
+        B, C, H, W = input.size()
+        _dev = input.device
+        mask_noise = torch.rand(B, 1, H, W, device=_dev) < self._params["amount"].view(B, 1, 1, 1).to(_dev)
+        mask_salt = torch.rand(B, 1, H, W, device=_dev) < self._params["salt_vs_pepper"].view(B, 1, 1, 1).to(_dev)
+        if C > 1:
+            mask_noise = mask_noise.repeat(1, C, 1, 1)
+            mask_salt = mask_salt.repeat(1, C, 1, 1)
+        mask_pepper = (~(~mask_salt & mask_noise)).float()
+        mask_salt = (mask_salt & mask_noise).float()
+        self._params["salt_and_pepper_noise"] = [mask_salt, mask_pepper]
+
+        return mask_salt, mask_pepper
+
+    def apply_transform(
+        self,
+        input: Tensor,
+        params: Dict[str, Tensor],
+        flags: Dict[str, Any],
+        transform: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Apply salt-and-pepper noise transformation to the input.
+
+        Args:
+            input (Tensor): Input tensor.
+            params (Dict[str, Tensor]): Transformation parameters.
+            flags (Dict[str, Any]): Transformation flags.
+            transform (Optional[Tensor]): Additional transformation.
+
+        Returns:
+            Tensor: Transformed input tensor.
+        """
+
+        # Create noisy image cloning input.
+        noisy_image = input.clone()
+
+        # Generate noisy masks or read from params.
+        if "salt_and_pepper_noise" in params:
+            mask_salt = params["salt_and_pepper_noise"][0]
+            mask_pepper = params["salt_and_pepper_noise"][1]
+        else:
+            mask_salt, mask_pepper = self._generate_params(input)
+            self._params["salt_and_pepper_noise"] = [mask_salt, mask_pepper]
+
+        # Apply add and multiply mask.
+        noisy_image += mask_salt
+        noisy_image *= mask_pepper
+
+        return torch.clamp(noisy_image, 0, 1)

--- a/kornia/augmentation/_2d/intensity/salt_pepper_noise.py
+++ b/kornia/augmentation/_2d/intensity/salt_pepper_noise.py
@@ -8,7 +8,7 @@ from kornia.core import Tensor
 from kornia.core.check import KORNIA_CHECK
 
 
-class SaltAndPepperNoise(IntensityAugmentationBase2D):
+class RandomSaltAndPepperNoise(IntensityAugmentationBase2D):
     """
     Apply salt-and-pepper noise to the input image.
 
@@ -34,7 +34,7 @@ class SaltAndPepperNoise(IntensityAugmentationBase2D):
         range of the salt vs. pepper ratio.
 
     Example:
-        >>> transform = SaltAndPepperNoise(amount=(0.02, 0.1), salt_vs_pepper=(0.3, 0.7), p=0.8)
+        >>> transform = RandomSaltAndPepperNoise(amount=(0.02, 0.1), salt_vs_pepper=(0.3, 0.7), p=1.0)
         >>> noisy_image = transform(input_image)
     """
 


### PR DESCRIPTION
#### Changes
Based on PR (https://github.com/kornia/kornia/pull/2612) and scikit-image implementation.
- Add random generator.
- Follow implementation of scikit image, but using element-wise operation (not indexing).

Fixes # (issue)
- same_on_batch: generate same parameter, but not same mask to apply. So is not same noise for all batch.

I created a alternative version using indexing (sk-image) and compare times with masking:
![image](https://github.com/kornia/kornia/assets/44602177/400e78e3-07cd-41e8-b70b-98694b139048)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
