### PR TITLE
CI: Add PR benchmark

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   benchmark_cpu:
     name: CPU Pytest benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: kornia/workflows/.github/actions/env@v1.5.3
@@ -25,6 +25,8 @@ jobs:
 
     - name: Setup benchmarks
       run: |
+        echo "BASE_SHA=$(echo ${{ github.event.pull_request.base.sha }} | cut -c1-8)" >> $GITHUB_ENV
+        echo "HEAD_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-8)" >> $GITHUB_ENV
         echo "HEAD_JSON=$(mktemp)" >> $GITHUB_ENV
         echo "BASE_JSON=$(mktemp)" >> $GITHUB_ENV
         echo "PR_COMMENT=$(mktemp)" >>  $GITHUB_ENV
@@ -36,9 +38,9 @@ jobs:
       run: |
         cd benchmarks/
         git checkout ${{ github.event.pull_request.base.sha }}
-        pytest -vvv --benchmark-json ${{ env.BASE_JSON }}
+        pytest ./ -vvv --benchmark-json ${{ env.BASE_JSON }}
         git checkout ${{ github.sha }}
-        pytest -vvv --benchmark-json ${{ env.HEAD_JSON }}
+        pytest ./ -vvv --benchmark-json ${{ env.HEAD_JSON }}
 
     - name: Comment results
       uses: apbard/pytest-benchmark-commenter@v3

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -28,7 +28,6 @@ jobs:
         echo "HEAD_JSON=$(mktemp)" >> $GITHUB_ENV
         echo "BASE_JSON=$(mktemp)" >> $GITHUB_ENV
         echo "PR_COMMENT=$(mktemp)" >>  $GITHUB_ENV
-        echo "RUN_BENCHMARK='pytest -vvv --benchmark-json '" >>  $GITHUB_ENV
 
     - name: Install benchmark requirements
       run: pip install -r requirements/requirements-benchmarks.txt
@@ -37,9 +36,9 @@ jobs:
       run: |
         cd benchmarks/
         git checkout ${{ github.event.pull_request.base.sha }}
-        ${{ env.RUN_BENCHMARK }} ${{ env.BASE_JSON }}
+        pytest -vvv --benchmark-json ${{ env.BASE_JSON }}
         git checkout ${{ github.sha }}
-        ${{ env.RUN_BENCHMARK }} ${{ env.HEAD_JSON }}
+        pytest -vvv --benchmark-json ${{ env.HEAD_JSON }}
 
     - name: Comment results
       uses: apbard/pytest-benchmark-commenter@v3

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -1,0 +1,54 @@
+name: Benchmark (PR)
+
+on:
+  push:
+    branches: [test-me-*]
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  benchmark_cpu:
+    name: CPU Pytest benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: kornia/workflows/.github/actions/env@v1.5.3
+      with:
+        fetch-depth: 25 # this is to make sure we obtain the target base commit
+
+    - name: Setup benchmarks
+      run: |
+        echo "HEAD_JSON=$(mktemp)" >> $GITHUB_ENV
+        echo "BASE_JSON=$(mktemp)" >> $GITHUB_ENV
+        echo "PR_COMMENT=$(mktemp)" >>  $GITHUB_ENV
+        echo "RUN_BENCHMARK='pytest -vvv --benchmark-json '" >>  $GITHUB_ENV
+
+    - name: Install benchmark requirements
+      run: pip install -r requirements/requirements-benchmarks.txt
+
+    - name: Run benchmarks
+      run: |
+        cd benchmarks/
+        git checkout ${{ github.event.pull_request.base.sha }}
+        ${{ env.RUN_BENCHMARK }} ${{ env.BASE_JSON }}
+        git checkout ${{ github.sha }}
+        ${{ env.RUN_BENCHMARK }} ${{ env.HEAD_JSON }}
+
+    - name: Comment results
+      uses: apbard/pytest-benchmark-commenter@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        benchmark-file: ${{ env.HEAD_JSON }}
+        comparison-benchmark-file: ${{ env.BASE_JSON }}
+        benchmark-metrics: 'name,max,mean,ops'
+        comparison-benchmark-metric: 'ops'
+        comparison-higher-is-better: true
+        comparison-threshold: 5
+        benchmark-title: 'Result of CPU Benchmark Tests'

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -15,8 +15,12 @@ concurrency:
 
 jobs:
   benchmark_cpu:
+    # NOTE: from https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#stability-of-virtual-environment
+    #As far as watching the benchmark results of examples in this repository, the amplitude of the benchmarks
+    #is about +- 10~20%. If your benchmarks use some resources such as networks or file I/O, the amplitude
+    #might be bigger.
     name: CPU Pytest benchmark
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: kornia/workflows/.github/actions/env@v1.5.3
@@ -25,8 +29,6 @@ jobs:
 
     - name: Setup benchmarks
       run: |
-        echo "BASE_SHA=$(echo ${{ github.event.pull_request.base.sha }} | cut -c1-8)" >> $GITHUB_ENV
-        echo "HEAD_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-8)" >> $GITHUB_ENV
         echo "HEAD_JSON=$(mktemp)" >> $GITHUB_ENV
         echo "BASE_JSON=$(mktemp)" >> $GITHUB_ENV
         echo "PR_COMMENT=$(mktemp)" >>  $GITHUB_ENV
@@ -34,22 +36,33 @@ jobs:
     - name: Install benchmark requirements
       run: pip install -r requirements/requirements-benchmarks.txt
 
-    - name: Run benchmarks
+    - name: Run benchmarks BASE
+      # TODO: Save it using actions/cache then we don't need to regenerate it.
+      # By caching the result, it will also use the same information across PR's
       run: |
         cd benchmarks/
         git checkout ${{ github.event.pull_request.base.sha }}
         pytest ./ -vvv --benchmark-json ${{ env.BASE_JSON }}
+
+    - name: Run benchmarks HEAD
+      run: |
+        cd benchmarks/
         git checkout ${{ github.sha }}
         pytest ./ -vvv --benchmark-json ${{ env.HEAD_JSON }}
 
-    - name: Comment results
-      uses: apbard/pytest-benchmark-commenter@v3
+    - name: Comment benchmark result
+      uses: benchmark-action/github-action-benchmark@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        benchmark-file: ${{ env.HEAD_JSON }}
-        comparison-benchmark-file: ${{ env.BASE_JSON }}
-        benchmark-metrics: 'name,max,mean,ops'
-        comparison-benchmark-metric: 'ops'
-        comparison-higher-is-better: true
-        comparison-threshold: 5
-        benchmark-title: 'Result of CPU Benchmark Tests'
+        tool: "pytest"
+        ref: ${{ github.sha }}
+        output-file-path: ${{ env.HEAD_JSON }}
+        external-data-json-path: ${{ env.BASE_JSON }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        comment-always: true
+        comment-on-alert: true
+        fail-on-alert: true
+        summary-always: true
+        skip-fetch-gh-pages: true
+        auto-push: false
+        save-data-file: false
+        # alert-comment-cc-users: '@johnnv1 @edgarriba'


### PR DESCRIPTION
Introduces a CI for benchmarking (https://github.com/kornia/kornia/pull/2777) on PRs, and  comparing its base (main branch) against the HEAD (PR last commit)

Should be fine to go after I add `fetch-depth` on kornia/workflows env and release the 1.5.3. Plus the #2777 should go first