### PR TITLE
chore (CI): bump pytorch to 2.3.1

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -20,11 +20,11 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.1
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.11"]'
-      pytorch-version: '["1.9.1", "2.3.0"]'
+      pytorch-version: '["1.9.1", "2.3.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   tests-cpu-macos:
@@ -36,16 +36,16 @@ jobs:
 
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.9.1
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.9.1
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.9.1
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.9.1
 
   collector:
     needs: [coverage, tests-cpu, tutorials, typing, docs]
@@ -66,7 +66,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest'] #, 'MacOS-latest'] add it when https://github.com/pytorch/pytorch/pull/89262 be merged
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.1
     with:
       os: ${{ matrix.os }}
       pytorch-version: '["nightly"]'

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -18,11 +18,11 @@ jobs:
         # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.1
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.8", "3.9", "3.10", "3.11"]'
-      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.2", "2.3.0"]'
+      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.2", "2.3.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       pytest-extra: '--runslow'
 
@@ -34,11 +34,11 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.1
     with:
       os: 'Windows-latest'
       python-version: '["3.11"]'
-      pytorch-version: '["1.9.1", "2.3.0"]'
+      pytorch-version: '["1.9.1", "2.3.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   tests-cpu-mac:
@@ -47,19 +47,19 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.9.1
     with:
       os: 'MacOS-latest'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.9.1
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.9.1
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.9.1
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.9.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.9.1

--- a/tests/filters/test_in_range.py
+++ b/tests/filters/test_in_range.py
@@ -119,7 +119,7 @@ class TestInRange(BaseTester):
 
     @pytest.mark.parametrize("batch_size", [1, 2])
     def test_dynamo(self, batch_size, device, dtype, torch_optimizer):
-        if device == torch.device("cpu") and torch_version() == "2.3.0":
+        if device == torch.device("cpu") and torch_version() in {"2.3.0", "2.3.1"}:
             pytest.skip("Failing to compile on CPU see pytorch/pytorch#126619")
         inpt = torch.rand(batch_size, 3, 5, 5, device=device, dtype=dtype)
         op = InRange(lower=(0.2, 0.2, 0.2), upper=(0.6, 0.6, 0.6), return_mask=True)

--- a/tests/geometry/transform/test_homography_warper.py
+++ b/tests/geometry/transform/test_homography_warper.py
@@ -262,7 +262,11 @@ class TestHomographyWarper(BaseTester):
     @pytest.mark.parametrize("align_corners", [True, False])
     @pytest.mark.parametrize("normalized_coordinates", [True, False])
     def test_dynamo(self, batch_size, align_corners, normalized_coordinates, device, dtype, torch_optimizer):
-        if device == torch.device("cpu") and batch_size != 1 and kornia.utils._compat.torch_version() == "2.3.0":
+        if (
+            device == torch.device("cpu")
+            and batch_size != 1
+            and kornia.utils._compat.torch_version() in {"2.3.0", "2.3.1"}
+        ):
             pytest.skip("Failing to compile batched inputs see pytorch/pytorch#126617")
 
         # generate input data


### PR DESCRIPTION
#### Changes
- update workflows references to v1.9.1
- Bump pytorch to 2.3.1
  - PyTorch notes: https://github.com/pytorch/pytorch/releases/tag/v2.3.1
