### PR TITLE
Quaternion conversions

### DIFF
--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -13,7 +13,7 @@ from kornia.geometry.conversions import (
     normalize_quaternion,
     quaternion_from_euler,
     quaternion_to_rotation_matrix,
-    rotation_matrix_to_quaternion,
+    rotation_matrix_to_quaternion, quaternion_to_axis_angle,
 )
 from kornia.geometry.linalg import batched_dot_product
 
@@ -310,6 +310,17 @@ class Quaternion(Module):
             tensor([[0.8776, 0.4794, 0.0000, 0.0000]], requires_grad=True)
         """
         return cls(axis_angle_to_quaternion(axis_angle))
+
+    def to_axis_angle(self) -> Tensor:
+        """Convert the quaternion to a rotation matrix of shape :math:`(B, 3, 3)`.
+
+        Example:
+            >>> q = Quaternion.identity()
+            >>> axis_angle = q.to_axis_angle()
+            >>> axis_angle
+            tensor([0., 0., 0.], grad_fn=<AsStridedBackward0>)
+        """
+        return quaternion_to_axis_angle(self.q)
 
     @classmethod
     def identity(

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -262,7 +262,7 @@ class Quaternion(Module):
 
     @classmethod
     def from_euler(cls, roll: Tensor, pitch: Tensor, yaw: Tensor) -> "Quaternion":
-        """Create a quaternion from euler angles.
+        """Create a quaternion from Euler angles.
 
         Args:
             roll: the roll euler angle.

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -312,7 +312,7 @@ class Quaternion(Module):
         return cls(axis_angle_to_quaternion(axis_angle))
 
     def to_axis_angle(self) -> Tensor:
-        """Convert the quaternion to a rotation matrix of shape :math:`(B, 3, 3)`.
+        """Converts the quaternion to an axis-angle representation.
 
         Example:
             >>> q = Quaternion.identity()

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -320,7 +320,7 @@ class Quaternion(Module):
             >>> axis_angle
             tensor([0., 0., 0.], grad_fn=<AsStridedBackward0>)
         """
-        return quaternion_to_axis_angle(self.q)
+        return quaternion_to_axis_angle(self.data)
 
     @classmethod
     def identity(

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -281,10 +281,7 @@ class Quaternion(Module):
         return cls(q)
 
     def to_euler(self) -> Tuple[Tensor, Tensor, Tensor]:
-        """Create a quaternion from euler angles.
-
-        Args:
-            matrix: the rotation matrix to convert of shape :math:`(B, 3, 3)`.
+        """Convert the quaternion to a triple of Euler angles (roll, pitch, yaw).
 
         Example:
             >>> q = Quaternion(tensor([2., 0., 1., 1.]))

--- a/tests/geometry/test_quaternion.py
+++ b/tests/geometry/test_quaternion.py
@@ -209,6 +209,28 @@ class TestQuaternion:
         self.assert_close(q1, q2)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
+    def test_to_axis_angle(self, device, dtype, batch_size):
+
+        # batch_s = 5
+        # random_coefs = Quaternion.random(batch_s).data
+        random_coefs = torch.tensor([[2.5398e-04, -2.2677e-01, -8.3897e-01, 4.9467e-01],
+                                     [-1.7005e-01, -1.0974e-01, 3.7635e-01, -9.0410e-01],
+                                     [9.1273e-01, 4.8935e-02, -6.2994e-03, 4.0558e-01],
+                                     [-9.8316e-01, 5.4078e-03, 1.4471e-01, 1.1145e-01],
+                                     [4.5794e-02, -7.0831e-01, 6.7577e-01, 1.9883e-01]], device=device, dtype=dtype)
+
+        q = Quaternion(random_coefs)
+        axis_angle_actual = q.to_axis_angle()
+
+        axis_angle_expected = torch.tensor([[-0.7123, -2.6353,  1.5538],
+                                            [0.3118, -1.0693,  2.5687],
+                                            [0.1008, -0.0130,  0.8356],
+                                            [-0.0109, -0.2911, -0.2242],
+                                            [-2.1626,  2.0632,  0.6071]], device=device, dtype=dtype)
+
+        self.assert_close(axis_angle_expected, axis_angle_actual, 1e-4, 1e-4)
+
+    @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_slerp(self, device, dtype, batch_size):
         for axis in torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]):
             axis = axis.to(device, dtype)


### PR DESCRIPTION
#### Changes
- Fixed documentation error in function Quaternion.to_euler() containing the description of Quaternion.from_euler()
- Typo in documentation (euler angles -> Euler angles)
- Added Quaternion.to_axis_angle() method (since Quaternion.matrix(), and Quaternion.to_euler() exist as well as conversion Quaternion.from_axis_angle(), it makes sense to fill conversion function to this commonly used rotation representation format).
- Added tests for Quaternion.to_axis_angle() with manually entered expected results on random vectors.

#### Type of change
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🔬 New feature (non-breaking change which adds functionality)
