### PR TITLE
fix: Wrong Type Hints in `augmentation.Normalize` (#3003)

### DIFF
--- a/kornia/augmentation/_2d/intensity/normalize.py
+++ b/kornia/augmentation/_2d/intensity/normalize.py
@@ -41,8 +41,8 @@ class Normalize(IntensityAugmentationBase2D):
 
     def __init__(
         self,
-        mean: Tensor | tuple[float] | list[float] | float,
-        std: Tensor | tuple[float] | list[float] | float,
+        mean: Tensor | tuple[float, ...] | list[float] | float,
+        std: Tensor | tuple[float, ...] | list[float] | float,
         p: float = 1.0,
         keepdim: bool = False,
     ) -> None:


### PR DESCRIPTION
#### Changes
Fix the type hints in the `__init__` of `augmentation.Normalize`.

Fixes #3003.


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?