### PR TITLE
Ignore invalid keys instead of raising an error

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -483,7 +483,7 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
 
         return keys, data_keys, data_unpacked, invalid_data
 
-    def _read_datakeys_from_dict(self, keys: Sequence[str]) -> List[DataKey]:
+    def _read_datakeys_from_dict(self, keys: Sequence[str]) -> Tuple[List[DataKey], Optional[List[str]]]:
         def retrieve_key(key: str) -> DataKey:
             """Try to retrieve the datakey value by matching `<datakey>*`"""
             # Alias cases, like INPUT, will not be get by the enum iterator.
@@ -496,12 +496,17 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
                 if key.upper().startswith(dk.name):
                     return DataKey.get(dk.name)
 
+            allowed_dk = " | ".join(f"`{d.name}`" for d in DataKey)
+            raise ValueError(
+                f"Your input data dictionary keys should start with some of datakey values: {allowed_dk}. Got `{key}`"
+            )
+
         valid_data_keys = []
         invalid_keys = []
         for k in keys:
             try:
                 valid_data_keys.append(DataKey.get(retrieve_key(k)))
-            except TypeError:
+            except ValueError:
                 invalid_keys.append(k)
 
         return valid_data_keys, invalid_keys

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -175,8 +175,9 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         ... )
         >>> out = aug_list(input, mask, bbox)
 
-    How to use a dictionary as input with AugmentationSequential? The dictionary should starts with
-    one of the datakey availables.
+    How to use a dictionary as input with AugmentationSequential? The dictionary keys that start with
+    one of the available datakeys will be augmented accordingly. Otherwise, the dictionary item is passed
+    without any augmentation.
 
         >>> import kornia.augmentation as K
         >>> img = torch.randn(1, 3, 256, 256)

--- a/tests/augmentation/test_container.py
+++ b/tests/augmentation/test_container.py
@@ -776,13 +776,14 @@ class TestAugmentationSequential:
             random_apply=random_apply,
         )
 
-        data = {"input": inp, "mask": mask, bbox_key: bbox, "keypoints": keypoints}
+        data = {"input": inp, "mask": mask, bbox_key: bbox, "keypoints": keypoints, "invalid": 45}
         out = aug(data)
         assert out["input"].shape == inp.shape
         assert out["mask"].shape == mask.shape
         assert out[bbox_key].shape == bbox.shape
         assert out["keypoints"].shape == keypoints.shape
         assert set(out["mask"].unique().tolist()).issubset(set(mask.unique().tolist()))
+        assert out["invalid"] == 45
 
         out_inv = aug.inverse(out)
         assert out_inv["input"].shape == inp.shape
@@ -790,6 +791,7 @@ class TestAugmentationSequential:
         assert out_inv[bbox_key].shape == bbox.shape
         assert out_inv["keypoints"].shape == keypoints.shape
         assert set(out_inv["mask"].unique().tolist()).issubset(set(mask.unique().tolist()))
+        assert out_inv["invalid"] == 45
 
         if random_apply is False:
             reproducibility_test(data, aug)

--- a/tests/augmentation/test_container.py
+++ b/tests/augmentation/test_container.py
@@ -776,14 +776,14 @@ class TestAugmentationSequential:
             random_apply=random_apply,
         )
 
-        data = {"input": inp, "mask": mask, bbox_key: bbox, "keypoints": keypoints, "invalid": 45}
+        data = {"input": inp, "mask": mask, bbox_key: bbox, "keypoints": keypoints, "id": 45}
         out = aug(data)
         assert out["input"].shape == inp.shape
         assert out["mask"].shape == mask.shape
         assert out[bbox_key].shape == bbox.shape
         assert out["keypoints"].shape == keypoints.shape
         assert set(out["mask"].unique().tolist()).issubset(set(mask.unique().tolist()))
-        assert out["invalid"] == 45
+        assert out["id"] == 45
 
         out_inv = aug.inverse(out)
         assert out_inv["input"].shape == inp.shape
@@ -791,7 +791,7 @@ class TestAugmentationSequential:
         assert out_inv[bbox_key].shape == bbox.shape
         assert out_inv["keypoints"].shape == keypoints.shape
         assert set(out_inv["mask"].unique().tolist()).issubset(set(mask.unique().tolist()))
-        assert out_inv["invalid"] == 45
+        assert out_inv["id"] == 45
 
         if random_apply is False:
             reproducibility_test(data, aug)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Earlier kornia expected all keys to be valid keys such as IMAGE, MASK and raised an error if it encountered any other key. This PR relaxes this constraint by allowing invalid keys to pass through without any augmentation.

So if the following dict is passed:

```python
x = {"image": tensor, "mask": tensor, "id": 0}
aug = K.AugmentationSequential(K.Normalize, data_keys=None)
y = aug(x) 
# y = {"image": augmented_tensor, "mask": augmented_tensor, "id": 0}

```


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
