### PR TITLE
Fix device bug in JPEG augmentation

### DIFF
--- a/kornia/augmentation/_2d/intensity/jpeg.py
+++ b/kornia/augmentation/_2d/intensity/jpeg.py
@@ -53,5 +53,5 @@ class RandomJPEG(IntensityAugmentationBase2D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        jpeg_output: Tensor = jpeg_codec_differentiable(input, params["jpeg_quality"])
+        jpeg_output: Tensor = jpeg_codec_differentiable(input, params["jpeg_quality"].to(input))
         return jpeg_output


### PR DESCRIPTION
#### Changes
When running random JPEG augmentation on CUDA, some tensors are not correctly moved to CUDA. To reproduce the bug just run the following code:

```python
import kornia
import torch
aug = kornia.augmentation.RandomJPEG(p=1.0)
aug.cuda()
aug(torch.rand(2, 3, 256, 256, device="cuda"))
# quantization_table[:, None] * _jpeg_quality_to_scale(jpeg_quality)[:, None, None, None]
# RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

This pull request fixes this bug by just moving the JPEG quality to the same device as the input.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
