### PR TITLE
Inplace draw convex polygon

### DIFF
--- a/kornia/utils/draw.py
+++ b/kornia/utils/draw.py
@@ -351,5 +351,5 @@ def draw_convex_polygon(images: Tensor, polygons: Union[Tensor, List[Tensor]], c
     x_left, x_right = _get_convex_edges(polygons, h_i, w_i)
     ws = torch.arange(w_i, device=device, dtype=dtype_p)[None, None, :]
     fill_region = (ws >= x_left[..., :, None]) & (ws <= x_right[..., :, None])
-    images.mul_((~fill_region[:, None])).add_(fill_region[:, None] * colors[..., None, None])
+    images.mul_(~fill_region[:, None]).add_(fill_region[:, None] * colors[..., None, None])
     return images

--- a/kornia/utils/draw.py
+++ b/kornia/utils/draw.py
@@ -351,5 +351,5 @@ def draw_convex_polygon(images: Tensor, polygons: Union[Tensor, List[Tensor]], c
     x_left, x_right = _get_convex_edges(polygons, h_i, w_i)
     ws = torch.arange(w_i, device=device, dtype=dtype_p)[None, None, :]
     fill_region = (ws >= x_left[..., :, None]) & (ws <= x_right[..., :, None])
-    images = (~fill_region[:, None]) * images + fill_region[:, None] * colors[..., None, None]
+    images.mul_((~fill_region[:, None])).add_(fill_region[:, None] * colors[..., None, None])
     return images


### PR DESCRIPTION
#### Changes
Fixes the issue mentioned below. Example:
```
import torch
from kornia.utils import draw_convex_polygon

img = torch.rand(1, 3, 12, 16)
poly = torch.tensor([[[4, 4], [12, 4], [12, 8], [4, 8]]])
color = torch.tensor([[0.5, 0.5, 0.5]])
print(img.data_ptr())
out = draw_convex_polygon(img, poly, color)
print(out.data_ptr())
```
Before would print different pointer values and now prints the same ones

Fixes #2969 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
