### PR TITLE
color jitter compile and set right device / dtype

### DIFF
--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -86,10 +86,11 @@ class ColorJitter(IntensityAugmentationBase2D):
         self.hue = hue
         self._param_generator = rg.ColorJitterGenerator(brightness, contrast, saturation, hue)
 
-        self.brightness_fn = torch.compile(adjust_brightness_accumulative, fullgraph=True)
-        self.contrast_fn = torch.compile(adjust_contrast_with_mean_subtraction, fullgraph=True)
-        self.saturation_fn = torch.compile(adjust_saturation_with_gray_subtraction, fullgraph=True)
-        self.hue_fn = torch.compile(adjust_hue, fullgraph=True)
+        # native functions
+        self.brightness_fn = adjust_brightness_accumulative
+        self.contrast_fn = adjust_contrast_with_mean_subtraction
+        self.saturation_fn = adjust_saturation_with_gray_subtraction
+        self.hue_fn = adjust_hue
 
     def apply_transform(
         self,
@@ -121,3 +122,51 @@ class ColorJitter(IntensityAugmentationBase2D):
             jittered = t(jittered)
 
         return jittered
+
+    def compile(
+        self,
+        *,
+        fullgraph: bool = False,
+        dynamic: bool = False,
+        backend: str = "inductor",
+        mode: Optional[str] = None,
+        options: Optional[Dict[Any, Any]] = None,
+        disable: bool = False,
+    ) -> None:
+        self.brightness_fn = torch.compile(
+            self.brightness_fn,
+            fullgraph=fullgraph,
+            dynamic=dynamic,
+            backend=backend,
+            mode=mode,
+            options=options,
+            disable=disable,
+        )
+        self.contrast_fn = torch.compile(
+            self.contrast_fn,
+            fullgraph=fullgraph,
+            dynamic=dynamic,
+            backend=backend,
+            mode=mode,
+            options=options,
+            disable=disable,
+        )
+        self.saturation_fn = torch.compile(
+            self.saturation_fn,
+            fullgraph=fullgraph,
+            dynamic=dynamic,
+            backend=backend,
+            mode=mode,
+            options=options,
+            disable=disable,
+        )
+        self.hue_fn = torch.compile(
+            self.hue_fn,
+            fullgraph=fullgraph,
+            dynamic=dynamic,
+            backend=backend,
+            mode=mode,
+            options=options,
+            disable=disable,
+        )
+        return self

--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -85,23 +85,33 @@ class ColorJitter(IntensityAugmentationBase2D):
         self._param_generator = rg.ColorJitterGenerator(brightness, contrast, saturation, hue)
 
     def apply_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
+        self,
+        input: Tensor,
+        params: Dict[str, Tensor],
+        flags: Dict[str, Any],
+        transform: Optional[Tensor] = None,
     ) -> Tensor:
         transforms = [
-            lambda img: adjust_brightness_accumulative(img, params["brightness_factor"])
-            if (params["brightness_factor"] != 0).any()
-            else img,
-            lambda img: adjust_contrast_with_mean_subtraction(img, params["contrast_factor"])
-            if (params["contrast_factor"] != 1).any()
-            else img,
-            lambda img: adjust_saturation_with_gray_subtraction(img, params["saturation_factor"])
-            if (params["saturation_factor"] != 1).any()
-            else img,
-            lambda img: adjust_hue(img, params["hue_factor"] * 2 * pi) if (params["hue_factor"] != 0).any() else img,
+            lambda img: (
+                adjust_brightness_accumulative(img, params["brightness_factor"])
+                if (params["brightness_factor"] != 0).any()
+                else img
+            ),
+            lambda img: (
+                adjust_contrast_with_mean_subtraction(img, params["contrast_factor"])
+                if (params["contrast_factor"] != 1).any()
+                else img
+            ),
+            lambda img: (
+                adjust_saturation_with_gray_subtraction(img, params["saturation_factor"])
+                if (params["saturation_factor"] != 1).any()
+                else img
+            ),
+            lambda img: (adjust_hue(img, params["hue_factor"] * 2 * pi) if (params["hue_factor"] != 0).any() else img),
         ]
 
         jittered = input
-        for idx in params["order"].tolist():
+        for idx in params["order"]:
             t = transforms[idx]
             jittered = t(jittered)
 

--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -132,7 +132,7 @@ class ColorJitter(IntensityAugmentationBase2D):
         mode: Optional[str] = None,
         options: Optional[Dict[Any, Any]] = None,
         disable: bool = False,
-    ) -> None:
+    ) -> "ColorJitter":
         self.brightness_fn = torch.compile(
             self.brightness_fn,
             fullgraph=fullgraph,

--- a/kornia/augmentation/random_generator/_2d/color_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/color_jitter.py
@@ -89,5 +89,5 @@ class ColorJitterGenerator(RandomGeneratorBase):
             "contrast_factor": contrast_factor,
             "hue_factor": hue_factor,
             "saturation_factor": saturation_factor,
-            "order": torch.randperm(4).tolist(),
+            "order": torch.randperm(4, dtype=torch.long),
         }

--- a/kornia/augmentation/random_generator/_2d/color_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/color_jitter.py
@@ -1,4 +1,3 @@
-import random
 from typing import Dict, List, Tuple, Union
 
 import torch
@@ -58,7 +57,6 @@ class ColorJitterGenerator(RandomGeneratorBase):
         self.contrast = contrast
         self.saturation = saturation
         self.hue = hue
-        self.randperm_list: List[int] = [0, 1, 2, 3]
 
     def __repr__(self) -> str:
         return f"brightness={self.brightness}, contrast={self.contrast}, saturation={self.saturation}, hue={self.hue}"
@@ -86,13 +84,10 @@ class ColorJitterGenerator(RandomGeneratorBase):
         hue_factor = _adapted_rsampling((batch_size,), self.hue_sampler, same_on_batch)
         saturation_factor = _adapted_rsampling((batch_size,), self.saturation_sampler, same_on_batch)
 
-        # perform random permutation of the order of the color adjustments
-        random.shuffle(self.randperm_list)
-
         return {
             "brightness_factor": brightness_factor,
             "contrast_factor": contrast_factor,
             "hue_factor": hue_factor,
             "saturation_factor": saturation_factor,
-            "order": self.randperm_list,
+            "order": torch.randperm(4).tolist(),
         }

--- a/kornia/augmentation/random_generator/_2d/color_jitter.py
+++ b/kornia/augmentation/random_generator/_2d/color_jitter.py
@@ -3,10 +3,16 @@ from typing import Dict, List, Tuple, Union
 
 import torch
 
-from kornia.augmentation.random_generator.base import RandomGeneratorBase, UniformDistribution
-from kornia.augmentation.utils import _adapted_rsampling, _common_param_check, _joint_range_check, _range_bound
+from kornia.augmentation.random_generator.base import (
+    RandomGeneratorBase,
+    UniformDistribution,
+)
+from kornia.augmentation.utils import (
+    _adapted_rsampling,
+    _joint_range_check,
+    _range_bound,
+)
 from kornia.core import Tensor
-from kornia.utils.helpers import _extract_device_dtype
 
 __all__ = ["ColorJitterGenerator"]
 
@@ -75,16 +81,14 @@ class ColorJitterGenerator(RandomGeneratorBase):
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, Tensor]:
         batch_size = batch_shape[0]
-        _common_param_check(batch_size, same_on_batch)
-        _device, _dtype = _extract_device_dtype([self.brightness, self.contrast, self.hue, self.saturation])
         brightness_factor = _adapted_rsampling((batch_size,), self.brightness_sampler, same_on_batch)
         contrast_factor = _adapted_rsampling((batch_size,), self.contrast_sampler, same_on_batch)
         hue_factor = _adapted_rsampling((batch_size,), self.hue_sampler, same_on_batch)
         saturation_factor = _adapted_rsampling((batch_size,), self.saturation_sampler, same_on_batch)
         return {
-            "brightness_factor": brightness_factor.to(device=_device, dtype=_dtype),
-            "contrast_factor": contrast_factor.to(device=_device, dtype=_dtype),
-            "hue_factor": hue_factor.to(device=_device, dtype=_dtype),
-            "saturation_factor": saturation_factor.to(device=_device, dtype=_dtype),
-            "order": self.randperm(4).to(device=_device, dtype=_dtype).long(),
+            "brightness_factor": brightness_factor,
+            "contrast_factor": contrast_factor,
+            "hue_factor": hue_factor,
+            "saturation_factor": saturation_factor,
+            "order": self.randperm(4, dtype=torch.long),
         }

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -393,7 +393,7 @@ def adjust_contrast_with_mean_subtraction(image: Tensor, factor: Union[float, Te
     while len(factor.shape) != len(image.shape):
         factor = factor[..., None]
 
-    KORNIA_CHECK(any(factor >= 0), "Contrast factor must be positive.")
+    # KORNIA_CHECK(any(factor >= 0), "Contrast factor must be positive.")
 
     if image.shape[-3] == 3:
         img_mean = rgb_to_grayscale(image).mean((-2, -1), True)

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -6,7 +6,11 @@ from torch import Tensor
 from torch.nn import Module, Parameter
 
 from kornia.color import hsv_to_rgb, rgb_to_grayscale, rgb_to_hsv
-from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_COLOR_OR_GRAY, KORNIA_CHECK_IS_TENSOR
+from kornia.core.check import (
+    KORNIA_CHECK,
+    KORNIA_CHECK_IS_COLOR_OR_GRAY,
+    KORNIA_CHECK_IS_TENSOR,
+)
 from kornia.utils.helpers import _torch_histc_cast
 from kornia.utils.image import perform_keep_shape_image, perform_keep_shape_video
 
@@ -625,7 +629,9 @@ def _solarize(input: Tensor, thresholds: Union[float, Tensor] = 0.5) -> Tensor:
 
 
 def solarize(
-    input: Tensor, thresholds: Union[float, Tensor] = 0.5, additions: Optional[Union[float, Tensor]] = None
+    input: Tensor,
+    thresholds: Union[float, Tensor] = 0.5,
+    additions: Optional[Union[float, Tensor]] = None,
 ) -> Tensor:
     r"""For each pixel in the image less than threshold.
 

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -175,7 +175,10 @@ class CommonTests(BaseTester):
         # apply_transform can be called and returns the correct batch sized output
         if to_apply.sum() != 0:
             output = augmentation.apply_transform(
-                test_input[to_apply], generated_params, augmentation.flags, transformation
+                test_input[to_apply],
+                generated_params,
+                augmentation.flags,
+                transformation,
             )
             assert output.shape[0] == to_apply.sum()
         else:
@@ -230,7 +233,11 @@ class CommonTests(BaseTester):
 
         # Output should match
         assert output.shape == expected_output.shape
-        self.assert_close(output, expected_output.to(device=self.device, dtype=self.dtype), low_tolerance=True)
+        self.assert_close(
+            output,
+            expected_output.to(device=self.device, dtype=self.dtype),
+            low_tolerance=True,
+        )
         if expected_transformation is not None:
             transform = augmentation.transform_matrix
             self.assert_close(transform, expected_transformation, low_tolerance=True)
@@ -271,7 +278,10 @@ class CommonTests(BaseTester):
             pytest.skip("Test not relevant for intensity augmentations.")
 
         indices = create_meshgrid(
-            height=output.shape[-2], width=output.shape[-1], normalized_coordinates=False, device=self.device
+            height=output.shape[-2],
+            width=output.shape[-1],
+            normalized_coordinates=False,
+            device=self.device,
         )
         output_indices = indices.reshape((1, -1, 2)).to(dtype=self.dtype)
         input_indices = transform_points(_torch_inverse_cast(transform.to(self.dtype)), output_indices)
@@ -336,7 +346,9 @@ class TestRandomEqualizeAlternative(CommonTests):
 
         parameters = {}
         self._test_random_p_1_implementation(
-            input_tensor=input_tensor, expected_output=expected_output, params=parameters
+            input_tensor=input_tensor,
+            expected_output=expected_output,
+            params=parameters,
         )
 
     def test_batch(self):
@@ -397,14 +409,19 @@ class TestCenterCropAlternative(CommonTests):
     _default_param_set: Dict["str", Any] = {"size": (2, 2), "align_corners": True}
 
     @pytest.fixture(
-        params=default_with_one_parameter_changed(default=_default_param_set, **possible_params), scope="class"
+        params=default_with_one_parameter_changed(default=_default_param_set, **possible_params),
+        scope="class",
     )
     def param_set(self, request):
         return request.param
 
     @pytest.mark.parametrize(
         "input_shape,expected_output_shape",
-        [((4, 5), (1, 1, 2, 3)), ((3, 4, 5), (1, 3, 2, 3)), ((2, 3, 4, 5), (2, 3, 2, 3))],
+        [
+            ((4, 5), (1, 1, 2, 3)),
+            ((3, 4, 5), (1, 3, 2, 3)),
+            ((2, 3, 4, 5), (2, 3, 2, 3)),
+        ],
     )
     def test_cardinality(self, input_shape, expected_output_shape):
         self._test_cardinality_implementation(
@@ -418,13 +435,17 @@ class TestCenterCropAlternative(CommonTests):
         torch.manual_seed(42)
 
         input_tensor = torch.tensor(
-            [[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 0.0, 0.1, 0.2]]], device=self.device, dtype=self.dtype
+            [[[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 0.0, 0.1, 0.2]]],
+            device=self.device,
+            dtype=self.dtype,
         )
         expected_output = torch.tensor([[[[0.6, 0.7]]]], device=self.device, dtype=self.dtype)
 
         parameters = {"size": (1, 2), "align_corners": True, "resample": 0}
         self._test_random_p_1_implementation(
-            input_tensor=input_tensor, expected_output=expected_output, params=parameters
+            input_tensor=input_tensor,
+            expected_output=expected_output,
+            params=parameters,
         )
 
     def test_batch(self):
@@ -433,9 +454,16 @@ class TestCenterCropAlternative(CommonTests):
         input_tensor = torch.rand((2, 3, 4, 4), device=self.device, dtype=self.dtype)
         expected_output = input_tensor[:, :, 1:3, 1:3]
         expected_transformation = torch.tensor(
-            [[[1.0, 0.0, -1.0], [0.0, 1.0, -1.0], [0.0, 0.0, 1.0]]], device=self.device, dtype=self.dtype
+            [[[1.0, 0.0, -1.0], [0.0, 1.0, -1.0], [0.0, 0.0, 1.0]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat(2, 1, 1)
-        parameters = {"size": (2, 2), "align_corners": True, "resample": 0, "cropping_mode": "resample"}
+        parameters = {
+            "size": (2, 2),
+            "align_corners": True,
+            "resample": 0,
+            "cropping_mode": "resample",
+        }
         self._test_random_p_1_implementation(
             input_tensor=input_tensor,
             expected_output=expected_output,
@@ -475,28 +503,40 @@ class TestRandomHorizontalFlipAlternative(CommonTests):
         torch.manual_seed(42)
 
         input_tensor = torch.tensor(
-            [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]], device=self.device, dtype=self.dtype
+            [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]],
+            device=self.device,
+            dtype=self.dtype,
         )
         expected_output = torch.tensor(
-            [[[[0.3, 0.2, 0.1], [0.6, 0.5, 0.4], [0.9, 0.8, 0.7]]]], device=self.device, dtype=self.dtype
+            [[[[0.3, 0.2, 0.1], [0.6, 0.5, 0.4], [0.9, 0.8, 0.7]]]],
+            device=self.device,
+            dtype=self.dtype,
         )
 
         parameters = {}
         self._test_random_p_1_implementation(
-            input_tensor=input_tensor, expected_output=expected_output, params=parameters
+            input_tensor=input_tensor,
+            expected_output=expected_output,
+            params=parameters,
         )
 
     def test_batch(self):
         torch.manual_seed(12)
 
         input_tensor = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]], device=self.device, dtype=self.dtype
+            [[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat((2, 1, 1, 1))
         expected_output = torch.tensor(
-            [[[[0.3, 0.2, 0.1], [0.6, 0.5, 0.4], [0.9, 0.8, 0.7]]]], device=self.device, dtype=self.dtype
+            [[[[0.3, 0.2, 0.1], [0.6, 0.5, 0.4], [0.9, 0.8, 0.7]]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat((2, 1, 1, 1))
         expected_transformation = torch.tensor(
-            [[[-1.0, 0.0, 2.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=self.device, dtype=self.dtype
+            [[[-1.0, 0.0, 2.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat((2, 1, 1))
         parameters = {}
         self._test_random_p_1_implementation(
@@ -524,28 +564,40 @@ class TestRandomVerticalFlipAlternative(CommonTests):
         torch.manual_seed(42)
 
         input_tensor = torch.tensor(
-            [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]], device=self.device, dtype=self.dtype
+            [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]],
+            device=self.device,
+            dtype=self.dtype,
         )
         expected_output = torch.tensor(
-            [[[[0.7, 0.8, 0.9], [0.4, 0.5, 0.6], [0.1, 0.2, 0.3]]]], device=self.device, dtype=self.dtype
+            [[[[0.7, 0.8, 0.9], [0.4, 0.5, 0.6], [0.1, 0.2, 0.3]]]],
+            device=self.device,
+            dtype=self.dtype,
         )
 
         parameters = {}
         self._test_random_p_1_implementation(
-            input_tensor=input_tensor, expected_output=expected_output, params=parameters
+            input_tensor=input_tensor,
+            expected_output=expected_output,
+            params=parameters,
         )
 
     def test_batch(self):
         torch.manual_seed(12)
 
         input_tensor = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]], device=self.device, dtype=self.dtype
+            [[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat((2, 1, 1, 1))
         expected_output = torch.tensor(
-            [[[[0.7, 0.8, 0.9], [0.4, 0.5, 0.6], [0.1, 0.2, 0.3]]]], device=self.device, dtype=self.dtype
+            [[[[0.7, 0.8, 0.9], [0.4, 0.5, 0.6], [0.1, 0.2, 0.3]]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat((2, 1, 1, 1))
         expected_transformation = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]], device=self.device, dtype=self.dtype
+            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat((2, 1, 1))
         parameters = {}
         self._test_random_p_1_implementation(
@@ -567,10 +619,14 @@ class TestRandomRotationAlternative(CommonTests):
         "align_corners": (False, True),
     }
     _augmentation_cls = RandomRotation
-    _default_param_set: Dict["str", Any] = {"degrees": (30.0, 30.0), "align_corners": True}
+    _default_param_set: Dict["str", Any] = {
+        "degrees": (30.0, 30.0),
+        "align_corners": True,
+    }
 
     @pytest.fixture(
-        params=default_with_one_parameter_changed(default=_default_param_set, **possible_params), scope="class"
+        params=default_with_one_parameter_changed(default=_default_param_set, **possible_params),
+        scope="class",
     )
     def param_set(self, request):
         return request.param
@@ -579,15 +635,21 @@ class TestRandomRotationAlternative(CommonTests):
         torch.manual_seed(42)
 
         input_tensor = torch.tensor(
-            [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]], device=self.device, dtype=self.dtype
+            [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]],
+            device=self.device,
+            dtype=self.dtype,
         )
         expected_output = torch.tensor(
-            [[[[0.3, 0.6, 0.9], [0.2, 0.5, 0.8], [0.1, 0.4, 0.7]]]], device=self.device, dtype=self.dtype
+            [[[[0.3, 0.6, 0.9], [0.2, 0.5, 0.8], [0.1, 0.4, 0.7]]]],
+            device=self.device,
+            dtype=self.dtype,
         )
 
         parameters = {"degrees": (90.0, 90.0), "align_corners": True}
         self._test_random_p_1_implementation(
-            input_tensor=input_tensor, expected_output=expected_output, params=parameters
+            input_tensor=input_tensor,
+            expected_output=expected_output,
+            params=parameters,
         )
 
     def test_batch(self):
@@ -597,7 +659,9 @@ class TestRandomRotationAlternative(CommonTests):
         torch.manual_seed(12)
 
         input_tensor = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]], device=self.device, dtype=self.dtype
+            [[[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat((2, 1, 1, 1))
         expected_output = input_tensor
         expected_transformation = kornia.eye_like(3, input_tensor)
@@ -641,18 +705,23 @@ class TestRandomGrayscaleAlternative(CommonTests):
         return request.param
 
     @pytest.mark.parametrize(
-        "input_shape,expected_output_shape", [((3, 4, 5), (1, 3, 4, 5)), ((2, 3, 4, 5), (2, 3, 4, 5))]
+        "input_shape,expected_output_shape",
+        [((3, 4, 5), (1, 3, 4, 5)), ((2, 3, 4, 5), (2, 3, 4, 5))],
     )
     def test_cardinality(self, input_shape, expected_output_shape):
         self._test_cardinality_implementation(
-            input_shape=input_shape, expected_output_shape=expected_output_shape, params=self._default_param_set
+            input_shape=input_shape,
+            expected_output_shape=expected_output_shape,
+            params=self._default_param_set,
         )
 
     def test_random_p_1(self):
         torch.manual_seed(42)
 
         input_tensor = torch.tensor(
-            [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 0.0, 0.1, 0.2]], device=self.device, dtype=self.dtype
+            [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 0.0, 0.1, 0.2]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat(1, 3, 1, 1)
         expected_output = (
             (input_tensor * torch.tensor([0.299, 0.587, 0.114], device=self.device, dtype=self.dtype).view(1, 3, 1, 1))
@@ -662,14 +731,18 @@ class TestRandomGrayscaleAlternative(CommonTests):
 
         parameters = {}
         self._test_random_p_1_implementation(
-            input_tensor=input_tensor, expected_output=expected_output, params=parameters
+            input_tensor=input_tensor,
+            expected_output=expected_output,
+            params=parameters,
         )
 
     def test_batch(self):
         torch.manual_seed(42)
 
         input_tensor = torch.tensor(
-            [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 0.0, 0.1, 0.2]], device=self.device, dtype=self.dtype
+            [[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8], [0.9, 0.0, 0.1, 0.2]],
+            device=self.device,
+            dtype=self.dtype,
         ).repeat(2, 3, 1, 1)
         expected_output = (
             (input_tensor * torch.tensor([0.299, 0.587, 0.114], device=self.device, dtype=self.dtype).view(1, 3, 1, 1))
@@ -710,21 +783,29 @@ class TestRandomHorizontalFlip(BaseTester):
         f1 = RandomHorizontalFlip(p=0.0, keepdim=True)
 
         input = torch.tensor(
-            [[[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 2.0]]], device=device, dtype=dtype
+            [[[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 2.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 4
 
         expected = torch.tensor(
-            [[[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [2.0, 1.0, 0.0, 0.0]]], device=device, dtype=dtype
+            [[[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [2.0, 1.0, 0.0, 0.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 4
 
         expected = expected.to(device)
 
         expected_transform = torch.tensor(
-            [[[-1.0, 0.0, 3.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[-1.0, 0.0, 3.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         identity = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         self.assert_close(f(input), expected)
@@ -739,19 +820,27 @@ class TestRandomHorizontalFlip(BaseTester):
         f1 = RandomHorizontalFlip(p=0.0)
 
         input = torch.tensor(
-            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype
+            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected = torch.tensor(
-            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]]]], device=device, dtype=dtype
+            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 0.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected_transform = torch.tensor(
-            [[[-1.0, 0.0, 2.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[-1.0, 0.0, 2.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         identity = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         input = input.repeat(5, 3, 1, 1)  # 5 x 3 x 3 x 3
@@ -777,11 +866,15 @@ class TestRandomHorizontalFlip(BaseTester):
         f = AugmentationSequential(RandomHorizontalFlip(p=1.0), RandomHorizontalFlip(p=1.0))
 
         input = torch.tensor(
-            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype
+            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected_transform = torch.tensor(
-            [[[-1.0, 0.0, 2.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[-1.0, 0.0, 2.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         expected_transform_1 = expected_transform @ expected_transform
@@ -795,7 +888,9 @@ class TestRandomHorizontalFlip(BaseTester):
         f = RandomHorizontalFlip(p=1.0)
 
         input = torch.tensor(
-            [[[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]]], device=device, dtype=dtype
+            [[[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 4
 
         input_coordinates = torch.tensor(
@@ -811,7 +906,9 @@ class TestRandomHorizontalFlip(BaseTester):
         )  # 1 x 3 x 3
 
         expected_output = torch.tensor(
-            [[[[4.0, 3.0, 2.0, 1.0], [8.0, 7.0, 6.0, 5.0], [12.0, 11.0, 10.0, 9.0]]]], device=device, dtype=dtype
+            [[[[4.0, 3.0, 2.0, 1.0], [8.0, 7.0, 6.0, 5.0], [12.0, 11.0, 10.0, 9.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 4
 
         output = f(input)
@@ -826,10 +923,16 @@ class TestRandomHorizontalFlip(BaseTester):
         self.assert_close(output, expected_output)
         # Transformed indices must not be out of bound
         assert (
-            torch.torch.logical_and(result_coordinates[0, 0, :] >= 0, result_coordinates[0, 0, :] < input.shape[-1])
+            torch.torch.logical_and(
+                result_coordinates[0, 0, :] >= 0,
+                result_coordinates[0, 0, :] < input.shape[-1],
+            )
         ).all()
         assert (
-            torch.torch.logical_and(result_coordinates[0, 1, :] >= 0, result_coordinates[0, 1, :] < input.shape[-2])
+            torch.torch.logical_and(
+                result_coordinates[0, 1, :] >= 0,
+                result_coordinates[0, 1, :] < input.shape[-2],
+            )
         ).all()
         # Values in the output tensor at the places of transformed indices must
         # have the same value as the input tensor has at the corresponding
@@ -859,19 +962,27 @@ class TestRandomVerticalFlip(BaseTester):
         f1 = RandomVerticalFlip(p=0.0)
 
         input = torch.tensor(
-            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype
+            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected = torch.tensor(
-            [[[[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]], device=device, dtype=dtype
+            [[[[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected_transform = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 3 x 3
 
         identity = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 3 x 3
 
         self.assert_close(f(input), expected, low_tolerance=True)
@@ -886,19 +997,27 @@ class TestRandomVerticalFlip(BaseTester):
         f = RandomVerticalFlip(p=1.0)
 
         input = torch.tensor(
-            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype
+            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected = torch.tensor(
-            [[[[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]], device=device, dtype=dtype
+            [[[[0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected_transform = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         identity = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         input = input.repeat(5, 3, 1, 1)  # 5 x 3 x 3 x 3
@@ -921,11 +1040,15 @@ class TestRandomVerticalFlip(BaseTester):
         f = AugmentationSequential(RandomVerticalFlip(p=1.0), RandomVerticalFlip(p=1.0))
 
         input = torch.tensor(
-            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype
+            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
 
         expected_transform = torch.tensor(
-            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+            [[[1.0, 0.0, 0.0], [0.0, -1.0, 2.0], [0.0, 0.0, 1.0]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 3 x 3
 
         expected_transform_1 = expected_transform @ expected_transform
@@ -937,7 +1060,9 @@ class TestRandomVerticalFlip(BaseTester):
         f = RandomVerticalFlip(p=1.0)
 
         input = torch.tensor(
-            [[[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]]], device=device, dtype=dtype
+            [[[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 4
 
         input_coordinates = torch.tensor(
@@ -953,7 +1078,9 @@ class TestRandomVerticalFlip(BaseTester):
         )  # 1 x 3 x 3
 
         expected_output = torch.tensor(
-            [[[[9.0, 10.0, 11.0, 12.0], [5.0, 6.0, 7.0, 8.0], [1.0, 2.0, 3.0, 4.0]]]], device=device, dtype=dtype
+            [[[[9.0, 10.0, 11.0, 12.0], [5.0, 6.0, 7.0, 8.0], [1.0, 2.0, 3.0, 4.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 4
 
         output = f(input)
@@ -968,10 +1095,16 @@ class TestRandomVerticalFlip(BaseTester):
         self.assert_close(output, expected_output)
         # Transformed indices must not be out of bound
         assert (
-            torch.torch.logical_and(result_coordinates[0, 0, :] >= 0, result_coordinates[0, 0, :] < input.shape[-1])
+            torch.torch.logical_and(
+                result_coordinates[0, 0, :] >= 0,
+                result_coordinates[0, 0, :] < input.shape[-1],
+            )
         ).all()
         assert (
-            torch.torch.logical_and(result_coordinates[0, 1, :] >= 0, result_coordinates[0, 1, :] < input.shape[-2])
+            torch.torch.logical_and(
+                result_coordinates[0, 1, :] >= 0,
+                result_coordinates[0, 1, :] < input.shape[-2],
+            )
         ).all()
         # Values in the output tensor at the places of transformed indices must
         # have the same value as the input tensor has at the corresponding
@@ -1028,14 +1161,38 @@ class TestColorJiggle(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.2529, 0.3529, 0.4529], [0.7529, 0.6529, 0.5529], [0.8529, 0.9529, 1.0000]],
-                    [[0.2529, 0.3529, 0.4529], [0.7529, 0.6529, 0.5529], [0.8529, 0.9529, 1.0000]],
-                    [[0.2529, 0.3529, 0.4529], [0.7529, 0.6529, 0.5529], [0.8529, 0.9529, 1.0000]],
+                    [
+                        [0.2529, 0.3529, 0.4529],
+                        [0.7529, 0.6529, 0.5529],
+                        [0.8529, 0.9529, 1.0000],
+                    ],
+                    [
+                        [0.2529, 0.3529, 0.4529],
+                        [0.7529, 0.6529, 0.5529],
+                        [0.8529, 0.9529, 1.0000],
+                    ],
+                    [
+                        [0.2529, 0.3529, 0.4529],
+                        [0.7529, 0.6529, 0.5529],
+                        [0.8529, 0.9529, 1.0000],
+                    ],
                 ],
                 [
-                    [[0.2660, 0.3660, 0.4660], [0.7660, 0.6660, 0.5660], [0.8660, 0.9660, 1.0000]],
-                    [[0.2660, 0.3660, 0.4660], [0.7660, 0.6660, 0.5660], [0.8660, 0.9660, 1.0000]],
-                    [[0.2660, 0.3660, 0.4660], [0.7660, 0.6660, 0.5660], [0.8660, 0.9660, 1.0000]],
+                    [
+                        [0.2660, 0.3660, 0.4660],
+                        [0.7660, 0.6660, 0.5660],
+                        [0.8660, 0.9660, 1.0000],
+                    ],
+                    [
+                        [0.2660, 0.3660, 0.4660],
+                        [0.7660, 0.6660, 0.5660],
+                        [0.8660, 0.9660, 1.0000],
+                    ],
+                    [
+                        [0.2660, 0.3660, 0.4660],
+                        [0.7660, 0.6660, 0.5660],
+                        [0.8660, 0.9660, 1.0000],
+                    ],
                 ],
             ],
             device=device,
@@ -1047,7 +1204,9 @@ class TestColorJiggle(BaseTester):
         f = ColorJiggle(brightness=0.2)
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1060,7 +1219,9 @@ class TestColorJiggle(BaseTester):
         f = ColorJiggle(brightness=(0.8, 1.2))
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1072,14 +1233,38 @@ class TestColorJiggle(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.0953, 0.1906, 0.2859], [0.5719, 0.4766, 0.3813], [0.6672, 0.7625, 0.9531]],
-                    [[0.0953, 0.1906, 0.2859], [0.5719, 0.4766, 0.3813], [0.6672, 0.7625, 0.9531]],
-                    [[0.0953, 0.1906, 0.2859], [0.5719, 0.4766, 0.3813], [0.6672, 0.7625, 0.9531]],
+                    [
+                        [0.0953, 0.1906, 0.2859],
+                        [0.5719, 0.4766, 0.3813],
+                        [0.6672, 0.7625, 0.9531],
+                    ],
+                    [
+                        [0.0953, 0.1906, 0.2859],
+                        [0.5719, 0.4766, 0.3813],
+                        [0.6672, 0.7625, 0.9531],
+                    ],
+                    [
+                        [0.0953, 0.1906, 0.2859],
+                        [0.5719, 0.4766, 0.3813],
+                        [0.6672, 0.7625, 0.9531],
+                    ],
                 ],
                 [
-                    [[0.1184, 0.2367, 0.3551], [0.7102, 0.5919, 0.4735], [0.8286, 0.9470, 1.0000]],
-                    [[0.1184, 0.2367, 0.3551], [0.7102, 0.5919, 0.4735], [0.8286, 0.9470, 1.0000]],
-                    [[0.1184, 0.2367, 0.3551], [0.7102, 0.5919, 0.4735], [0.8286, 0.9470, 1.0000]],
+                    [
+                        [0.1184, 0.2367, 0.3551],
+                        [0.7102, 0.5919, 0.4735],
+                        [0.8286, 0.9470, 1.0000],
+                    ],
+                    [
+                        [0.1184, 0.2367, 0.3551],
+                        [0.7102, 0.5919, 0.4735],
+                        [0.8286, 0.9470, 1.0000],
+                    ],
+                    [
+                        [0.1184, 0.2367, 0.3551],
+                        [0.7102, 0.5919, 0.4735],
+                        [0.8286, 0.9470, 1.0000],
+                    ],
                 ],
             ],
             device=device,
@@ -1091,7 +1276,9 @@ class TestColorJiggle(BaseTester):
         f = ColorJiggle(contrast=0.2)
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1104,7 +1291,9 @@ class TestColorJiggle(BaseTester):
         f = ColorJiggle(contrast=[0.8, 1.2])
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1116,14 +1305,38 @@ class TestColorJiggle(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1876, 0.2584, 0.3389], [0.6292, 0.5000, 0.4000], [0.7097, 0.8000, 1.0000]],
-                    [[1.0000, 0.5292, 0.6097], [0.6292, 0.3195, 0.2195], [0.8000, 0.1682, 0.2779]],
-                    [[0.6389, 0.8000, 0.7000], [0.9000, 0.3195, 0.2195], [0.8000, 0.4389, 0.5487]],
+                    [
+                        [0.1876, 0.2584, 0.3389],
+                        [0.6292, 0.5000, 0.4000],
+                        [0.7097, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.5292, 0.6097],
+                        [0.6292, 0.3195, 0.2195],
+                        [0.8000, 0.1682, 0.2779],
+                    ],
+                    [
+                        [0.6389, 0.8000, 0.7000],
+                        [0.9000, 0.3195, 0.2195],
+                        [0.8000, 0.4389, 0.5487],
+                    ],
                 ],
                 [
-                    [[0.0000, 0.1295, 0.2530], [0.5648, 0.5000, 0.4000], [0.6883, 0.8000, 1.0000]],
-                    [[1.0000, 0.4648, 0.5883], [0.5648, 0.2765, 0.1765], [0.8000, 0.0178, 0.1060]],
-                    [[0.5556, 0.8000, 0.7000], [0.9000, 0.2765, 0.1765], [0.8000, 0.3530, 0.4413]],
+                    [
+                        [0.0000, 0.1295, 0.2530],
+                        [0.5648, 0.5000, 0.4000],
+                        [0.6883, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4648, 0.5883],
+                        [0.5648, 0.2765, 0.1765],
+                        [0.8000, 0.0178, 0.1060],
+                    ],
+                    [
+                        [0.5556, 0.8000, 0.7000],
+                        [0.9000, 0.2765, 0.1765],
+                        [0.8000, 0.3530, 0.4413],
+                    ],
                 ],
             ],
             device=device,
@@ -1196,14 +1409,38 @@ class TestColorJiggle(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1000, 0.2000, 0.3000], [0.6000, 0.5000, 0.4000], [0.7000, 0.8000, 1.0000]],
-                    [[1.0000, 0.5251, 0.6167], [0.6126, 0.3000, 0.2000], [0.8000, 0.1000, 0.2000]],
-                    [[0.5623, 0.8000, 0.7000], [0.9000, 0.3084, 0.2084], [0.7958, 0.4293, 0.5335]],
+                    [
+                        [0.1000, 0.2000, 0.3000],
+                        [0.6000, 0.5000, 0.4000],
+                        [0.7000, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.5251, 0.6167],
+                        [0.6126, 0.3000, 0.2000],
+                        [0.8000, 0.1000, 0.2000],
+                    ],
+                    [
+                        [0.5623, 0.8000, 0.7000],
+                        [0.9000, 0.3084, 0.2084],
+                        [0.7958, 0.4293, 0.5335],
+                    ],
                 ],
                 [
-                    [[0.1000, 0.2000, 0.3000], [0.6116, 0.5000, 0.4000], [0.7000, 0.8000, 1.0000]],
-                    [[1.0000, 0.4769, 0.5846], [0.6000, 0.3077, 0.2077], [0.7961, 0.1000, 0.2000]],
-                    [[0.6347, 0.8000, 0.7000], [0.9000, 0.3000, 0.2000], [0.8000, 0.3730, 0.4692]],
+                    [
+                        [0.1000, 0.2000, 0.3000],
+                        [0.6116, 0.5000, 0.4000],
+                        [0.7000, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4769, 0.5846],
+                        [0.6000, 0.3077, 0.2077],
+                        [0.7961, 0.1000, 0.2000],
+                    ],
+                    [
+                        [0.6347, 0.8000, 0.7000],
+                        [0.9000, 0.3000, 0.2000],
+                        [0.8000, 0.3730, 0.4692],
+                    ],
                 ],
             ],
             device=device,
@@ -1339,14 +1576,38 @@ class TestColorJitter(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1153, 0.2306, 0.3459], [0.6917, 0.5764, 0.4612], [0.8070, 0.9223, 1.0000]],
-                    [[0.1153, 0.2306, 0.3459], [0.6917, 0.5764, 0.4612], [0.8070, 0.9223, 1.0000]],
-                    [[0.1153, 0.2306, 0.3459], [0.6917, 0.5764, 0.4612], [0.8070, 0.9223, 1.0000]],
+                    [
+                        [0.1153, 0.2306, 0.3459],
+                        [0.6917, 0.5764, 0.4612],
+                        [0.8070, 0.9223, 1.0000],
+                    ],
+                    [
+                        [0.1153, 0.2306, 0.3459],
+                        [0.6917, 0.5764, 0.4612],
+                        [0.8070, 0.9223, 1.0000],
+                    ],
+                    [
+                        [0.1153, 0.2306, 0.3459],
+                        [0.6917, 0.5764, 0.4612],
+                        [0.8070, 0.9223, 1.0000],
+                    ],
                 ],
                 [
-                    [[0.1166, 0.2332, 0.3498], [0.6996, 0.5830, 0.4664], [0.8162, 0.9328, 1.0000]],
-                    [[0.1166, 0.2332, 0.3498], [0.6996, 0.5830, 0.4664], [0.8162, 0.9328, 1.0000]],
-                    [[0.1166, 0.2332, 0.3498], [0.6996, 0.5830, 0.4664], [0.8162, 0.9328, 1.0000]],
+                    [
+                        [0.1166, 0.2332, 0.3498],
+                        [0.6996, 0.5830, 0.4664],
+                        [0.8162, 0.9328, 1.0000],
+                    ],
+                    [
+                        [0.1166, 0.2332, 0.3498],
+                        [0.6996, 0.5830, 0.4664],
+                        [0.8162, 0.9328, 1.0000],
+                    ],
+                    [
+                        [0.1166, 0.2332, 0.3498],
+                        [0.6996, 0.5830, 0.4664],
+                        [0.8162, 0.9328, 1.0000],
+                    ],
                 ],
             ],
             device=device,
@@ -1358,7 +1619,9 @@ class TestColorJitter(BaseTester):
         f = ColorJitter(brightness=0.2)
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1371,7 +1634,9 @@ class TestColorJitter(BaseTester):
         f = ColorJitter(brightness=(0.8, 1.2))
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1383,14 +1648,38 @@ class TestColorJitter(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1193, 0.2146, 0.3099], [0.5958, 0.5005, 0.4052], [0.6911, 0.7865, 0.9771]],
-                    [[0.1193, 0.2146, 0.3099], [0.5958, 0.5005, 0.4052], [0.6911, 0.7865, 0.9771]],
-                    [[0.1193, 0.2146, 0.3099], [0.5958, 0.5005, 0.4052], [0.6911, 0.7865, 0.9771]],
+                    [
+                        [0.1193, 0.2146, 0.3099],
+                        [0.5958, 0.5005, 0.4052],
+                        [0.6911, 0.7865, 0.9771],
+                    ],
+                    [
+                        [0.1193, 0.2146, 0.3099],
+                        [0.5958, 0.5005, 0.4052],
+                        [0.6911, 0.7865, 0.9771],
+                    ],
+                    [
+                        [0.1193, 0.2146, 0.3099],
+                        [0.5958, 0.5005, 0.4052],
+                        [0.6911, 0.7865, 0.9771],
+                    ],
                 ],
                 [
-                    [[0.0245, 0.1428, 0.2612], [0.6163, 0.4980, 0.3796], [0.7347, 0.8531, 1.0000]],
-                    [[0.0245, 0.1428, 0.2612], [0.6163, 0.4980, 0.3796], [0.7347, 0.8531, 1.0000]],
-                    [[0.0245, 0.1428, 0.2612], [0.6163, 0.4980, 0.3796], [0.7347, 0.8531, 1.0000]],
+                    [
+                        [0.0245, 0.1428, 0.2612],
+                        [0.6163, 0.4980, 0.3796],
+                        [0.7347, 0.8531, 1.0000],
+                    ],
+                    [
+                        [0.0245, 0.1428, 0.2612],
+                        [0.6163, 0.4980, 0.3796],
+                        [0.7347, 0.8531, 1.0000],
+                    ],
+                    [
+                        [0.0245, 0.1428, 0.2612],
+                        [0.6163, 0.4980, 0.3796],
+                        [0.7347, 0.8531, 1.0000],
+                    ],
                 ],
             ],
             device=device,
@@ -1402,7 +1691,9 @@ class TestColorJitter(BaseTester):
         f = ColorJitter(contrast=0.2)
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1415,7 +1706,9 @@ class TestColorJitter(BaseTester):
         f = ColorJitter(contrast=[0.8, 1.2])
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1427,14 +1720,38 @@ class TestColorJitter(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1570, 0.2238, 0.3216], [0.6033, 0.4863, 0.3863], [0.7068, 0.7555, 0.9487]],
-                    [[0.9693, 0.4946, 0.5924], [0.6033, 0.3058, 0.2058], [0.7971, 0.1237, 0.2266]],
-                    [[0.6083, 0.7654, 0.6826], [0.8741, 0.3058, 0.2058], [0.7971, 0.3945, 0.4974]],
+                    [
+                        [0.1570, 0.2238, 0.3216],
+                        [0.6033, 0.4863, 0.3863],
+                        [0.7068, 0.7555, 0.9487],
+                    ],
+                    [
+                        [0.9693, 0.4946, 0.5924],
+                        [0.6033, 0.3058, 0.2058],
+                        [0.7971, 0.1237, 0.2266],
+                    ],
+                    [
+                        [0.6083, 0.7654, 0.6826],
+                        [0.8741, 0.3058, 0.2058],
+                        [0.7971, 0.3945, 0.4974],
+                    ],
                 ],
                 [
-                    [[0.0312, 0.1713, 0.2740], [0.5960, 0.5165, 0.4165], [0.6918, 0.8536, 1.0000]],
-                    [[1.0000, 0.5065, 0.6092], [0.5960, 0.2930, 0.1930], [0.8035, 0.0714, 0.1679]],
-                    [[0.5900, 0.8418, 0.7210], [0.9312, 0.2930, 0.1930], [0.8035, 0.4066, 0.5031]],
+                    [
+                        [0.0312, 0.1713, 0.2740],
+                        [0.5960, 0.5165, 0.4165],
+                        [0.6918, 0.8536, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.5065, 0.6092],
+                        [0.5960, 0.2930, 0.1930],
+                        [0.8035, 0.0714, 0.1679],
+                    ],
+                    [
+                        [0.5900, 0.8418, 0.7210],
+                        [0.9312, 0.2930, 0.1930],
+                        [0.8035, 0.4066, 0.5031],
+                    ],
                 ],
             ],
             device=device,
@@ -1507,14 +1824,38 @@ class TestColorJitter(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1000, 0.2000, 0.3000], [0.6000, 0.5000, 0.4000], [0.7000, 0.8000, 1.0000]],
-                    [[1.0000, 0.5251, 0.6167], [0.6126, 0.3000, 0.2000], [0.8000, 0.1000, 0.2000]],
-                    [[0.5623, 0.8000, 0.7000], [0.9000, 0.3084, 0.2084], [0.7958, 0.4293, 0.5335]],
+                    [
+                        [0.1000, 0.2000, 0.3000],
+                        [0.6000, 0.5000, 0.4000],
+                        [0.7000, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.5251, 0.6167],
+                        [0.6126, 0.3000, 0.2000],
+                        [0.8000, 0.1000, 0.2000],
+                    ],
+                    [
+                        [0.5623, 0.8000, 0.7000],
+                        [0.9000, 0.3084, 0.2084],
+                        [0.7958, 0.4293, 0.5335],
+                    ],
                 ],
                 [
-                    [[0.1000, 0.2000, 0.3000], [0.6116, 0.5000, 0.4000], [0.7000, 0.8000, 1.0000]],
-                    [[1.0000, 0.4769, 0.5846], [0.6000, 0.3077, 0.2077], [0.7961, 0.1000, 0.2000]],
-                    [[0.6347, 0.8000, 0.7000], [0.9000, 0.3000, 0.2000], [0.8000, 0.3730, 0.4692]],
+                    [
+                        [0.1000, 0.2000, 0.3000],
+                        [0.6116, 0.5000, 0.4000],
+                        [0.7000, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4769, 0.5846],
+                        [0.6000, 0.3077, 0.2077],
+                        [0.7961, 0.1000, 0.2000],
+                    ],
+                    [
+                        [0.6347, 0.8000, 0.7000],
+                        [0.9000, 0.3000, 0.2000],
+                        [0.8000, 0.3730, 0.4692],
+                    ],
                 ],
             ],
             device=device,
@@ -1593,6 +1934,7 @@ class TestColorJitter(BaseTester):
         self.assert_close(f(input), expected)
         self.assert_close(f.transform_matrix, expected_transform)
 
+    @pytest.mark.slow
     @pytest.mark.skipif(torch_version_le(2, 1, 0), reason="not supported in this pytorch version")
     def test_compile(self, device):
         input = torch.rand((1, 3, 5, 5), device=device)
@@ -1631,14 +1973,38 @@ class TestRandomBrightness(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.2529, 0.3529, 0.4529], [0.7529, 0.6529, 0.5529], [0.8529, 0.9529, 1.0000]],
-                    [[0.2529, 0.3529, 0.4529], [0.7529, 0.6529, 0.5529], [0.8529, 0.9529, 1.0000]],
-                    [[0.2529, 0.3529, 0.4529], [0.7529, 0.6529, 0.5529], [0.8529, 0.9529, 1.0000]],
+                    [
+                        [0.2529, 0.3529, 0.4529],
+                        [0.7529, 0.6529, 0.5529],
+                        [0.8529, 0.9529, 1.0000],
+                    ],
+                    [
+                        [0.2529, 0.3529, 0.4529],
+                        [0.7529, 0.6529, 0.5529],
+                        [0.8529, 0.9529, 1.0000],
+                    ],
+                    [
+                        [0.2529, 0.3529, 0.4529],
+                        [0.7529, 0.6529, 0.5529],
+                        [0.8529, 0.9529, 1.0000],
+                    ],
                 ],
                 [
-                    [[0.2660, 0.3660, 0.4660], [0.7660, 0.6660, 0.5660], [0.8660, 0.9660, 1.0000]],
-                    [[0.2660, 0.3660, 0.4660], [0.7660, 0.6660, 0.5660], [0.8660, 0.9660, 1.0000]],
-                    [[0.2660, 0.3660, 0.4660], [0.7660, 0.6660, 0.5660], [0.8660, 0.9660, 1.0000]],
+                    [
+                        [0.2660, 0.3660, 0.4660],
+                        [0.7660, 0.6660, 0.5660],
+                        [0.8660, 0.9660, 1.0000],
+                    ],
+                    [
+                        [0.2660, 0.3660, 0.4660],
+                        [0.7660, 0.6660, 0.5660],
+                        [0.8660, 0.9660, 1.0000],
+                    ],
+                    [
+                        [0.2660, 0.3660, 0.4660],
+                        [0.7660, 0.6660, 0.5660],
+                        [0.8660, 0.9660, 1.0000],
+                    ],
                 ],
             ],
             device=device,
@@ -1650,7 +2016,9 @@ class TestRandomBrightness(BaseTester):
         f = RandomBrightness(brightness=(0.8, 1.2))
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1716,14 +2084,38 @@ class TestRandomContrast(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1153, 0.2306, 0.3459], [0.6917, 0.5765, 0.4612], [0.8070, 0.9225, 1.0000]],
-                    [[0.1153, 0.2306, 0.3459], [0.6917, 0.5765, 0.4612], [0.8070, 0.9225, 1.0000]],
-                    [[0.1153, 0.2306, 0.3459], [0.6917, 0.5765, 0.4612], [0.8070, 0.9225, 1.0000]],
+                    [
+                        [0.1153, 0.2306, 0.3459],
+                        [0.6917, 0.5765, 0.4612],
+                        [0.8070, 0.9225, 1.0000],
+                    ],
+                    [
+                        [0.1153, 0.2306, 0.3459],
+                        [0.6917, 0.5765, 0.4612],
+                        [0.8070, 0.9225, 1.0000],
+                    ],
+                    [
+                        [0.1153, 0.2306, 0.3459],
+                        [0.6917, 0.5765, 0.4612],
+                        [0.8070, 0.9225, 1.0000],
+                    ],
                 ],
                 [
-                    [[0.1166, 0.2332, 0.3498], [0.6996, 0.5830, 0.4664], [0.8162, 0.9328, 1.0000]],
-                    [[0.1166, 0.2332, 0.3498], [0.6996, 0.5830, 0.4664], [0.8162, 0.9328, 1.0000]],
-                    [[0.1166, 0.2332, 0.3498], [0.6996, 0.5830, 0.4664], [0.8162, 0.9328, 1.0000]],
+                    [
+                        [0.1166, 0.2332, 0.3498],
+                        [0.6996, 0.5830, 0.4664],
+                        [0.8162, 0.9328, 1.0000],
+                    ],
+                    [
+                        [0.1166, 0.2332, 0.3498],
+                        [0.6996, 0.5830, 0.4664],
+                        [0.8162, 0.9328, 1.0000],
+                    ],
+                    [
+                        [0.1166, 0.2332, 0.3498],
+                        [0.6996, 0.5830, 0.4664],
+                        [0.8162, 0.9328, 1.0000],
+                    ],
                 ],
             ],
             device=device,
@@ -1735,7 +2127,9 @@ class TestRandomContrast(BaseTester):
         f = RandomContrast(contrast=(0.8, 1.2))
 
         input = torch.tensor(
-            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]], device=device, dtype=dtype
+            [[[[0.1, 0.2, 0.3], [0.6, 0.5, 0.4], [0.7, 0.8, 1.0]]]],
+            device=device,
+            dtype=dtype,
         )  # 1 x 1 x 3 x 3
         input = input.repeat(2, 3, 1, 1)  # 2 x 3 x 3
 
@@ -1801,14 +2195,38 @@ class TestRandomHue(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.1000, 0.2000, 0.3000], [0.6438, 0.5000, 0.4000], [0.7000, 0.8000, 1.0000]],
-                    [[1.0000, 0.4124, 0.5416], [0.6000, 0.3292, 0.2292], [0.7854, 0.1000, 0.2000]],
-                    [[0.7314, 0.8000, 0.7000], [0.9000, 0.3000, 0.2000], [0.8000, 0.2978, 0.3832]],
+                    [
+                        [0.1000, 0.2000, 0.3000],
+                        [0.6438, 0.5000, 0.4000],
+                        [0.7000, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4124, 0.5416],
+                        [0.6000, 0.3292, 0.2292],
+                        [0.7854, 0.1000, 0.2000],
+                    ],
+                    [
+                        [0.7314, 0.8000, 0.7000],
+                        [0.9000, 0.3000, 0.2000],
+                        [0.8000, 0.2978, 0.3832],
+                    ],
                 ],
                 [
-                    [[0.1000, 0.2000, 0.3000], [0.6476, 0.5000, 0.4000], [0.7000, 0.8000, 1.0000]],
-                    [[1.0000, 0.4049, 0.5366], [0.6000, 0.3317, 0.2317], [0.7841, 0.1000, 0.2000]],
-                    [[0.7427, 0.8000, 0.7000], [0.9000, 0.3000, 0.2000], [0.8000, 0.2890, 0.3732]],
+                    [
+                        [0.1000, 0.2000, 0.3000],
+                        [0.6476, 0.5000, 0.4000],
+                        [0.7000, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4049, 0.5366],
+                        [0.6000, 0.3317, 0.2317],
+                        [0.7841, 0.1000, 0.2000],
+                    ],
+                    [
+                        [0.7427, 0.8000, 0.7000],
+                        [0.9000, 0.3000, 0.2000],
+                        [0.8000, 0.2890, 0.3732],
+                    ],
                 ],
             ],
             device=device,
@@ -1894,14 +2312,38 @@ class TestRandomSaturation(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.0000, 0.0000, 0.1471], [0.4853, 0.5000, 0.4000], [0.6618, 0.8000, 1.0000]],
-                    [[1.0000, 0.4000, 0.5618], [0.4853, 0.2235, 0.1235], [0.8000, 0.0000, 0.0000]],
-                    [[0.5556, 0.8000, 0.7000], [0.9000, 0.2235, 0.1235], [0.8000, 0.3429, 0.3750]],
+                    [
+                        [0.0000, 0.0000, 0.1471],
+                        [0.4853, 0.5000, 0.4000],
+                        [0.6618, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4000, 0.5618],
+                        [0.4853, 0.2235, 0.1235],
+                        [0.8000, 0.0000, 0.0000],
+                    ],
+                    [
+                        [0.5556, 0.8000, 0.7000],
+                        [0.9000, 0.2235, 0.1235],
+                        [0.8000, 0.3429, 0.3750],
+                    ],
                 ],
                 [
-                    [[0.0000, 0.0000, 0.1340], [0.4755, 0.5000, 0.4000], [0.6585, 0.8000, 1.0000]],
-                    [[1.0000, 0.4000, 0.5585], [0.4755, 0.2170, 0.1170], [0.8000, 0.0000, 0.0000]],
-                    [[0.5556, 0.8000, 0.7000], [0.9000, 0.2170, 0.1170], [0.8000, 0.3429, 0.3750]],
+                    [
+                        [0.0000, 0.0000, 0.1340],
+                        [0.4755, 0.5000, 0.4000],
+                        [0.6585, 0.8000, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4000, 0.5585],
+                        [0.4755, 0.2170, 0.1170],
+                        [0.8000, 0.0000, 0.0000],
+                    ],
+                    [
+                        [0.5556, 0.8000, 0.7000],
+                        [0.9000, 0.2170, 0.1170],
+                        [0.8000, 0.3429, 0.3750],
+                    ],
                 ],
             ],
             device=device,
@@ -2021,14 +2463,38 @@ class TestRandomGamma(BaseTester):
         return torch.tensor(
             [
                 [
-                    [[0.0703, 0.1564, 0.2496], [0.5549, 0.4497, 0.3477], [0.6628, 0.7732, 1.0000]],
-                    [[1.0000, 0.4497, 0.5549], [0.5549, 0.2496, 0.1564], [0.7732, 0.0703, 0.1564]],
-                    [[0.5549, 0.7732, 0.6628], [0.8856, 0.2496, 0.1564], [0.7732, 0.3477, 0.4497]],
+                    [
+                        [0.0703, 0.1564, 0.2496],
+                        [0.5549, 0.4497, 0.3477],
+                        [0.6628, 0.7732, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4497, 0.5549],
+                        [0.5549, 0.2496, 0.1564],
+                        [0.7732, 0.0703, 0.1564],
+                    ],
+                    [
+                        [0.5549, 0.7732, 0.6628],
+                        [0.8856, 0.2496, 0.1564],
+                        [0.7732, 0.3477, 0.4497],
+                    ],
                 ],
                 [
-                    [[0.0682, 0.1531, 0.2457], [0.5512, 0.4457, 0.3436], [0.6598, 0.7709, 1.0000]],
-                    [[1.0000, 0.4457, 0.5512], [0.5512, 0.2457, 0.1531], [0.7709, 0.0682, 0.1531]],
-                    [[0.5512, 0.7709, 0.6598], [0.8844, 0.2457, 0.1531], [0.7709, 0.3436, 0.4457]],
+                    [
+                        [0.0682, 0.1531, 0.2457],
+                        [0.5512, 0.4457, 0.3436],
+                        [0.6598, 0.7709, 1.0000],
+                    ],
+                    [
+                        [1.0000, 0.4457, 0.5512],
+                        [0.5512, 0.2457, 0.1531],
+                        [0.7709, 0.0682, 0.1531],
+                    ],
+                    [
+                        [0.5512, 0.7709, 0.6598],
+                        [0.8844, 0.2457, 0.1531],
+                        [0.7709, 0.3436, 0.4457],
+                    ],
                 ],
             ],
             device=device,
@@ -2420,7 +2886,12 @@ class TestRandomRotation(BaseTester):
         f = RandomRotation(degrees=45.0, p=1.0)
 
         input = torch.tensor(
-            [[1.0, 0.0, 0.0, 2.0], [0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 2.0, 0.0], [0.0, 0.0, 1.0, 2.0]],
+            [
+                [1.0, 0.0, 0.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 2.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0],
+            ],
             device=device,
             dtype=dtype,
         )  # 4 x 4
@@ -2441,7 +2912,13 @@ class TestRandomRotation(BaseTester):
         )  # 1 x 4 x 4
 
         expected_transform = torch.tensor(
-            [[[1.0000, -0.0059, 0.0088], [0.0059, 1.0000, -0.0088], [0.0000, 0.0000, 1.0000]]],
+            [
+                [
+                    [1.0000, -0.0059, 0.0088],
+                    [0.0059, 1.0000, -0.0088],
+                    [0.0000, 0.0000, 1.0000],
+                ]
+            ],
             device=device,
             dtype=dtype,
         )  # 1 x 3 x 3
@@ -2456,7 +2933,16 @@ class TestRandomRotation(BaseTester):
         f = RandomRotation(degrees=45.0, p=1.0)
 
         input = torch.tensor(
-            [[[[1.0, 0.0, 0.0, 2.0], [0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 2.0, 0.0], [0.0, 0.0, 1.0, 2.0]]]],
+            [
+                [
+                    [
+                        [1.0, 0.0, 0.0, 2.0],
+                        [0.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 2.0, 0.0],
+                        [0.0, 0.0, 1.0, 2.0],
+                    ]
+                ]
+            ],
             device=device,
             dtype=dtype,
         )  # 1 x 1 x 4 x 4
@@ -2486,8 +2972,16 @@ class TestRandomRotation(BaseTester):
 
         expected_transform = torch.tensor(
             [
-                [[1.0000, -0.0059, 0.0088], [0.0059, 1.0000, -0.0088], [0.0000, 0.0000, 1.0000]],
-                [[0.9125, 0.4090, -0.4823], [-0.4090, 0.9125, 0.7446], [0.0000, 0.0000, 1.0000]],
+                [
+                    [1.0000, -0.0059, 0.0088],
+                    [0.0059, 1.0000, -0.0088],
+                    [0.0000, 0.0000, 1.0000],
+                ],
+                [
+                    [0.9125, 0.4090, -0.4823],
+                    [-0.4090, 0.9125, 0.7446],
+                    [0.0000, 0.0000, 1.0000],
+                ],
             ],
             device=device,
             dtype=dtype,
@@ -2508,10 +3002,18 @@ class TestRandomRotation(BaseTester):
     def test_sequential(self, device, dtype):
         torch.manual_seed(0)  # for random reproductibility
 
-        f = AugmentationSequential(RandomRotation(torch.tensor([-45.0, 90]), p=1.0), RandomRotation(10.4, p=1.0))
+        f = AugmentationSequential(
+            RandomRotation(torch.tensor([-45.0, 90]), p=1.0),
+            RandomRotation(10.4, p=1.0),
+        )
 
         input = torch.tensor(
-            [[1.0, 0.0, 0.0, 2.0], [0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 2.0, 0.0], [0.0, 0.0, 1.0, 2.0]],
+            [
+                [1.0, 0.0, 0.0, 2.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 2.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0],
+            ],
             device=device,
             dtype=dtype,
         )  # 4 x 4
@@ -2532,7 +3034,13 @@ class TestRandomRotation(BaseTester):
         )  # 1 x 4 x 4
 
         expected_transform = torch.tensor(
-            [[[0.8864, 0.4629, -0.5240], [-0.4629, 0.8864, 0.8647], [0.0000, 0.0000, 1.0000]]],
+            [
+                [
+                    [0.8864, 0.4629, -0.5240],
+                    [-0.4629, 0.8864, 0.8647],
+                    [0.0000, 0.0000, 1.0000],
+                ]
+            ],
             device=device,
             dtype=dtype,
         )  # 1 x 3 x 3
@@ -2563,7 +3071,11 @@ class TestRandomCrop(BaseTester):
 
     def test_no_padding(self, device, dtype):
         torch.manual_seed(0)
-        inp = torch.tensor([[[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]], device=device, dtype=dtype)
+        inp = torch.tensor(
+            [[[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]],
+            device=device,
+            dtype=dtype,
+        )
         expected = torch.tensor([[[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]], device=device, dtype=dtype)
         rc = RandomCrop(size=(2, 3), padding=None, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2574,8 +3086,18 @@ class TestRandomCrop(BaseTester):
         self.assert_close(out, expected)
         self.assert_close(out2, expected)
         torch.manual_seed(0)
-        inversed = torch.tensor([[[[0.0, 0.0, 0.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]], device=device, dtype=dtype)
-        aug = RandomCrop(size=(2, 3), padding=None, align_corners=True, p=1.0, cropping_mode="resample")
+        inversed = torch.tensor(
+            [[[[0.0, 0.0, 0.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]],
+            device=device,
+            dtype=dtype,
+        )
+        aug = RandomCrop(
+            size=(2, 3),
+            padding=None,
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
+        )
         out = aug(inp)
         self.assert_close(out, expected)
         self.assert_close(aug.inverse(out), inversed)
@@ -2583,11 +3105,18 @@ class TestRandomCrop(BaseTester):
     def test_no_padding_batch(self, device, dtype):
         torch.manual_seed(42)
         batch_size = 2
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype).repeat(
-            batch_size, 1, 1, 1
-        )
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        ).repeat(batch_size, 1, 1, 1)
         expected = torch.tensor(
-            [[[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]], [[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]], device=device, dtype=dtype
+            [
+                [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]],
+                [[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            ],
+            device=device,
+            dtype=dtype,
         )
         rc = RandomCrop(size=(2, 3), padding=None, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2602,7 +3131,13 @@ class TestRandomCrop(BaseTester):
             device=device,
             dtype=dtype,
         )
-        aug = RandomCrop(size=(2, 3), padding=None, align_corners=True, p=1.0, cropping_mode="resample")
+        aug = RandomCrop(
+            size=(2, 3),
+            padding=None,
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
+        )
         out = aug(inp)
         self.assert_close(out, expected)
         self.assert_close(aug.inverse(out), inversed)
@@ -2615,7 +3150,11 @@ class TestRandomCrop(BaseTester):
 
     def test_padding(self, device, dtype):
         torch.manual_seed(42)
-        inp = torch.tensor([[[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]], device=device, dtype=dtype)
+        inp = torch.tensor(
+            [[[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]],
+            device=device,
+            dtype=dtype,
+        )
         expected = torch.tensor([[[[7.0, 8.0, 7.0], [4.0, 5.0, 4.0]]]], device=device, dtype=dtype)
         rc = RandomCrop(size=(2, 3), padding=1, padding_mode="reflect", align_corners=True, p=1.0)
         out = rc(inp)
@@ -2626,9 +3165,18 @@ class TestRandomCrop(BaseTester):
         self.assert_close(out, expected)
         self.assert_close(out2, expected)
         torch.manual_seed(42)
-        inversed = torch.tensor([[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 7.0, 8.0]]]], device=device, dtype=dtype)
+        inversed = torch.tensor(
+            [[[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 7.0, 8.0]]]],
+            device=device,
+            dtype=dtype,
+        )
         aug = RandomCrop(
-            size=(2, 3), padding=1, padding_mode="reflect", align_corners=True, p=1.0, cropping_mode="resample"
+            size=(2, 3),
+            padding=1,
+            padding_mode="reflect",
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
         )
         out = aug(inp)
         self.assert_close(out, expected)
@@ -2637,11 +3185,18 @@ class TestRandomCrop(BaseTester):
     def test_padding_batch_1(self, device, dtype):
         torch.manual_seed(42)
         batch_size = 2
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype).repeat(
-            batch_size, 1, 1, 1
-        )
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        ).repeat(batch_size, 1, 1, 1)
         expected = torch.tensor(
-            [[[[1.0, 2.0, 0.0], [4.0, 5.0, 0.0]]], [[[7.0, 8.0, 0.0], [0.0, 0.0, 0.0]]]], device=device, dtype=dtype
+            [
+                [[[1.0, 2.0, 0.0], [4.0, 5.0, 0.0]]],
+                [[[7.0, 8.0, 0.0], [0.0, 0.0, 0.0]]],
+            ],
+            device=device,
+            dtype=dtype,
         )
         rc = RandomCrop(size=(2, 3), padding=1, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2666,11 +3221,18 @@ class TestRandomCrop(BaseTester):
         torch.manual_seed(42)
         batch_size = 2
         padding = (0, 1)  # order: left-right, top-bottom
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype).repeat(
-            batch_size, 1, 1, 1
-        )
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        ).repeat(batch_size, 1, 1, 1)
         expected = torch.tensor(
-            [[[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]], [[[6.0, 7.0, 8.0], [10.0, 10.0, 10.0]]]], device=device, dtype=dtype
+            [
+                [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]],
+                [[[6.0, 7.0, 8.0], [10.0, 10.0, 10.0]]],
+            ],
+            device=device,
+            dtype=dtype,
         )
         rc = RandomCrop(size=(2, 3), padding=padding, fill=10, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2687,7 +3249,14 @@ class TestRandomCrop(BaseTester):
             device=device,
             dtype=dtype,
         )
-        aug = RandomCrop(size=(2, 3), padding=padding, fill=10, align_corners=True, p=1.0, cropping_mode="resample")
+        aug = RandomCrop(
+            size=(2, 3),
+            padding=padding,
+            fill=10,
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
+        )
         out = aug(inp)
         self.assert_close(out, expected)
         self.assert_close(aug.inverse(out), inversed)
@@ -2696,11 +3265,18 @@ class TestRandomCrop(BaseTester):
         torch.manual_seed(0)
         batch_size = 2
         padding = (0, 1, 2, 3)  # order: left, top, right, bottom
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype).repeat(
-            batch_size, 1, 1, 1
-        )
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        ).repeat(batch_size, 1, 1, 1)
         expected = torch.tensor(
-            [[[[8.0, 8.0, 8.0], [1.0, 2.0, 8.0]]], [[[8.0, 8.0, 8.0], [2.0, 8.0, 8.0]]]], device=device, dtype=dtype
+            [
+                [[[8.0, 8.0, 8.0], [1.0, 2.0, 8.0]]],
+                [[[8.0, 8.0, 8.0], [2.0, 8.0, 8.0]]],
+            ],
+            device=device,
+            dtype=dtype,
         )
         rc = RandomCrop(size=(2, 3), padding=padding, fill=8, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2718,7 +3294,14 @@ class TestRandomCrop(BaseTester):
             device=device,
             dtype=dtype,
         )
-        aug = RandomCrop(size=(2, 3), padding=(0, 1, 2, 3), fill=8, align_corners=True, p=1.0, cropping_mode="resample")
+        aug = RandomCrop(
+            size=(2, 3),
+            padding=(0, 1, 2, 3),
+            fill=8,
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
+        )
         out = aug(inp)
         self.assert_close(out, expected, low_tolerance=True)
         self.assert_close(aug.inverse(out), inversed, low_tolerance=True)
@@ -2728,7 +3311,14 @@ class TestRandomCrop(BaseTester):
         inp = torch.tensor([[[[3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]]], device=device, dtype=dtype)
         trans = torch.eye(3, device=device, dtype=dtype)[None]
         # Not return transform
-        rc = RandomCrop(size=(2, 3), padding=(0, 1, 2, 3), fill=9, align_corners=True, p=0.0, cropping_mode="resample")
+        rc = RandomCrop(
+            size=(2, 3),
+            padding=(0, 1, 2, 3),
+            fill=9,
+            align_corners=True,
+            p=0.0,
+            cropping_mode="resample",
+        )
 
         out = rc(inp)
         self.assert_close(out, inp)
@@ -2739,7 +3329,12 @@ class TestRandomCrop(BaseTester):
         batch_size = 2
         inp = torch.tensor([[[0.0], [1.0], [2.0]]], device=device, dtype=dtype).repeat(batch_size, 1, 1, 1)
         expected = torch.tensor(
-            [[[[9.0, 0.0], [9.0, 1.0], [9.0, 2.0]]], [[[0.0, 9.0], [1.0, 9.0], [2.0, 9.0]]]], device=device, dtype=dtype
+            [
+                [[[9.0, 0.0], [9.0, 1.0], [9.0, 2.0]]],
+                [[[0.0, 9.0], [1.0, 9.0], [2.0, 9.0]]],
+            ],
+            device=device,
+            dtype=dtype,
         )
         rc = RandomCrop(size=(3, 2), pad_if_needed=True, fill=9, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2747,7 +3342,14 @@ class TestRandomCrop(BaseTester):
         self.assert_close(out, expected)
 
         torch.manual_seed(0)
-        aug = RandomCrop(size=(3, 2), pad_if_needed=True, fill=9, align_corners=True, p=1.0, cropping_mode="resample")
+        aug = RandomCrop(
+            size=(3, 2),
+            pad_if_needed=True,
+            fill=9,
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
+        )
         out = aug(inp)
         self.assert_close(out, expected)
         self.assert_close(aug.inverse(out), inp)
@@ -2757,7 +3359,12 @@ class TestRandomCrop(BaseTester):
         batch_size = 2
         inp = torch.tensor([[[0.0, 1.0, 2.0]]], device=device, dtype=dtype).repeat(batch_size, 1, 1, 1)
         expected = torch.tensor(
-            [[[[9.0, 9.0, 9.0], [0.0, 1.0, 2.0]]], [[[9.0, 9.0, 9.0], [0.0, 1.0, 2.0]]]], device=device, dtype=dtype
+            [
+                [[[9.0, 9.0, 9.0], [0.0, 1.0, 2.0]]],
+                [[[9.0, 9.0, 9.0], [0.0, 1.0, 2.0]]],
+            ],
+            device=device,
+            dtype=dtype,
         )
         rc = RandomCrop(size=(2, 3), pad_if_needed=True, fill=9, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2765,7 +3372,14 @@ class TestRandomCrop(BaseTester):
         self.assert_close(out, expected)
 
         torch.manual_seed(0)
-        aug = RandomCrop(size=(2, 3), pad_if_needed=True, fill=9, align_corners=True, p=1.0, cropping_mode="resample")
+        aug = RandomCrop(
+            size=(2, 3),
+            pad_if_needed=True,
+            fill=9,
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
+        )
         out = aug(inp)
         self.assert_close(out, expected)
         self.assert_close(aug.inverse(out), inp)
@@ -2775,7 +3389,12 @@ class TestRandomCrop(BaseTester):
         batch_size = 2
         inp = torch.tensor([[[0.0], [1.0]]], device=device, dtype=dtype).repeat(batch_size, 1, 1, 1)
         expected = torch.tensor(
-            [[[[9.0, 9.0], [9.0, 0.0], [9.0, 1.0]]], [[[9.0, 9.0], [0.0, 9.0], [1.0, 9.0]]]], device=device, dtype=dtype
+            [
+                [[[9.0, 9.0], [9.0, 0.0], [9.0, 1.0]]],
+                [[[9.0, 9.0], [0.0, 9.0], [1.0, 9.0]]],
+            ],
+            device=device,
+            dtype=dtype,
         )
         rc = RandomCrop(size=(3, 2), pad_if_needed=True, fill=9, align_corners=True, p=1.0)
         out = rc(inp)
@@ -2783,14 +3402,25 @@ class TestRandomCrop(BaseTester):
         self.assert_close(out, expected)
 
         torch.manual_seed(0)
-        aug = RandomCrop(size=(3, 2), pad_if_needed=True, fill=9, align_corners=True, p=1.0, cropping_mode="resample")
+        aug = RandomCrop(
+            size=(3, 2),
+            pad_if_needed=True,
+            fill=9,
+            align_corners=True,
+            p=1.0,
+            cropping_mode="resample",
+        )
         out = aug(inp)
         self.assert_close(out, expected)
         self.assert_close(aug.inverse(out), inp)
 
     def test_crop_modes(self, device, dtype):
         torch.manual_seed(0)
-        img = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype)
+        img = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        )
 
         op1 = RandomCrop(size=(2, 2), cropping_mode="resample")
         out = op1(img)
@@ -2849,9 +3479,17 @@ class TestRandomResizedCrop(BaseTester):
 
     def test_no_resize(self, device, dtype):
         torch.manual_seed(0)
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype)
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        )
 
-        expected = torch.tensor([[[[0.0000, 1.0000, 2.0000], [6.0000, 7.0000, 8.0000]]]], device=device, dtype=dtype)
+        expected = torch.tensor(
+            [[[[0.0000, 1.0000, 2.0000], [6.0000, 7.0000, 8.0000]]]],
+            device=device,
+            dtype=dtype,
+        )
 
         rrc = RandomResizedCrop(size=(2, 3), scale=(1.0, 1.0), ratio=(1.0, 1.0))
         # It will crop a size of (2, 3) from the aspect ratio implementation of torch
@@ -2866,15 +3504,21 @@ class TestRandomResizedCrop(BaseTester):
 
     def test_same_on_batch(self, device, dtype):
         f = RandomResizedCrop(size=(2, 3), scale=(1.0, 1.0), ratio=(1.0, 1.0), same_on_batch=True)
-        input = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype).repeat(
-            2, 1, 1, 1
-        )
+        input = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        ).repeat(2, 1, 1, 1)
         res = f(input)
         self.assert_close(res[0], res[1])
 
         torch.manual_seed(0)
         aug = RandomResizedCrop(
-            size=(2, 3), scale=(1.0, 1.0), ratio=(1.0, 1.0), same_on_batch=True, cropping_mode="resample"
+            size=(2, 3),
+            scale=(1.0, 1.0),
+            ratio=(1.0, 1.0),
+            same_on_batch=True,
+            cropping_mode="resample",
         )
         out = aug(input)
         inversed = aug.inverse(out)
@@ -2883,10 +3527,22 @@ class TestRandomResizedCrop(BaseTester):
     def test_crop_scale_ratio(self, device, dtype):
         # This is included in doctest
         torch.manual_seed(0)
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype)
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        )
 
         expected = torch.tensor(
-            [[[[1.0000, 1.5000, 2.0000], [4.0000, 4.5000, 5.0000], [7.0000, 7.5000, 8.0000]]]],
+            [
+                [
+                    [
+                        [1.0000, 1.5000, 2.0000],
+                        [4.0000, 4.5000, 5.0000],
+                        [7.0000, 7.5000, 8.0000],
+                    ]
+                ]
+            ],
             device=device,
             dtype=dtype,
         )
@@ -2896,7 +3552,11 @@ class TestRandomResizedCrop(BaseTester):
         self.assert_close(out, expected)
 
         torch.manual_seed(0)
-        inversed = torch.tensor([[[[0.0, 1.0, 2.0], [0.0, 4.0, 5.0], [0.0, 7.0, 8.0]]]], device=device, dtype=dtype)
+        inversed = torch.tensor(
+            [[[[0.0, 1.0, 2.0], [0.0, 4.0, 5.0], [0.0, 7.0, 8.0]]]],
+            device=device,
+            dtype=dtype,
+        )
         aug = RandomResizedCrop(size=(3, 3), scale=(3.0, 3.0), ratio=(2.0, 2.0), cropping_mode="resample")
         out = aug(inp)
         self.assert_close(out, expected)
@@ -2905,7 +3565,11 @@ class TestRandomResizedCrop(BaseTester):
     def test_crop_size_greater_than_input(self, device, dtype):
         # This is included in doctest
         torch.manual_seed(0)
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype)
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        )
 
         exp = torch.tensor(
             [
@@ -2929,7 +3593,11 @@ class TestRandomResizedCrop(BaseTester):
         self.assert_close(out, exp, low_tolerance=True)
 
         torch.manual_seed(0)
-        inversed = torch.tensor([[[[0.0, 1.0, 2.0], [0.0, 4.0, 5.0], [0.0, 7.0, 8.0]]]], device=device, dtype=dtype)
+        inversed = torch.tensor(
+            [[[[0.0, 1.0, 2.0], [0.0, 4.0, 5.0], [0.0, 7.0, 8.0]]]],
+            device=device,
+            dtype=dtype,
+        )
         aug = RandomResizedCrop(size=(4, 4), scale=(3.0, 3.0), ratio=(2.0, 2.0), cropping_mode="resample")
         out = aug(inp)
         self.assert_close(out, exp, low_tolerance=True)
@@ -2938,14 +3606,28 @@ class TestRandomResizedCrop(BaseTester):
     def test_crop_scale_ratio_batch(self, device, dtype):
         torch.manual_seed(0)
         batch_size = 2
-        inp = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype).repeat(
-            batch_size, 1, 1, 1
-        )
+        inp = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        ).repeat(batch_size, 1, 1, 1)
 
         expected = torch.tensor(
             [
-                [[[1.0000, 1.5000, 2.0000], [4.0000, 4.5000, 5.0000], [7.0000, 7.5000, 8.0000]]],
-                [[[0.0000, 0.5000, 1.0000], [3.0000, 3.5000, 4.0000], [6.0000, 6.5000, 7.0000]]],
+                [
+                    [
+                        [1.0000, 1.5000, 2.0000],
+                        [4.0000, 4.5000, 5.0000],
+                        [7.0000, 7.5000, 8.0000],
+                    ]
+                ],
+                [
+                    [
+                        [0.0000, 0.5000, 1.0000],
+                        [3.0000, 3.5000, 4.0000],
+                        [6.0000, 6.5000, 7.0000],
+                    ]
+                ],
             ],
             device=device,
             dtype=dtype,
@@ -2971,7 +3653,11 @@ class TestRandomResizedCrop(BaseTester):
 
     def test_crop_modes(self, device, dtype):
         torch.manual_seed(0)
-        img = torch.tensor([[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]], device=device, dtype=dtype)
+        img = torch.tensor(
+            [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0]]],
+            device=device,
+            dtype=dtype,
+        )
 
         op1 = RandomResizedCrop(size=(4, 4), cropping_mode="resample")
         out = op1(img)
@@ -3142,7 +3828,11 @@ class TestRandomGaussianBlur(BaseTester):
 
         # evaluate function gradient
         input = torch.rand(batch_shape, device=device, dtype=torch.float64)
-        self.gradcheck(RandomGaussianBlur(kernel_size, sigma, "replicate", p=1.0), (input,), fast_mode=False)
+        self.gradcheck(
+            RandomGaussianBlur(kernel_size, sigma, "replicate", p=1.0),
+            (input,),
+            fast_mode=False,
+        )
 
     @pytest.mark.xfail(
         reason="might fail due to the sampling distribution gradcheck errors. "
@@ -3158,7 +3848,11 @@ class TestRandomGaussianBlur(BaseTester):
 
         # evaluate function gradient
         input = torch.rand(batch_shape, device=device, dtype=torch.float64)
-        self.gradcheck(RandomGaussianBlur(kernel_size, sigma, "replicate", p=1.0), (input,), fast_mode=False)
+        self.gradcheck(
+            RandomGaussianBlur(kernel_size, sigma, "replicate", p=1.0),
+            (input,),
+            fast_mode=False,
+        )
 
     def test_module(self, device, dtype):
         func_params = [(3, 3), torch.tensor([1.5, 1.5]).view(1, -1)]
@@ -3200,7 +3894,13 @@ class TestRandomChannelShuffle(BaseTester):
         img = torch.arange(1 * 3 * 2 * 2, device=device, dtype=dtype).view(1, 3, 2, 2)
 
         out_expected = torch.tensor(
-            [[[[8.0, 9.0], [10.0, 11.0]], [[0.0, 1.0], [2.0, 3.0]], [[4.0, 5.0], [6.0, 7.0]]]],
+            [
+                [
+                    [[8.0, 9.0], [10.0, 11.0]],
+                    [[0.0, 1.0], [2.0, 3.0]],
+                    [[4.0, 5.0], [6.0, 7.0]],
+                ]
+            ],
             device=device,
             dtype=dtype,
         )
@@ -3359,7 +4059,10 @@ class TestRandomGaussianIllumination(BaseTester):
         with pytest.raises(ValueError, match="gain must be a tuple or a float"):
             RandomGaussianIllumination(gain=[0.01, 0.06])
 
-        with pytest.raises(Exception, match="gain values must be between 0 and 1. Recommended values less than 0.2."):
+        with pytest.raises(
+            Exception,
+            match="gain values must be between 0 and 1. Recommended values less than 0.2.",
+        ):
             RandomGaussianIllumination(gain=(0.01, 2))
 
         with pytest.raises(Exception, match="sigma of gaussian value must be between 0 and 1."):
@@ -3428,7 +4131,10 @@ class TestRandomLinearIllumination(BaseTester):
         with pytest.raises(ValueError, match="gain must be a tuple or a float"):
             RandomLinearIllumination(gain=[0.01, 0.06])
 
-        with pytest.raises(Exception, match="gain values must be between 0 and 1. Recommended values less than 0.2."):
+        with pytest.raises(
+            Exception,
+            match="gain values must be between 0 and 1. Recommended values less than 0.2.",
+        ):
             RandomLinearIllumination(gain=(0.01, 2))
 
         with pytest.raises(Exception, match="sign of linear value must be between -1 and 1."):
@@ -3491,7 +4197,10 @@ class TestRandomLinearCornerIllumination(BaseTester):
         with pytest.raises(ValueError, match="gain must be a tuple or a float"):
             RandomLinearCornerIllumination(gain=[0.01, 0.06])
 
-        with pytest.raises(Exception, match="gain values must be between 0 and 1. Recommended values less than 0.2."):
+        with pytest.raises(
+            Exception,
+            match="gain values must be between 0 and 1. Recommended values less than 0.2.",
+        ):
             RandomLinearCornerIllumination(gain=(0.01, 2))
 
         with pytest.raises(Exception, match="sign of linear value must be between -1 and 1."):
@@ -3522,7 +4231,12 @@ class TestNormalize(BaseTester):
         assert str(f) == repr
 
     @pytest.mark.parametrize(
-        "mean, std", [((1.0, 1.0, 1.0), (0.5, 0.5, 0.5)), (1.0, 0.5), (torch.tensor([1.0]), torch.tensor([0.5]))]
+        "mean, std",
+        [
+            ((1.0, 1.0, 1.0), (0.5, 0.5, 0.5)),
+            (1.0, 0.5),
+            (torch.tensor([1.0]), torch.tensor([0.5])),
+        ],
     )
     def test_random_normalize_different_parameter_types(self, mean, std):
         f = Normalize(mean=mean, std=std, p=1)
@@ -3534,7 +4248,10 @@ class TestNormalize(BaseTester):
         self.assert_close(f(data), expected)
 
     @staticmethod
-    @pytest.mark.parametrize("mean, std", [((1.0, 1.0, 1.0, 1.0), (0.5, 0.5, 0.5, 0.5)), ((1.0, 1.0), (0.5, 0.5))])
+    @pytest.mark.parametrize(
+        "mean, std",
+        [((1.0, 1.0, 1.0, 1.0), (0.5, 0.5, 0.5, 0.5)), ((1.0, 1.0), (0.5, 0.5))],
+    )
     def test_random_normalize_invalid_parameter_shape(mean, std):
         f = Normalize(mean=mean, std=std, p=1.0)
         inputs = torch.arange(0.0, 16.0, step=1).reshape(1, 4, 4).unsqueeze(0)
@@ -3576,7 +4293,10 @@ class TestNormalize(BaseTester):
         torch.manual_seed(0)  # for random reproductibility
 
         input = torch.rand((3, 3, 3), device=device, dtype=torch.float64)  # 3 x 3 x 3
-        self.gradcheck(Normalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0), (input,))
+        self.gradcheck(
+            Normalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0),
+            (input,),
+        )
 
 
 class TestDenormalize(BaseTester):
@@ -3623,7 +4343,10 @@ class TestDenormalize(BaseTester):
         torch.manual_seed(0)  # for random reproductibility
 
         input = torch.rand((3, 3, 3), device=device, dtype=torch.float64)  # 3 x 3 x 3
-        self.gradcheck(Denormalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0), (input,))
+        self.gradcheck(
+            Denormalize(mean=torch.tensor([1.0]), std=torch.tensor([1.0]), p=1.0),
+            (input,),
+        )
 
 
 class TestRandomFisheye(BaseTester):
@@ -3682,7 +4405,10 @@ class TestRandomElasticTransform(BaseTester):
 
         # The transformed values are fine if we use mask input type
         labels_transformed = compose(features, labels, data_keys=["input", "mask"])[1]
-        self.assert_close(labels_transformed.unique(), torch.tensor([0, 10], dtype=dtype, device=device))
+        self.assert_close(
+            labels_transformed.unique(),
+            torch.tensor([0, 10], dtype=dtype, device=device),
+        )
 
     @pytest.mark.parametrize("batch_prob", [[True, True], [False, True], [False, False]])
     def test_apply(self, batch_prob, device, dtype):
@@ -4025,7 +4751,10 @@ class TestRandomRGBShift(BaseTester):
     def test_random_rgb_shift(self, device, dtype):
         torch.manual_seed(0)
         input = torch.tensor(
-            [[[[0.2, 0.0]], [[0.3, 0.5]], [[0.4, 0.7]]], [[[0.2, 0.7]], [[0.0, 0.8]], [[0.2, 0.3]]]],
+            [
+                [[[0.2, 0.0]], [[0.3, 0.5]], [[0.4, 0.7]]],
+                [[[0.2, 0.7]], [[0.0, 0.8]], [[0.2, 0.3]]],
+            ],
             device=device,
             dtype=dtype,
         )
@@ -4044,7 +4773,10 @@ class TestRandomRGBShift(BaseTester):
     def test_random_rgb_shift_same_batch(self, device, dtype):
         torch.manual_seed(0)
         input = torch.tensor(
-            [[[[0.2, 0.0]], [[0.3, 0.5]], [[0.4, 0.7]]], [[[0.2, 0.7]], [[0.0, 0.8]], [[0.2, 0.3]]]],
+            [
+                [[[0.2, 0.0]], [[0.3, 0.5]], [[0.4, 0.7]]],
+                [[[0.2, 0.7]], [[0.0, 0.8]], [[0.2, 0.3]]],
+            ],
             device=device,
             dtype=dtype,
         )
@@ -4104,14 +4836,54 @@ class TestRandomSnow(BaseTester):
         err_msg_wrong_sh = "Input size must have a shape of either (H, W), (C, H, W) or (*, C, H, W)."
 
         return [
-            (err_msg_sw_coef, (-0.3, 0.6), (1.2, 3.4), torch.rand(1, 3, 3, device=device, dtype=dtype)),
-            (err_msg_sw_coef, (0.3, -0.9), (1.3, 2.5), torch.rand(1, 3, 4, device=device, dtype=dtype)),
-            (err_msg_sw_coef, (-0.6, -0.9), (1.1, 3.1), torch.rand(2, 3, 4, device=device, dtype=dtype)),
-            (err_msg_brght_coef, (0.1, 0.7), (0.3, 1.5), torch.rand(1, 3, 5, device=device, dtype=dtype)),
-            (err_msg_brght_coef, (0.4, 0.6), (1.3, 0.8), torch.rand(1, 3, 6, device=device, dtype=dtype)),
-            (err_msg_brght_coef, (0.3, 0.9), (0.5, 0.7), torch.rand(1, 3, 7, device=device, dtype=dtype)),
-            (err_msg_wrong_ch, (0.2, 0.8), (1.6, 3.7), torch.rand(1, 4, 7, device=device, dtype=dtype)),
-            (err_msg_wrong_sh, (0.1, 0.5), (1.1, 2.5), torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype)),
+            (
+                err_msg_sw_coef,
+                (-0.3, 0.6),
+                (1.2, 3.4),
+                torch.rand(1, 3, 3, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_sw_coef,
+                (0.3, -0.9),
+                (1.3, 2.5),
+                torch.rand(1, 3, 4, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_sw_coef,
+                (-0.6, -0.9),
+                (1.1, 3.1),
+                torch.rand(2, 3, 4, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_brght_coef,
+                (0.1, 0.7),
+                (0.3, 1.5),
+                torch.rand(1, 3, 5, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_brght_coef,
+                (0.4, 0.6),
+                (1.3, 0.8),
+                torch.rand(1, 3, 6, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_brght_coef,
+                (0.3, 0.9),
+                (0.5, 0.7),
+                torch.rand(1, 3, 7, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_wrong_ch,
+                (0.2, 0.8),
+                (1.6, 3.7),
+                torch.rand(1, 4, 7, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_wrong_sh,
+                (0.1, 0.5),
+                (1.1, 2.5),
+                torch.rand(1, 2, 3, 4, 5, device=device, dtype=dtype),
+            ),
         ]
 
     @pytest.mark.parametrize("batch_shape", [(1, 3, 4, 7), (1, 3, 6, 9)])
@@ -4155,7 +4927,16 @@ class TestRandomMedianBlur(BaseTester):
         out = RandomMedianBlur((3, 3), p=0.5)(img)
 
         expected = torch.tensor(
-            [[[[0.0, 1.0, 1.0, 0.0], [1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0], [0.0, 1.0, 1.0, 0.0]]]],
+            [
+                [
+                    [
+                        [0.0, 1.0, 1.0, 0.0],
+                        [1.0, 1.0, 1.0, 1.0],
+                        [1.0, 1.0, 1.0, 1.0],
+                        [0.0, 1.0, 1.0, 0.0],
+                    ]
+                ]
+            ],
             device=device,
             dtype=dtype,
         )
@@ -4172,19 +4953,43 @@ class TestRandomRain(BaseTester):
         err_msg_wrong_ch = "Number of color channels should be 1 or 3."
 
         return [
-            (err_msg_height_bigger, (-2, 0), (2, 3), torch.rand(1, 5, 5, device=device, dtype=dtype)),
-            (err_msg_height_bigger, (6, 6), (2, 3), torch.rand(1, 5, 5, device=device, dtype=dtype)),
-            (err_msg_width_bigger, (2, 2), (6, 6), torch.rand(1, 5, 5, device=device, dtype=dtype)),
-            (err_msg_wrong_ch, (1, 2), (1, 2), torch.rand(2, 4, 5, device=device, dtype=dtype)),
+            (
+                err_msg_height_bigger,
+                (-2, 0),
+                (2, 3),
+                torch.rand(1, 5, 5, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_height_bigger,
+                (6, 6),
+                (2, 3),
+                torch.rand(1, 5, 5, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_width_bigger,
+                (2, 2),
+                (6, 6),
+                torch.rand(1, 5, 5, device=device, dtype=dtype),
+            ),
+            (
+                err_msg_wrong_ch,
+                (1, 2),
+                (1, 2),
+                torch.rand(2, 4, 5, device=device, dtype=dtype),
+            ),
         ]
 
     @pytest.mark.parametrize("batch_shape", [(1, 3, 5, 7), (1, 3, 6, 9), (5, 7)])
     @pytest.mark.parametrize("keepdim", [True, False])
     def test_cardinality(self, batch_shape, keepdim, device, dtype):
         input_data = torch.rand(batch_shape, device=device, dtype=dtype)
-        output_data = RandomRain(p=1.0, drop_height=(3, 4), drop_width=(2, 3), number_of_drops=(1, 3), keepdim=keepdim)(
-            input_data
-        )
+        output_data = RandomRain(
+            p=1.0,
+            drop_height=(3, 4),
+            drop_width=(2, 3),
+            number_of_drops=(1, 3),
+            keepdim=keepdim,
+        )(input_data)
         if keepdim:
             assert output_data.shape == batch_shape
         else:

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -1592,10 +1592,11 @@ class TestColorJitter(BaseTester):
         self.assert_close(f(input), expected)
         self.assert_close(f.transform_matrix, expected_transform)
 
-    @pytest.mark.slow
-    def test_gradcheck(self, device):
-        input = torch.rand((3, 5, 5), device=device, dtype=torch.float64).unsqueeze(0)  # 3 x 3
-        self.gradcheck(ColorJitter(p=1.0), (input,))
+    def test_compile(self, device):
+        input = torch.rand((1, 3, 5, 5), device=device)
+        f = ColorJitter(p=1.0).compile(fullgraph=True)
+        out = f(input)
+        assert out.shape == input.shape
 
 
 class TestRandomBrightness(BaseTester):

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -58,6 +58,7 @@ from kornia.augmentation._2d.base import AugmentationBase2D
 from kornia.constants import Resample, pi
 from kornia.geometry import transform_points
 from kornia.utils import create_meshgrid
+from kornia.utils._compat import torch_version_le
 from kornia.utils.helpers import _torch_inverse_cast
 
 from testing.augmentation.datasets import DummyMPDataset
@@ -1592,6 +1593,7 @@ class TestColorJitter(BaseTester):
         self.assert_close(f(input), expected)
         self.assert_close(f.transform_matrix, expected_transform)
 
+    @pytest.mark.skipif(torch_version_le(2, 1, 0), reason="not supported in this pytorch version")
     def test_compile(self, device):
         input = torch.rand((1, 3, 5, 5), device=device)
         f = ColorJitter(p=1.0).compile(fullgraph=True)

--- a/tests/augmentation/test_random_generator.py
+++ b/tests/augmentation/test_random_generator.py
@@ -195,7 +195,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
                 device=device,
                 dtype=dtype,
             ),
-            "order": torch.tensor([3, 2, 0, 1], device=device, dtype=dtype),
+            "order": torch.tensor([3, 2, 0, 1], device=device, dtype=torch.long),
         }
 
         assert set(jitter_params.keys()) == {
@@ -232,7 +232,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
             atol=1e-4,
         )
         assert_close(
-            jitter_params["order"].to(dtype),
+            jitter_params["order"],
             expected_jitter_params["order"],
             rtol=1e-4,
             atol=1e-4,
@@ -269,7 +269,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
                 device=device,
                 dtype=dtype,
             ),
-            "order": torch.tensor([3, 2, 0, 1], device=device, dtype=dtype),
+            "order": torch.tensor([3, 2, 0, 1], device=device, dtype=torch.long),
         }
 
         assert set(jitter_params.keys()) == {
@@ -306,7 +306,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
             atol=1e-4,
         )
         assert_close(
-            jitter_params["order"].to(dtype),
+            jitter_params["order"],
             expected_jitter_params["order"],
             rtol=1e-4,
             atol=1e-4,
@@ -327,7 +327,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
             "contrast_factor": torch.tensor([1.2490] * batch_size, device=device, dtype=dtype),
             "hue_factor": torch.tensor([-0.0234] * batch_size, device=device, dtype=dtype),
             "saturation_factor": torch.tensor([1.3674] * batch_size, device=device, dtype=dtype),
-            "order": torch.tensor([2, 3, 0, 1], device=device, dtype=dtype),
+            "order": torch.tensor([2, 3, 0, 1], device=device, dtype=torch.long),
         }
 
         assert_close(

--- a/tests/augmentation/test_random_generator.py
+++ b/tests/augmentation/test_random_generator.py
@@ -18,7 +18,6 @@ from kornia.augmentation.random_generator import (
     ResizedCropGenerator,
     center_crop_generator,
 )
-from kornia.utils._compat import torch_version_ge
 
 from testing.base import assert_close
 
@@ -58,7 +57,11 @@ class TestRandomProbGen(RandomGeneratorBaseTests):
 
     @pytest.mark.parametrize(
         "p,expected",
-        [(0.0, [False] * 8), (0.5, [False, False, True, False, True, False, True, False]), (1.0, [True] * 8)],
+        [
+            (0.0, [False] * 8),
+            (0.5, [False, False, True, False, True, False, True, False]),
+            (1.0, [True] * 8),
+        ],
     )
     def test_random_gen(self, p, expected, device, dtype):
         torch.manual_seed(42)
@@ -82,17 +85,37 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize("batch_size", [0, 1, 8])
     @pytest.mark.parametrize("same_on_batch", [True, False])
     def test_valid_param_combinations(
-        self, brightness, contrast, saturation, hue, batch_size, same_on_batch, device, dtype
+        self,
+        brightness,
+        contrast,
+        saturation,
+        hue,
+        batch_size,
+        same_on_batch,
+        device,
+        dtype,
     ):
         ColorJiggleGenerator(
             torch.as_tensor(
-                brightness if brightness is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                brightness if brightness is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
             ),
-            torch.as_tensor(contrast if contrast is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype),
             torch.as_tensor(
-                saturation if saturation is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                contrast if contrast is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
             ),
-            torch.as_tensor(hue if hue is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype),
+            torch.as_tensor(
+                saturation if saturation is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
+            ),
+            torch.as_tensor(
+                hue if hue is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
+            ),
         )(torch.Size([batch_size]), same_on_batch)
 
     @pytest.mark.parametrize(
@@ -119,15 +142,25 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
         with pytest.raises(Exception):
             ColorJiggleGenerator(
                 torch.as_tensor(
-                    brightness if brightness is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                    brightness if brightness is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
                 ),
                 torch.as_tensor(
-                    contrast if contrast is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                    contrast if contrast is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
                 ),
                 torch.as_tensor(
-                    saturation if saturation is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                    saturation if saturation is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
                 ),
-                torch.as_tensor(hue if hue is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype),
+                torch.as_tensor(
+                    hue if hue is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
+                ),
             )(torch.Size([8]))
 
     def test_random_gen(self, device, dtype):
@@ -142,16 +175,24 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
 
         expected_jitter_params = {
             "brightness_factor": torch.tensor(
-                [1.1529, 1.1660, 0.9531, 1.1837, 0.9562, 1.0404, 0.9026, 1.1175], device=device, dtype=dtype
+                [1.1529, 1.1660, 0.9531, 1.1837, 0.9562, 1.0404, 0.9026, 1.1175],
+                device=device,
+                dtype=dtype,
             ),
             "contrast_factor": torch.tensor(
-                [1.2645, 0.7799, 1.2608, 1.0561, 1.2216, 1.0406, 1.1447, 0.9576], device=device, dtype=dtype
+                [1.2645, 0.7799, 1.2608, 1.0561, 1.2216, 1.0406, 1.1447, 0.9576],
+                device=device,
+                dtype=dtype,
             ),
             "hue_factor": torch.tensor(
-                [0.0771, 0.0148, -0.0467, 0.0255, -0.0461, -0.0117, -0.0406, 0.0663], device=device, dtype=dtype
+                [0.0771, 0.0148, -0.0467, 0.0255, -0.0461, -0.0117, -0.0406, 0.0663],
+                device=device,
+                dtype=dtype,
             ),
             "saturation_factor": torch.tensor(
-                [0.6843, 0.8156, 0.8871, 0.7595, 1.0378, 0.6049, 1.3612, 0.6602], device=device, dtype=dtype
+                [0.6843, 0.8156, 0.8871, 0.7595, 1.0378, 0.6049, 1.3612, 0.6602],
+                device=device,
+                dtype=dtype,
             ),
             "order": torch.tensor([3, 2, 0, 1], device=device, dtype=dtype),
         }
@@ -166,14 +207,35 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
                 'brightness_factor', 'contrast_factor', 'hue_factor', 'saturation_factor', 'order'"
 
         assert_close(
-            jitter_params["brightness_factor"], expected_jitter_params["brightness_factor"], rtol=1e-4, atol=1e-4
+            jitter_params["brightness_factor"],
+            expected_jitter_params["brightness_factor"],
+            rtol=1e-4,
+            atol=1e-4,
         )
-        assert_close(jitter_params["contrast_factor"], expected_jitter_params["contrast_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["hue_factor"], expected_jitter_params["hue_factor"], rtol=1e-4, atol=1e-4)
         assert_close(
-            jitter_params["saturation_factor"], expected_jitter_params["saturation_factor"], rtol=1e-4, atol=1e-4
+            jitter_params["contrast_factor"],
+            expected_jitter_params["contrast_factor"],
+            rtol=1e-4,
+            atol=1e-4,
         )
-        assert_close(jitter_params["order"].to(dtype), expected_jitter_params["order"], rtol=1e-4, atol=1e-4)
+        assert_close(
+            jitter_params["hue_factor"],
+            expected_jitter_params["hue_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["saturation_factor"],
+            expected_jitter_params["saturation_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["order"].to(dtype),
+            expected_jitter_params["order"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
 
     def test_random_gen_accumulative_additive_additive(self, device, dtype):
         torch.manual_seed(42)
@@ -187,16 +249,24 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
 
         expected_jitter_params = {
             "brightness_factor": torch.tensor(
-                [1.1529, 1.1660, 0.9531, 1.1837, 0.9562, 1.0404, 0.9026, 1.1175], device=device, dtype=dtype
+                [1.1529, 1.1660, 0.9531, 1.1837, 0.9562, 1.0404, 0.9026, 1.1175],
+                device=device,
+                dtype=dtype,
             ),
             "contrast_factor": torch.tensor(
-                [1.2645, 0.7799, 1.2608, 1.0561, 1.2216, 1.0406, 1.1447, 0.9576], device=device, dtype=dtype
+                [1.2645, 0.7799, 1.2608, 1.0561, 1.2216, 1.0406, 1.1447, 0.9576],
+                device=device,
+                dtype=dtype,
             ),
             "hue_factor": torch.tensor(
-                [0.0771, 0.0148, -0.0467, 0.0255, -0.0461, -0.0117, -0.0406, 0.0663], device=device, dtype=dtype
+                [0.0771, 0.0148, -0.0467, 0.0255, -0.0461, -0.0117, -0.0406, 0.0663],
+                device=device,
+                dtype=dtype,
             ),
             "saturation_factor": torch.tensor(
-                [0.6843, 0.8156, 0.8871, 0.7595, 1.0378, 0.6049, 1.3612, 0.6602], device=device, dtype=dtype
+                [0.6843, 0.8156, 0.8871, 0.7595, 1.0378, 0.6049, 1.3612, 0.6602],
+                device=device,
+                dtype=dtype,
             ),
             "order": torch.tensor([3, 2, 0, 1], device=device, dtype=dtype),
         }
@@ -211,14 +281,35 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
                 'brightness_factor', 'contrast_factor', 'hue_factor', 'saturation_factor', 'order'"
 
         assert_close(
-            jitter_params["brightness_factor"], expected_jitter_params["brightness_factor"], rtol=1e-4, atol=1e-4
+            jitter_params["brightness_factor"],
+            expected_jitter_params["brightness_factor"],
+            rtol=1e-4,
+            atol=1e-4,
         )
-        assert_close(jitter_params["contrast_factor"], expected_jitter_params["contrast_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["hue_factor"], expected_jitter_params["hue_factor"], rtol=1e-4, atol=1e-4)
         assert_close(
-            jitter_params["saturation_factor"], expected_jitter_params["saturation_factor"], rtol=1e-4, atol=1e-4
+            jitter_params["contrast_factor"],
+            expected_jitter_params["contrast_factor"],
+            rtol=1e-4,
+            atol=1e-4,
         )
-        assert_close(jitter_params["order"].to(dtype), expected_jitter_params["order"], rtol=1e-4, atol=1e-4)
+        assert_close(
+            jitter_params["hue_factor"],
+            expected_jitter_params["hue_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["saturation_factor"],
+            expected_jitter_params["saturation_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["order"].to(dtype),
+            expected_jitter_params["order"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
 
     def test_same_on_batch(self, device, dtype):
         torch.manual_seed(42)
@@ -238,11 +329,36 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
             "order": torch.tensor([2, 3, 0, 1], device=device, dtype=dtype),
         }
 
-        assert_close(jitter_params["brightness_factor"], expected_res["brightness_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["contrast_factor"], expected_res["contrast_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["hue_factor"], expected_res["hue_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["saturation_factor"], expected_res["saturation_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["order"].to(dtype), expected_res["order"], rtol=1e-4, atol=1e-4)
+        assert_close(
+            jitter_params["brightness_factor"],
+            expected_res["brightness_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["contrast_factor"],
+            expected_res["contrast_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["hue_factor"],
+            expected_res["hue_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["saturation_factor"],
+            expected_res["saturation_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["order"].to(dtype),
+            expected_res["order"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
 
 
 class TestColorJitterGen(RandomGeneratorBaseTests):
@@ -253,17 +369,37 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize("batch_size", [0, 1, 8])
     @pytest.mark.parametrize("same_on_batch", [True, False])
     def test_valid_param_combinations(
-        self, brightness, contrast, saturation, hue, batch_size, same_on_batch, device, dtype
+        self,
+        brightness,
+        contrast,
+        saturation,
+        hue,
+        batch_size,
+        same_on_batch,
+        device,
+        dtype,
     ):
         ColorJitterGenerator(
             torch.as_tensor(
-                brightness if brightness is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                brightness if brightness is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
             ),
-            torch.as_tensor(contrast if contrast is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype),
             torch.as_tensor(
-                saturation if saturation is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                contrast if contrast is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
             ),
-            torch.as_tensor(hue if hue is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype),
+            torch.as_tensor(
+                saturation if saturation is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
+            ),
+            torch.as_tensor(
+                hue if hue is not None else torch.tensor([0.0, 0.0]),
+                device=device,
+                dtype=dtype,
+            ),
         )(torch.Size([batch_size]), same_on_batch)
 
     @pytest.mark.parametrize(
@@ -289,44 +425,63 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
         with pytest.raises(Exception):
             ColorJitterGenerator(
                 torch.as_tensor(
-                    brightness if brightness is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                    brightness if brightness is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
                 ),
                 torch.as_tensor(
-                    contrast if contrast is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                    contrast if contrast is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
                 ),
                 torch.as_tensor(
-                    saturation if saturation is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype
+                    saturation if saturation is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
                 ),
-                torch.as_tensor(hue if hue is not None else torch.tensor([0.0, 0.0]), device=device, dtype=dtype),
+                torch.as_tensor(
+                    hue if hue is not None else torch.tensor([0.0, 0.0]),
+                    device=device,
+                    dtype=dtype,
+                ),
             )(torch.Size([8]))
 
     def test_random_gen(self, device, dtype):
         # TODO(jian): crashes with pytorch 1.10, cuda and fp64
-        if torch_version_ge(1, 10) and "cuda" in str(device):
+        if "cuda" in str(device):
             pytest.skip("AssertionError: Tensor-likes are not close!")
         torch.manual_seed(42)
         batch_size = 8
-        jitter_params = ColorJitterGenerator(
+        gen = ColorJitterGenerator(
             brightness=torch.tensor([0.8, 1.2], device=device, dtype=dtype),
             contrast=torch.tensor([0.7, 1.3], device=device, dtype=dtype),
             saturation=torch.tensor([0.6, 1.4], device=device, dtype=dtype),
             hue=torch.tensor([-0.1, 0.1], device=device, dtype=dtype),
-        )(torch.Size([batch_size]))
+        ).to(device)
+        jitter_params = gen(torch.Size([batch_size]))
 
         expected_jitter_params = {
             "brightness_factor": torch.tensor(
-                [1.1529, 1.1660, 0.9531, 1.1837, 0.9562, 1.0404, 0.9026, 1.1175], device=device, dtype=dtype
+                [1.1529, 1.1660, 0.9531, 1.1837, 0.9562, 1.0404, 0.9026, 1.1175],
+                device=device,
+                dtype=dtype,
             ),
             "contrast_factor": torch.tensor(
-                [1.2645, 0.7799, 1.2608, 1.0561, 1.2216, 1.0406, 1.1447, 0.9576], device=device, dtype=dtype
+                [1.2645, 0.7799, 1.2608, 1.0561, 1.2216, 1.0406, 1.1447, 0.9576],
+                device=device,
+                dtype=dtype,
             ),
             "hue_factor": torch.tensor(
-                [0.0771, 0.0148, -0.0467, 0.0255, -0.0461, -0.0117, -0.0406, 0.0663], device=device, dtype=dtype
+                [0.0771, 0.0148, -0.0467, 0.0255, -0.0461, -0.0117, -0.0406, 0.0663],
+                device=device,
+                dtype=dtype,
             ),
             "saturation_factor": torch.tensor(
-                [0.6843, 0.8156, 0.8871, 0.7595, 1.0378, 0.6049, 1.3612, 0.6602], device=device, dtype=dtype
+                [0.6843, 0.8156, 0.8871, 0.7595, 1.0378, 0.6049, 1.3612, 0.6602],
+                device=device,
+                dtype=dtype,
             ),
-            "order": torch.tensor([3, 2, 0, 1], device=device, dtype=dtype),
+            "order": torch.tensor([3, 2, 0, 1], device=device, dtype=torch.long),
         }
 
         assert set(jitter_params.keys()) == {
@@ -339,14 +494,35 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
                 'brightness_factor', 'contrast_factor', 'hue_factor', 'saturation_factor', 'order'"
 
         assert_close(
-            jitter_params["brightness_factor"], expected_jitter_params["brightness_factor"], rtol=1e-4, atol=1e-4
+            jitter_params["brightness_factor"],
+            expected_jitter_params["brightness_factor"],
+            rtol=1e-4,
+            atol=1e-4,
         )
-        assert_close(jitter_params["contrast_factor"], expected_jitter_params["contrast_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["hue_factor"], expected_jitter_params["hue_factor"], rtol=1e-4, atol=1e-4)
         assert_close(
-            jitter_params["saturation_factor"], expected_jitter_params["saturation_factor"], rtol=1e-4, atol=1e-4
+            jitter_params["contrast_factor"],
+            expected_jitter_params["contrast_factor"],
+            rtol=1e-4,
+            atol=1e-4,
         )
-        assert_close(jitter_params["order"].to(dtype), expected_jitter_params["order"], rtol=1e-4, atol=1e-4)
+        assert_close(
+            jitter_params["hue_factor"],
+            expected_jitter_params["hue_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["saturation_factor"],
+            expected_jitter_params["saturation_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["order"],
+            expected_jitter_params["order"].tolist(),
+            rtol=1e-4,
+            atol=1e-4,
+        )
 
     def test_same_on_batch(self, device, dtype):
         torch.manual_seed(42)
@@ -366,11 +542,36 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
             "order": torch.tensor([2, 3, 0, 1], device=device, dtype=dtype),
         }
 
-        assert_close(jitter_params["brightness_factor"], expected_res["brightness_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["contrast_factor"], expected_res["contrast_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["hue_factor"], expected_res["hue_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["saturation_factor"], expected_res["saturation_factor"], rtol=1e-4, atol=1e-4)
-        assert_close(jitter_params["order"].to(dtype), expected_res["order"], rtol=1e-4, atol=1e-4)
+        assert_close(
+            jitter_params["brightness_factor"],
+            expected_res["brightness_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["contrast_factor"],
+            expected_res["contrast_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["hue_factor"],
+            expected_res["hue_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["saturation_factor"],
+            expected_res["saturation_factor"],
+            rtol=1e-4,
+            atol=1e-4,
+        )
+        assert_close(
+            jitter_params["order"],
+            expected_res["order"].tolist(),
+            rtol=1e-4,
+            atol=1e-4,
+        )
 
 
 class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
@@ -414,8 +615,18 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
             ),
             "end_points": torch.tensor(
                 [
-                    [[44.1135, 45.7502], [179.8568, 47.9653], [179.4776, 168.9552], [12.8286, 159.3179]],
-                    [[47.0386, 6.6593], [152.2701, 29.6790], [155.5298, 170.6142], [37.0547, 177.5298]],
+                    [
+                        [44.1135, 45.7502],
+                        [179.8568, 47.9653],
+                        [179.4776, 168.9552],
+                        [12.8286, 159.3179],
+                    ],
+                    [
+                        [47.0386, 6.6593],
+                        [152.2701, 29.6790],
+                        [155.5298, 170.6142],
+                        [37.0547, 177.5298],
+                    ],
                 ],
                 device=device,
                 dtype=dtype,
@@ -433,10 +644,19 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
         )
         expected = {
             "start_points": torch.tensor(
-                [[[0.0, 0.0], [199.0, 0.0], [199.0, 199.0], [0.0, 199.0]]], device=device, dtype=dtype
+                [[[0.0, 0.0], [199.0, 0.0], [199.0, 199.0], [0.0, 199.0]]],
+                device=device,
+                dtype=dtype,
             ).repeat(2, 1, 1),
             "end_points": torch.tensor(
-                [[[44.1135, 45.7502], [179.8568, 47.9653], [179.4776, 168.9552], [12.8286, 159.3179]]],
+                [
+                    [
+                        [44.1135, 45.7502],
+                        [179.8568, 47.9653],
+                        [179.4776, 168.9552],
+                        [12.8286, 159.3179],
+                    ]
+                ],
                 device=device,
                 dtype=dtype,
             ).repeat(2, 1, 1),
@@ -448,9 +668,10 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
     def test_sampling_method(self, device, dtype):
         torch.manual_seed(42)
         batch_size = 2
-        res = PerspectiveGenerator(torch.tensor(0.5, device=device, dtype=dtype), sampling_method="area_preserving")(
-            torch.Size([batch_size, 1, 200, 200])
-        )
+        res = PerspectiveGenerator(
+            torch.tensor(0.5, device=device, dtype=dtype),
+            sampling_method="area_preserving",
+        )(torch.Size([batch_size, 1, 200, 200]))
 
         expected = {
             "start_points": torch.tensor(
@@ -463,8 +684,18 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
             ),
             "end_points": torch.tensor(
                 [
-                    [[38.2269, 41.5004], [187.2864, 45.9306], [188.0448, 209.0895], [-24.3428, 228.3641]],
-                    [[44.0771, -36.6814], [242.4598, 9.3580], [235.9404, 205.7715], [24.1094, 191.9404]],
+                    [
+                        [38.2269, 41.5004],
+                        [187.2864, 45.9306],
+                        [188.0448, 209.0895],
+                        [-24.3428, 228.3641],
+                    ],
+                    [
+                        [44.0771, -36.6814],
+                        [242.4598, 9.3580],
+                        [235.9404, 205.7715],
+                        [24.1094, 191.9404],
+                    ],
                 ],
                 device=device,
                 dtype=dtype,
@@ -477,9 +708,10 @@ class TestRandomPerspectiveGen(RandomGeneratorBaseTests):
     def test_not_implemented_sampling_method(self, device, dtype):
         batch_size = 2
         with pytest.raises(NotImplementedError):
-            PerspectiveGenerator(torch.tensor(0.5, device=device, dtype=dtype), sampling_method="non_existing_method")(
-                torch.Size([batch_size, 1, 200, 200])
-            )
+            PerspectiveGenerator(
+                torch.tensor(0.5, device=device, dtype=dtype),
+                sampling_method="non_existing_method",
+            )(torch.Size([batch_size, 1, 200, 200]))
 
 
 class TestRandomAffineGen(RandomGeneratorBaseTests):
@@ -492,11 +724,21 @@ class TestRandomAffineGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize("shear", [None, torch.tensor([[0, 20], [0, 20]])])
     @pytest.mark.parametrize("same_on_batch", [True, False])
     def test_valid_param_combinations(
-        self, batch_size, height, width, degrees, translate, scale, shear, same_on_batch, device, dtype
+        self,
+        batch_size,
+        height,
+        width,
+        degrees,
+        translate,
+        scale,
+        shear,
+        same_on_batch,
+        device,
+        dtype,
     ):
         AffineGenerator(
             degrees=degrees.to(device=device, dtype=dtype),
-            translate=translate.to(device=device, dtype=dtype) if translate is not None else None,
+            translate=(translate.to(device=device, dtype=dtype) if translate is not None else None),
             scale=scale.to(device=device, dtype=dtype) if scale is not None else None,
             shear=shear.to(device=device, dtype=dtype) if shear is not None else None,
         )(torch.Size([batch_size, 1, height, width]), same_on_batch)
@@ -521,9 +763,9 @@ class TestRandomAffineGen(RandomGeneratorBaseTests):
         with pytest.raises(Exception):
             AffineGenerator(
                 degrees=degrees.to(device=device, dtype=dtype),
-                translate=translate.to(device=device, dtype=dtype) if translate is not None else None,
-                scale=scale.to(device=device, dtype=dtype) if scale is not None else None,
-                shear=shear.to(device=device, dtype=dtype) if shear is not None else None,
+                translate=(translate.to(device=device, dtype=dtype) if translate is not None else None),
+                scale=(scale.to(device=device, dtype=dtype) if scale is not None else None),
+                shear=(shear.to(device=device, dtype=dtype) if shear is not None else None),
             )(torch.Size([8, 1, height, width]))
 
     def test_random_gen(self, device, dtype):
@@ -534,7 +776,7 @@ class TestRandomAffineGen(RandomGeneratorBaseTests):
         shear = torch.tensor([[10, 20], [10, 20]], device=device, dtype=dtype)
         res = AffineGenerator(
             degrees=degrees.to(device=device, dtype=dtype),
-            translate=translate.to(device=device, dtype=dtype) if translate is not None else None,
+            translate=(translate.to(device=device, dtype=dtype) if translate is not None else None),
             scale=scale.to(device=device, dtype=dtype) if scale is not None else None,
             shear=shear.to(device=device, dtype=dtype) if shear is not None else None,
         )(torch.Size([2, 1, 200, 200]))
@@ -562,7 +804,7 @@ class TestRandomAffineGen(RandomGeneratorBaseTests):
         shear = torch.tensor([[10, 20], [10, 20]], device=device, dtype=dtype)
         res = AffineGenerator(
             degrees=degrees.to(device=device, dtype=dtype),
-            translate=translate.to(device=device, dtype=dtype) if translate is not None else None,
+            translate=(translate.to(device=device, dtype=dtype) if translate is not None else None),
             scale=scale.to(device=device, dtype=dtype) if scale is not None else None,
             shear=shear.to(device=device, dtype=dtype) if shear is not None else None,
         )(torch.Size([2, 1, 200, 200]), True)
@@ -596,14 +838,18 @@ class TestRandomCropGen(RandomGeneratorBaseTests):
 
     @pytest.mark.parametrize(
         "input_size,size,resize_to",
-        [((-300, 300), (200, 200), (100, 100)), ((200, 200), torch.tensor([50, 50]), (100, 100))],
+        [
+            ((-300, 300), (200, 200), (100, 100)),
+            ((200, 200), torch.tensor([50, 50]), (100, 100)),
+        ],
     )
     def test_invalid_param_combinations(self, input_size, size, resize_to, device, dtype):
         batch_size = 2
         with pytest.raises(Exception):
-            CropGenerator(size.to(device=device, dtype=dtype) if isinstance(size, Tensor) else size, resize_to)(
-                torch.Size([batch_size, 1, *input_size])
-            )
+            CropGenerator(
+                (size.to(device=device, dtype=dtype) if isinstance(size, Tensor) else size),
+                resize_to,
+            )(torch.Size([batch_size, 1, *input_size]))
 
     def test_random_gen(self, device, dtype):
         torch.manual_seed(42)
@@ -612,12 +858,18 @@ class TestRandomCropGen(RandomGeneratorBaseTests):
         )
         expected = {
             "src": torch.tensor(
-                [[[36, 19], [95, 19], [95, 68], [36, 68]], [[19, 29], [98, 29], [98, 98], [19, 98]]],
+                [
+                    [[36, 19], [95, 19], [95, 68], [36, 68]],
+                    [[19, 29], [98, 29], [98, 98], [19, 98]],
+                ],
                 device=device,
                 dtype=dtype,
             ),
             "dst": torch.tensor(
-                [[[0, 0], [199, 0], [199, 199], [0, 199]], [[0, 0], [199, 0], [199, 199], [0, 199]]],
+                [
+                    [[0, 0], [199, 0], [199, 199], [0, 199]],
+                    [[0, 0], [199, 0], [199, 199], [0, 199]],
+                ],
                 device=device,
                 dtype=dtype,
             ),
@@ -635,12 +887,18 @@ class TestRandomCropGen(RandomGeneratorBaseTests):
         )
         expected = {
             "src": torch.tensor(
-                [[[36, 46], [95, 46], [95, 95], [36, 95]], [[36, 46], [115, 46], [115, 115], [36, 115]]],
+                [
+                    [[36, 46], [95, 46], [95, 95], [36, 95]],
+                    [[36, 46], [115, 46], [115, 115], [36, 115]],
+                ],
                 device=device,
                 dtype=dtype,
             ),
             "dst": torch.tensor(
-                [[[0, 0], [199, 0], [199, 199], [0, 199]], [[0, 0], [199, 0], [199, 199], [0, 199]]],
+                [
+                    [[0, 0], [199, 0], [199, 199], [0, 199]],
+                    [[0, 0], [199, 0], [199, 199], [0, 199]],
+                ],
                 device=device,
                 dtype=dtype,
             ),
@@ -660,7 +918,9 @@ class TestRandomCropSizeGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize("same_on_batch", [True, False])
     def test_valid_param_combinations(self, batch_size, size, scale, ratio, same_on_batch, device, dtype):
         ResizedCropGenerator(
-            size, torch.as_tensor(scale, device=device, dtype=dtype), torch.as_tensor(ratio, device=device, dtype=dtype)
+            size,
+            torch.as_tensor(scale, device=device, dtype=dtype),
+            torch.as_tensor(ratio, device=device, dtype=dtype),
         )(torch.Size([batch_size, 1, 300, 300]), same_on_batch)
 
     @pytest.mark.parametrize(
@@ -757,10 +1017,21 @@ class TestRandomRectangleGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize("value", [0])
     @pytest.mark.parametrize("same_on_batch", [True, False])
     def test_valid_param_combinations(
-        self, batch_size, height, width, scale, ratio, value, same_on_batch, device, dtype
+        self,
+        batch_size,
+        height,
+        width,
+        scale,
+        ratio,
+        value,
+        same_on_batch,
+        device,
+        dtype,
     ):
         RectangleEraseGenerator(
-            scale=scale.to(device=device, dtype=dtype), ratio=ratio.to(device=device, dtype=dtype), value=value
+            scale=scale.to(device=device, dtype=dtype),
+            ratio=ratio.to(device=device, dtype=dtype),
+            value=value,
         )(torch.Size([batch_size, 1, height, width]), same_on_batch)
 
     @pytest.mark.parametrize(
@@ -774,14 +1045,22 @@ class TestRandomRectangleGen(RandomGeneratorBaseTests):
             (100, 100, torch.tensor([0.7, 1.3]), torch.tensor([0.7, 1.3, 1.5]), 0),
             (100, 100, torch.tensor([0.7, 1.3]), torch.tensor([0.7, 1.3]), -1),
             (100, 100, torch.tensor([0.7, 1.3]), torch.tensor([0.7, 1.3]), 2),
-            (100, 100, torch.tensor([0.5, 0.7]), torch.tensor([0.7, 0.9]), torch.tensor(0.5)),
+            (
+                100,
+                100,
+                torch.tensor([0.5, 0.7]),
+                torch.tensor([0.7, 0.9]),
+                torch.tensor(0.5),
+            ),
         ],
     )
     def test_invalid_param_combinations(self, height, width, scale, ratio, value, device, dtype):
         batch_size = 8
         with pytest.raises(Exception):
             RectangleEraseGenerator(
-                scale=scale.to(device=device, dtype=dtype), ratio=ratio.to(device=device, dtype=dtype), value=value
+                scale=scale.to(device=device, dtype=dtype),
+                ratio=ratio.to(device=device, dtype=dtype),
+                value=value,
             )(torch.Size([batch_size, 1, height, width]))
 
     def test_random_gen(self, device, dtype):
@@ -791,7 +1070,9 @@ class TestRandomRectangleGen(RandomGeneratorBaseTests):
         ratio = torch.tensor([0.7, 1.3], device=device, dtype=dtype)
         value = 0.5
         res = RectangleEraseGenerator(
-            scale=scale.to(device=device, dtype=dtype), ratio=ratio.to(device=device, dtype=dtype), value=value
+            scale=scale.to(device=device, dtype=dtype),
+            ratio=ratio.to(device=device, dtype=dtype),
+            value=value,
         )(torch.Size([2, 1, height, width]))
         expected = {
             "widths": torch.tensor([100, 100], device=device, dtype=dtype),
@@ -814,7 +1095,9 @@ class TestRandomRectangleGen(RandomGeneratorBaseTests):
         ratio = torch.tensor([0.7, 1.3], device=device, dtype=dtype)
         value = 0.5
         res = RectangleEraseGenerator(
-            scale=scale.to(device=device, dtype=dtype), ratio=ratio.to(device=device, dtype=dtype), value=value
+            scale=scale.to(device=device, dtype=dtype),
+            ratio=ratio.to(device=device, dtype=dtype),
+            value=value,
         )(torch.Size([2, 1, height, width]), True)
         expected = {
             "widths": torch.tensor([100, 100], device=device, dtype=dtype),
@@ -859,12 +1142,18 @@ class TestCenterCropGen(RandomGeneratorBaseTests):
         res = center_crop_generator(batch_size=2, height=200, width=200, size=(120, 150))
         expected = {
             "src": torch.tensor(
-                [[[25, 40], [174, 40], [174, 159], [25, 159]], [[25, 40], [174, 40], [174, 159], [25, 159]]],
+                [
+                    [[25, 40], [174, 40], [174, 159], [25, 159]],
+                    [[25, 40], [174, 40], [174, 159], [25, 159]],
+                ],
                 device=device,
                 dtype=torch.long,
             ),
             "dst": torch.tensor(
-                [[[0, 0], [149, 0], [149, 119], [0, 119]], [[0, 0], [149, 0], [149, 119], [0, 119]]],
+                [
+                    [[0, 0], [149, 0], [149, 119], [0, 119]],
+                    [[0, 0], [149, 0], [149, 119], [0, 119]],
+                ],
                 device=device,
                 dtype=torch.long,
             ),
@@ -956,7 +1245,15 @@ class TestRandomPosterizeGen(RandomGeneratorBaseTests):
     def test_valid_param_combinations(self, batch_size, bits, same_on_batch, device, dtype):
         PosterizeGenerator(bits)(torch.Size([batch_size]), same_on_batch)
 
-    @pytest.mark.parametrize("bits", [(torch.tensor([-1, 1])), (torch.tensor([0, 9])), (torch.tensor([3])), ([0, 8],)])
+    @pytest.mark.parametrize(
+        "bits",
+        [
+            (torch.tensor([-1, 1])),
+            (torch.tensor([0, 9])),
+            (torch.tensor([3])),
+            ([0, 8],),
+        ],
+    )
     def test_invalid_param_combinations(self, bits, device, dtype):
         with pytest.raises(Exception):
             if isinstance(bits, Tensor):
@@ -998,18 +1295,30 @@ class TestPlainUniformGenerator(RandomGeneratorBaseTests):
         with pytest.raises(Exception):
             PlainUniformGenerator(
                 (sharpness.to(device=device, dtype=dtype), "sharpness", None, None),
-                (sharpness.to(device=device, dtype=dtype), "sharpness", 0.0, (0.0, 1.0)),
+                (
+                    sharpness.to(device=device, dtype=dtype),
+                    "sharpness",
+                    0.0,
+                    (0.0, 1.0),
+                ),
             )(torch.Size([8, 1]))
 
     def test_random_gen(self, device, dtype):
         torch.manual_seed(42)
         batch_size = 8
         res = PlainUniformGenerator(
-            (torch.tensor([0.0, 1.0], device=device, dtype=dtype), "sharpness_factor", None, None)
+            (
+                torch.tensor([0.0, 1.0], device=device, dtype=dtype),
+                "sharpness_factor",
+                None,
+                None,
+            )
         )(torch.Size([batch_size, 1]))
         expected = {
             "sharpness_factor": torch.tensor(
-                [0.8823, 0.9150, 0.3829, 0.9593, 0.3904, 0.6009, 0.2566, 0.7936], device=device, dtype=dtype
+                [0.8823, 0.9150, 0.3829, 0.9593, 0.3904, 0.6009, 0.2566, 0.7936],
+                device=device,
+                dtype=dtype,
             )
         }
         assert res.keys() == expected.keys()
@@ -1019,11 +1328,18 @@ class TestPlainUniformGenerator(RandomGeneratorBaseTests):
         torch.manual_seed(42)
         batch_size = 8
         res = PlainUniformGenerator(
-            (torch.tensor([0.0, 1.0], device=device, dtype=dtype), "sharpness_factor", None, None)
+            (
+                torch.tensor([0.0, 1.0], device=device, dtype=dtype),
+                "sharpness_factor",
+                None,
+                None,
+            )
         )(torch.Size([batch_size, 1]), True)
         expected = {
             "sharpness_factor": torch.tensor(
-                [0.8823, 0.8823, 0.8823, 0.8823, 0.8823, 0.8823, 0.8823, 0.8823], device=device, dtype=dtype
+                [0.8823, 0.8823, 0.8823, 0.8823, 0.8823, 0.8823, 0.8823, 0.8823],
+                device=device,
+                dtype=dtype,
             )
         }
         assert res.keys() == expected.keys()
@@ -1038,11 +1354,17 @@ class TestRandomMixUpGen(RandomGeneratorBaseTests):
     def test_valid_param_combinations(self, batch_size, p, lambda_val, same_on_batch, device, dtype):
         MixupGenerator(
             p=p,
-            lambda_val=lambda_val.to(device=device, dtype=dtype) if isinstance(lambda_val, (Tensor)) else lambda_val,
+            lambda_val=(lambda_val.to(device=device, dtype=dtype) if isinstance(lambda_val, (Tensor)) else lambda_val),
         )(torch.Size([batch_size, 3, 200, 200]), same_on_batch=same_on_batch)
 
     @pytest.mark.parametrize(
-        "lambda_val", [(torch.tensor([-1, 1])), (torch.tensor([0, 2])), (torch.tensor([0, 0.5, 1])), ([0.0, 1.0])]
+        "lambda_val",
+        [
+            (torch.tensor([-1, 1])),
+            (torch.tensor([0, 2])),
+            (torch.tensor([0, 0.5, 1])),
+            ([0.0, 1.0]),
+        ],
     )
     def test_invalid_param_combinations(self, lambda_val, device, dtype):
         with pytest.raises(Exception):
@@ -1059,7 +1381,9 @@ class TestRandomMixUpGen(RandomGeneratorBaseTests):
         expected = {
             "mixup_pairs": torch.tensor([6, 1, 0, 7, 2, 5, 3, 4], device=device, dtype=torch.long),
             "mixup_lambdas": torch.tensor(
-                [0.0000, 0.0000, 0.5739, 0.0000, 0.6274, 0.0000, 0.4414, 0.0000], device=device, dtype=dtype
+                [0.0000, 0.0000, 0.5739, 0.0000, 0.6274, 0.0000, 0.4414, 0.0000],
+                device=device,
+                dtype=dtype,
             ),
         }
         assert res.keys() == expected.keys()
@@ -1075,7 +1399,9 @@ class TestRandomMixUpGen(RandomGeneratorBaseTests):
         expected = {
             "mixup_pairs": torch.tensor([4, 6, 7, 5, 0, 1, 3, 2], device=device, dtype=torch.long),
             "mixup_lambdas": torch.tensor(
-                [0.3804, 0.3804, 0.3804, 0.3804, 0.3804, 0.3804, 0.3804, 0.3804], device=device, dtype=dtype
+                [0.3804, 0.3804, 0.3804, 0.3804, 0.3804, 0.3804, 0.3804, 0.3804],
+                device=device,
+                dtype=dtype,
             ),
         }
         assert res.keys() == expected.keys()
@@ -1092,13 +1418,23 @@ class TestRandomCutMixGen(RandomGeneratorBaseTests):
     @pytest.mark.parametrize("cut_size", [None, torch.tensor([0.0, 1.0]), torch.tensor([0.3, 0.6])])
     @pytest.mark.parametrize("same_on_batch", [True, False])
     def test_valid_param_combinations(
-        self, batch_size, p, width, height, num_mix, beta, cut_size, same_on_batch, device, dtype
+        self,
+        batch_size,
+        p,
+        width,
+        height,
+        num_mix,
+        beta,
+        cut_size,
+        same_on_batch,
+        device,
+        dtype,
     ):
         CutmixGenerator(
             p=p,
             num_mix=num_mix,
-            beta=beta.to(device=device, dtype=dtype) if isinstance(beta, (Tensor)) else beta,
-            cut_size=cut_size.to(device=device, dtype=dtype) if isinstance(cut_size, (Tensor)) else cut_size,
+            beta=(beta.to(device=device, dtype=dtype) if isinstance(beta, (Tensor)) else beta),
+            cut_size=(cut_size.to(device=device, dtype=dtype) if isinstance(cut_size, (Tensor)) else cut_size),
         )(torch.Size([batch_size, 3, height, width]), same_on_batch=same_on_batch)
 
     @pytest.mark.parametrize(
@@ -1119,8 +1455,8 @@ class TestRandomCutMixGen(RandomGeneratorBaseTests):
             CutmixGenerator(
                 p=0.5,
                 num_mix=num_mix,
-                beta=beta.to(device=device, dtype=dtype) if isinstance(beta, (Tensor)) else beta,
-                cut_size=cut_size.to(device=device, dtype=dtype) if isinstance(cut_size, (Tensor)) else cut_size,
+                beta=(beta.to(device=device, dtype=dtype) if isinstance(beta, (Tensor)) else beta),
+                cut_size=(cut_size.to(device=device, dtype=dtype) if isinstance(cut_size, (Tensor)) else cut_size),
             )(torch.Size([8, 3, height, width]), same_on_batch=same_on_batch)
 
     def test_random_gen(self, device, dtype):
@@ -1169,7 +1505,12 @@ class TestRandomCutMixGen(RandomGeneratorBaseTests):
         expected = {
             "mix_pairs": torch.tensor([[1, 0]], device=device, dtype=torch.long),
             "crop_src": torch.tensor(
-                [[[[114, 53], [113, 53], [113, 52], [114, 52]], [[114, 53], [113, 53], [113, 52], [114, 52]]]],
+                [
+                    [
+                        [[114, 53], [113, 53], [113, 52], [114, 52]],
+                        [[114, 53], [113, 53], [113, 52], [114, 52]],
+                    ]
+                ],
                 device=device,
                 dtype=dtype,
             ),

--- a/tests/augmentation/test_random_generator.py
+++ b/tests/augmentation/test_random_generator.py
@@ -355,7 +355,7 @@ class TestColorJiggleGen(RandomGeneratorBaseTests):
             atol=1e-4,
         )
         assert_close(
-            jitter_params["order"].to(dtype),
+            jitter_params["order"],
             expected_res["order"],
             rtol=1e-4,
             atol=1e-4,
@@ -520,7 +520,7 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
         )
         assert_close(
             jitter_params["order"],
-            expected_jitter_params["order"].tolist(),
+            expected_jitter_params["order"],
             rtol=1e-4,
             atol=1e-4,
         )
@@ -540,7 +540,7 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
             "contrast_factor": torch.tensor([1.2490] * batch_size, device=device, dtype=dtype),
             "hue_factor": torch.tensor([-0.0234] * batch_size, device=device, dtype=dtype),
             "saturation_factor": torch.tensor([1.3674] * batch_size, device=device, dtype=dtype),
-            "order": torch.tensor([2, 3, 0, 1], device=device, dtype=dtype),
+            "order": torch.tensor([2, 3, 0, 1], device=device, dtype=torch.long),
         }
 
         assert_close(
@@ -569,7 +569,7 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
         )
         assert_close(
             jitter_params["order"],
-            expected_res["order"].tolist(),
+            expected_res["order"],
             rtol=1e-4,
             atol=1e-4,
         )

--- a/tests/augmentation/test_random_generator.py
+++ b/tests/augmentation/test_random_generator.py
@@ -18,6 +18,7 @@ from kornia.augmentation.random_generator import (
     ResizedCropGenerator,
     center_crop_generator,
 )
+from kornia.utils._compat import torch_version_ge
 
 from testing.base import assert_close
 
@@ -448,7 +449,7 @@ class TestColorJitterGen(RandomGeneratorBaseTests):
 
     def test_random_gen(self, device, dtype):
         # TODO(jian): crashes with pytorch 1.10, cuda and fp64
-        if "cuda" in str(device):
+        if torch_version_ge(1, 10) and "cuda" in str(device):
             pytest.skip("AssertionError: Tensor-likes are not close!")
         torch.manual_seed(42)
         batch_size = 8


### PR DESCRIPTION
#### Changes

don't force the random generators to use the set device of the Module

```python
aug =  K.augmentation.ColorJitter(0.1, 0.1, 0.1, 0.1).to(accelerate.device),
```

TODO: support the following @johnnv1 @shijianjian 

```python
aug =  K.augmentation.ColorJitter(0.1, 0.1, 0.1, 0.1).cuda()
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
