### PR TITLE
Add torch.compile to RandomGaussianIllumination

### DIFF
--- a/kornia/augmentation/_2d/intensity/gaussian_illumination.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_illumination.py
@@ -143,14 +143,15 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         # Generator of random parameters and masks.
         self._param_generator = GaussianIlluminationGenerator(gain, center, sigma, sign)
 
-    def _apply_transform(
-        self,
-        input: Tensor,
-        params: Dict[str, Tensor],
-        flags: Dict[str, Any],
-        transform: Optional[Tensor] = None,
-    ) -> Tensor:
-        return input.add_(params["gradient"]).clamp_(0, 1)
+        def _apply_transform(
+            input: Tensor,
+            params: Dict[str, Tensor],
+            flags: Dict[str, Any],
+            transform: Optional[Tensor] = None,
+        ) -> Tensor:
+            return input.add_(params["gradient"]).clamp_(0, 1)
+
+        self._fn = _apply_transform
 
     def apply_transform(
         self,
@@ -160,7 +161,7 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         transform: Optional[Tensor] = None,
     ) -> Tensor:
         r"""Apply random gaussian gradient illumination to the input image."""
-        return self._apply_transform(input=input, params=params, flags=flags, transform=transform)
+        return self._fn(input=input, params=params, flags=flags, transform=transform)
 
     def compile(
         self,
@@ -172,8 +173,8 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         options: Optional[Dict[Any, Any]] = None,
         disable: bool = False,
     ) -> "RandomGaussianIllumination":
-        self._apply_transform = torch.compile(
-            self._apply_transform,
+        self._fn = torch.compile(
+            self._fn,
             fullgraph=fullgraph,
             dynamic=dynamic,
             backend=backend,

--- a/kornia/augmentation/_2d/intensity/gaussian_illumination.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_illumination.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Optional, Tuple, Union
 
+import torch
+
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.augmentation.random_generator._2d import GaussianIlluminationGenerator
 from kornia.core import Tensor
@@ -141,6 +143,17 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         # Generator of random parameters and masks.
         self._param_generator = GaussianIlluminationGenerator(gain, center, sigma, sign)
 
+        def _apply_transform(
+            self,
+            input: Tensor,
+            params: Dict[str, Tensor],
+            flags: Dict[str, Any],
+            transform: Optional[Tensor] = None,
+        ) -> Tensor:
+            return input.add_(params["gradient"]).clamp_(0, 1)
+
+        self._fn = _apply_transform
+
     def apply_transform(
         self,
         input: Tensor,
@@ -149,4 +162,26 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         transform: Optional[Tensor] = None,
     ) -> Tensor:
         r"""Apply random gaussian gradient illumination to the input image."""
-        return input.add_(params["gradient"]).clamp_(0, 1)
+        return self._fn(self, input=input, params=params, flags=flags, transform=transform)
+
+    def compile(
+        self,
+        *,
+        fullgraph: bool = False,
+        dynamic: bool = False,
+        backend: str = "inductor",
+        mode: Optional[str] = None,
+        options: Optional[Dict[Any, Any]] = None,
+        disable: bool = False,
+    ) -> "RandomGaussianIllumination":
+        self._fn = torch.compile(
+            self._fn,
+            fullgraph=fullgraph,
+            dynamic=dynamic,
+            backend=backend,
+            mode=mode,
+            options=options,
+            disable=disable,
+        )
+
+        return self

--- a/kornia/augmentation/_2d/intensity/gaussian_illumination.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_illumination.py
@@ -143,16 +143,14 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         # Generator of random parameters and masks.
         self._param_generator = GaussianIlluminationGenerator(gain, center, sigma, sign)
 
-        def _apply_transform(
-            self,
-            input: Tensor,
-            params: Dict[str, Tensor],
-            flags: Dict[str, Any],
-            transform: Optional[Tensor] = None,
-        ) -> Tensor:
-            return input.add_(params["gradient"]).clamp_(0, 1)
-
-        self._fn = _apply_transform
+    def _apply_transform(
+        self,
+        input: Tensor,
+        params: Dict[str, Tensor],
+        flags: Dict[str, Any],
+        transform: Optional[Tensor] = None,
+    ) -> Tensor:
+        return input.add_(params["gradient"]).clamp_(0, 1)
 
     def apply_transform(
         self,
@@ -162,7 +160,7 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         transform: Optional[Tensor] = None,
     ) -> Tensor:
         r"""Apply random gaussian gradient illumination to the input image."""
-        return self._fn(self, input=input, params=params, flags=flags, transform=transform)
+        return self._apply_transform(input=input, params=params, flags=flags, transform=transform)
 
     def compile(
         self,
@@ -174,8 +172,8 @@ class RandomGaussianIllumination(IntensityAugmentationBase2D):
         options: Optional[Dict[Any, Any]] = None,
         disable: bool = False,
     ) -> "RandomGaussianIllumination":
-        self._fn = torch.compile(
-            self._fn,
+        self._apply_transform = torch.compile(
+            self._apply_transform,
             fullgraph=fullgraph,
             dynamic=dynamic,
             backend=backend,

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -4071,6 +4071,20 @@ class TestRandomGaussianIllumination(BaseTester):
         output_tensor = transform(input_tensor)
         self.assert_close(output_tensor[0], output_tensor[1])
 
+    @pytest.mark.slow
+    @pytest.mark.skipif(
+        torch_version_le(1, 13, 1),
+        reason="torch.compile is not available in previous versions",
+    )
+    def test_compile(self, device, dtype):
+        input_tensor = torch.ones(1, 3, 3, 3, device=device, dtype=dtype) * 0.5
+        aug = RandomGaussianIllumination(gain=0.5, p=1.0)
+        expected = aug(input_tensor)
+        aug = aug.compile(fullgraph=True)
+        actual = aug(input_tensor)
+        assert actual.shape == input_tensor.shape
+        self.assert_close(expected, actual)
+
 
 class TestRandomLinearIllumination(BaseTester):
     def _get_expected(self, device, dtype):

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -4061,18 +4061,12 @@ class TestRandomGaussianIllumination(BaseTester):
         self.assert_close(output_tensor[0], output_tensor[1])
 
     @pytest.mark.slow
-    @pytest.mark.skipif(
-        torch_version_le(1, 13, 1),
-        reason="torch.compile is not available in previous versions",
-    )
-    def test_compile(self, device, dtype):
+    def test_dynamo(self, device, dtype, torch_optimizer):
         input_tensor = torch.ones(1, 3, 3, 3, device=device, dtype=dtype) * 0.5
         aug = RandomGaussianIllumination(gain=0.5, p=1.0)
-        expected = aug(input_tensor)
         aug = aug.compile(fullgraph=True)
         actual = aug(input_tensor)
         assert actual.shape == input_tensor.shape
-        self.assert_close(expected, actual)
 
 
 class TestRandomLinearIllumination(BaseTester):


### PR DESCRIPTION
#### Changes
Add torch.compile to RandomGaussianIllumination following #2866.

I have created a function _apply_transform that performs the operation of applying the gaussian illum.
With this we can compile the function if .compiled() is called.

```
rng = torch.manual_seed(1)
input = torch.ones(1, 3, 3, 3) * 0.5
aug = RandomGaussianIllumination(gain=0.5, p=1.)
aug_compile = RandomGaussianIllumination(gain=0.5, p=1.).compile(fullgraph=True)
print((aug(input) == aug_compile(input)).all())
tensor(True)
```

GPU testing is needed, as I don't have a GPU and my gcolab time has run out.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
