### PR TITLE
Fix off-by-one pixel denormalization bug in DeDoDe

### DIFF
--- a/kornia/feature/dedode/dedode.py
+++ b/kornia/feature/dedode/dedode.py
@@ -9,7 +9,7 @@ from kornia.enhance.normalize import Normalize
 from kornia.utils.helpers import map_location_to_cpu
 
 from .dedode_models import DeDoDeDescriptor, DeDoDeDetector, get_descriptor, get_detector
-from .utils import sample_keypoints, dedode_denormalize_pixel_coordinates
+from .utils import dedode_denormalize_pixel_coordinates, sample_keypoints
 
 urls: Dict[str, Dict[str, str]] = {
     "detector": {

--- a/kornia/feature/dedode/dedode.py
+++ b/kornia/feature/dedode/dedode.py
@@ -6,11 +6,10 @@ import torch.nn.functional as F
 from kornia.core import Module, Tensor
 from kornia.core.check import KORNIA_CHECK_SHAPE
 from kornia.enhance.normalize import Normalize
-from kornia.geometry.conversions import denormalize_pixel_coordinates
 from kornia.utils.helpers import map_location_to_cpu
 
 from .dedode_models import DeDoDeDescriptor, DeDoDeDetector, get_descriptor, get_detector
-from .utils import sample_keypoints
+from .utils import sample_keypoints, dedode_denormalize_pixel_coordinates
 
 urls: Dict[str, Dict[str, str]] = {
     "detector": {
@@ -92,7 +91,7 @@ class DeDoDe(Module):
             images = torch.nn.functional.pad(images, (0, pd_w, 0, pd_h), value=0.0)
         keypoints, scores = self.detect(images, n=n, apply_imagenet_normalization=False, crop_h=h, crop_w=w)
         descriptions = self.describe(images, keypoints, apply_imagenet_normalization=False)
-        return denormalize_pixel_coordinates(keypoints, H, W), scores, descriptions
+        return dedode_denormalize_pixel_coordinates(keypoints, H, W), scores, descriptions
 
     @torch.inference_mode()
     def detect(

--- a/kornia/feature/dedode/utils.py
+++ b/kornia/feature/dedode/utils.py
@@ -37,13 +37,11 @@ def get_grid(B: int, H: int, W: int, device: torch.device) -> torch.Tensor:
 
 
 def dedode_denormalize_pixel_coordinates(flow: torch.Tensor, h: int, w: int) -> torch.Tensor:
-    flow = (
-        torch.stack(
-            (
-                w * (flow[..., 0] + 1) / 2,
-                h * (flow[..., 1] + 1) / 2,
-            ),
-            axis=-1,
-        )
+    flow = torch.stack(
+        (
+            w * (flow[..., 0] + 1) / 2,
+            h * (flow[..., 1] + 1) / 2,
+        ),
+        axis=-1,
     )
     return flow

--- a/kornia/feature/dedode/utils.py
+++ b/kornia/feature/dedode/utils.py
@@ -34,3 +34,16 @@ def get_grid(B: int, H: int, W: int, device: torch.device) -> torch.Tensor:
     )
     x1_n = torch.stack((x1_n_[2], x1_n_[1]), dim=-1).reshape(B, H * W, 2)
     return x1_n
+
+
+def dedode_denormalize_pixel_coordinates(flow: torch.Tensor, h: int, w: int) -> torch.Tensor:
+    flow = (
+        torch.stack(
+            (
+                w * (flow[..., 0] + 1) / 2,
+                h * (flow[..., 1] + 1) / 2,
+            ),
+            axis=-1,
+        )
+    )
+    return flow

--- a/kornia/feature/dedode/utils.py
+++ b/kornia/feature/dedode/utils.py
@@ -42,6 +42,6 @@ def dedode_denormalize_pixel_coordinates(flow: torch.Tensor, h: int, w: int) -> 
             w * (flow[..., 0] + 1) / 2,
             h * (flow[..., 1] + 1) / 2,
         ),
-        axis=-1,
+        dim=-1,
     )
     return flow


### PR DESCRIPTION
#### Changes
The "pixel denormalization" in Kornia and DeDoDe differ by the fact that Kornia rescales by (height-1) and (width-1) while DeDoDe rescales by height and width.

Kornia:
https://github.com/kornia/kornia/blob/af3e28d3ff76a9a814fd5221ebab79fa41dd60ed/kornia/geometry/conversions.py#L876-L902

DeDoDe:
```python
def to_pixel_coords(flow, h1, w1):
    flow = (
        torch.stack(
            (
                w1 * (flow[..., 0] + 1) / 2,
                h1 * (flow[..., 1] + 1) / 2,
            ),
            axis=-1,
        )
    )
    return flow
```
https://github.com/Parskatt/DeDoDe/blob/0928debd09de6e814c90647a639a7219437bf49a/DeDoDe/utils.py#L610-L620

This commit implements the latter into Kornia for use with DeDoDe keypoints.

@Parskatt 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)



#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
