### PR TITLE
feat: 2d augmentation benchmarks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,7 @@ $ make benchmark-docker
 ```
 
 which will build and run the image [docker/Dockerfile.benchmark](docker/Dockerfile.benchmark).
+ The benchmark command can be used within `BENCHMARK_BACKENDS` and `BENCHMARK_SOURCE`.
 
 # Coding Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,13 @@ We are using as default:
 - the default for `BENCHMARK_BACKENDS` are `'inductor,eager'`.
 - the default for `BENCHMARK_SOURCE` is `benchmarks/`.
 
+You can also run the benchmark within docker:
+```console
+$ make benchmark-docker
+```
+
+which will build and run the image [docker/Dockerfile.benchmark](docker/Dockerfile.benchmark).
+
 # Coding Standards
 
 This section provides general guidance for developing code for the project. The following rules will serve as a guide in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,47 @@ repository under your GitHub account.
     commands of the [Makefile](./Makefile). Read more about the code standards adopted [here](#coding-standards).
 
 
+## Benchmarking
+
+We have a benchmark suite configured in [benchmarks/](./benchmarks/). We used the
+ [pytest-benchmark](https://pypi.org/project/pytest-benchmark/) library to benchmark our functions units.
+
+Our [Makefile](./Makefile) has an `benchmark` command as an alias on how to run our benchmarks.
+
+```console
+# To run all suite
+$ make benchmark
+
+# To run a specific file you can pass `BENCHMARK_SOURCE`
+$ make benchmark BENCHMARK_SOURCE=benchmarks/augmentation/2d_geometric_test.py
+
+# To run a specific benchmark you use `BENCHMARK_SOURCE` as the pytest standard behaviour
+$ make benchmark BENCHMARK_SOURCE=benchmarks/augmentation/2d_geometric_test.py::test_aug_2d_elastic_transform
+
+# To update the optimizer backends desired to execute you can pass `BENCHMARK_BACKENDS=`
+$ make benchmark BENCHMARK_BACKENDS='inductor,eager'
+
+# To pass other options to the runner, you can use `BENCHMARK_OPTS`
+# Example, setup to run the benchmark on cuda on verbose mode
+$ make benchmark BENCHMARK_OPTS='--device=cuda -vv'
+```
+
+We use the same tests generator suite, so you can setup the device within `--device`, the dtype within
+`--dtype`, and the optimizer backend within `--optimizer`.
+
+The optimizer backend supported on the suite, are the torch compile backend on non experimental mode,
+ and the `''` or `None` which will do the same as `eager` mode and do anything, and `'jit'` which will
+ try to `torch.jit.script` the operation.
+
+You can use the `BENCHMARK_OPTS` on `make benchmark` to overload the default options we use on pytest-benchmark.
+
+We are using as default:
+- the warmup, because the optimizer/jit may had an overhead.
+- the group: to display the benchmark per each test
+- the precision: to have a better precision on the results
+- the default for `BENCHMARK_BACKENDS` are `'inductor,eager'`.
+- the default for `BENCHMARK_SOURCE` is `benchmarks/`.
+
 # Coding Standards
 
 This section provides general guidance for developing code for the project. The following rules will serve as a guide in

--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,10 @@ benchmark: FORCE
 	# We want to always run within warmup because torch optimizer backend
 	pytest $(BENCHMARK_SOURCE) --benchmark-warmup=on --benchmark-warmup-iterations=100 --benchmark-calibration-precision=10 --benchmark-group-by=func --optimizer=$(BENCHMARK_BACKENDS) $(BENCHMARK_OPTS) $(0)
 
+benchmark-docker:
+	docker image rm kornia-benchmark:latest --force
+	docker build -t kornia-benchmark:latest -f docker/Dockerfile.benchmark .
+	docker run -e "TERM=xterm-256color" -it kornia-benchmark:latest
+
 uninstall: FORCE
 	pip uninstall kornia

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,10 @@ benchmark: FORCE
 benchmark-docker:
 	docker image rm kornia-benchmark:latest --force
 	docker build -t kornia-benchmark:latest -f docker/Dockerfile.benchmark .
-	docker run -e "TERM=xterm-256color" -it kornia-benchmark:latest
+	docker run -e "TERM=xterm-256color" \
+			   -e BACKENDS=$(BENCHMARK_BACKENDS) \
+			   -e OPTS=$(BENCHMARK_OPTS) \
+			   -it kornia-benchmark:latest
 
 uninstall: FORCE
 	pip uninstall kornia

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ benchmark-docker:
 	docker run -e "TERM=xterm-256color" \
 			   -e BACKENDS=$(BENCHMARK_BACKENDS) \
 			   -e OPTS=$(BENCHMARK_OPTS) \
+			   --gpus all\
 			   -it kornia-benchmark:latest
 
 uninstall: FORCE

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+BENCHMARK_SOURCE 	= benchmarks/
+BENCHMARK_BACKENDS 	= inductor,eager
+BENCHMARK_OPTS 		=
+
 .PHONY: test test-cpu test-cuda lint mypy build-docs install uninstall FORCE
 
 test: mypy lint build-docs test-all
@@ -57,7 +61,7 @@ install-dev: FORCE
 	python setup.py develop
 
 benchmark: FORCE
-	for f in tests/performance/*.py  ; do python -utt $${f}; done
+	pytest $(BENCHMARK_SOURCE) --optimizer=$(BENCHMARK_BACKENDS) $(BENCHMARK_OPTS) $(0)
 
 uninstall: FORCE
 	pip uninstall kornia

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ install-dev: FORCE
 	python setup.py develop
 
 benchmark: FORCE
-	pytest $(BENCHMARK_SOURCE) --optimizer=$(BENCHMARK_BACKENDS) $(BENCHMARK_OPTS) $(0)
+	# We want to always run within warmup because torch optimizer backend
+	pytest $(BENCHMARK_SOURCE) --benchmark-warmup=on --benchmark-warmup-iterations=100 --benchmark-calibration-precision=10 --benchmark-group-by=func --optimizer=$(BENCHMARK_BACKENDS) $(BENCHMARK_OPTS) $(0)
 
 uninstall: FORCE
 	pip uninstall kornia

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ benchmark-docker:
 	docker image rm kornia-benchmark:latest --force
 	docker build -t kornia-benchmark:latest -f docker/Dockerfile.benchmark .
 	docker run -e "TERM=xterm-256color" \
-			   -e BACKENDS=$(BENCHMARK_BACKENDS) \
-			   -e OPTS=$(BENCHMARK_OPTS) \
+			   -e "BACKENDS=$(BENCHMARK_BACKENDS)" \
+			   -e "OPTS=$(BENCHMARK_OPTS)" \
 			   --gpus all\
 			   -it kornia-benchmark:latest
 

--- a/benchmarks/augmentation/2d_geometric_test.py
+++ b/benchmarks/augmentation/2d_geometric_test.py
@@ -1,0 +1,23 @@
+import torch
+
+from kornia.augmentation import RandomHorizontalFlip, RandomVerticalFlip
+
+
+def test_aug_2d_horizontal_flip(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomHorizontalFlip()
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_vertical_flip(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomVerticalFlip()
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape

--- a/benchmarks/augmentation/2d_geometric_test.py
+++ b/benchmarks/augmentation/2d_geometric_test.py
@@ -6,6 +6,7 @@ from kornia.augmentation import (
     RandomAffine,
     RandomCrop,
     RandomElasticTransform,
+    RandomErasing,
     RandomFisheye,
     RandomHorizontalFlip,
     RandomPerspective,
@@ -65,6 +66,16 @@ def test_aug_2d_crop(benchmark, device, dtype, torch_optimizer, shape):
 def test_aug_2d_elastic_transform(benchmark, device, dtype, torch_optimizer, shape):
     data = torch.rand(*shape, device=device, dtype=dtype)
     aug = RandomElasticTransform(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_erasing(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomErasing(p=1.0)
     op = torch_optimizer(aug)
 
     actual = benchmark(op, input=data)

--- a/benchmarks/augmentation/2d_geometric_test.py
+++ b/benchmarks/augmentation/2d_geometric_test.py
@@ -1,11 +1,153 @@
 import torch
 
-from kornia.augmentation import RandomHorizontalFlip, RandomVerticalFlip
+from kornia.augmentation import (
+    CenterCrop,
+    PadTo,
+    RandomAffine,
+    RandomCrop,
+    RandomElasticTransform,
+    RandomFisheye,
+    RandomHorizontalFlip,
+    RandomPerspective,
+    RandomResizedCrop,
+    RandomRotation,
+    RandomShear,
+    RandomThinPlateSpline,
+    RandomTranslate,
+    RandomVerticalFlip,
+    Resize,
+)
+
+
+def test_aug_2d_centercrop(benchmark, device, dtype, torch_optimizer, shape):
+    w_target = h_target = 64
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = CenterCrop((h_target, w_target), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == (*shape[:-2], h_target, w_target)
+
+
+def test_aug_2d_padto(benchmark, device, dtype, torch_optimizer, shape):
+    w_target = h_target = 256
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = PadTo((h_target, w_target))
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == (*shape[:-2], h_target, w_target)
+
+
+def test_aug_2d_affine(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomAffine(degrees=45, translate=0.25, scale=(0.9, 1.1), shear=1.25, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_crop(benchmark, device, dtype, torch_optimizer, shape):
+    w_target = h_target = 64
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomCrop((h_target, w_target), pad_if_needed=True, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == (*shape[:-2], h_target, w_target)
+
+
+def test_aug_2d_elastic_transform(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomElasticTransform(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_fisheye(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    center_x = center_y = torch.tensor([-0.3, 0.3], device=device, dtype=dtype)
+    gamma = torch.tensor([0.9, 1.0], device=device, dtype=dtype)
+    aug = RandomFisheye(center_x, center_y, gamma, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
 
 
 def test_aug_2d_horizontal_flip(benchmark, device, dtype, torch_optimizer, shape):
     data = torch.rand(*shape, device=device, dtype=dtype)
-    aug = RandomHorizontalFlip()
+    aug = RandomHorizontalFlip(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_perspective(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomPerspective(0.5, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_resized_crop(benchmark, device, dtype, torch_optimizer, shape):
+    w_target = h_target = 64
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomResizedCrop((h_target, w_target), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == (*shape[:-2], h_target, w_target)
+
+
+def test_aug_2d_rotation(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomRotation(45, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_shear(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomShear((-5.0, 2.0, 5.0, 10.0), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_thin_plate_spline(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomThinPlateSpline(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_translate(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomTranslate((-0.2, 0.2), (-0.1, 0.1), p=1.0)
     op = torch_optimizer(aug)
 
     actual = benchmark(op, input=data)
@@ -15,9 +157,20 @@ def test_aug_2d_horizontal_flip(benchmark, device, dtype, torch_optimizer, shape
 
 def test_aug_2d_vertical_flip(benchmark, device, dtype, torch_optimizer, shape):
     data = torch.rand(*shape, device=device, dtype=dtype)
-    aug = RandomVerticalFlip()
+    aug = RandomVerticalFlip(p=1.0)
     op = torch_optimizer(aug)
 
     actual = benchmark(op, input=data)
 
     assert actual.shape == shape
+
+
+def test_aug_2d_resize(benchmark, device, dtype, torch_optimizer, shape):
+    w_target = h_target = 64
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = Resize((h_target, w_target), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == (*shape[:-2], h_target, w_target)

--- a/benchmarks/augmentation/2d_intensity_test.py
+++ b/benchmarks/augmentation/2d_intensity_test.py
@@ -1,0 +1,407 @@
+import pytest
+import torch
+
+from kornia.augmentation import (
+    ColorJiggle,
+    ColorJitter,
+    Denormalize,
+    Normalize,
+    RandomAutoContrast,
+    RandomBoxBlur,
+    RandomBrightness,
+    RandomChannelShuffle,
+    RandomClahe,
+    RandomContrast,
+    RandomEqualize,
+    RandomGamma,
+    RandomGaussianBlur,
+    RandomGaussianIllumination,
+    RandomGaussianNoise,
+    RandomGrayscale,
+    RandomHue,
+    RandomInvert,
+    RandomLinearCornerIllumination,
+    RandomLinearIllumination,
+    RandomMedianBlur,
+    RandomMotionBlur,
+    RandomPlanckianJitter,
+    RandomPlasmaBrightness,
+    RandomPlasmaContrast,
+    RandomPlasmaShadow,
+    RandomPosterize,
+    RandomRain,
+    RandomRGBShift,
+    RandomSaltAndPepperNoise,
+    RandomSaturation,
+    RandomSharpness,
+    RandomSnow,
+    RandomSolarize,
+)
+
+
+def test_aug_2d_collor_jiggle(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = ColorJiggle(0.1, 0.1, 0.1, 0.1, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_collor_jitter(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = ColorJitter(0.1, 0.1, 0.1, 0.1, p=1.0)
+    op = torch_optimizer(aug)
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_denormalize(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = Denormalize(0.0, 1.0, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_auto_contrast(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomAutoContrast(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_box_blur(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomBoxBlur(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_brightness(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomBrightness((0.1, 1), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_channel_shuffle(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomChannelShuffle(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_clahe(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomClahe((10, 40), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_contrast(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomContrast((0.1, 1), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_equalize(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomEqualize(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_gamma(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomGamma((0.0, 1.0), (0.0, 1.0), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_gaussian_blur(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomGaussianBlur(3, (1.6, 1.7), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_gaussian_illumination(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomGaussianIllumination(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_gaussian_noise(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomGaussianNoise(0.0, 1.0, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_grayscale(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomGrayscale(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_hue(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomHue((0.0, 0.5), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_invert(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomInvert(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+# TODO(joao.amorim): figure out dynamo issue with it
+# def test_aug_2d_jpeg(benchmark, device, dtype, torch_optimizer, shape):
+#     data = torch.rand(*shape, device=device, dtype=dtype)
+#     aug = RandomJPEG(p=1.0)
+#     op = torch_optimizer(aug)
+#
+#     actual = benchmark(op, input=data)
+#
+#     assert actual.shape == shape
+
+
+def test_aug_2d_linear_corner_illumination(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomLinearCornerIllumination(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_linear_illumination(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomLinearIllumination(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_median_blur(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomMedianBlur(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_motion_blur(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomMotionBlur((3, 3), 45.0, 5.5, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_normalize(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = Normalize(25.0, 2.5, p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_plackian_jitter(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomPlanckianJitter(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_plasma_briggtness(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomPlasmaBrightness(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_plasma_contrast(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomPlasmaContrast(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_plasma_shadow(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomPlasmaShadow(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_posterize(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomPosterize(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_rain(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomRain(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_rgb_shift(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomRGBShift(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_salt_and_peper_noise(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomSaltAndPepperNoise(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_saturation(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomSaturation((0.0, 2.0), p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_sharpness(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomSharpness(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_snow(benchmark, device, dtype, torch_optimizer, shape):
+    if shape[1] != 3:
+        pytest.skip("Skipping because input should be rgb")
+
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomSnow(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape
+
+
+def test_aug_2d_solarize(benchmark, device, dtype, torch_optimizer, shape):
+    data = torch.rand(*shape, device=device, dtype=dtype)
+    aug = RandomSolarize(p=1.0)
+    op = torch_optimizer(aug)
+
+    actual = benchmark(op, input=data)
+
+    assert actual.shape == shape

--- a/benchmarks/augmentation/conftest.py
+++ b/benchmarks/augmentation/conftest.py
@@ -1,0 +1,16 @@
+from itertools import product
+
+import pytest
+
+
+@pytest.fixture
+def shape(B, C, H, W):
+    return (B, C, H, W)
+
+
+def pytest_generate_tests(metafunc):
+    B = [1, 5]
+    C = [1, 3]
+    H = W = [128]  # , 237, 512]
+    params = list(product(B, C, H, W))
+    metafunc.parametrize("B, C, H, W", params)

--- a/benchmarks/color/gray_test.py
+++ b/benchmarks/color/gray_test.py
@@ -8,21 +8,8 @@ from kornia.color import grayscale_to_rgb
 @pytest.mark.parametrize("C", [1])
 @pytest.mark.parametrize("H", [128, 237, 512])
 @pytest.mark.parametrize("W", [128, 237, 512])
-def test_grayscale_to_rgb(benchmark, device, dtype, B, C, H, W):
+def test_grayscale_to_rgb(benchmark, device, dtype, torch_optimizer, B, C, H, W):
     data = torch.rand(B, C, H, W, device=device, dtype=dtype)
-
-    actual = benchmark(grayscale_to_rgb, image=data)
-
-    assert actual.shape == (B, 3, H, W)
-
-
-@pytest.mark.parametrize("B", [1, 5])
-@pytest.mark.parametrize("C", [1])
-@pytest.mark.parametrize("H", [128, 237, 512])
-@pytest.mark.parametrize("W", [128, 237, 512])
-def test_grayscale_to_rgb_compile(benchmark, device, dtype, torch_optimizer, B, C, H, W):
-    data = torch.rand(B, C, H, W, device=device, dtype=dtype)
-
     op = torch_optimizer(grayscale_to_rgb)
 
     actual = benchmark(op, image=data)

--- a/conftest.py
+++ b/conftest.py
@@ -214,6 +214,7 @@ def _get_env_info() -> Dict[str, Dict[str, str]]:
         "cpu": _get_cpu_info(),
         "gpu": _get_gpu_info(),
         "nvidia": torch.utils.collect_env.get_nvidia_driver_version(run_lmb),
+        "gcc": torch.utils.collect_env.get_gcc_version(run_lmb),
     }
 
 
@@ -250,6 +251,7 @@ x deps:
 dev deps:
     - kornia_rs-{kornia_rs.__version__}
     - onnx-{onnx.__version__}
+gcc info: {env_info['gcc']}
 available optimizers: {TEST_OPTIMIZER_BACKEND}
 """
 

--- a/conftest.py
+++ b/conftest.py
@@ -241,18 +241,9 @@ def pytest_report_header(config):
 
     env_info = _get_env_info()
 
-    cpu_info = (
-        f"""
-cpu info:
-    - Model name: {env_info['cpu']['Model name']}
-    - Architecture: {env_info['cpu']['Architecture']}
-    - CPU(s): {env_info['cpu']['CPU(s)']}
-    - Thread(s) per core: {env_info['cpu']['Thread(s) per core']}
-    - CPU max MHz: {env_info['cpu']['CPU max MHz']}
-    - CPU min MHz: {env_info['cpu']['CPU min MHz']}
-"""
-        if "cpu" in env_info
-        else ""
+    desired_cpu_info = ["Model name", "Architecture", "CPU(s)", "Thread(s) per core", "CPU max MHz", "CPU min MHz"]
+    cpu_info = "cpu info:\n" + "\n".join(
+        f'\t- {i}: {env_info["cpu"][i]}' for i in desired_cpu_info if i in env_info["cpu"]
     )
     gpu_info = f"gpu info: {env_info['gpu']}" if "gpu" in env_info else ""
     gcc_info = f"gcc info: {env_info['gcc']}" if "gcc" in env_info else ""

--- a/conftest.py
+++ b/conftest.py
@@ -79,7 +79,7 @@ def torch_optimizer(optimizer_backend):
         return lambda x: x
 
     if optimizer_backend == "jit":
-        raise NotImplementedError
+        return torch.jit.script
 
     if hasattr(torch, "compile") and sys.platform == "linux":
         if not (sys.version_info[:2] == (3, 11) and torch_version() in {"2.0.0", "2.0.1"}):

--- a/conftest.py
+++ b/conftest.py
@@ -151,7 +151,7 @@ def pytest_collection_modifyitems(config, items):
 def pytest_addoption(parser):
     parser.addoption("--device", action="store", default="cpu")
     parser.addoption("--dtype", action="store", default="float32")
-    parser.addoption("--optimizer", action="store", default="")
+    parser.addoption("--optimizer", action="store", default="inductor")
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -241,10 +241,13 @@ def pytest_report_header(config):
 
     env_info = _get_env_info()
 
-    desired_cpu_info = ["Model name", "Architecture", "CPU(s)", "Thread(s) per core", "CPU max MHz", "CPU min MHz"]
-    cpu_info = "cpu info:\n" + "\n".join(
-        f'\t- {i}: {env_info["cpu"][i]}' for i in desired_cpu_info if i in env_info["cpu"]
-    )
+    if "cpu" in env_info:
+        desired_cpu_info = ["Model name", "Architecture", "CPU(s)", "Thread(s) per core", "CPU max MHz", "CPU min MHz"]
+        cpu_info = "cpu info:\n" + "\n".join(
+            f'\t- {i}: {env_info["cpu"][i]}' for i in desired_cpu_info if i in env_info["cpu"]
+        )
+    else:
+        cpu_info = ""
     gpu_info = f"gpu info: {env_info['gpu']}" if "gpu" in env_info else ""
     gcc_info = f"gcc info: {env_info['gcc']}" if "gcc" in env_info else ""
 

--- a/conftest.py
+++ b/conftest.py
@@ -183,7 +183,7 @@ def pytest_sessionstart(session):
     # TODO: cache all torch.load weights/states here to not impact on test suite
 
 
-def _get_env_info() -> dict[str, dict[str, str]]:
+def _get_env_info() -> Dict[str, Dict[str, str]]:
     run_lmb = torch.utils.collect_env.run
     separator = ":"
     br = "\n"
@@ -192,7 +192,7 @@ def _get_env_info() -> dict[str, dict[str, str]]:
         parts = v.split(separator)
         return parts[0].strip(), parts[-1].strip()
 
-    def _get_cpu_info() -> dict[str, str]:
+    def _get_cpu_info() -> Dict[str, str]:
         cpu_info = {}
         cpu_str = torch.utils.collect_env.get_cpu_info(run_lmb)
         for data in cpu_str.split(br):
@@ -201,7 +201,7 @@ def _get_env_info() -> dict[str, dict[str, str]]:
 
         return cpu_info
 
-    def _get_gpu_info() -> dict[str, str]:
+    def _get_gpu_info() -> Dict[str, str]:
         gpu_info = {}
         gpu_str = torch.utils.collect_env.get_gpu_info(run_lmb)
         for data in gpu_str.split(br):

--- a/docker/Dockerfile.benchmark
+++ b/docker/Dockerfile.benchmark
@@ -1,14 +1,12 @@
 FROM pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
 
-# This will allow the compile inductor optimizer install g++ with conda
-ENV TORCH_INDUCTOR_INSTALL_GXX=True
-
 # This allow us to setup the benchmark parameters from env vars
 ENV BACKENDS='eager,inductor'
 ENV OPTS=''
 
-# Setup make
-RUN DEBIAN_FRONTEND=noninteractive apt update && apt install make
+# Setup make and gcc
+RUN DEBIAN_FRONTEND=noninteractive apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install make g++ -y
 
 # Setup Kornia dev mode
 WORKDIR /tmp/kornia-lib/

--- a/docker/Dockerfile.benchmark
+++ b/docker/Dockerfile.benchmark
@@ -3,6 +3,10 @@ FROM pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
 # This will allow the compile inductor optimizer install g++ with conda
 ENV TORCH_INDUCTOR_INSTALL_GXX=True
 
+# This allow us to setup the benchmark parameters from env vars
+ENV BACKENDS='eager,inductor'
+ENV OPTS=''
+
 # Setup make
 RUN DEBIAN_FRONTEND=noninteractive apt update && apt install make
 
@@ -28,4 +32,4 @@ RUN DEBIAN_FRONTEND=noninteractive apt autoremove -y
 RUN rm -rf /var/lib/apt/lists/*
 
 # CMD
-CMD ["make", "benchmark", "BENCHMARK_OPTS='--device=all'"]
+CMD ["make", "benchmark", "BENCHMARK_BACKENDS=$(BACKENDS)", "BENCHMARK_OPTS=$(OPTS)"]

--- a/docker/Dockerfile.benchmark
+++ b/docker/Dockerfile.benchmark
@@ -1,0 +1,31 @@
+FROM pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
+
+# This will allow the compile inductor optimizer install g++ with conda
+ENV TORCH_INDUCTOR_INSTALL_GXX=True
+
+# Setup make
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt install make
+
+# Setup Kornia dev mode
+WORKDIR /tmp/kornia-lib/
+COPY kornia/ kornia/
+COPY pyproject.toml ./
+COPY requirements/ requirements/
+
+RUN pip install .[dev,x]
+
+# Setup benchmarks
+WORKDIR /kornia-benchmarks/
+COPY benchmarks/ benchmarks/
+COPY Makefile ./
+COPY conftest.py ./
+
+# Cleanup
+RUN rm -rf /tmp/kornia-lib/
+RUN DEBIAN_FRONTEND=noninteractive apt autopurge -y
+RUN DEBIAN_FRONTEND=noninteractive apt autoclean -y
+RUN DEBIAN_FRONTEND=noninteractive apt autoremove -y
+RUN rm -rf /var/lib/apt/lists/*
+
+# CMD
+CMD ["make", "benchmark", "BENCHMARK_OPTS='--device=all'"]

--- a/docs/source/augmentation.module.rst
+++ b/docs/source/augmentation.module.rst
@@ -13,6 +13,7 @@ Intensity
 
 .. autoclass:: ColorJiggle
 .. autoclass:: ColorJitter
+.. autoclass:: RandomAutoContrast
 .. autoclass:: RandomBoxBlur
 .. autoclass:: RandomBrightness
 .. autoclass:: RandomChannelShuffle
@@ -25,9 +26,10 @@ Intensity
 .. autoclass:: RandomGaussianNoise
 .. autoclass:: RandomGrayscale
 .. autoclass:: RandomHue
+.. autoclass:: RandomInvert
 .. autoclass:: RandomJPEG
-.. autoclass:: RandomLinearIllumination
 .. autoclass:: RandomLinearCornerIllumination
+.. autoclass:: RandomLinearIllumination
 .. autoclass:: RandomMedianBlur
 .. autoclass:: RandomMotionBlur
 .. autoclass:: RandomPlanckianJitter
@@ -35,13 +37,14 @@ Intensity
 .. autoclass:: RandomPlasmaContrast
 .. autoclass:: RandomPlasmaShadow
 .. autoclass:: RandomPosterize
-.. autoclass:: RandomRGBShift
 .. autoclass:: RandomRain
-.. autoclass:: RandomSaturation
+.. autoclass:: RandomRGBShift
 .. autoclass:: RandomSaltAndPepperNoise
+.. autoclass:: RandomSaturation
 .. autoclass:: RandomSharpness
 .. autoclass:: RandomSnow
 .. autoclass:: RandomSolarize
+
 
 Geometric
 ~~~~~~~~~
@@ -58,8 +61,10 @@ Geometric
 .. autoclass:: RandomPerspective
 .. autoclass:: RandomResizedCrop
 .. autoclass:: RandomRotation
+.. autoclass:: RandomShear
 .. autoclass:: RandomThinPlateSpline
 .. autoclass:: RandomVerticalFlip
+
 
 Mix
 ~~~

--- a/docs/source/augmentation.module.rst
+++ b/docs/source/augmentation.module.rst
@@ -57,7 +57,6 @@ Geometric
 .. autoclass:: RandomErasing
 .. autoclass:: RandomFisheye
 .. autoclass:: RandomHorizontalFlip
-.. autoclass:: RandomInvert
 .. autoclass:: RandomPerspective
 .. autoclass:: RandomResizedCrop
 .. autoclass:: RandomRotation

--- a/kornia/augmentation/_2d/geometric/perspective.py
+++ b/kornia/augmentation/_2d/geometric/perspective.py
@@ -13,11 +13,11 @@ class RandomPerspective(GeometricAugmentationBase2D):
     .. image:: _static/img/RandomPerspective.png
 
     Args:
-        p: probability of the image being perspectively transformed.
         distortion_scale: the degree of distortion, ranged from 0 to 1.
         resample: the interpolation method to use.
         same_on_batch: apply the same transformation across the batch. Default: False.
         align_corners: interpolation flag.
+        p: probability of the image being perspectively transformed.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
         sampling_method: ``'basic'`` | ``'area_preserving'``. Default: ``'basic'``

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -19,6 +19,7 @@ class Resize(GeometricAugmentationBase2D):
         resample: Resampling mode.
         align_corners: interpolation flag.
         antialias: if True, then image will be filtered with Gaussian before downscaling. No effect for upscaling.
+        p: probability of the augmentation been applied.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
             to the batch form (False).
     """

--- a/kornia/augmentation/_2d/geometric/resized_crop.py
+++ b/kornia/augmentation/_2d/geometric/resized_crop.py
@@ -20,6 +20,7 @@ class RandomResizedCrop(GeometricAugmentationBase2D):
         resample: the interpolation mode.
         same_on_batch: apply the same transformation across the batch.
         align_corners: interpolation flag.
+        p: probability of the augmentation been applied.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                         to the batch form (False).
         cropping_mode: The used algorithm to crop. ``slice`` will use advanced slicing to extract the tensor based

--- a/kornia/augmentation/_2d/intensity/brightness.py
+++ b/kornia/augmentation/_2d/intensity/brightness.py
@@ -15,11 +15,11 @@ class RandomBrightness(IntensityAugmentationBase2D):
     .. image:: _static/img/RandomBrightness.png
 
     Args:
-        p: probability of applying the transformation.
         brightness: the brightness factor to apply
         clip_output: if true clip output
         silence_instantiation_warning: if True, silence the warning at instantiation.
         same_on_batch: apply the same transformation across the batch.
+        p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:

--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -22,13 +22,13 @@ class ColorJitter(IntensityAugmentationBase2D):
     .. image:: _static/img/ColorJitter.png
 
     Args:
-        p: probability of applying the transformation.
         brightness: The brightness factor to apply.
         contrast: The contrast factor to apply.
         saturation: The saturation factor to apply.
         hue: The hue factor to apply.
         silence_instantiation_warning: if True, silence the warning at instantiation.
         same_on_batch: apply the same transformation across the batch.
+        p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:

--- a/kornia/augmentation/_2d/intensity/contrast.py
+++ b/kornia/augmentation/_2d/intensity/contrast.py
@@ -15,10 +15,10 @@ class RandomContrast(IntensityAugmentationBase2D):
     .. image:: _static/img/RandomContrast.png
 
     Args:
-        p: probability of applying the transformation.
         contrast: the contrast factor to apply.
         clip_output: if true clip output.
         same_on_batch: apply the same transformation across the batch.
+        p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:

--- a/kornia/augmentation/_2d/intensity/hue.py
+++ b/kornia/augmentation/_2d/intensity/hue.py
@@ -16,9 +16,9 @@ class RandomHue(IntensityAugmentationBase2D):
     .. image:: _static/img/RandomHue.png
 
     Args:
-        p: probability of applying the transformation.
         hue: the saturation factor to apply.
         same_on_batch: apply the same transformation across the batch.
+        p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
     Shape:

--- a/kornia/augmentation/_2d/intensity/planckian_jitter.py
+++ b/kornia/augmentation/_2d/intensity/planckian_jitter.py
@@ -158,6 +158,7 @@ class RandomPlanckianJitter(IntensityAugmentationBase2D):
         if select_from is not None:
             _pl = _pl[select_from]
         self.register_buffer("pl", _pl)
+        self.pl: Tensor
 
         # the range of the sampling parameters
         _param_min: float = 0.0

--- a/kornia/augmentation/_2d/intensity/planckian_jitter.py
+++ b/kornia/augmentation/_2d/intensity/planckian_jitter.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.core import Tensor, stack, tensor
+from kornia.core.check import KORNIA_CHECK_SHAPE
 
 
 def get_planckian_coeffs(mode: str) -> Tensor:
@@ -168,7 +169,8 @@ class RandomPlanckianJitter(IntensityAugmentationBase2D):
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
         list_idx = params["idx"].tolist()
-
+        KORNIA_CHECK_SHAPE(input, ["*", "3", "H", "W"])
+        self.pl = self.pl.to(device=input.device)
         coeffs = self.pl[list_idx]
 
         r_w = coeffs[:, 0][..., None, None]

--- a/kornia/augmentation/_2d/intensity/random_rain.py
+++ b/kornia/augmentation/_2d/intensity/random_rain.py
@@ -36,12 +36,12 @@ class RandomRain(IntensityAugmentationBase2D):
 
     def __init__(
         self,
-        same_on_batch: bool = False,
-        p: float = 0.5,
-        keepdim: bool = False,
         number_of_drops: tuple[int, int] = (1000, 2000),
         drop_height: tuple[int, int] = (5, 20),
         drop_width: tuple[int, int] = (-5, 5),
+        same_on_batch: bool = False,
+        p: float = 0.5,
+        keepdim: bool = False,
     ) -> None:
         super().__init__(p=p, same_on_batch=same_on_batch, p_batch=1.0, keepdim=keepdim)
         self._param_generator = RainGenerator(number_of_drops, drop_height, drop_width)

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -5,5 +5,6 @@ onnx
 pre-commit>=2
 pydocstyle
 pytest==8.1.1
+pytest-benchmark
 pytest-timeout
 requests

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -3976,14 +3976,14 @@ class TestPlanckianJitter(BaseTester):
 
     def test_planckian_jitter_blackbody(self, device, dtype):
         torch.manual_seed(0)
-        f = RandomPlanckianJitter(select_from=1).to(device)
+        f = RandomPlanckianJitter(select_from=1)
         input = self._get_input(device, dtype)
         expected = self._get_expected_output_blackbody(device, dtype)
         self.assert_close(f(input), expected, low_tolerance=True)
 
     def test_planckian_jitter_cied(self, device, dtype):
         torch.manual_seed(0)
-        f = RandomPlanckianJitter(mode="CIED", select_from=1).to(device)
+        f = RandomPlanckianJitter(mode="CIED", select_from=1)
         input = self._get_input(device, dtype)
         expected = self._get_expected_output_cied(device, dtype)
         self.assert_close(f(input), expected, low_tolerance=True)
@@ -3993,7 +3993,7 @@ class TestPlanckianJitter(BaseTester):
         input = self._get_input(device, dtype).repeat(2, 1, 1, 1)
 
         select_from = [1, 2, 24]
-        f = RandomPlanckianJitter(select_from=select_from).to(device)
+        f = RandomPlanckianJitter(select_from=select_from)
         expected = self._get_expected_output_batch(device, dtype)
         self.assert_close(f(input), expected, low_tolerance=True)
 
@@ -4002,7 +4002,7 @@ class TestPlanckianJitter(BaseTester):
         input = self._get_input(device, dtype).repeat(2, 1, 1, 1)
 
         select_from = [1, 2, 24, 3, 4, 5]
-        f = RandomPlanckianJitter(select_from=select_from, same_on_batch=True, p=1.0).to(device)
+        f = RandomPlanckianJitter(select_from=select_from, same_on_batch=True, p=1.0)
         expected = self._get_expected_output_same_on_batch(device, dtype)
         self.assert_close(f(input), expected, low_tolerance=True)
 

--- a/tests/contrib/test_prompter.py
+++ b/tests/contrib/test_prompter.py
@@ -88,7 +88,7 @@ class TestVisualPrompter(BaseTester):
         ...
 
     @pytest.mark.skipif(torch_version() in {"2.0.0", "2.0.1", "2.1.2"}, reason="Not working on 2.0.x and 2.1.x")
-    def test_dynamo(self, device, torch_optimizer):
+    def test_dynamo(self, device):
         dtype = torch.float32
         batch_size = 1
         N = 2


### PR DESCRIPTION
- added the 2d augmentation benchmarks
- setup optimizer backend as a pytest option, so we can select which backend to use e.g inductor, onnxrt, eager within torch compile, or jit itself using `torch.jit.script`
- added a docker for benchmark
- fixes on augmentation docs
- fixes to plackian_jitter related to https://github.com/kornia/kornia/issues/2791
- added benchmark on contributing
- added CPU and GPU info into pytest header

To run all benchmarks within default configs, you can use
```console
$ make benchmark-docker
```
which will build a docker image based on pytorch cuda 12.1, and run the benchmark suite