### PR TITLE
Update torch.inverse to torch.linalg.inv

### DIFF
--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -156,7 +156,7 @@ def _torch_inverse_cast(input: Tensor) -> Tensor:
     dtype: torch.dtype = input.dtype
     if dtype not in (torch.float32, torch.float64):
         dtype = torch.float32
-    return torch.inverse(input.to(dtype)).to(input.dtype)
+    return torch.linalg.inv(input.to(dtype)).to(input.dtype)
 
 
 def _torch_histc_cast(input: Tensor, bins: int, min: int, max: int) -> Tensor:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -82,7 +82,7 @@ class TestInverseCast:
         op = _torch_inverse_cast
         op_jit = torch.jit.script(op)
         assert_close(op(x), op_jit(x))
-    
+
     def test_not_invertible(self, device, dtype):
         with pytest.raises(RuntimeError):
             x = torch.tensor([[0.0, 0.0], [0.0, 0.0]], device=device, dtype=dtype)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -88,14 +88,6 @@ class TestInverseCast:
             x = torch.tensor([[0.0, 0.0], [0.0, 0.0]], device=device, dtype=dtype)
             _ = _torch_inverse_cast(x)
 
-    def test_not_invertible(self, device, dtype):
-        x = torch.tensor([[0.0, 0.0], [0.0, 0.0]], device=device, dtype=dtype)
-
-        try:
-            _ = _torch_inverse_cast(x)
-        except Exception as e:
-            assert isinstance(e, torch._C._LinAlgError)
-
 
 class TestHistcCast:
     def test_smoke(self, device, dtype):

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -62,7 +62,7 @@ def test_extract_device_dtype(tensor_list, out_device, out_dtype, will_throw_err
 
 
 class TestInverseCast:
-    @pytest.mark.parametrize("input_shape", [(1, 3, 4, 4), (2, 4, 5, 5)])
+    @pytest.mark.parametrize("input_shape", [(4, 4), (1, 3, 4, 4), (2, 4, 5, 5)])
     def test_smoke(self, device, dtype, input_shape):
         x = torch.rand(input_shape, device=device, dtype=dtype)
         y = _torch_inverse_cast(x)
@@ -82,6 +82,11 @@ class TestInverseCast:
         op = _torch_inverse_cast
         op_jit = torch.jit.script(op)
         assert_close(op(x), op_jit(x))
+    
+    def test_not_invertible(self, device, dtype):
+        with pytest.raises(RuntimeError):
+            x = torch.tensor([[0.0, 0.0], [0.0, 0.0]], device=device, dtype=dtype)
+            _ = _torch_inverse_cast(x)
 
 
 class TestHistcCast:


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🔬 New feature (non-breaking change which adds functionality)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?

#### Why
[torch.inverse()](https://pytorch.org/docs/1.8.0/generated/torch.inverse.html?highlight=inverse#torch.inverse) is deprecated since torch 1.9.0, change that to [torch.linalg.inv()](https://pytorch.org/docs/1.8.0/linalg.html#torch.linalg.inv) following the offical.