### PR TITLE
ViT: Load Jax augreg weights

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -174,6 +174,7 @@ Image Classification
 --------------------
 
 .. autoclass:: VisionTransformer
+    :members:
 .. autoclass:: MobileViT
 .. autoclass:: TinyViT
     :members:

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -311,15 +311,16 @@ class VisionTransformer(Module):
         model_type, patch_size_str = variant.split("/")
         patch_size = int(patch_size_str)
 
-        _kwargs = {
+        model_config = {
             "vit_ti": {"embed_dim": 192, "depth": 12, "num_heads": 3},
             "vit_s": {"embed_dim": 384, "depth": 12, "num_heads": 6},
             "vit_b": {"embed_dim": 768, "depth": 12, "num_heads": 12},
             "vit_l": {"embed_dim": 1024, "depth": 24, "num_heads": 16},
             "vit_h": {"embed_dim": 1280, "depth": 32, "num_heads": 16},
         }[model_type]
+        kwargs.update(model_config, patch_size=patch_size)
 
-        model = VisionTransformer(patch_size=patch_size, **_kwargs, **kwargs)
+        model = VisionTransformer(**kwargs)
 
         if pretrained:
             KORNIA_CHECK(variant in _checkpoint_dict, f"Variant {variant} does not have pre-trained checkpoint")

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -281,6 +281,7 @@ class VisionTransformer(Module):
 
 _AVAILABLE_WEIGHTS = ["vit_l/16", "vit_b/16", "vit_s/16", "vit_ti/16", "vit_b/32", "vit_s/32"]
 
+
 def _get_weight_url(variant: str) -> str:
     """Return the URL of the model weights."""
     KORNIA_CHECK(variant in _AVAILABLE_WEIGHTS, f"Variant {variant} does not have pre-trained checkpoint")

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -301,7 +301,7 @@ class VisionTransformer(Module):
             block[1].fn[1][0].bias.copy_(_get(prefix + "MlpBlock_3/Dense_0/bias"))
             block[1].fn[1][3].weight.copy_(_get(prefix + "MlpBlock_3/Dense_1/kernel").T)
             block[1].fn[1][3].bias.copy_(_get(prefix + "MlpBlock_3/Dense_1/bias"))
-        
+
         self.norm.weight.copy_(_get("Transformer/encoder_norm/scale"))
         self.norm.bias.copy_(_get("Transformer/encoder_norm/bias"))
 

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -247,12 +247,14 @@ class VisionTransformer(Module):
         The weights are hosted on HuggingFace's model hub: https://huggingface.co/kornia.
 
         .. note::
-            The available weights are: ``vit_l/16``, ``vit_b/16``, ``vit_s/16``, ``vit_ti/16``, ``vit_b/32``, ``vit_s/32``.
+            The available weights are: ``vit_l/16``, ``vit_b/16``, ``vit_s/16``, ``vit_ti/16``,
+            ``vit_b/32``, ``vit_s/32``.
 
         Args:
             variant: ViT model variant e.g. ``vit_b/16``.
             pretrained: whether to load pre-trained AugReg weights.
-            kwargs: other keyword arguments that will be passed to :func:`kornia.contrib.vit.VisionTransformer.__init__`.
+            kwargs: other keyword arguments that will be passed to
+                :func:`kornia.contrib.vit.VisionTransformer.__init__`.
         Returns:
             The respective ViT model
 

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -242,15 +242,15 @@ class VisionTransformer(Module):
 
     @staticmethod
     def from_config(variant: str, pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
-        """Build ViT model based on the given config string. The format is `vit_{size}/{patch_size}`.
-        E.g. `vit_b/16` means ViT-Base, patch size 16x16. If `pretrained=True`, AugReg weights are loaded.
+        """Build ViT model based on the given config string. The format is ``vit_{size}/{patch_size}``.
+        E.g. ``vit_b/16`` means ViT-Base, patch size 16x16. If ``pretrained=True``, AugReg weights are loaded.
         The weights are hosted on HuggingFace's model hub: https://huggingface.co/kornia.
 
         .. note::
-            The available weights are: "vit_l/16", "vit_b/16", "vit_s/16", "vit_ti/16", "vit_b/32", "vit_s/32"
+            The available weights are: ``vit_l/16``, ``vit_b/16``, ``vit_s/16``, ``vit_ti/16``, ``vit_b/32``, ``vit_s/32``.
 
         Args:
-            variant: ViT model variant e.g. `vit_b/16`.
+            variant: ViT model variant e.g. ``vit_b/16``.
             pretrained: whether to load pre-trained AugReg weights.
             kwargs: other keyword arguments that will be passed to :func:`kornia.contrib.vit.VisionTransformer.__init__`.
         Returns:

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -253,8 +253,7 @@ class VisionTransformer(Module):
         Args:
             variant: ViT model variant e.g. ``vit_b/16``.
             pretrained: whether to load pre-trained AugReg weights.
-            kwargs: other keyword arguments that will be passed to
-                :func:`kornia.contrib.vit.VisionTransformer.__init__`.
+            kwargs: other keyword arguments that will be passed to :func:`kornia.contrib.vit.VisionTransformer`.
         Returns:
             The respective ViT model
 

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -308,8 +308,8 @@ class VisionTransformer(Module):
 
     @staticmethod
     def from_config(variant: str, pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
-        model_type, patch_size = variant.split("/")
-        patch_size = int(patch_size)
+        model_type, patch_size_str = variant.split("/")
+        patch_size = int(patch_size_str)
 
         _kwargs = {
             "vit_ti": {"embed_dim": 192, "depth": 12, "num_heads": 3},

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -94,7 +94,7 @@ class TransformerEncoderBlock(nn.Sequential):
             ResidualAdd(
                 nn.Sequential(
                     nn.LayerNorm(embed_dim),
-                    FeedForward(embed_dim, embed_dim, embed_dim, dropout_rate=dropout_rate),
+                    FeedForward(embed_dim, embed_dim * 4, embed_dim, dropout_rate=dropout_rate),
                     nn.Dropout(dropout_rate),
                 )
             ),

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -308,8 +308,8 @@ class VisionTransformer(Module):
 
     @staticmethod
     def from_config(variant: str, pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
-        """Build ViT model based on the given config string. The format is `vit_{size}/{patch_size}`.
-        E.g. vit_b/16 means ViT-Base, patch size 16x16.
+        """Build ViT model based on the given config string. The format is `vit_{size}/{patch_size}`. E.g. vit_b/16
+        means ViT-Base, patch size 16x16.
 
         Args:
             config: ViT model config

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -308,6 +308,18 @@ class VisionTransformer(Module):
 
     @staticmethod
     def from_config(variant: str, pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
+        """Build ViT model based on the given config string. The format is `vit_{size}/{patch_size}`.
+        E.g. vit_b/16 means ViT-Base, patch size 16x16.
+
+        Args:
+            config: ViT model config
+        Returns:
+            The respective ViT model
+
+        Example:
+            >>> from kornia.contrib import VisionTransformer
+            >>> vit_model = VisionTransformer.from_config("vit_b/16")
+        """
         model_type, patch_size_str = variant.split("/")
         patch_size = int(patch_size_str)
 

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -113,14 +113,14 @@ class TransformerEncoderBlock(nn.Sequential):
         super().__init__(
             ResidualAdd(
                 nn.Sequential(
-                    nn.LayerNorm(embed_dim),
+                    nn.LayerNorm(embed_dim, 1e-6),
                     MultiHeadAttention(embed_dim, num_heads, dropout_attn, dropout_rate),
                     nn.Dropout(dropout_rate),
                 )
             ),
             ResidualAdd(
                 nn.Sequential(
-                    nn.LayerNorm(embed_dim),
+                    nn.LayerNorm(embed_dim, 1e-6),
                     FeedForward(embed_dim, embed_dim * 4, embed_dim, dropout_rate=dropout_rate),
                     nn.Dropout(dropout_rate),
                 )
@@ -244,7 +244,7 @@ class VisionTransformer(Module):
         self.patch_embedding = PatchEmbedding(in_channels, embed_dim, patch_size, image_size, backbone)
         hidden_dim = self.patch_embedding.out_channels
         self.encoder = TransformerEncoder(hidden_dim, depth, num_heads, dropout_rate, dropout_attn)
-        self.norm = nn.LayerNorm(embed_dim)
+        self.norm = nn.LayerNorm(embed_dim, 1e-6)
 
     @property
     def encoder_results(self) -> list[Tensor]:
@@ -304,7 +304,6 @@ class VisionTransformer(Module):
 
         self.norm.weight.copy_(_get("Transformer/encoder_norm/scale"))
         self.norm.bias.copy_(_get("Transformer/encoder_norm/bias"))
-
         return self
 
     @staticmethod

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -244,7 +244,7 @@ class VisionTransformer(Module):
         self.patch_embedding = PatchEmbedding(in_channels, embed_dim, patch_size, image_size, backbone)
         hidden_dim = self.patch_embedding.out_channels
         self.encoder = TransformerEncoder(hidden_dim, depth, num_heads, dropout_rate, dropout_attn)
-        self.norm = nn.LayerNorm(embed_dim, 1e-6)
+        self.norm = nn.LayerNorm(hidden_dim, 1e-6)
 
     @property
     def encoder_results(self) -> list[Tensor]:

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -303,7 +303,7 @@ class VisionTransformer(Module):
             block[1].fn[1][3].bias.copy_(_get(prefix + "MlpBlock_3/Dense_1/bias"))
 
         unused_keys = [k for k in jax_ckpt.keys() if k not in used_keys]
-        print(unused_keys)  # debug
+        KORNIA_CHECK(len(unused_keys) == 0, f"The following weights are unused: {unused_keys}")
         return self
 
     @staticmethod

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -286,4 +286,4 @@ def _get_weight_url(variant: str) -> str:
     """Return the URL of the model weights."""
     KORNIA_CHECK(variant in _AVAILABLE_WEIGHTS, f"Variant {variant} does not have pre-trained checkpoint")
     model_type, patch_size = variant.split("/")
-    return f"https://huggingface.co/kornia/vit_{model_type}{patch_size}_i21k/resolve/main/vit_{model_type}-{patch_size}.pth"
+    return f"https://huggingface.co/kornia/vit_{model_type}{patch_size}_augreg_i21k_r224/resolve/main/vit_{model_type}-{patch_size}.pth"

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -244,7 +244,7 @@ class VisionTransformer(Module):
     def from_config(variant: str, pretrained: bool = False, **kwargs: Any) -> VisionTransformer:
         """Build ViT model based on the given config string. The format is `vit_{size}/{patch_size}`.
         E.g. `vit_b/16` means ViT-Base, patch size 16x16. If `pretrained=True`, AugReg weights are loaded.
-        The weights are hosted HuggingFace's model hub: https://huggingface.co/kornia.
+        The weights are hosted on HuggingFace's model hub: https://huggingface.co/kornia.
 
         Args:
             variant: ViT model variant e.g. `vit_b/16`.

--- a/kornia/contrib/vit.py
+++ b/kornia/contrib/vit.py
@@ -246,10 +246,13 @@ class VisionTransformer(Module):
         E.g. `vit_b/16` means ViT-Base, patch size 16x16. If `pretrained=True`, AugReg weights are loaded.
         The weights are hosted on HuggingFace's model hub: https://huggingface.co/kornia.
 
+        .. note::
+            The available weights are: "vit_l/16", "vit_b/16", "vit_s/16", "vit_ti/16", "vit_b/32", "vit_s/32"
+
         Args:
             variant: ViT model variant e.g. `vit_b/16`.
             pretrained: whether to load pre-trained AugReg weights.
-            kwargs: other arguments that will be passed to :func:`kornia.contrib.vit.VisionTransformer.__init__`.
+            kwargs: other keyword arguments that will be passed to :func:`kornia.contrib.vit.VisionTransformer.__init__`.
         Returns:
             The respective ViT model
 
@@ -286,4 +289,4 @@ def _get_weight_url(variant: str) -> str:
     """Return the URL of the model weights."""
     KORNIA_CHECK(variant in _AVAILABLE_WEIGHTS, f"Variant {variant} does not have pre-trained checkpoint")
     model_type, patch_size = variant.split("/")
-    return f"https://huggingface.co/kornia/vit_{model_type}{patch_size}_augreg_i21k_r224/resolve/main/vit_{model_type}-{patch_size}.pth"
+    return f"https://huggingface.co/kornia/{model_type}{patch_size}_augreg_i21k_r224/resolve/main/{model_type}-{patch_size}.pth"

--- a/tests/contrib/test_contrib.py
+++ b/tests/contrib/test_contrib.py
@@ -77,8 +77,8 @@ class TestVisionTransformer(BaseTester):
         assert out.shape == (1, 197, 128)
 
     @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_b/16"])
-    def test_from_config(self, variant):
-        model = kornia.contrib.VisionTransformer.from_config(variant)
+    def test_from_config_pretrained(self, variant):
+        model = kornia.contrib.VisionTransformer.from_config(variant, pretrained=True)
         assert isinstance(model, kornia.contrib.VisionTransformer)
 
 

--- a/tests/contrib/test_contrib.py
+++ b/tests/contrib/test_contrib.py
@@ -76,7 +76,7 @@ class TestVisionTransformer(BaseTester):
         out = vit(img)
         assert out.shape == (1, 197, 128)
 
-    @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_b/16", "vit_l/16"])
+    @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_b/16"])
     def test_from_config(self, variant):
         model = kornia.contrib.VisionTransformer.from_config(variant)
         assert isinstance(model, kornia.contrib.VisionTransformer)

--- a/tests/contrib/test_contrib.py
+++ b/tests/contrib/test_contrib.py
@@ -76,6 +76,11 @@ class TestVisionTransformer(BaseTester):
         out = vit(img)
         assert out.shape == (1, 197, 128)
 
+    @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_s/32", "vit_b/16", "vit_l/32"])
+    def test_from_config(self, variant):
+        model = kornia.contrib.VisionTransformer.from_config(variant)
+        assert isinstance(model, kornia.contrib.VisionTransformer)
+
 
 class TestMobileViT(BaseTester):
     @pytest.mark.parametrize("B", [1, 2])

--- a/tests/contrib/test_contrib.py
+++ b/tests/contrib/test_contrib.py
@@ -76,7 +76,12 @@ class TestVisionTransformer(BaseTester):
         out = vit(img)
         assert out.shape == (1, 197, 128)
 
-    @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_b/16"])
+    @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_b/16", "vit_l/16"])
+    def test_from_config(self, variant):
+        model = kornia.contrib.VisionTransformer.from_config(variant)
+        assert isinstance(model, kornia.contrib.VisionTransformer)
+
+    @pytest.mark.parametrize("variant", ["vit_ti/16"])
     def test_from_config_pretrained(self, variant):
         model = kornia.contrib.VisionTransformer.from_config(variant, pretrained=True)
         assert isinstance(model, kornia.contrib.VisionTransformer)

--- a/tests/contrib/test_contrib.py
+++ b/tests/contrib/test_contrib.py
@@ -76,7 +76,7 @@ class TestVisionTransformer(BaseTester):
         out = vit(img)
         assert out.shape == (1, 197, 128)
 
-    @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_s/32", "vit_b/16", "vit_l/32"])
+    @pytest.mark.parametrize("variant", ["vit_ti/16", "vit_b/16"])
     def test_from_config(self, variant):
         model = kornia.contrib.VisionTransformer.from_config(variant)
         assert isinstance(model, kornia.contrib.VisionTransformer)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2453 

Some architecture code changes
- Change hidden dim in FFN from embed_dim to embed_dim * 4
- Change LayerNorm eps from 1e-5 (PyTorch's default) to 1e-6 (Jax's default)
  - This change is necessary to get Jax weights work correctly
  - Might make this an `__init__` argument? i.e. `norm_eps`
- Add a LayerNorm layer at the end

I haven't added a test to check if the loaded weights are correct. Currently I use the code snippet below to check for correctness.

```python
from kornia.contrib.vit import VisionTransformer
import torch
import timm

model = VisionTransformer.from_config("vit_ti/16", pretrained=True).eval()
model_ref = timm.create_model("vit_tiny_patch16_224.augreg_in21k", pretrained=True).eval()

inputs = torch.randn(1, 3, 224, 224)
with torch.no_grad():
    outputs = model(inputs)
    outputs_ref = model_ref.forward_features(inputs)

diff = outputs - outputs_ref
print(diff.abs().mean())
torch.testing.assert_close(outputs, outputs_ref)
```

On my Mac M1, the average absolute error is `9.1483e-06`. `torch.testing.assert_close` returns

```
Mismatched elements: 9049 / 37824 (23.9%)
Greatest absolute difference: 8.487701416015625e-05 at index (0, 178, 115) (up to 1e-05 allowed)
Greatest relative difference: 0.025102879852056503 at index (0, 115, 17) (up to 1.3e-06 allowed)
```

The difference is due to `F.scaled_dot_product_attention()` (which timm uses). If I change the attention implementation to `F.scaled_dot_product_attention()`, the outputs are identical.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
