### PR TITLE
Vectorize lovasz_softmax loss

### DIFF
--- a/kornia/losses/lovasz_softmax.py
+++ b/kornia/losses/lovasz_softmax.py
@@ -91,9 +91,10 @@ def lovasz_softmax_loss(pred: Tensor, target: Tensor, weight: Optional[Tensor] =
     # compute softmax over the classes axis
     pred_soft: Tensor = pred_flatten.softmax(1)
 
-
     # compute actual loss
-    foreground: Tensor = torch.nn.functional.one_hot(target_flatten.to(torch.int64), num_classes=C).permute(0, 2, 1).to(pred.dtype)
+    foreground: Tensor = (
+        torch.nn.functional.one_hot(target_flatten.to(torch.int64), num_classes=C).permute(0, 2, 1).to(pred.dtype)
+    )
     errors: Tensor = (pred_soft - foreground).abs()
     errors_sorted, permutations = torch.sort(errors, dim=2, descending=True)
     batch_index = torch.arange(B, device=pred.device).unsqueeze(1).unsqueeze(2).expand(B, C, N)


### PR DESCRIPTION
#### Changes
Currently the lovasz_softmax loss performs a for loop in range of number of classes. 
This PR removes the for loop.

Speed benchmark (M1 CPU):

```
from kornia.losses import lovasz_softmax_loss
import torch
label = torch.randint(0, 15, (2, 256, 256))
pred = torch.rand(2, 15, 256, 256)
%timeit l=lovasz_softmax_loss(pred, label)
```

Before: 

```
93.8 ms ± 630 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

After the change:

```
36.8 ms ± 4.33 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

#### Type of change
- [x] 🔬 New feature (non-breaking change which adds functionality)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

