### PR TITLE
[test suite] add slow marker vit

### DIFF
--- a/tests/contrib/models/test_efficient_vit.py
+++ b/tests/contrib/models/test_efficient_vit.py
@@ -23,7 +23,13 @@ class TestEfficientViT:
         assert "stage_final" in out
         assert out["stage_final"].shape[-2:] == torch.Size([expected_resolution, expected_resolution])
 
-    @pytest.mark.parametrize("model_name", ["b0", "b1", "b2", "b3"])
+    @pytest.mark.parametrize("model_name", ["b3"])
+    @pytest.mark.parametrize("img_size,expected_resolution", [(224, 7), (256, 8), (288, 9)])
+    @pytest.mark.slow
+    def test_smoke_slow(self, device, dtype, img_size: int, expected_resolution: int, model_name: str):
+        self._test_smoke(device, dtype, img_size, expected_resolution, model_name)
+
+    @pytest.mark.parametrize("model_name", ["b0", "b1", "b2"])
     @pytest.mark.parametrize("img_size,expected_resolution", [(224, 7), (256, 8), (288, 9)])
     def test_smoke(self, device, dtype, img_size: int, expected_resolution: int, model_name: str):
         self._test_smoke(device, dtype, img_size, expected_resolution, model_name)


### PR DESCRIPTION
This test just failed on the main CI 
![image](https://github.com/kornia/kornia/assets/20444345/a3d0a85f-a378-430c-8722-cb525b8c50a1)


------

I think we should somehow first download/cache all the weights that are downloaded on tests, then start the test suite