### PR TITLE
[SAM] document the image (tensor) should be scaled between [0,1]

### DIFF
--- a/docs/source/models/segment_anything.rst
+++ b/docs/source/models/segment_anything.rst
@@ -57,8 +57,8 @@ About the :code:`VisualPrompter`:
    augmentations. Where we use the :class:`kornia.geometry.augmentation.AugmentationSequential` to handle with the different
    data formats (keypoints, boxes, masks, image).
 
-#. When you use :code:`prompter.set_image(...)`, the prompter will preprocess this image, and then pass it to the encoder,
-   and cache the embeddings to query it after.
+#. When you use :code:`prompter.set_image(...)`, the prompter will preprocess this image, then pass it to the encoder,
+   and cache the embeddings to query it after. Note that the image should be scaled within the range [0,1].
 
     * The preprocess steps are: 1) Resize the image to have its longer side the same size as :code:`image_encoder` image size
       input. 2) Cache the information of this transformation to apply into the prompts. 3) normalize the image based on the


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Per https://github.com/kornia/kornia/discussions/2711, update the documentation to note that the image (tensor) should be scaled between [0,1]. The docs for [VisualPrompter.set_image](https://github.com/kornia/kornia/blob/v0.7.1/kornia/contrib/visual_prompter.py#L109) already note this.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
