### PR TITLE
feat: in_range filtering

### DIFF
--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -525,7 +525,7 @@ def main():
     # kornia.filters.in_range
     mod = importlib.import_module("kornia.filters")
     transforms: dict = {
-        "in_range": (((0.314, 0.2, 0.2), (0.47, 1.0, 1.0)), 1),
+        "in_range": (((0.314, 0.2, 0.2), (0.47, 1.0, 1.0), True), 1),
     }
     # ITERATE OVER THE TRANSFORMS
     for fn_name, (args, num_samples) in transforms.items():

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -537,6 +537,7 @@ def main():
         fn = getattr(mod, fn_name)
         mask = fn(*args_in)
         filtered = img1 * mask
+        mask = mask.repeat(1, img1.shape[1], 1, 1)
         # save the output image
         out = torch.cat([img1[0], mask[0], filtered[0]], dim=-1)
         out_np = K.utils.tensor_to_image((out * 255.0).byte())

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -522,6 +522,26 @@ def main():
         sig = f"{fn_name}({', '.join([str(a) for a in args])})"
         print(f"Generated image example for {fn_name}. {sig}")
 
+    # kornia.filters.in_range
+    mod = importlib.import_module("kornia.filters")
+    transforms: dict = {"in_range": (((0.314, 0.2, 0.2), (0.47, 1.0, 1.0)), 1), }
+    # ITERATE OVER THE TRANSFORMS
+    for fn_name, (args, num_samples) in transforms.items():
+        img_hsv = K.color.rgb_to_hsv(img1)
+        h, s, v = torch.split(img_hsv, split_size_or_sections=1, dim=1)
+        h = h / (2*torch.pi)
+        img_hsv = torch.cat((h, s, v), dim=1)
+        args_in = (img_hsv, *args)
+        fn = getattr(mod, fn_name)
+        mask = fn(*args_in)
+        filtered = img1 * mask
+        # save the output image
+        out = torch.cat([img1[0], mask[0], filtered[0]], dim=-1)
+        out_np = K.utils.tensor_to_image((out * 255.0).byte())
+        cv2.imwrite(str(OUTPUT_PATH / f"{fn_name}.png"), out_np)
+        sig = f"{fn_name}({', '.join([str(a) for a in args])})"
+        print(f"Generated image example for {fn_name}. {sig}")
+
     # korna.geometry.transform module
     mod = importlib.import_module("kornia.geometry.transform")
     h, w = img6.shape[-2:]

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -524,12 +524,14 @@ def main():
 
     # kornia.filters.in_range
     mod = importlib.import_module("kornia.filters")
-    transforms: dict = {"in_range": (((0.314, 0.2, 0.2), (0.47, 1.0, 1.0)), 1), }
+    transforms: dict = {
+        "in_range": (((0.314, 0.2, 0.2), (0.47, 1.0, 1.0)), 1),
+    }
     # ITERATE OVER THE TRANSFORMS
     for fn_name, (args, num_samples) in transforms.items():
         img_hsv = K.color.rgb_to_hsv(img1)
         h, s, v = torch.split(img_hsv, split_size_or_sections=1, dim=1)
-        h = h / (2*torch.pi)
+        h = h / (2 * torch.pi)
         img_hsv = torch.cat((h, s, v), dim=1)
         args_in = (img_hsv, *args)
         fn = getattr(mod, fn_name)

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -55,6 +55,11 @@ Interactive Demo
 Visit the `Kornia edge detector demo on the Hugging Face Spaces
 <https://huggingface.co/spaces/kornia/edge_detector>`_.
 
+Segmentation
+--------------
+
+.. autofunction:: in_range
+.. autoclass:: InRange
 
 Filtering API
 -------------

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -15,6 +15,7 @@ from .dexined import DexiNed
 from .filter import filter2d, filter2d_separable, filter3d
 from .gaussian import GaussianBlur2d, gaussian_blur2d, gaussian_blur2d_t
 from .guided import GuidedBlur, guided_blur
+from .in_range import InRange, in_range
 from .kernels import (
     gaussian,
     get_binary_kernel2d,
@@ -67,6 +68,8 @@ __all__ = [
     "get_diff_kernel2d",
     "gaussian_blur2d",
     "guided_blur",
+    "InRange",
+    "in_range",
     "laplacian",
     "laplacian_1d",
     "unsharp_mask",

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -23,7 +23,8 @@ def in_range(input: Tensor, lower: Union[tuple[Any, ...], Tensor], upper: Union[
     The formula applied for multi-channel tensor is:
 
     .. math::
-        \text{out}(I) = \bigwedge_{c=0}^{C}\left( \text{lower}_c(I) \leq \text{input}_c(I) \geq \text{upper}_c(I) \right)
+        \text{out}(I) = \bigwedge_{c=0}^{C}
+        \left( \text{lower}_c(I) \leq \text{input}_c(I) \geq \text{upper}_c(I) \right)
 
     where `C` is the number of channels.
 
@@ -44,12 +45,14 @@ def in_range(input: Tensor, lower: Union[tuple[Any, ...], Tensor], upper: Union[
 
     .. note::
         Clarification of `lower` and `upper`:
-            If provided as a tuple, it should have the same number of elements as the channels in the input tensor.
-                This bound is then applied uniformly across all batches.
-            When provided as a tensor, it allows for different bounds to be applied to each batch.
-                The tensor shape should be (B, C, 1, 1), where B is the batch size and C is the number of channels.
-            If the tensor has a 1-D shape, same bound will be applied across all batches.
-            Refer to the example below.
+
+        - If provided as a tuple, it should have the same number of elements as the channels in the input tensor.
+        This bound is then applied uniformly across all batches.
+
+        - When provided as a tensor, it allows for different bounds to be applied to each batch.
+        The tensor shape should be (B, C, 1, 1), where B is the batch size and C is the number of channels.
+
+        - If the tensor has a 1-D shape, same bound will be applied across all batches.
 
     Examples:
         >>> rng = torch.manual_seed(1)

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -15,12 +15,13 @@ def in_range(input: Tensor, lower: Union[tuple[Any, ...], Tensor], upper: Union[
 
     .. image:: _static/img/in_range.png
 
-    The formula applied is:
+    The formula applied for single-channel tensor is:
     .. math::
-        For single-channel tensor:
-            \text{out}(I) = \text{lower}(I) \leq \text{input}(I) \geq \text{upper}(I)
-        For multi-channel tensor:
-            \text{out}(I) = \bigwedge_{c=0}^{C}\left( \text{lower}_c(I) \leq \text{input}_c(I) \geq \text{upper}_c(I) \right)
+        \text{out}(I) = \text{lower}(I) \leq \text{input}(I) \geq \text{upper}(I)
+    The formula applied for multi-channel tensor is:
+    .. math::
+        \text{out}(I) = \bigwedge_{c=0}^{C}\left( \text{lower}_c(I) \leq \text{input}_c(I) \geq \text{upper}_c(I) \right)
+    Where `C` is the number of channels.
 
     Args:
         input: The input tensor to be filtered.

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -16,12 +16,16 @@ def in_range(input: Tensor, lower: Union[tuple[Any, ...], Tensor], upper: Union[
     .. image:: _static/img/in_range.png
 
     The formula applied for single-channel tensor is:
+
     .. math::
         \text{out}(I) = \text{lower}(I) \leq \text{input}(I) \geq \text{upper}(I)
+
     The formula applied for multi-channel tensor is:
+
     .. math::
         \text{out}(I) = \bigwedge_{c=0}^{C}\left( \text{lower}_c(I) \leq \text{input}_c(I) \geq \text{upper}_c(I) \right)
-    Where `C` is the number of channels.
+
+    where `C` is the number of channels.
 
     Args:
         input: The input tensor to be filtered.

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import torch
+
+from kornia.core import Module, Tensor
+from kornia.core.check import KORNIA_CHECK
+from kornia.utils.image import perform_keep_shape_image
+
+
+@perform_keep_shape_image
+def in_range(input: Tensor, lower: tuple | Tensor, upper: tuple | Tensor) -> Tensor:
+    r"""Creates a mask indicating whether elements of the input tensor are within the specified range.
+
+    .. image:: _static/img/in_range.png
+
+    The formula applied is:
+    .. math::
+        For single-channel tensor:
+            \text{out}(I) = \text{lower}(I) \leq \text{input}(I) \geq \text{upper}(I)
+        For multi-channel tensor:
+            \text{out}(I) = \bigwedge_{c=0}^{C}\left( \text{lower}_c(I) \leq \text{input}_c(I) \geq \text{upper}_c(I) \right)
+
+    Args:
+        input: The input tensor to be filtered.
+        lower: The lower bounds of the filter (inclusive).
+        upper: The upper bounds of the filter (inclusive).
+
+    Returns:
+        A binary mask with same dtye of input indicating whether elements are within the range.
+
+    Shape:
+        - Input: :math:`(B, C, H, W)`
+        - Output: :math:`(B, 1, H, W)`
+
+    Raises:
+        ValueError: If the shape of `lower`, `upper`, and `input` image channels do not match.
+
+    .. note::
+        Clarification of `lower` and `upper`:
+            If provided as a tuple, it should have the same number of elements as the channels in the input tensor.
+                This bound is then applied uniformly across all batches.
+            When provided as a tensor, it allows for different bounds to be applied to each batch.
+                The tensor shape should be (B, C, 1, 1), where B is the batch size and C is the number of channels.
+            If the tensor has a 1-D shape, same bound will be applied across all batches.
+            Refer to the example below.
+
+    Examples:
+        >>> rng = torch.manual_seed(1)
+        >>> input = torch.rand(1, 3, 3, 3)
+        >>> lower = (0.2, 0.3, 0.4)
+        >>> upper = (0.8, 0.9, 1.0)
+        >>> mask = in_range(input, lower, upper)
+        >>> mask
+        tensor([[[[1., 1., 0.],
+                  [0., 0., 0.],
+                  [0., 1., 1.]]]])
+        >>> mask.shape
+        torch.Size([1, 1, 3, 3])
+
+    Apply different bounds (`lower` and `upper`) for each batch:
+
+        >>> rng = torch.manual_seed(1)
+        >>> input_tensor = torch.rand((2, 3, 3, 3))
+        >>> input_shape = input_tensor.shape
+        >>> lower = torch.tensor([[0.2, 0.2, 0.2], [0.2, 0.2, 0.2]]).reshape(input_shape[0], input_shape[1], 1, 1)
+        >>> upper = torch.tensor([[0.6, 0.6, 0.6], [0.8, 0.8, 0.8]]).reshape(input_shape[0], input_shape[1], 1, 1)
+        >>> mask = in_range(input_tensor, lower, upper)
+        >>> mask
+        tensor([[[[0., 0., 1.],
+                  [0., 0., 0.],
+                  [1., 0., 0.]]],
+        <BLANKLINE>
+        <BLANKLINE>
+                [[[0., 0., 0.],
+                  [1., 0., 0.],
+                  [0., 0., 1.]]]])
+        >>> mask.shape
+        torch.Size([2, 1, 3, 3])
+    """
+    input_shape = input.shape
+
+    KORNIA_CHECK(
+        isinstance(lower, (tuple, Tensor)) and isinstance(upper, (tuple, Tensor)),
+        "Invalid `lower` and `upper` format. Should be tuple or Tensor.",
+    )
+
+    if isinstance(lower, tuple) and isinstance(upper, tuple):
+        if len(lower) != input_shape[1] or len(upper) != input_shape[1]:
+            raise ValueError("Shape of `lower`, `upper` and `input` image channels must have same shape.")
+
+        lower = torch.tensor(lower).reshape(1, -1, 1, 1).repeat(input_shape[0], 1, 1, 1)
+        upper = torch.tensor(upper).reshape(1, -1, 1, 1).repeat(input_shape[0], 1, 1, 1)
+
+    elif isinstance(lower, Tensor) and isinstance(upper, Tensor):
+        valid_tensor_shape = (input_shape[0], input_shape[1], 1, 1)
+        if valid_tensor_shape not in (lower.shape, upper.shape):
+            raise ValueError(
+                "`lower` and `upper` bounds as Tensors must have compatible shapes with the input (B, C, 1, 1)."
+            )
+
+    lower = lower.to(input)
+    upper = upper.to(input)
+
+    # Apply lower and upper bounds. Combine masks with logical_and.
+    mask = torch.logical_and(input >= lower, input <= upper)
+    mask = mask.all(dim=(1), keepdim=True).to(input.dtype)
+
+    return mask
+
+
+class InRange(Module):
+    r"""Creates a module for applying lower and upper bounds to input tensors.
+
+    Args:
+        input: The input tensor to be filtered.
+        lower: The lower bounds of the filter (inclusive).
+        upper: The upper bounds of the filter (inclusive).
+
+    Returns:
+        A binary mask with same dtye of input indicating whether elements are within the range.
+
+    .. note::
+        View complete documentation in :func:`kornia.filters.in_range`.
+
+    Examples:
+        >>> rng = torch.manual_seed(1)
+        >>> input = torch.rand(1, 3, 3, 3)
+        >>> lower = (0.2, 0.3, 0.4)
+        >>> upper = (0.8, 0.9, 1.0)
+        >>> mask = InRange(lower, upper)(input)
+        >>> mask
+        tensor([[[[1., 1., 0.],
+                  [0., 0., 0.],
+                  [0., 1., 1.]]]])
+        >>> mask.shape
+        torch.Size([1, 1, 3, 3])
+    """
+
+    def __init__(self, lower: tuple | Tensor, upper: tuple | Tensor) -> None:
+        super().__init__()
+        self.lower = lower
+        self.upper = upper
+
+    def forward(self, input: Tensor) -> Tensor:
+        return in_range(input, self.lower, self.upper)

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import Union, Any
+
+from typing import Any, Union
 
 import torch
 

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -87,8 +87,6 @@ def in_range(
                 [[[0., 0., 0.],
                   [1., 0., 0.],
                   [0., 0., 1.]]]])
-        >>> mask.shape
-        torch.Size([2, 1, 3, 3])
     """
     input_shape = input.shape
 
@@ -161,8 +159,6 @@ class InRange(Module):
         tensor([[[[1., 1., 0.],
                   [0., 0., 0.],
                   [0., 1., 1.]]]])
-        >>> mask.shape
-        torch.Size([1, 1, 3, 3])
     """
 
     def __init__(

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -50,10 +50,10 @@ def in_range(
         Clarification of `lower` and `upper`:
 
         - If provided as a tuple, it should have the same number of elements as the channels in the input tensor.
-        This bound is then applied uniformly across all batches.
+          This bound is then applied uniformly across all batches.
 
         - When provided as a tensor, it allows for different bounds to be applied to each batch.
-        The tensor shape should be (B, C, 1, 1), where B is the batch size and C is the number of channels.
+          The tensor shape should be (B, C, 1, 1), where B is the batch size and C is the number of channels.
 
         - If the tensor has a 1-D shape, same bound will be applied across all batches.
 
@@ -162,7 +162,10 @@ class InRange(Module):
     """
 
     def __init__(
-        self, lower: Union[tuple[Any, ...], Tensor], upper: Union[tuple[Any, ...], Tensor], return_mask: bool = False
+        self,
+        lower: Union[tuple[Any, ...], Tensor],
+        upper: Union[tuple[Any, ...], Tensor],
+        return_mask: bool = False,
     ) -> None:
         super().__init__()
         self.lower = lower

--- a/tests/filters/test_in_range.py
+++ b/tests/filters/test_in_range.py
@@ -41,7 +41,7 @@ class TestInRange(BaseTester):
             ((1, 3, 3, 3), (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)),
             ((2, 3, 3, 3), (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)),
             ((5, 5, 3, 3), (0.2, 0.2, 0.2, 0.2, 0.2), (0.6, 0.6, 0.6, 0.6, 0.6)),
-            ((3, 3), (0.2, ), (0.6, )),
+            ((3, 3), (0.2,), (0.6,)),
             ((2, 3, 3), (0.2, 0.2), (0.6, 0.6)),
         ],
     )
@@ -57,7 +57,6 @@ class TestInRange(BaseTester):
             assert res.shape == (res.shape[0], 1, res.shape[-2], res.shape[-1])
 
     def test_exception(self, device, dtype):
-
         input_tensor = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
         with pytest.raises(Exception, match="Invalid `lower` and `upper` format. Should be tuple or Tensor."):
             InRange(lower=3, upper=3)(input_tensor)
@@ -75,7 +74,9 @@ class TestInRange(BaseTester):
 
         with pytest.raises(
             ValueError,
-            match=re.escape("`lower` and `upper` bounds as Tensors must have compatible shapes with the input (B, C, 1, 1)."),
+            match=re.escape(
+                "`lower` and `upper` bounds as Tensors must have compatible shapes with the input (B, C, 1, 1)."
+            ),
         ):
             lower = torch.tensor([0.2, 0.2, 0.2])
             upper = torch.tensor([0.6, 0.6, 0.6])

--- a/tests/filters/test_in_range.py
+++ b/tests/filters/test_in_range.py
@@ -10,7 +10,7 @@ from testing.base import BaseTester, assert_close
 
 def test_in_range(device, dtype):
     rng = torch.manual_seed(1)
-    input_tensor = torch.randn(1, 3, 3, 3, device=device)
+    input_tensor = torch.rand(1, 3, 3, 3, device=device)
     input_tensor = input_tensor.to(dtype=dtype)
     expected = torch.tensor([[[[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype)
     lower = (0.2, 0.3, 0.4)

--- a/tests/filters/test_in_range.py
+++ b/tests/filters/test_in_range.py
@@ -9,12 +9,13 @@ from testing.base import BaseTester, assert_close
 
 
 def test_in_range(device, dtype):
-    torch.manual_seed(1)
-    input = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
+    rng = torch.manual_seed(1)
+    input_tensor = torch.randn(1, 3, 3, 3, device=device)
+    input_tensor = input_tensor.to(dtype=dtype)
     expected = torch.tensor([[[[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype)
     lower = (0.2, 0.3, 0.4)
     upper = (0.8, 0.9, 1.0)
-    result = in_range(input, lower, upper)
+    result = in_range(input_tensor, lower, upper)
 
     assert_close(result, expected, atol=1e-4, rtol=1e-4)
 
@@ -28,8 +29,9 @@ class TestInRange(BaseTester):
         )
 
     def test_smoke(self, device, dtype):
-        torch.manual_seed(1)
-        input_tensor = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
+        rng = torch.manual_seed(1)
+        input_tensor = torch.rand(1, 3, 3, 3, device=device)
+        input_tensor = input_tensor.to(dtype=dtype)
         expected = self._get_expected(device=device, dtype=dtype)
         res = InRange(lower=(0.2, 0.3, 0.4), upper=(0.8, 0.9, 1.0))(input_tensor)
         assert expected.shape == res.shape

--- a/tests/filters/test_in_range.py
+++ b/tests/filters/test_in_range.py
@@ -9,7 +9,7 @@ from testing.base import BaseTester, assert_close
 
 
 def test_in_range(device, dtype):
-    rng = torch.manual_seed(1)
+    torch.manual_seed(1)
     input_tensor = torch.rand(1, 3, 3, 3, device=device)
     input_tensor = input_tensor.to(dtype=dtype)
     expected = torch.tensor([[[[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype)
@@ -29,7 +29,7 @@ class TestInRange(BaseTester):
         )
 
     def test_smoke(self, device, dtype):
-        rng = torch.manual_seed(1)
+        torch.manual_seed(1)
         input_tensor = torch.rand(1, 3, 3, 3, device=device)
         input_tensor = input_tensor.to(dtype=dtype)
         expected = self._get_expected(device=device, dtype=dtype)

--- a/tests/filters/test_in_range.py
+++ b/tests/filters/test_in_range.py
@@ -15,7 +15,7 @@ def test_in_range(device, dtype):
     expected = torch.tensor([[[[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype)
     lower = (0.2, 0.3, 0.4)
     upper = (0.8, 0.9, 1.0)
-    result = in_range(input_tensor, lower, upper)
+    result = in_range(input_tensor, lower, upper, return_mask=True)
 
     assert_close(result, expected, atol=1e-4, rtol=1e-4)
 
@@ -33,7 +33,7 @@ class TestInRange(BaseTester):
         input_tensor = torch.rand(1, 3, 3, 3, device=device)
         input_tensor = input_tensor.to(dtype=dtype)
         expected = self._get_expected(device=device, dtype=dtype)
-        res = InRange(lower=(0.2, 0.3, 0.4), upper=(0.8, 0.9, 1.0))(input_tensor)
+        res = InRange(lower=(0.2, 0.3, 0.4), upper=(0.8, 0.9, 1.0), return_mask=True)(input_tensor)
         assert expected.shape == res.shape
         self.assert_close(res, expected, rtol=1e-4, atol=1e-4)
 
@@ -49,7 +49,7 @@ class TestInRange(BaseTester):
     )
     def test_cardinality(self, input_shape, lower, upper, device, dtype):
         input_tensor = torch.rand(input_shape, device=device, dtype=dtype)
-        res = InRange(lower=lower, upper=upper)(input_tensor)
+        res = InRange(lower=lower, upper=upper, return_mask=True)(input_tensor)
 
         if len(input_tensor.shape) == 2:
             assert res.shape == (res.shape[-2], res.shape[-1])
@@ -84,16 +84,21 @@ class TestInRange(BaseTester):
             upper = torch.tensor([0.6, 0.6, 0.6])
             InRange(lower=lower, upper=upper)(input_tensor)
 
+        with pytest.raises(Exception, match="Invalid `return_mask` format. Should be boolean."):
+            lower = torch.tensor([0.2, 0.2, 0.2])
+            upper = torch.tensor([0.6, 0.6, 0.6])
+            InRange(lower=lower, upper=upper, return_mask=2)(input_tensor)
+
     def test_noncontiguous(self, device, dtype):
         batch_size = 3
         inp = torch.rand(1, 3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
-        actual = InRange((0.2, 0.2, 0.2), (0.6, 0.6, 0.6))(inp)
+        actual = InRange((0.2, 0.2, 0.2), (0.6, 0.6, 0.6), return_mask=True)(inp)
         assert actual.is_contiguous()
 
     def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 3, 5, 5
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
-        self.gradcheck(in_range, (img, (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)))
+        self.gradcheck(in_range, (img, (0.2, 0.2, 0.2), (0.6, 0.6, 0.6), True))
 
     @pytest.mark.parametrize(
         "input_shape, lower, upper",
@@ -106,14 +111,14 @@ class TestInRange(BaseTester):
     def test_module(self, input_shape, lower, upper, device, dtype):
         img = torch.rand(input_shape, device=device, dtype=dtype)
         op = in_range
-        op_module = InRange(lower=lower, upper=upper)
+        op_module = InRange(lower=lower, upper=upper, return_mask=True)
         actual = op_module(img)
-        expected = op(img, lower, upper)
+        expected = op(img, lower, upper, True)
         self.assert_close(actual, expected)
 
     @pytest.mark.parametrize("batch_size", [1, 2])
     def test_dynamo(self, batch_size, device, dtype, torch_optimizer):
         inpt = torch.rand(batch_size, 3, 5, 5, device=device, dtype=dtype)
-        op = InRange(lower=(0.2, 0.2, 0.2), upper=(0.6, 0.6, 0.6))
+        op = InRange(lower=(0.2, 0.2, 0.2), upper=(0.6, 0.6, 0.6), return_mask=True)
         op_optimized = torch_optimizer(op)
         self.assert_close(op(inpt), op_optimized(inpt))

--- a/tests/filters/test_in_range.py
+++ b/tests/filters/test_in_range.py
@@ -1,0 +1,116 @@
+import re
+
+import pytest
+import torch
+
+from kornia.filters import InRange, in_range
+
+from testing.base import BaseTester, assert_close
+
+
+def test_in_range(device, dtype):
+    torch.manual_seed(1)
+    input = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
+    expected = torch.tensor([[[[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]], device=device, dtype=dtype)
+    lower = (0.2, 0.3, 0.4)
+    upper = (0.8, 0.9, 1.0)
+    result = in_range(input, lower, upper)
+
+    assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+
+class TestInRange(BaseTester):
+    def _get_expected(self, device, dtype):
+        return torch.tensor(
+            [[[[1.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 1.0]]]],
+            device=device,
+            dtype=dtype,
+        )
+
+    def test_smoke(self, device, dtype):
+        torch.manual_seed(1)
+        input_tensor = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
+        expected = self._get_expected(device=device, dtype=dtype)
+        res = InRange(lower=(0.2, 0.3, 0.4), upper=(0.8, 0.9, 1.0))(input_tensor)
+        assert expected.shape == res.shape
+        self.assert_close(res, expected, rtol=1e-4, atol=1e-4)
+
+    @pytest.mark.parametrize(
+        "input_shape, lower, upper",
+        [
+            ((1, 3, 3, 3), (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)),
+            ((2, 3, 3, 3), (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)),
+            ((5, 5, 3, 3), (0.2, 0.2, 0.2, 0.2, 0.2), (0.6, 0.6, 0.6, 0.6, 0.6)),
+            ((3, 3), (0.2, ), (0.6, )),
+            ((2, 3, 3), (0.2, 0.2), (0.6, 0.6)),
+        ],
+    )
+    def test_cardinality(self, input_shape, lower, upper, device, dtype):
+        input_tensor = torch.rand(input_shape, device=device, dtype=dtype)
+        res = InRange(lower=lower, upper=upper)(input_tensor)
+
+        if len(input_tensor.shape) == 2:
+            assert res.shape == (res.shape[-2], res.shape[-1])
+        elif len(input_tensor.shape) == 3:
+            assert res.shape == (1, res.shape[-2], res.shape[-1])
+        else:
+            assert res.shape == (res.shape[0], 1, res.shape[-2], res.shape[-1])
+
+    def test_exception(self, device, dtype):
+
+        input_tensor = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
+        with pytest.raises(Exception, match="Invalid `lower` and `upper` format. Should be tuple or Tensor."):
+            InRange(lower=3, upper=3)(input_tensor)
+
+        with pytest.raises(Exception, match="Invalid `lower` and `upper` format. Should be tuple or Tensor."):
+            InRange(lower=[0.2, 0.2], upper=[0.2, 0.2])(input_tensor)
+
+        with pytest.raises(Exception, match="Invalid `lower` and `upper` format. Should be tuple or Tensor."):
+            InRange(lower=(0.2), upper=(0.2))(input_tensor)
+
+        with pytest.raises(
+            ValueError, match="Shape of `lower`, `upper` and `input` image channels must have same shape."
+        ):
+            InRange(lower=(0.2,), upper=(0.2,))(input_tensor)
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("`lower` and `upper` bounds as Tensors must have compatible shapes with the input (B, C, 1, 1)."),
+        ):
+            lower = torch.tensor([0.2, 0.2, 0.2])
+            upper = torch.tensor([0.6, 0.6, 0.6])
+            InRange(lower=lower, upper=upper)(input_tensor)
+
+    def test_noncontiguous(self, device, dtype):
+        batch_size = 3
+        inp = torch.rand(1, 3, 5, 5, device=device, dtype=dtype).expand(batch_size, -1, -1, -1)
+        actual = InRange((0.2, 0.2, 0.2), (0.6, 0.6, 0.6))(inp)
+        assert actual.is_contiguous()
+
+    def test_gradcheck(self, device):
+        batch_size, channels, height, width = 1, 3, 5, 5
+        img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
+        self.gradcheck(in_range, (img, (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)))
+
+    @pytest.mark.parametrize(
+        "input_shape, lower, upper",
+        [
+            ((1, 3, 3, 3), (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)),
+            ((2, 3, 3, 3), (0.2, 0.2, 0.2), (0.6, 0.6, 0.6)),
+            ((3, 3), (0.2,), (0.6,)),
+        ],
+    )
+    def test_module(self, input_shape, lower, upper, device, dtype):
+        img = torch.rand(input_shape, device=device, dtype=dtype)
+        op = in_range
+        op_module = InRange(lower=lower, upper=upper)
+        actual = op_module(img)
+        expected = op(img, lower, upper)
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize("batch_size", [1, 2])
+    def test_dynamo(self, batch_size, device, dtype, torch_optimizer):
+        inpt = torch.rand(batch_size, 3, 5, 5, device=device, dtype=dtype)
+        op = InRange(lower=(0.2, 0.2, 0.2), upper=(0.6, 0.6, 0.6))
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(inpt), op_optimized(inpt))


### PR DESCRIPTION
#### Changes
Following cv2.inRange [OpenCV function](https://docs.opencv.org/3.4/d2/de8/group__core__array.html#ga48af0ab51e36436c5d04340e036ce981), I've implemented a pytorch version for batched images. 
The function needs the image, and two bounds for filtering (lower and upper). 
There is the possibility to add a parameter (return_mask) to return the mask and otherwise the filtered image.

Code to get image:
```
BASE_IMAGE_URL = "https://raw.githubusercontent.com/kornia/data/main/panda.jpg"
dev = 'cpu'
img = read_img_from_url(BASE_IMAGE_URL, (256, 256))
img_hsv = K.color.rgb_to_hsv(img)
h, s, v = torch.split(img_hsv, split_size_or_sections=1, dim=1)
h = h / (2*torch.pi)
img_hsv = torch.cat((h, s, v), dim=1)
img_hsv = img_hsv.to(dev)
img = img.to(dev)
lower = (0.314, 0.2, 0.2)
upper = (0.47, 1.0, 1.0)
lower = torch.tensor(lower).reshape(1,3,1,1)
upper = torch.tensor(upper).reshape(1,3,1,1)
mask = in_range(img_hsv, lower, upper)
out = img * mask
```
![image](https://github.com/kornia/kornia/assets/44602177/22d1ae94-7213-42d6-87fe-8fa6fa5a3a35)

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
