### PR TITLE
Ensure support to `torch==2.2.0`

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -25,7 +25,7 @@ jobs:
           - os: 'MacOS-latest'
             pytorch-dtype: 'float64'
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.2
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.11"]'
@@ -33,16 +33,16 @@ jobs:
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.5.2
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.5.2
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.5.2
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.5.2
 
   collector:
     needs: [coverage, tests-cpu, tutorials, typing, docs]
@@ -63,7 +63,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest'] #, 'MacOS-latest'] add it when https://github.com/pytorch/pytorch/pull/89262 be merged
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.2
     with:
       os: ${{ matrix.os }}
       pytorch-version: '["nightly"]'

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -25,24 +25,24 @@ jobs:
           - os: 'MacOS-latest'
             pytorch-dtype: 'float64'
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.11"]'
-      pytorch-version: '["1.9.1", "2.1.2"]'
+      pytorch-version: '["1.9.1", "2.2.0"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.5.0
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.5.0
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.5.0
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.5.0
 
   collector:
     needs: [coverage, tests-cpu, tutorials, typing, docs]
@@ -63,7 +63,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest'] #, 'MacOS-latest'] add it when https://github.com/pytorch/pytorch/pull/89262 be merged
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
     with:
       os: ${{ matrix.os }}
       pytorch-version: '["nightly"]'

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -18,7 +18,7 @@ jobs:
         # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.2
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.8", "3.9", "3.10", "3.11"]'
@@ -34,7 +34,7 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.2
     with:
       os: 'Windows-latest'
       python-version: '["3.11"]'
@@ -47,19 +47,19 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.2
     with:
       os: 'MacOS-latest'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.5.2
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.5.2
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.5.2
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.5.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.5.2

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -18,11 +18,11 @@ jobs:
         # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.8", "3.9", "3.10", "3.11"]'
-      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2"]'
+      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.0"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       pytest-extra: '--runslow'
 
@@ -34,11 +34,11 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
     with:
       os: 'Windows-latest'
       python-version: '["3.11"]'
-      pytorch-version: '["1.9.1", "2.1.2"]'
+      pytorch-version: '["1.9.1", "2.2.0"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   tests-cpu-mac:
@@ -47,19 +47,19 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.5.0
     with:
       os: 'MacOS-latest'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.5.0
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.5.0
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.5.0
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.4.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.5.0

--- a/kornia/contrib/models/rt_detr/architecture/hybrid_encoder.py
+++ b/kornia/contrib/models/rt_detr/architecture/hybrid_encoder.py
@@ -34,6 +34,9 @@ class RepVggBlock(Module):
     @torch.no_grad()
     def optimize_for_deployment(self) -> None:
         def _fuse_conv_bn_weights(m: ConvNormAct) -> tuple[nn.Parameter, nn.Parameter]:
+            if m.norm.running_mean is None or m.norm.running_var is None:
+                raise ValueError
+
             return fuse_conv_bn_weights(
                 m.conv.weight,
                 m.conv.bias,


### PR DESCRIPTION
Ensure support to [torch 2.2.0](https://github.com/pytorch/pytorch/releases/tag/v2.2.0)

- [x] [Bump workflows version with new default pytorch ](https://github.com/kornia/workflows/pull/10)
- [x] Fix falling tests and report regressions to pytorch team
  - [x] typing: issue with `ConvNormAct.norm.mean` and `ConvNormAct.norm.running_var` can be None, but the `torch.nn.utils.fusion.fuse_conv_bn_weights` didn't support None.