### PR TITLE
skip unsupported tests cases for torch==1.9.1

### DIFF
--- a/tests/contrib/models/test_efficient_vit.py
+++ b/tests/contrib/models/test_efficient_vit.py
@@ -48,6 +48,7 @@ class TestEfficientViT:
 
         assert model_path.is_file()
 
+    @pytest.mark.slow
     def test_load_pretrained(self, device, dtype):
         model = EfficientViT.from_config(EfficientViTConfig())
         model = model.to(device=device, dtype=dtype)

--- a/tests/feature/test_lightglue_onnx.py
+++ b/tests/feature/test_lightglue_onnx.py
@@ -3,6 +3,7 @@ import torch
 
 from kornia.feature import OnnxLightGlue
 from kornia.feature.lightglue_onnx.utils import normalize_keypoints
+from kornia.utils._compat import torch_version_le
 
 try:
     import onnxruntime as ort
@@ -11,6 +12,7 @@ except ImportError:
 
 
 @pytest.mark.skipif(ort is None, reason="OnnxLightGlue requires onnxruntime-gpu")
+@pytest.mark.skipif(torch_version_le(1, 9, 1), reason="Needs dlpack")
 class TestOnnxLightGlue:
     @pytest.mark.slow
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires CUDA")

--- a/tests/feature/test_matching.py
+++ b/tests/feature/test_matching.py
@@ -13,6 +13,7 @@ from kornia.feature.matching import (
     match_smnn,
     match_snn,
 )
+from kornia.utils._compat import torch_version_le
 
 from testing.base import BaseTester
 from testing.casts import dict_to
@@ -448,6 +449,7 @@ class TestAdalam(BaseTester):
 
 class TestLightGlueDISK(BaseTester):
     @pytest.mark.slow
+    @pytest.mark.skipif(torch_version_le(1, 9, 1), reason="Needs autocast")
     @pytest.mark.parametrize("data", ["lightglue_idxs"], indirect=True)
     def test_real(self, device, dtype, data):
         torch.random.manual_seed(0)


### PR DESCRIPTION
We have some failing tests on the main, this patch skipped these tests because the features didn't support the 1.9.1 

- OnnxLightGlue: needs dlpack available on torch
- LightGlueDISK: needs autocast available on torch