### PR TITLE
Fix type mis-match between out and patches during mixed-precision training

### DIFF
--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -443,7 +443,7 @@ def extract_patches_from_pyramid(
             patches = F.grid_sample(
                 cur_img[i : i + 1].expand(grid.shape[0], ch, h, w), grid, padding_mode="border", align_corners=False
             )
-            out[i].masked_scatter_(scale_mask.view(-1, 1, 1, 1), patches)
+            out[i].masked_scatter_(scale_mask.view(-1, 1, 1, 1), patches.to(nlaf.dtype))
         we_are_in_business = min(cur_img.size(2), cur_img.size(3)) >= PS
         if not we_are_in_business:
             break


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->
During mixed-precision training, I came across an error reported in 
https://github.com/kornia/kornia/blob/343357d8a777ce749d446680301c8c9901417e9e/kornia/feature/laf.py#L446
, where the types of out[i] and patches did not match (Float vs Half)

Since the type of out[i] is the same as nlaf(laf) as defined in L432,
https://github.com/kornia/kornia/blob/343357d8a777ce749d446680301c8c9901417e9e/kornia/feature/laf.py#L432

change the patch type as well.
Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
