### PR TITLE
Fixes the use of the gtag extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -151,6 +151,12 @@ html_theme_options = {
 # html_logo = '_static/img/kornia_logo_only.png'
 html_favicon = "_static/img/kornia_logo_favicon.png"
 
+# Config the `sphinxcontrib.gtagjs` extension
+# NOTE: if this didn't work, we can remove the extension itself
+gtagjs_ids = [
+    "G-YSCFZB2WDV",  # Shouldn't be necessary if the readthedocs autoinjection work
+]
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
We have this `sphinxcontrib.gtagjs` extension, but it isn't configured at all, this patches try to add the gtag id for the extension auto inject the gtag on our docs.


The extension added the script in the PR docs page -- so maybe this fixes our issue within analytics

![image](https://github.com/kornia/kornia/assets/20444345/49c6b67a-c114-4108-b116-30fa659a5b5b)
