### PR TITLE
Aug: Add simple support to dict for AugSequential

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -290,9 +290,9 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
 
         self.transform_op.data_keys = self.transform_op.preproc_datakeys(data_keys)
 
-        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)
+        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
 
-        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)
+        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
 
         if params is None:
             if self._params is None:
@@ -396,9 +396,9 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
 
         self.transform_op.data_keys = self.transform_op.preproc_datakeys(data_keys)
 
-        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)
+        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
 
-        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)
+        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
 
         if params is None:
             # image data must exist if params is not provided.

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -290,9 +290,9 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
 
         self.transform_op.data_keys = self.transform_op.preproc_datakeys(data_keys)
 
-        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
+        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)  # type: ignore
 
-        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
+        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)  # type: ignore
 
         if params is None:
             if self._params is None:
@@ -396,9 +396,9 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
 
         self.transform_op.data_keys = self.transform_op.preproc_datakeys(data_keys)
 
-        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
+        self._validate_args_datakeys(*args, data_keys=self.transform_op.data_keys)  # type: ignore
 
-        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)  # typing: ignore
+        in_args = self._arguments_preproc(*args, data_keys=self.transform_op.data_keys)  # type: ignore
 
         if params is None:
             # image data must exist if params is not provided.

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -67,15 +67,15 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
 
 
 class AugmentationSequentialOps:
-    def __init__(self, data_keys: List[DataKey] | None) -> None:
+    def __init__(self, data_keys: Optional[List[DataKey]]) -> None:
         self._data_keys = data_keys
 
     @property
-    def data_keys(self) -> List[DataKey] | None:
+    def data_keys(self) -> Optional[List[DataKey]]:
         return self._data_keys
 
     @data_keys.setter
-    def data_keys(self, data_keys: List[DataKey] | None) -> None:
+    def data_keys(self, data_keys: Optional[List[DataKey]]) -> None:
         if data_keys:
             self._data_keys = [DataKey.get(inp) for inp in data_keys]
         else:

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -67,16 +67,19 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
 
 
 class AugmentationSequentialOps:
-    def __init__(self, data_keys: List[DataKey]) -> None:
+    def __init__(self, data_keys: List[DataKey] | None) -> None:
         self._data_keys = data_keys
 
     @property
-    def data_keys(self) -> List[DataKey]:
+    def data_keys(self) -> List[DataKey] | None:
         return self._data_keys
 
     @data_keys.setter
-    def data_keys(self, data_keys: List[DataKey]) -> None:
-        self._data_keys = [DataKey.get(inp) for inp in data_keys]
+    def data_keys(self, data_keys: List[DataKey] | None) -> None:
+        if data_keys:
+            self._data_keys = [DataKey.get(inp) for inp in data_keys]
+        else:
+            self._data_keys = None
 
     def preproc_datakeys(self, data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None) -> List[DataKey]:
         if data_keys is None:

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -75,7 +75,7 @@ class AugmentationSequentialOps:
         return self._data_keys
 
     @data_keys.setter
-    def data_keys(self, data_keys: Optional[List[DataKey]]) -> None:
+    def data_keys(self, data_keys: Optional[Union[List[DataKey], List[str], List[int]]]) -> None:
         if data_keys:
             self._data_keys = [DataKey.get(inp) for inp in data_keys]
         else:
@@ -83,7 +83,9 @@ class AugmentationSequentialOps:
 
     def preproc_datakeys(self, data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None) -> List[DataKey]:
         if data_keys is None:
-            return self.data_keys
+            if isinstance(self.data_keys, list):
+                return self.data_keys
+            raise ValueError("Sequential ops needs data keys to be able to process.")
         else:
             return [DataKey.get(inp) for inp in data_keys]
 

--- a/tests/contrib/test_prompter.py
+++ b/tests/contrib/test_prompter.py
@@ -88,17 +88,21 @@ class TestVisualPrompter(BaseTester):
 
     def test_dynamo(self, device, torch_optimizer):
         dtype = torch.float32
-        img = torch.rand(3, 128, 75, device=device, dtype=dtype)
+        batch_size = 1
+        N = 2
+        inpt = torch.rand(3, 77, 128, device=device, dtype=dtype)
+        keypoints = torch.randint(0, min(inpt.shape[-2:]), (batch_size, N, 2), device=device).to(dtype=dtype)
+        labels = torch.randint(0, 1, (batch_size, N), device=device).to(dtype=dtype)
 
         prompter = VisualPrompter(SamConfig("vit_b"), device, dtype)
-        prompter.set_image(img)
+        prompter.set_image(inpt)
 
-        expected = prompter.predict(img)
+        expected = prompter.predict(keypoints=keypoints, keypoints_labels=labels)
         prompter.reset_image()
 
         prompter.compile()
-        prompter.set_image(img)
-        actual = prompter.predict(img)
+        prompter.set_image(inpt)
+        actual = prompter.predict(keypoints=keypoints, keypoints_labels=labels)
 
         self.assert_close(expected.logits, actual.logits)
         self.assert_close(expected.scores, actual.scores)


### PR DESCRIPTION
#### Changes
With this patch, we will be able to use the `AugmentationSequential` within a dictionary as input instead of `datakeys`. Just an extra option of input for the container. In other PR(s) in the future, we will look at how to improve this functionality to better handle cases instance segmentation 😄 

Fixes #2119

Instead of
```python
...
aug = AugmentationSequential(..., data_keys=["input", "mask", "bbox", "keypoints"])
o_img, o_mask, o_bbox, 0_keypoints = aug(input, mask, bbox, keypoints)
```

we will be able to use 

```python
...
aug = AugmentationSequential(..., data_keys=None)
data = {'input': input, 'mask': mask, 'bbox': bbox, 'keypoints': keypoints}

augmented_data = aug(data)
print(augmented_data['input'].shape)
print(augmented_data['mask'].shape)
print(augmented_data['bbox'].shape)
print(augmented_data['keypoints'].shape)
```

To use duplicated/multiple data keys equals in your dictionary,  you need to match the datakey name in the start of the dictionary key.
```python
...
aug = AugmentationSequential(..., data_keys=None)
data = {'input': input, 'mask-a': mask_a, 'mask_b': mask_b, 'bbox': bbox}

augmented_data = aug(data)
print(augmented_data['input'].shape)
print(augmented_data['mask-a'].shape)
print(augmented_data['mask_b'].shape)
print(augmented_data['bbox'].shape)
```



#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


cc @adamjstewart 
