### PR TITLE
remove unused dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,6 @@ mypy: FORCE
 doctest:
 	pytest -v --doctest-modules kornia/
 
-docstyle: FORCE
-	pydocstyle kornia/
-
 build-docs: FORCE
 	cd docs; make clean html
 

--- a/docker/Dockerfile.benchmark
+++ b/docker/Dockerfile.benchmark
@@ -14,7 +14,8 @@ COPY kornia/ kornia/
 COPY pyproject.toml ./
 COPY requirements/ requirements/
 
-RUN pip install .[dev,x]
+RUN pip install -r requirements/requirements-benchmarks.txt --no-cache-dir
+RUN pip install .[dev,x] --no-cache-dir
 
 # Setup benchmarks
 WORKDIR /kornia-benchmarks/

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -3,8 +3,6 @@ mypy
 numpy
 onnx
 pre-commit>=2
-pydocstyle
 pytest==8.1.1
-pytest-benchmark
 pytest-timeout
 requests


### PR DESCRIPTION
The `pytest-benchmark` is already in a separate file. And the pydocstyle is handled by pre-commit itself