### PR TITLE
Fix of possible CPU and GPU device error

### DIFF
--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -89,7 +89,7 @@ def gaussian(
 
     mean = float(window_size // 2) if mean is None else mean
     if isinstance(mean, float):
-        mean = tensor([[mean]], device=device, dtype=dtype)
+        mean = tensor([[mean]], device=sigma.device, dtype=sigma.dtype)
 
     KORNIA_CHECK_IS_TENSOR(mean)
     KORNIA_CHECK_SHAPE(mean, ["B", "1"])


### PR DESCRIPTION
#### Changes
Fixed possible error of two different (CPU and GPU) devices in gaussian function.

device and dtype of `mean` are always the same as `sigma`, so it can be reused without any possible errors, but fixing possible error of `sigma` being GPU tensor and `mean` being float value, binding to CPU by default.

I've met `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!` while using new `kornia.enhance.jpeg_codec_differentiable` function with GPU tensors. With this fix everything works as expected and now without unnecessary logic branching

Fixes #2837


#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
