### PR TITLE
Fixes `extract_tensor_patches` to work with partial patches cases

### DIFF
--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -1,5 +1,6 @@
-import math
+from math import ceil
 from typing import Optional, Tuple, Union, cast
+from warnings import warn
 
 import torch
 import torch.nn.functional as F
@@ -7,19 +8,45 @@ from torch.nn.modules.utils import _pair
 
 from kornia.core import Module, Tensor, pad
 
+FullPadType = Tuple[int, int, int, int]
+TuplePadType = Union[Tuple[int, int], FullPadType]
+PadType = Union[int, TuplePadType]
+
+
+def create_padding_tuple(padding: PadType, unpadding: bool = False) -> FullPadType:
+    padding = cast(TuplePadType, _pair(padding))
+
+    if len(padding) not in [2, 4]:
+        raise AssertionError(
+            f"{'Unpadding' if unpadding else 'Padding'} must be either an int, tuple of two ints or tuple of four ints"
+        )
+
+    if len(padding) == 2:
+        pad_vert = _pair(padding[0])
+        pad_horz = _pair(padding[1])
+    else:
+        pad_vert = padding[:2]
+        pad_horz = padding[2:]
+    padding = cast(FullPadType, pad_horz + pad_vert)
+
+    return padding
+
 
 def compute_padding(
-    original_size: Union[int, Tuple[int, int]], window_size: Union[int, Tuple[int, int]]
-) -> Tuple[int, int]:
+    original_size: Union[int, Tuple[int, int]],
+    window_size: Union[int, Tuple[int, int]],
+    stride: Optional[Union[int, Tuple[int, int]]] = None,
+) -> FullPadType:
     r"""Compute required padding to ensure chaining of :func:`extract_tensor_patches` and
     :func:`combine_tensor_patches` produces expected result.
 
     Args:
         original_size: the size of the original tensor.
         window_size: the size of the sliding window used while extracting patches.
+        stride: The stride of the sliding window. Optional: if not specified, window_size will be used.
 
     Return:
-        The required padding for `(vertical, horizontal)` as a tuple of 2 ints.
+        The required padding as a tuple of four ints: (top, bottom, left, right)
 
     Example:
         >>> image = torch.arange(12).view(1, 1, 4, 3)
@@ -32,22 +59,44 @@ def compute_padding(
                   [ 9, 10, 11]]]])
 
     .. note::
-        This function is supposed to be used in conjunction with :func:`extract_tensor_patches`
-        and :func:`combine_tensor_patches`.
+        This function will be implicitly used in :func:`extract_tensor_patches` and :func:`combine_tensor_patches` if
+        `allow_auto_(un)padding` is set to True.
     """
     original_size = cast(Tuple[int, int], _pair(original_size))
     window_size = cast(Tuple[int, int], _pair(window_size))
+    if stride is None:
+        stride = window_size
+    stride = cast(Tuple[int, int], _pair(stride))
 
-    if original_size[0] % window_size[0] != 0:
-        padh = math.ceil((window_size[0] - original_size[0] % window_size[0]) / 2)
+    remainder_vertical = (original_size[0] - window_size[0]) % stride[0]
+    remainder_horizontal = (original_size[1] - window_size[1]) % stride[1]
+    # it might be best to apply padding only to the far edges (right, bottom), so
+    # that fewer patches are affected by the padding.
+    # For now, just use the default padding
+    if remainder_vertical != 0:
+        vertical_padding = stride[0] - remainder_vertical
     else:
-        padh = 0
-    if original_size[1] % window_size[1] != 0:
-        padw = math.ceil((window_size[1] - original_size[1] % window_size[1]) / 2)
-    else:
-        padw = 0
+        vertical_padding = 0
 
-    return (padh, padw)
+    if remainder_horizontal != 0:
+        horizontal_padding = stride[1] - remainder_horizontal
+    else:
+        horizontal_padding = 0
+
+    if vertical_padding % 2 == 0:
+        top_padding = bottom_padding = vertical_padding // 2
+    else:
+        top_padding = vertical_padding // 2
+        bottom_padding = ceil(vertical_padding / 2)
+
+    if horizontal_padding % 2 == 0:
+        left_padding = right_padding = horizontal_padding // 2
+    else:
+        left_padding = horizontal_padding // 2
+        right_padding = ceil(horizontal_padding / 2)
+    # the new implementation with unfolding requires symmetric padding
+    padding = int(top_padding), int(bottom_padding), int(left_padding), int(right_padding)
+    return cast(FullPadType, padding)
 
 
 class ExtractTensorPatches(Module):
@@ -71,6 +120,8 @@ class ExtractTensorPatches(Module):
       regulates the overlapping between the extracted patches.
     * :attr:`padding` controls the amount of implicit zeros-paddings on both
       sizes at each dimension.
+    * :attr:`allow_auto_padding` allows automatic calculation of the padding required
+      to fit the window and stride into the image.
 
     The parameters :attr:`window_size`, :attr:`stride` and :attr:`padding` can
     be either:
@@ -80,10 +131,16 @@ class ExtractTensorPatches(Module):
         - a ``tuple`` of two ints -- in which case, the first `int` is used for
           the height dimension, and the second `int` for the width dimension.
 
+    :attr:`padding` can also be a ``tuple`` of four ints -- in which case, the
+    first two ints are for the height dimension while the last two ints are for
+    the width dimension.
+
     Args:
+        input: tensor image where to extract the patches with shape :math:`(B, C, H, W)`.
         window_size: the size of the sliding window and the output patch size.
         stride: stride of the sliding window.
         padding: Zero-padding added to both side of the input.
+        allow_auto_adding: whether to allow automatic padding if the window and stride do not fit into the image.
 
     Shape:
         - Input: :math:`(B, C, H, W)`
@@ -107,20 +164,28 @@ class ExtractTensorPatches(Module):
     def __init__(
         self,
         window_size: Union[int, Tuple[int, int]],
-        stride: Optional[Union[int, Tuple[int, int]]] = 1,
-        padding: Optional[Union[int, Tuple[int, int]]] = 0,
+        stride: Union[int, Tuple[int, int]] = 1,
+        padding: PadType = 0,
+        allow_auto_padding: bool = False,
     ) -> None:
         super().__init__()
-        self.window_size: Tuple[int, int] = _pair(window_size)
-        self.stride: Tuple[int, int] = _pair(stride)
-        self.padding: Tuple[int, int] = _pair(padding)
+        self.window_size: Union[int, Tuple[int, int]] = window_size
+        self.stride: Union[int, Tuple[int, int]] = stride
+        self.padding: PadType = padding
+        self.allow_auto_padding: bool = allow_auto_padding
 
     def forward(self, input: Tensor) -> Tensor:
-        return extract_tensor_patches(input, self.window_size, stride=self.stride, padding=self.padding)
+        return extract_tensor_patches(
+            input,
+            self.window_size,
+            stride=self.stride,
+            padding=self.padding,
+            allow_auto_padding=self.allow_auto_padding,
+        )
 
 
 class CombineTensorPatches(Module):
-    r"""Module that combine patches from tensors.
+    r"""Module that combines patches back into full tensors.
 
     In the simplest case, the output value of the operator with input size
     :math:`(B, N, C, H_{out}, W_{out})` is :math:`(B, C, H, W)`.
@@ -134,14 +199,19 @@ class CombineTensorPatches(Module):
         defined in the function signature.
         left-right and top-bottom order.
 
+
     * :attr:`original_size` is the size of the original image prior to
       extracting tensor patches and defines the shape of the output patch.
     * :attr:`window_size` is the size of the sliding window used while
       extracting tensor patches.
     * :attr:`stride` controls the stride to apply to the sliding window and
       regulates the overlapping between the extracted patches.
-    * :attr:`unpadding` is the amount of padding to be removed. This value
-      must be the same as padding used while extracting tensor patches.
+    * :attr:`unpadding` is the amount of padding to be removed. If specified,
+      this value must be the same as padding used while extracting tensor patches.
+    * :attr:`allow_auto_unpadding` allows automatic calculation of the padding required
+      to fit the window and stride into the image. This must be used if the
+      `allow_auto_padding` flag was used for extracting the patches.
+
 
     The parameters :attr:`original_size`, :attr:`window_size`, :attr:`stride`, and :attr:`unpadding` can
     be either:
@@ -151,12 +221,19 @@ class CombineTensorPatches(Module):
         - a ``tuple`` of two ints -- in which case, the first `int` is used for
           the height dimension, and the second `int` for the width dimension.
 
+    :attr:`unpadding` can also be a ``tuple`` of four ints -- in which case, the
+    first two ints are for the height dimension while the last two ints are for
+    the width dimension.
+
     Args:
-        patches: patched tensor.
-        original_size: the size of the original tensor and the output patch size.
-        window_size: the size of the sliding window used.
+        patches: patched tensor with shape :math:`(B, N, C, H_{out}, W_{out})`.
+        original_size: the size of the original tensor and the output size.
+        window_size: the size of the sliding window used while extracting patches.
         stride: stride of the sliding window.
         unpadding: remove the padding added to both side of the input.
+        allow_auto_unpadding: whether to allow automatic unpadding of the input
+            if the window and stride do not fit into the original_size.
+        eps: small value used to prevent division by zero.
 
     Shape:
         - Input: :math:`(B, N, C, H_{out}, W_{out})`
@@ -176,21 +253,41 @@ class CombineTensorPatches(Module):
 
     def __init__(
         self,
-        original_size: Union[int, Tuple[int, int]],
+        original_size: Tuple[int, int],
         window_size: Union[int, Tuple[int, int]],
-        stride: Union[int, Tuple[int, int]],
-        unpadding: Union[int, Tuple[int, int]] = 0,
+        stride: Optional[Union[int, Tuple[int, int]]] = None,
+        unpadding: PadType = 0,
+        allow_auto_unpadding: bool = False,
     ) -> None:
         super().__init__()
-        self.original_size: Tuple[int, int] = _pair(original_size)
-        self.window_size: Tuple[int, int] = _pair(window_size)
-        self.stride: Tuple[int, int] = _pair(stride)
-        self.unpadding: Tuple[int, int] = _pair(unpadding)
+        self.original_size: Tuple[int, int] = original_size
+        self.window_size: Union[int, Tuple[int, int]] = window_size
+        self.stride: Union[int, Tuple[int, int]] = stride if stride is not None else window_size
+        self.unpadding: PadType = unpadding
+        self.allow_auto_unpadding: bool = allow_auto_unpadding
 
     def forward(self, input: Tensor) -> Tensor:
         return combine_tensor_patches(
-            input, self.original_size, self.window_size, stride=self.stride, unpadding=self.unpadding
+            input,
+            self.original_size,
+            self.window_size,
+            stride=self.stride,
+            unpadding=self.unpadding,
+            allow_auto_unpadding=self.allow_auto_unpadding,
         )
+
+
+def _check_patch_fit(original_size: Tuple[int, int], window_size: Tuple[int, int], stride: Tuple[int, int]) -> bool:
+    remainder_vertical = (original_size[0] - window_size[0]) % stride[0]
+    remainder_horizontal = (original_size[1] - window_size[1]) % stride[1]
+    # the remainder takes into account half a window on each side,
+    # the rest of the image is divided based on the stride, not the window
+    # size
+    if (remainder_horizontal != 0) or (remainder_vertical != 0):
+        # needs padding to fit
+        return False
+    # we can fit a full number of patches in, based on the stride
+    return True
 
 
 def combine_tensor_patches(
@@ -198,7 +295,8 @@ def combine_tensor_patches(
     original_size: Union[int, Tuple[int, int]],
     window_size: Union[int, Tuple[int, int]],
     stride: Union[int, Tuple[int, int]],
-    unpadding: Union[int, Tuple[int, int]] = 0,
+    allow_auto_unpadding: bool = False,
+    unpadding: PadType = 0,
     eps: float = 1e-8,
 ) -> Tensor:
     r"""Restore input from patches.
@@ -207,10 +305,13 @@ def combine_tensor_patches(
 
     Args:
         patches: patched tensor with shape :math:`(B, N, C, H_{out}, W_{out})`.
-        original_size: the size of the original tensor and the output patch size.
+        original_size: the size of the original tensor and the output size.
         window_size: the size of the sliding window used while extracting patches.
         stride: stride of the sliding window.
         unpadding: remove the padding added to both side of the input.
+        allow_auto_unpadding: whether to allow automatic unpadding of the input
+            if the window and stride do not fit into the original_size.
+        eps: small value used to prevent division by zero.
 
     Return:
         The combined patches in an image tensor with shape :math:`(B, C, H, W)`.
@@ -233,10 +334,32 @@ def combine_tensor_patches(
     original_size = cast(Tuple[int, int], _pair(original_size))
     window_size = cast(Tuple[int, int], _pair(window_size))
     stride = cast(Tuple[int, int], _pair(stride))
-    unpadding = cast(Tuple[int, int], _pair(unpadding))
 
-    if len(unpadding) != 2:
-        raise AssertionError("Unpadding must be either an int or a tuple of two ints")
+    if (stride[0] > window_size[0]) | (stride[1] > window_size[1]):
+        raise AssertionError(
+            f"Stride={stride} should be less than or equal to Window size={window_size}, information is missing"
+        )
+
+    if not unpadding:
+        # if padding is specified, we leave it up to the user to ensure it fits
+        # otherwise we check here if it will fit and offer to calculate padding
+        if not _check_patch_fit(original_size, window_size, stride):
+            if not allow_auto_unpadding:
+                warn(
+                    f"The window will not fit into the image. \nWindow size: {window_size}\nStride: {stride}\n"
+                    f"Image size: {original_size}\n"
+                    "This means we probably cannot correctly recombine patches. By enabling `allow_auto_unpadding`, "
+                    "the input will be unpadded to fit the window and stride.\n"
+                    "If the patches have been obtained through `extract_tensor_patches` with the correct padding or "
+                    "the argument `allow_auto_padding`, this will result in a correct reconstruction."
+                )
+            else:
+                unpadding = compute_padding(original_size=original_size, window_size=window_size, stride=stride)
+                # TODO: Can't we just do actual size minus original size to get padding?
+
+    if unpadding:
+        unpadding = create_padding_tuple(unpadding)
+        unpadding = cast(FullPadType, unpadding)
 
     ones = torch.ones(
         patches.shape[0],
@@ -246,6 +369,11 @@ def combine_tensor_patches(
         device=patches.device,
         dtype=patches.dtype,
     )
+
+    if unpadding:
+        ones = pad(ones, pad=unpadding)  # type: ignore
+    restored_size = ones.shape[2:]
+
     patches = patches.permute(0, 2, 3, 4, 1)
     patches = patches.reshape(patches.shape[0], -1, patches.shape[-1])
     int_flag = 0
@@ -256,15 +384,15 @@ def combine_tensor_patches(
         ones = ones.float()
 
     # Calculate normalization map
-    unfold_ones = F.unfold(ones, kernel_size=window_size, stride=stride, padding=unpadding)
-    norm_map = F.fold(
-        input=unfold_ones, output_size=original_size, kernel_size=window_size, stride=stride, padding=unpadding
-    )
+    unfold_ones = F.unfold(ones, kernel_size=window_size, stride=stride)
+    norm_map = F.fold(input=unfold_ones, output_size=restored_size, kernel_size=window_size, stride=stride)
+    if unpadding:
+        norm_map = pad(norm_map, [-i for i in unpadding])  # type: ignore
 
     # Restored tensor
-    saturated_restored_tensor = F.fold(
-        input=patches, output_size=original_size, kernel_size=window_size, stride=stride, padding=unpadding
-    )
+    saturated_restored_tensor = F.fold(input=patches, output_size=restored_size, kernel_size=window_size, stride=stride)
+    if unpadding:
+        saturated_restored_tensor = pad(saturated_restored_tensor, [-i for i in unpadding])  # type: ignore
 
     # Remove satuation effect due to multiple summations
     restored_tensor = saturated_restored_tensor / (norm_map + eps)
@@ -286,9 +414,10 @@ def extract_tensor_patches(
     input: Tensor,
     window_size: Union[int, Tuple[int, int]],
     stride: Union[int, Tuple[int, int]] = 1,
-    padding: Union[int, Tuple[int, int]] = 0,
+    padding: PadType = 0,
+    allow_auto_padding: bool = False,
 ) -> Tensor:
-    r"""Function that extract patches from tensors and stack them.
+    r"""Function that extract patches from tensors and stacks them.
 
     See :class:`~kornia.contrib.ExtractTensorPatches` for details.
 
@@ -297,6 +426,7 @@ def extract_tensor_patches(
         window_size: the size of the sliding window and the output patch size.
         stride: stride of the sliding window.
         padding: Zero-padding added to both side of the input.
+        allow_auto_adding: whether to allow automatic padding if the window and stride do not fit into the image.
 
     Returns:
         the tensor with the extracted patches with shape :math:`(B, N, C, H_{out}, W_{out})`.
@@ -318,21 +448,28 @@ def extract_tensor_patches(
     if len(input.shape) != 4:
         raise ValueError(f"Invalid input shape, we expect BxCxHxW. Got: {input.shape}")
 
+    # check if the window sliding over the image will fit into the image
+    # torch's unfold drops the final patches that don't fit
     window_size = cast(Tuple[int, int], _pair(window_size))
     stride = cast(Tuple[int, int], _pair(stride))
+    original_size = (input.shape[-2], input.shape[-1])
 
-    if (stride[0] > window_size[0]) | (stride[1] > window_size[1]):
-        raise AssertionError(f"Stride={stride} should be less than or equal to Window size={window_size}")
+    if not padding:
+        # if padding is specified, we leave it up to the user to ensure it fits
+        # otherwise we check here if it will fit and offer to calculate padding
+        if not _check_patch_fit(original_size, window_size, stride):
+            if not allow_auto_padding:
+                warn(
+                    f"The window will not fit into the image. \nWindow size: {window_size}\nStride: {stride}\n"
+                    f"Image size: {original_size}\n"
+                    "This means that the final incomplete patches will be dropped. By enabling `allow_auto_padding`, "
+                    "the input will be padded to fit the window and stride."
+                )
+            else:
+                padding = compute_padding(original_size=original_size, window_size=window_size, stride=stride)
 
     if padding:
-        padding = cast(Tuple[int, int], _pair(padding))
-
-        if len(padding) != 2:
-            raise AssertionError("Padding must be either an int or a tuple of two ints")
-
-        pad_vert = _pair(padding[0])
-        pad_horz = _pair(padding[1])
-        padding4 = cast(Tuple[int, int, int, int], pad_horz + pad_vert)
-        input = pad(input, padding4)
+        padding = create_padding_tuple(padding)
+        input = pad(input, padding)
 
     return _extract_tensor_patchesnd(input, window_size, stride)


### PR DESCRIPTION
#### Changes
This PR put the changes from #2657 by @DanielNobbe into a single commit based on the main branch

fix #2655

from #2657 (by @DanielNobbe):
> Fixes https://github.com/kornia/kornia/issues/2655: By default, the folding method used inside extract_tensor_patches drops any remainders, i.e. any parts of the image that would result in a partial patch. This has the additional downside that if no padding was specified, the combine_tensor_patches function could no longer reconstruct the image, since the original_size is no longer correct. This PR fixes this by adding an option to automatically add patching to extract_tensor_patches, and automatically remove padding through the same calculations in combine_tensor_patches.
Calculating if the current image fits into the stride and window size uses the assumption that there needs to be an integer amount of strides within the image width/height minus one window size (half a window size to the 'left' of the first patch center, and half a window size to the 'right' of the last patch center).

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
