### PR TITLE
fix (CI): ensure support test suite w/ numpy

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -20,7 +20,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.1
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.12"]'
@@ -28,7 +28,7 @@ jobs:
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   tests-cpu-macos:
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.1
     with:
       os: 'MacOS-latest'
       python-version: '["3.8", "3.12"]'
@@ -36,16 +36,16 @@ jobs:
 
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.10.1
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.10.1
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.10.1
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.10.1
     with:
       python-version: "3.11"
 
@@ -68,7 +68,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest'] #, 'MacOS-latest'] add it when https://github.com/pytorch/pytorch/pull/89262 be merged
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.1
     with:
       os: ${{ matrix.os }}
       pytorch-version: '["nightly"]'

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -18,7 +18,7 @@ jobs:
         # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.1
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.8", "3.9", "3.10", "3.11", "3.12"]'
@@ -34,7 +34,7 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.1
     with:
       os: 'Windows-latest'
       python-version: '["3.12"]'
@@ -47,21 +47,21 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.10.1
     with:
       os: 'MacOS-latest'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.10.1
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.10.1
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.10.1
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.10.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.10.1
     with:
       python-version: "3.11"


### PR DESCRIPTION
Ensure support to use numpy>2.0.0 on newer torch versions (torch>=2.3) for older torchs versions it'll use numpy<2.0.0.

Without it, the CI will be failing, because the older torch versions aren't compiled within the new numpy API.

