### PR TITLE
Fix `ruff 0.2.1` config 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: pyproject-fmt
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.0
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,13 +77,15 @@ requires = [
 [tool.ruff]
   line-length = 120
   target-version = "py38"
+
+  [tool.ruff.lint]
   select = [
     "AIR",    # Airflow
     "ASYNC",  # flake8-async
     "BLE",    # flake8-blind-except
     "C4",     # flake8-comprehensions
     "C90",    # McCabe cyclomatic complexity
-    "CPY",    # Copyright-related rules
+    # "CPY",    # Copyright-related rules
     "DTZ",    # flake8-datetimez
     "E",      # pycodestyle
     "F",      # Pyflakes
@@ -141,26 +143,22 @@ requires = [
     "UP007", # Prefer Optional[], Union[] over | due to torch jit scripting
   ]
 
-  [tool.ruff.format]
-    skip-magic-trailing-comma = false
-
-  [tool.ruff.isort]
+  [tool.ruff.lint.isort]
     known-first-party = ["kornia"]
     split-on-trailing-comma = true
     forced-separate = ["testing", "tests"]
 
-
-  [tool.ruff.mccabe]
+  [tool.ruff.lint.mccabe]
     max-complexity = 20
 
-  [tool.ruff.pylint]
+  [tool.ruff.lint.pylint]
     allow-magic-value-types = ["bytes", "float", "int", "str"]
     max-args = 17  # Recommended: 5
     max-branches = 21  # Recommended: 12
     max-returns = 13  # Recommended: 6
     max-statements = 64  # Recommended: 50
 
-  [tool.ruff.per-file-ignores]
+  [tool.ruff.lint.per-file-ignores]
     "*/__init__.py" = ["F401", "F403"] # Allow unused imports and star imports
     "docs/*" = ["S101", "PLR0912", "PLR0915"] # allow assert, ignore max branches and statements
     "docs/generate_examples.py" = ["C901"] # Allow too complex function
@@ -168,6 +166,9 @@ requires = [
     "tests/*" = ["S101", "S311", "BLE", "RUF012", "RUF005"] # allow assert, random, ignore BLE, mutable class attr
     "benchmarks/*" = ["S101", "S311", "BLE", "RUF012", "RUF005"] # allow assert, random, ignore BLE, mutable class attr
     "testing/*" = ["S101",] # allow assert
+
+  [tool.ruff.format]
+    skip-magic-trailing-comma = false
 
 [tool.pytest.ini_options]
   addopts = "--color=yes"


### PR DESCRIPTION
Based on the deprecations from https://github.com/astral-sh/ruff/releases/tag/v0.2.0