### PR TITLE
[Fix] Add Support for Images not Div by 16 (Diff. JPEG)

### DIFF
--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import math
+from typing import Tuple
+
 import torch
+import torch.nn.functional as F
 
 from kornia.color import rgb_to_ycbcr, ycbcr_to_rgb
 from kornia.constants import pi
@@ -106,7 +110,7 @@ def _dct_8x8(input: Tensor) -> Tensor:
     x, y, u, v = torch.meshgrid(index, index, index, index)
     dct_tensor: Tensor = ((2.0 * x + 1.0) * u * pi / 16.0).cos() * ((2.0 * y + 1.0) * v * pi / 16.0).cos()
     alpha: Tensor = torch.ones(8, dtype=dtype, device=device)
-    alpha[0] = 1.0 / (2**0.5)
+    alpha[0] = 1.0 / (2 ** 0.5)
     dct_scale: Tensor = torch.einsum("i, j -> ij", alpha, alpha) * 0.25
     # Apply DCT
     output: Tensor = dct_scale[None, None] * torch.tensordot(input - 128.0, dct_tensor)
@@ -127,7 +131,7 @@ def _idct_8x8(input: Tensor) -> Tensor:
     device: Device = input.device
     # Make and apply scaling
     alpha: Tensor = torch.ones(8, dtype=dtype, device=device)
-    alpha[0] = 1.0 / (2**0.5)
+    alpha[0] = 1.0 / (2 ** 0.5)
     dct_scale: Tensor = torch.outer(alpha, alpha)
     input = input * dct_scale[None, None]
     # Make DCT tensor and scaling
@@ -140,7 +144,7 @@ def _idct_8x8(input: Tensor) -> Tensor:
 
 
 def _jpeg_quality_to_scale(
-    compression_strength: Tensor,
+        compression_strength: Tensor,
 ) -> Tensor:
     """Converts a given JPEG quality to the scaling factor.
 
@@ -158,9 +162,9 @@ def _jpeg_quality_to_scale(
 
 
 def _quantize(
-    input: Tensor,
-    jpeg_quality: Tensor,
-    quantization_table: Tensor,
+        input: Tensor,
+        jpeg_quality: Tensor,
+        quantization_table: Tensor,
 ) -> Tensor:
     """Function performs quantization.
 
@@ -174,7 +178,7 @@ def _quantize(
     """
     # Scale quantization table
     quantization_table_scaled: Tensor = (
-        quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
+            quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
     )
     # Perform scaling
     quantization_table = differentiable_polynomial_floor(
@@ -187,9 +191,9 @@ def _quantize(
 
 
 def _dequantize(
-    input: Tensor,
-    jpeg_quality: Tensor,
-    quantization_table: Tensor,
+        input: Tensor,
+        jpeg_quality: Tensor,
+        quantization_table: Tensor,
 ) -> Tensor:
     """Function performs dequantization.
 
@@ -203,7 +207,7 @@ def _dequantize(
     """
     # Scale quantization table
     quantization_table_scaled: Tensor = (
-        quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
+            quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
     )
     # Perform scaling
     output: Tensor = input * differentiable_polynomial_floor(
@@ -250,10 +254,10 @@ def _chroma_upsampling(input_c: Tensor) -> Tensor:
 
 
 def _jpeg_encode(
-    image_rgb: Tensor,
-    jpeg_quality: Tensor,
-    quantization_table_y: Tensor,
-    quantization_table_c: Tensor,
+        image_rgb: Tensor,
+        jpeg_quality: Tensor,
+        quantization_table_y: Tensor,
+        quantization_table_c: Tensor,
 ) -> tuple[Tensor, Tensor, Tensor]:
     """Performs JPEG encoding.
 
@@ -292,14 +296,14 @@ def _jpeg_encode(
 
 
 def _jpeg_decode(
-    input_y: Tensor,
-    input_cb: Tensor,
-    input_cr: Tensor,
-    jpeg_quality: Tensor,
-    H: int,
-    W: int,
-    quantization_table_y: Tensor,
-    quantization_table_c: Tensor,
+        input_y: Tensor,
+        input_cb: Tensor,
+        input_cr: Tensor,
+        jpeg_quality: Tensor,
+        H: int,
+        W: int,
+        quantization_table_y: Tensor,
+        quantization_table_c: Tensor,
 ) -> Tensor:
     """Performs JPEG decoding.
 
@@ -344,12 +348,33 @@ def _jpeg_decode(
     return rgb_decoded
 
 
+def _perform_padding(image: Tensor) -> Tuple[Tensor, int, int]:
+    """Pads a given image to be dividable by 16.
+
+    Args:
+        image (Tensor): Image of the shape :math:`(*, 3, H, W)`.
+
+    Returns:
+        image_padded (Tensor): Padded image of the shape :math:`(*, 3, H_{new}, W_{new})`.
+        h_pad (int): Padded pixels along the horizontal axis.
+        w_pad (int): Padded pixels along the vertical axis.
+    """
+    # Get spatial dimensions of the image
+    H, W = image.shape[-2:]
+    # Compute horizontal and vertical padding
+    h_pad: int = math.ceil(H / 16) * 16 - H
+    w_pad: int = math.ceil(W / 16) * 16 - W
+    # Perform padding (we follow JPEG and pad only the bottom and right side of the image)
+    image_padded: Tensor = F.pad(image, (0, w_pad, 0, h_pad), "replicate") if (h_pad != 0) or (w_pad != 0) else image
+    return image_padded, h_pad, w_pad
+
+
 @perform_keep_shape_image
 def jpeg_codec_differentiable(
-    image_rgb: Tensor,
-    jpeg_quality: Tensor,
-    quantization_table_y: Tensor | None = None,
-    quantization_table_c: Tensor | None = None,
+        image_rgb: Tensor,
+        jpeg_quality: Tensor,
+        quantization_table_y: Tensor | None = None,
+        quantization_table_c: Tensor | None = None,
 ) -> Tensor:
     r"""Differentiable JPEG encoding-decoding module.
 
@@ -437,10 +462,6 @@ def jpeg_codec_differentiable(
     KORNIA_CHECK_IS_TENSOR(quantization_table_c)
     # Check shape of inputs
     KORNIA_CHECK_SHAPE(image_rgb, ["*", "3", "H", "W"])
-    KORNIA_CHECK(
-        (image_rgb.shape[-1] % 16 == 0) and (image_rgb.shape[-2] % 16 == 0),
-        f"image dimension must be divisible by 16. Got the shape {image_rgb.shape}.",
-    )
     KORNIA_CHECK_SHAPE(jpeg_quality, ["B"])
     # Add batch dimension to quantization tables if needed
     if quantization_table_y.ndim == 2:
@@ -456,6 +477,8 @@ def jpeg_codec_differentiable(
         f"JPEG quality is out of range. Expected range is [0, 100], "
         f"got [{jpeg_quality.amin().item()}, {jpeg_quality.amax().item()}]. Consider clipping jpeg_quality.",
     )
+    # Pad the image to a shape dividable by 16
+    image_rgb, h_pad, w_pad = _perform_padding(image_rgb)
     # Get height and shape
     H, W = image_rgb.shape[-2:]
     # Check matching batch dimensions
@@ -499,8 +522,9 @@ def jpeg_codec_differentiable(
     )
     # Clip coded image
     image_rgb_jpeg = differentiable_clipping(input=image_rgb_jpeg, min_val=0.0, max_val=255.0)
-    # Back to original shape
-    # image_rgb_jpeg = image_rgb_jpeg.view(original_shape)
+    # Crop the image again to the original shape if needed
+    if (h_pad != 0) or (w_pad != 0):
+        image_rgb_jpeg = image_rgb_jpeg[..., :-h_pad, :-w_pad]
     return image_rgb_jpeg
 
 
@@ -577,9 +601,9 @@ class JPEGCodecDifferentiable(Module):
     """
 
     def __init__(
-        self,
-        quantization_table_y: Tensor | Parameter | None = None,
-        quantization_table_c: Tensor | Parameter | None = None,
+            self,
+            quantization_table_y: Tensor | Parameter | None = None,
+            quantization_table_c: Tensor | Parameter | None = None,
     ) -> None:
         super().__init__()
         # Get default quantization tables if needed
@@ -595,9 +619,9 @@ class JPEGCodecDifferentiable(Module):
             self.register_buffer("quantization_table_c", quantization_table_c)
 
     def forward(
-        self,
-        image_rgb: Tensor,
-        jpeg_quality: Tensor,
+            self,
+            image_rgb: Tensor,
+            jpeg_quality: Tensor,
     ) -> Tensor:
         # Perform encoding-decoding
         image_rgb_jpeg: Tensor = jpeg_codec_differentiable(

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -523,7 +523,7 @@ def jpeg_codec_differentiable(
     # Clip coded image
     image_rgb_jpeg = differentiable_clipping(input=image_rgb_jpeg, min_val=0.0, max_val=255.0)
     # Crop the image again to the original shape
-    image_rgb_jpeg = image_rgb_jpeg[..., :H - h_pad, :W - w_pad]
+    image_rgb_jpeg = image_rgb_jpeg[..., : H - h_pad, : W - w_pad]
     return image_rgb_jpeg
 
 

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -365,7 +365,7 @@ def _perform_padding(image: Tensor) -> Tuple[Tensor, int, int]:
     h_pad: int = math.ceil(H / 16) * 16 - H
     w_pad: int = math.ceil(W / 16) * 16 - W
     # Perform padding (we follow JPEG and pad only the bottom and right side of the image)
-    image_padded: Tensor = F.pad(image, (0, w_pad, 0, h_pad), "replicate") if (h_pad != 0) or (w_pad != 0) else image
+    image_padded: Tensor = F.pad(image, (0, w_pad, 0, h_pad), "replicate")
     return image_padded, h_pad, w_pad
 
 
@@ -522,9 +522,8 @@ def jpeg_codec_differentiable(
     )
     # Clip coded image
     image_rgb_jpeg = differentiable_clipping(input=image_rgb_jpeg, min_val=0.0, max_val=255.0)
-    # Crop the image again to the original shape if needed
-    if (h_pad != 0) or (w_pad != 0):
-        image_rgb_jpeg = image_rgb_jpeg[..., :-h_pad, :-w_pad]
+    # Crop the image again to the original shape
+    image_rgb_jpeg = image_rgb_jpeg[..., :H - h_pad, :W - w_pad]
     return image_rgb_jpeg
 
 

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -110,7 +110,7 @@ def _dct_8x8(input: Tensor) -> Tensor:
     x, y, u, v = torch.meshgrid(index, index, index, index)
     dct_tensor: Tensor = ((2.0 * x + 1.0) * u * pi / 16.0).cos() * ((2.0 * y + 1.0) * v * pi / 16.0).cos()
     alpha: Tensor = torch.ones(8, dtype=dtype, device=device)
-    alpha[0] = 1.0 / (2 ** 0.5)
+    alpha[0] = 1.0 / (2**0.5)
     dct_scale: Tensor = torch.einsum("i, j -> ij", alpha, alpha) * 0.25
     # Apply DCT
     output: Tensor = dct_scale[None, None] * torch.tensordot(input - 128.0, dct_tensor)
@@ -131,7 +131,7 @@ def _idct_8x8(input: Tensor) -> Tensor:
     device: Device = input.device
     # Make and apply scaling
     alpha: Tensor = torch.ones(8, dtype=dtype, device=device)
-    alpha[0] = 1.0 / (2 ** 0.5)
+    alpha[0] = 1.0 / (2**0.5)
     dct_scale: Tensor = torch.outer(alpha, alpha)
     input = input * dct_scale[None, None]
     # Make DCT tensor and scaling
@@ -144,7 +144,7 @@ def _idct_8x8(input: Tensor) -> Tensor:
 
 
 def _jpeg_quality_to_scale(
-        compression_strength: Tensor,
+    compression_strength: Tensor,
 ) -> Tensor:
     """Converts a given JPEG quality to the scaling factor.
 
@@ -162,9 +162,9 @@ def _jpeg_quality_to_scale(
 
 
 def _quantize(
-        input: Tensor,
-        jpeg_quality: Tensor,
-        quantization_table: Tensor,
+    input: Tensor,
+    jpeg_quality: Tensor,
+    quantization_table: Tensor,
 ) -> Tensor:
     """Function performs quantization.
 
@@ -178,7 +178,7 @@ def _quantize(
     """
     # Scale quantization table
     quantization_table_scaled: Tensor = (
-            quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
+        quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
     )
     # Perform scaling
     quantization_table = differentiable_polynomial_floor(
@@ -191,9 +191,9 @@ def _quantize(
 
 
 def _dequantize(
-        input: Tensor,
-        jpeg_quality: Tensor,
-        quantization_table: Tensor,
+    input: Tensor,
+    jpeg_quality: Tensor,
+    quantization_table: Tensor,
 ) -> Tensor:
     """Function performs dequantization.
 
@@ -207,7 +207,7 @@ def _dequantize(
     """
     # Scale quantization table
     quantization_table_scaled: Tensor = (
-            quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
+        quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
     )
     # Perform scaling
     output: Tensor = input * differentiable_polynomial_floor(
@@ -254,10 +254,10 @@ def _chroma_upsampling(input_c: Tensor) -> Tensor:
 
 
 def _jpeg_encode(
-        image_rgb: Tensor,
-        jpeg_quality: Tensor,
-        quantization_table_y: Tensor,
-        quantization_table_c: Tensor,
+    image_rgb: Tensor,
+    jpeg_quality: Tensor,
+    quantization_table_y: Tensor,
+    quantization_table_c: Tensor,
 ) -> tuple[Tensor, Tensor, Tensor]:
     """Performs JPEG encoding.
 
@@ -296,14 +296,14 @@ def _jpeg_encode(
 
 
 def _jpeg_decode(
-        input_y: Tensor,
-        input_cb: Tensor,
-        input_cr: Tensor,
-        jpeg_quality: Tensor,
-        H: int,
-        W: int,
-        quantization_table_y: Tensor,
-        quantization_table_c: Tensor,
+    input_y: Tensor,
+    input_cb: Tensor,
+    input_cr: Tensor,
+    jpeg_quality: Tensor,
+    H: int,
+    W: int,
+    quantization_table_y: Tensor,
+    quantization_table_c: Tensor,
 ) -> Tensor:
     """Performs JPEG decoding.
 
@@ -371,10 +371,10 @@ def _perform_padding(image: Tensor) -> Tuple[Tensor, int, int]:
 
 @perform_keep_shape_image
 def jpeg_codec_differentiable(
-        image_rgb: Tensor,
-        jpeg_quality: Tensor,
-        quantization_table_y: Tensor | None = None,
-        quantization_table_c: Tensor | None = None,
+    image_rgb: Tensor,
+    jpeg_quality: Tensor,
+    quantization_table_y: Tensor | None = None,
+    quantization_table_c: Tensor | None = None,
 ) -> Tensor:
     r"""Differentiable JPEG encoding-decoding module.
 
@@ -601,9 +601,9 @@ class JPEGCodecDifferentiable(Module):
     """
 
     def __init__(
-            self,
-            quantization_table_y: Tensor | Parameter | None = None,
-            quantization_table_c: Tensor | Parameter | None = None,
+        self,
+        quantization_table_y: Tensor | Parameter | None = None,
+        quantization_table_c: Tensor | Parameter | None = None,
     ) -> None:
         super().__init__()
         # Get default quantization tables if needed
@@ -619,9 +619,9 @@ class JPEGCodecDifferentiable(Module):
             self.register_buffer("quantization_table_c", quantization_table_c)
 
     def forward(
-            self,
-            image_rgb: Tensor,
-            jpeg_quality: Tensor,
+        self,
+        image_rgb: Tensor,
+        jpeg_quality: Tensor,
     ) -> Tensor:
         # Perform encoding-decoding
         image_rgb_jpeg: Tensor = jpeg_codec_differentiable(

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -352,12 +352,12 @@ def _perform_padding(image: Tensor) -> Tuple[Tensor, int, int]:
     """Pads a given image to be dividable by 16.
 
     Args:
-        image (Tensor): Image of the shape :math:`(*, 3, H, W)`.
+        image: Image of the shape :math:`(*, 3, H, W)`.
 
     Returns:
-        image_padded (Tensor): Padded image of the shape :math:`(*, 3, H_{new}, W_{new})`.
-        h_pad (int): Padded pixels along the horizontal axis.
-        w_pad (int): Padded pixels along the vertical axis.
+        image_padded: Padded image of the shape :math:`(*, 3, H_{new}, W_{new})`.
+        h_pad: Padded pixels along the horizontal axis.
+        w_pad: Padded pixels along the vertical axis.
     """
     # Get spatial dimensions of the image
     H, W = image.shape[-2:]

--- a/tests/enhance/test_jpeg.py
+++ b/tests/enhance/test_jpeg.py
@@ -16,6 +16,15 @@ class TestDiffJPEG(BaseTester):
         assert img_jpeg is not None
         assert img_jpeg.shape == img.shape
 
+    def test_smoke_not_div_by_16(self, device, dtype) -> None:
+        """This test standard usage."""
+        B, H, W = 2, 33, 33
+        img = torch.rand(B, 3, H, W, device=device, dtype=dtype)
+        jpeg_quality = torch.randint(low=0, high=100, size=(B,), device=device, dtype=dtype)
+        img_jpeg = kornia.enhance.jpeg_codec_differentiable(img, jpeg_quality)
+        assert img_jpeg is not None
+        assert img_jpeg.shape == img.shape
+
     def test_multi_batch(self, device, dtype) -> None:
         """Here we test two batch dimensions."""
         B, H, W = 4, 32, 32
@@ -80,13 +89,6 @@ class TestDiffJPEG(BaseTester):
             jpeg_quality = torch.randint(low=0, high=100, size=(B, 3, 2, 1), device=device, dtype=dtype)
             kornia.enhance.jpeg_codec_differentiable(img, jpeg_quality)
         assert "shape must be [" in str(errinfo)
-
-        with pytest.raises(Exception) as errinfo:
-            B, H, W = 2, 31, 31
-            img = torch.rand(B, 3, H, W, device=device, dtype=dtype)
-            jpeg_quality = torch.randint(low=0, high=100, size=(B,), device=device, dtype=dtype)
-            kornia.enhance.jpeg_codec_differentiable(img, jpeg_quality)
-        assert "divisible" in str(errinfo)
 
         with pytest.raises(Exception) as errinfo:
             B, H, W = 4, 32, 32


### PR DESCRIPTION
This pull request adds support for images not divisible by 16 to differentiable JPEG coding. As discussed in #2845 the current differentiable JPEG implementation just supports images that are divisible by 16. This is due to the fact that JPEG performs a (8 x 8) patch-wise DCT on downsampled (by 2) images. Thus the image must be divisible by 16. This pull request adds support for arbitrarily shaped images by performing padding and cropping. This implementation follows the common padding approach used before coding. In particular, the bottom and right sides of the image are padded by replication (see slide 442 of this [reference](https://iphome.hhi.de/schwarz/assets/pdfs/08_ImageCoding.pdf)). To go back to the original shape the JPEG-coded image is simply cropped again.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
