### PR TITLE
test suite: skip fp64 canny dynamo test

### DIFF
--- a/tests/filters/test_canny.py
+++ b/tests/filters/test_canny.py
@@ -300,7 +300,7 @@ class TestCanny(BaseTester):
     @pytest.mark.skipif(torch_version() in {"2.0.0", "2.0.1"}, reason="Not working on 2.0")
     def test_dynamo(self, batch_size, kernel_size, device, dtype, torch_optimizer):
         if (
-            torch_version() in {"2.1.1", "2.1.2"}
+            torch_version() in {"2.1.1", "2.1.2", "2.2.0"}
             and dtype == torch.float64
             and (isinstance(kernel_size, int) or kernel_size[0] == kernel_size[1])
         ):


### PR DESCRIPTION
Skip canny test for float64 due to precision error https://github.com/kornia/kornia/actions/runs/7841025684/job/21396613672#step:2:11053

Trying to get all green light on the scheduled CI

![image](https://github.com/kornia/kornia/assets/20444345/29be5122-7292-472d-9436-3ae2a5601763)