### PR TITLE
docs: add not-found option

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinxcontrib.gtagjs",
     "sphinxcontrib.youtube",
     "sphinx_design",
+    "notfound.extension",
 ]
 
 # substitutes the default values

--- a/requirements/requirements-docs.txt
+++ b/requirements/requirements-docs.txt
@@ -8,6 +8,7 @@ sphinx-autodoc-defaultargs
 sphinx-autodoc-typehints
 sphinx-copybutton>=0.3
 sphinx-design
+sphinx-notfound-page
 sphinxcontrib-bibtex
 sphinxcontrib-gtagjs
 sphinxcontrib-youtube


### PR DESCRIPTION
As recommended by readthedocs: https://docs.readthedocs.io/en/stable/reference/404-not-found.html

Add the extension to have a 404 page injected on the docs matching the theme: https://sphinx-notfound-page.readthedocs.io/en/latest/index.html

This way the user still "inside the docs pages"

----------

Our current 404 docs page

![image](https://github.com/kornia/kornia/assets/20444345/b4cfb073-7a60-4e22-b1d7-7ba8f4682315)

With this patch

![image](https://github.com/kornia/kornia/assets/20444345/055823be-e3db-461e-acb4-49f17793ac0b)

