### PR TITLE
remove retrigger CI on PR's when labeled

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -5,7 +5,7 @@ on:
     branches: [test-me-*]
   pull_request:
     branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review, labeled]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This was introduced back when we just had dynamo feature (torch compile) under the nightly torch version. At the moment it's just retriggering the CI for nothing when we add labels to a PR