### PR TITLE
Delete manual `robots.txt` from docs

### DIFF
--- a/docs/source/_extra/robots.txt
+++ b/docs/source/_extra/robots.txt
@@ -1,6 +1,0 @@
-User-agent: *
-    Allow: /*/latest/
-    Allow: /en/latest/
-    Allow: /*/stable/
-    Allow: /en/stable/
-    Disallow: /

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -155,7 +155,7 @@ html_favicon = "_static/img/kornia_logo_favicon.png"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_extra_path = ["_extra/robots.txt"]
+html_extra_path = []
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "Kornia"


### PR DESCRIPTION
We added (#2790) for block web crawlers to index the older Kornia docs in the results. As a result, we are getting worse results like searching `kornia color` on Google and it redirecting to an unexistent page "kornia.readthedocs.io/color.html".

Instead of disallowing everything under `/` and just allowing the latest and the stable. Let's try to use again the auto-generated `robots.txt` from read the docs. I have manually hidden the version older than 0.6.3 releases on read the docs, so they should add these hidden versions in the `disallow` session of robots.txt.

Another thing I found out, our robots.txt is missing the `sitemap` (https://kornia.readthedocs.io/sitemap.xml) -- the read the docs will also auto-inject it.

We also should verify the docs in https://search.google.com/search-console/ to get more info about other issues within the docs SEO. (For some reason our google analytics isn't working on the page, so I cannot verify the page using it :sad:)

---------
from https://docs.readthedocs.io/en/stable/reference/robots.html#robots-txt-support

![image](https://github.com/kornia/kornia/assets/20444345/12f4b568-7fc3-45a4-be80-daebb1976213)
