### PR TITLE
smaller gpu memory usage in erosion

### DIFF
--- a/kornia/morphology/morphology.py
+++ b/kornia/morphology/morphology.py
@@ -183,7 +183,7 @@ def erosion(
 
     if engine == "unfold":
         output = output.unfold(2, se_h, 1).unfold(3, se_w, 1)
-        output, _ = torch.min(output - neighborhood, 4)
+        output, _ = torch.min(output.sub_(neighborhood), 4)
         output, _ = torch.min(output, 4)
     elif engine == "convolution":
         B, C, H, W = tensor.size()

--- a/kornia/morphology/morphology.py
+++ b/kornia/morphology/morphology.py
@@ -182,7 +182,7 @@ def erosion(
         neighborhood[kernel == 0] = -max_val
 
     if engine == "unfold":
-        output = output.unfold(2, se_h, 1).unfold(3, se_w, 1)
+        output = output.unfold(2, se_h, 1).unfold(3, se_w, 1).contiguous()
         output, _ = torch.min(output.sub_(neighborhood), 4)
         output, _ = torch.min(output, 4)
     elif engine == "convolution":


### PR DESCRIPTION
#### Changes
Drastically reduces memory usage in erosion function. For the case we see in the issue below, on my gpu it was allocating 13 GB(From the code provided in the issue). With this change it only allocates 2GB while also getting exactly the same result. 

Fixes #2948 

I provide code below which can be run from the main branch(to keep the erosion function from inside of the Kornia library on the old implementation and compare it with new one). I've included time.sleep so you can look at memory usage in nvidia-smi if interested:
```
import torch
import kornia as K
import torch.nn.functional as F
import time

def log_gpu_usage(stage: str) -> None:
    print(
        f'{stage} - Allocated: {torch.cuda.memory_allocated() / 1024 ** 2:.2f} MB, '
        f'Cached: {torch.cuda.memory_reserved() / 1024 ** 2:.2f} MB')

def erosion(
    tensor: torch.Tensor,
    kernel: torch.Tensor,
    structuring_element = None,
    origin = None,
    border_type: str = "geodesic",
    border_value: float = 0.0,
    max_val: float = 1e4,
    engine: str = "unfold",
) -> torch.Tensor:
    if not isinstance(tensor, torch.Tensor):
        raise TypeError(f"Input type is not a torch.Tensor. Got {type(tensor)}")

    if len(tensor.shape) != 4:
        raise ValueError(f"Input size must have 4 dimensions. Got {tensor.dim()}")

    if not isinstance(kernel, torch.Tensor):
        raise TypeError(f"Kernel type is not a torch.Tensor. Got {type(kernel)}")

    if len(kernel.shape) != 2:
        raise ValueError(f"Kernel size must have 2 dimensions. Got {kernel.dim()}")

    # origin
    se_h, se_w = kernel.shape
    if origin is None:
        origin = [se_h // 2, se_w // 2]

    # pad
    pad_e: List[int] = [origin[1], se_w - origin[1] - 1, origin[0], se_h - origin[0] - 1]
    if border_type == "geodesic":
        border_value = max_val
        border_type = "constant"
    output: torch.Tensor = F.pad(tensor, pad_e, mode=border_type, value=border_value)

    # computation
    if structuring_element is None:
        neighborhood = torch.zeros_like(kernel)
        neighborhood[kernel == 0] = -max_val
    else:
        neighborhood = structuring_element.clone()
        neighborhood[kernel == 0] = -max_val
    if engine == "unfold":
        output = output.unfold(2, se_h, 1).unfold(3, se_w, 1)
        output, _ = torch.min(output.sub_(neighborhood), 4) # .sub_(neighborhood)
        output, _ = torch.min(output, 4)
    elif engine == "convolution":
        B, C, H, W = tensor.size()
        Hpad, Wpad = output.shape[-2:]
        reshape_kernel = K.morphology._neight2channels_like_kernel(kernel)
        output, _ = F.conv2d(
            output.view(B * C, 1, Hpad, Wpad), reshape_kernel, padding=0, bias=-neighborhood.view(-1)
        ).min(dim=1)
        output = output.view(B, C, H, W)
    else:
        raise NotImplementedError(f"engine {engine} is unknown, use 'convolution' or 'unfold'")

    return output


device = 'cuda:0'
dummy_tensor = torch.randn((1, 3, 958, 640), device=device)
kernel = torch.ones((40, 40), device=device)


result = K.morphology.erosion(dummy_tensor, kernel)
result = result.cpu()
time.sleep(5)
log_gpu_usage('kornia_test_old')
torch.cuda.empty_cache()
result_new = erosion(dummy_tensor, kernel)

torch.testing.assert_close(result, result_new.cpu())

log_gpu_usage('kornia_test_new')

time.sleep(5)
```


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
