### PR TITLE
Use named args in update_attribute

### DIFF
--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -114,7 +114,7 @@ class SequentialBase(BasicSequentialBase):
         super().__init__(*args)
         self._same_on_batch = same_on_batch
         self._keepdim = keepdim
-        self.update_attribute(same_on_batch, keepdim)
+        self.update_attribute(same_on_batch, keepdim=keepdim)
 
     def update_attribute(
         self,

--- a/tests/augmentation/test_container.py
+++ b/tests/augmentation/test_container.py
@@ -546,8 +546,6 @@ class TestAugmentationSequential:
             keepdim=keepdim,
         )
 
-        aug.keepdim = keepdim  # FIXME(@shijianjian): This shouldn't be necessary
-
         out = aug(inp, mask)
         if keepdim:
             assert out[0].shape == img_shape


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes #2848

Issue was caused by incorrect passing of arguments. `update_attribute` takes in 3 args - `same_on_batch`, `return_transform` and `keepdim` in that order. 

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
