### PR TITLE
compute_area fix for ndim=3 tensors

### DIFF
--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -392,9 +392,9 @@ class Boxes:
 
     def compute_area(self) -> torch.Tensor:
         """Returns :math:`(B, N)`."""
-        w = self._data[:, :, 1, 0] - self._data[:, :, 0, 0]
-        h = self._data[:, :, 2, 1] - self._data[:, :, 0, 1]
-        return w * h
+        w = self._data[..., 1, 0] - self._data[..., 0, 0]
+        h = self._data[..., 2, 1] - self._data[..., 0, 1]
+        return (w * h).unsqueeze(0) if self._data.ndim == 3 else (w * h)
 
     @classmethod
     def from_tensor(


### PR DESCRIPTION
#### Changes
Small change,`Boxes.compute_area()` fails if the Boxes class is created with ndim=3 tensor
```
import torch
from kornia.geometry.boxes import Boxes

a = torch.tensor([0, 0, 1, 0, 1, 1, 0, 1], dtype=torch.float32)
a = a.reshape(1, 1, 4, 2)
boxes = Boxes(a)
# succeeds
boxes.compute_area().shape

# fails
boxes = Boxes(a.reshape(1, 4, 2))
print(a.shape)
boxes.compute_area()
```

unsqueeze is done in the end(in PR) to keep up with the docs(return "BxN tensor")

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
