### PR TITLE
remove typing report

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -25,7 +25,7 @@ jobs:
           - os: 'MacOS-latest'
             pytorch-dtype: 'float64'
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.11"]'
@@ -33,16 +33,16 @@ jobs:
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.4.0
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.4.0
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.4.0
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.4.0
 
   collector:
     needs: [coverage, tests-cpu, tutorials, typing, docs]
@@ -63,7 +63,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest'] #, 'MacOS-latest'] add it when https://github.com/pytorch/pytorch/pull/89262 be merged
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
     with:
       os: ${{ matrix.os }}
       pytorch-version: '["nightly"]'

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -18,7 +18,7 @@ jobs:
         # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.8", "3.9", "3.10", "3.11"]'
@@ -34,7 +34,7 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
     with:
       os: 'Windows-latest'
       python-version: '["3.11"]'
@@ -47,19 +47,19 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
     with:
       os: 'MacOS-latest'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.4.0
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.4.0
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.4.0
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.3.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.4.0

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage
 kornia-rs==0.0.8
-mypy[reports]
+mypy
 numpy
 onnx
 pre-commit>=2


### PR DESCRIPTION
For a while we haven't using the mypy reporting (XML generated and uploaded to codecov), these patches update to remove this extra dep and also update the workflows -- https://github.com/kornia/workflows/pull/8