### PR TITLE
Fix datakey retreival for BBOX_XYWH and BBOX_XYXY

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -456,11 +456,11 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         def retrieve_key(key: str) -> DataKey:
             """Try to retrieve the datakey value by matching `<datakey>*`"""
             # Alias cases, like INPUT, will not be get by the enum iterator.
-            if key.upper().startswith("INPUT"):
+            if key.upper() == "INPUT":
                 return DataKey.INPUT
 
             for dk in DataKey:
-                if key.upper().startswith(dk.name):
+                if key.upper() == dk.name:
                     return DataKey.get(dk.name)
 
             allowed_dk = " | ".join(f"`{d.name}`" for d in DataKey)

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -460,7 +460,7 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
                 return DataKey.INPUT
 
             for dk in DataKey:
-                if key.upper() in ["BBOX_XYXY", "BBOX_XYWH"]:
+                if key.upper() in {"BBOX_XYXY", "BBOX_XYWH"}:
                     return DataKey.get(key.upper())
                 if key.upper().startswith(dk.name):
                     return DataKey.get(dk.name)

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -456,11 +456,13 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         def retrieve_key(key: str) -> DataKey:
             """Try to retrieve the datakey value by matching `<datakey>*`"""
             # Alias cases, like INPUT, will not be get by the enum iterator.
-            if key.upper() == "INPUT":
+            if key.upper().startswith("INPUT"):
                 return DataKey.INPUT
 
             for dk in DataKey:
-                if key.upper() == dk.name:
+                if key.upper() in ["BBOX_XYXY", "BBOX_XYWH"]:
+                    return DataKey.get(key.upper())
+                if key.upper().startswith(dk.name):
                     return DataKey.get(dk.name)
 
             allowed_dk = " | ".join(f"`{d.name}`" for d in DataKey)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Previously keys like `BBOX_XYXY` would be incorrectly assigned to `BBOX` like so:

```
>>> x = "BBOX"
>>> y = "bbox_xyxy"
>>> y.upper().startswith(x)
True
```

`mask-a`, `mask-b` etc can correspond to MASK but `bbox_xywh`, `bbox_xyxy` cannot correspond to `BBOX`.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
