### PR TITLE
Fix type mis-match during mixed-precision training.

### DIFF
--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -438,11 +438,12 @@ def extract_patches_from_pyramid(
             scale_mask = (pyr_idx[i] == cur_pyr_level).squeeze()
             if (scale_mask.float().sum().item()) == 0:
                 continue
-            scale_mask = (scale_mask > 0).view(-1)
+            scale_mask = (scale_mask > 0).view(-1).to(nlaf.dtype).to(nlaf.device)
             grid = generate_patch_grid_from_normalized_LAF(cur_img[i : i + 1], nlaf[i : i + 1, scale_mask, :, :], PS)
             patches = F.grid_sample(
                 cur_img[i : i + 1].expand(grid.shape[0], ch, h, w), grid, padding_mode="border", align_corners=False
             )
+            patches = patches.to(nlaf.dtype).to(nlaf.device)
             out[i].masked_scatter_(scale_mask.view(-1, 1, 1, 1), patches)
         we_are_in_business = min(cur_img.size(2), cur_img.size(3)) >= PS
         if not we_are_in_business:


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
Fix type mis-match during mixed-precision training with extract_patches_from_pyramid

<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)

Since out and patches can be different type (Float Half) with mixed-type training, it will causes crash in L447 when performing masked_scatter_.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
