### PR TITLE
is_autocast_enabled: fix deprecation warning

### DIFF
--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -305,7 +305,7 @@ def is_autocast_enabled(both: bool = True) -> bool:
     Returns:
         Return a Bool,
         will always return False for a torch without support, otherwise will be: if both is True
-        `torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()`. If both is False will return just
+        `torch.is_autocast_enabled() or torch.is_autocast_enabled('cpu')`. If both is False will return just
         `torch.is_autocast_enabled()`.
     """
     if TYPE_CHECKING:
@@ -316,7 +316,7 @@ def is_autocast_enabled(both: bool = True) -> bool:
         return False
 
     if both:
-        return torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()
+        return torch.is_autocast_enabled() or torch.is_autocast_enabled("cpu")
 
     return torch.is_autocast_enabled()
 

--- a/kornia/utils/helpers.py
+++ b/kornia/utils/helpers.py
@@ -316,7 +316,10 @@ def is_autocast_enabled(both: bool = True) -> bool:
         return False
 
     if both:
-        return torch.is_autocast_enabled() or torch.is_autocast_enabled("cpu")
+        if torch_version_ge(2, 4):
+            return torch.is_autocast_enabled() or torch.is_autocast_enabled("cpu")
+        else:
+            return torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()
 
     return torch.is_autocast_enabled()
 


### PR DESCRIPTION
#### Changes

Solves the following deprecation warning:
```
kornia/utils/helpers.py:319: DeprecationWarning: torch.is_autocast_cpu_enabled() is deprecated. Please use torch.is_autocast_enabled('cpu') instead. (Triggered internally at ../torch/csrc/autograd/init.cpp:609.)
```

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
