### PR TITLE
Add ignore_index to dice, focal and tversky loss

### DIFF
--- a/kornia/losses/_utils.py
+++ b/kornia/losses/_utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional
 
 import torch

--- a/kornia/losses/_utils.py
+++ b/kornia/losses/_utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Optional
 
 import torch

--- a/kornia/losses/_utils.py
+++ b/kornia/losses/_utils.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+import torch
+
+
+def mask_ignore_pixels(
+    target: torch.Tensor, ignore_index: Optional[int]
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    if ignore_index is None:
+        return target, None
+
+    target_mask = target != ignore_index
+
+    if target_mask.all():
+        return target, None
+
+    # map invalid pixels to a valid class (0)
+    # they need to be manually excluded from the loss computation after
+    target = target.where(target_mask, target.new_zeros(1))
+
+    return target, target_mask

--- a/kornia/losses/dice.py
+++ b/kornia/losses/dice.py
@@ -88,7 +88,7 @@ def dice_loss(
     if not all_valid:
         # map invalid pixels to a valid mask for one hot encoding
         # will be mapped to zero after
-        target[~valid_idx] = 0
+        target = target.where(valid_idx, target.new_zeros(1))
 
     # create the labels one hot tensor
     target_one_hot: Tensor = one_hot(target, num_classes=pred.shape[1], device=pred.device, dtype=pred.dtype)

--- a/kornia/losses/focal.py
+++ b/kornia/losses/focal.py
@@ -76,7 +76,7 @@ def focal_loss(
     if not all_valid:
         # map invalid pixels to a valid mask for one hot encoding
         # will be mapped to zero after
-        target[~valid_idx] = 0
+        target = target.where(valid_idx, target.new_zeros(1))
 
     # create the labels one hot tensor
     target_one_hot: Tensor = one_hot(target, num_classes=pred.shape[1], device=pred.device, dtype=pred.dtype)
@@ -244,9 +244,9 @@ def binary_focal_loss_with_logits(
     valid_idx = target != ignore_index
     all_valid = valid_idx.all()
     if not all_valid:
-        # map invalid pixels to a valid mask for one hot encoding
+        # map invalid pixels to a valid class
         # will be mapped to zero after
-        target[~valid_idx] = 0
+        target = target.where(valid_idx, target.new_zeros(1))
 
         #  mask ignore pixels
         log_probs_neg = log_probs_neg * valid_idx

--- a/kornia/losses/focal.py
+++ b/kornia/losses/focal.py
@@ -250,7 +250,7 @@ def binary_focal_loss_with_logits(
 
         #  mask ignore pixels
         log_probs_neg = log_probs_neg * valid_idx
-        log_probs_pos = log_probs_neg * valid_idx
+        log_probs_pos = log_probs_pos * valid_idx
 
     pos_term: Tensor = -log_probs_neg.exp().pow(gamma) * target * log_probs_pos
     neg_term: Tensor = -log_probs_pos.exp().pow(gamma) * (1.0 - target) * log_probs_neg

--- a/kornia/losses/tversky.py
+++ b/kornia/losses/tversky.py
@@ -78,7 +78,7 @@ def tversky_loss(
     if not all_valid:
         # map invalid pixels to a valid mask for one hot encoding
         # will be mapped to zero after
-        target[~valid_idx] = 0
+        target = target.where(valid_idx, target.new_zeros(1))
 
     # create the labels one hot tensor
     target_one_hot: torch.Tensor = one_hot(target, num_classes=pred.shape[1], device=pred.device, dtype=pred.dtype)

--- a/tests/losses/test_dice.py
+++ b/tests/losses/test_dice.py
@@ -16,7 +16,8 @@ class TestDiceLoss(BaseTester):
         criterion = kornia.losses.DiceLoss()
         assert criterion(logits, labels) is not None
 
-    def test_all_zeros(self, device, dtype):
+    @pytest.mark.parametrize("ignore_index", [-100, None])
+    def test_all_zeros(self, device, dtype, ignore_index):
         num_classes = 3
         logits = torch.zeros(2, num_classes, 1, 2, device=device, dtype=dtype)
         logits[:, 0] = 10.0
@@ -24,7 +25,7 @@ class TestDiceLoss(BaseTester):
         logits[:, 2] = 1.0
         labels = torch.zeros(2, 1, 2, device=device, dtype=torch.int64)
 
-        criterion = kornia.losses.DiceLoss()
+        criterion = kornia.losses.DiceLoss(ignore_index=ignore_index)
         loss = criterion(logits, labels)
         self.assert_close(loss, torch.zeros_like(loss), rtol=1e-3, atol=1e-3)
 

--- a/tests/losses/test_dice.py
+++ b/tests/losses/test_dice.py
@@ -105,6 +105,22 @@ class TestDiceLoss(BaseTester):
         loss = criterion(logits, labels)
         self.assert_close(loss, expected_loss, rtol=1e-3, atol=1e-3)
 
+    @pytest.mark.parametrize("ignore_index", [-100, 255])
+    def test_ignore_index(self, device, dtype, ignore_index):
+        num_classes = 2
+        eps = 1e-8
+
+        logits = torch.zeros(2, num_classes, 1, 4, device=device, dtype=dtype)
+        logits[:, 0, :, 0] = 100.0
+        logits[:, 1, :, 1:] = 100.0
+        labels = torch.zeros(2, 1, 4, device=device, dtype=torch.int64)
+
+        labels[..., 2:] = ignore_index
+        expected_loss = torch.tensor([1.0 / 2.0], device=device, dtype=dtype).squeeze()
+        criterion = kornia.losses.DiceLoss(average="micro", eps=eps, ignore_index=ignore_index)
+        loss = criterion(logits, labels)
+        self.assert_close(loss, expected_loss, rtol=1e-3, atol=1e-3)
+
     def test_gradcheck(self, device):
         num_classes = 3
         logits = torch.rand(2, num_classes, 3, 2, device=device, dtype=torch.float64)

--- a/tests/losses/test_dice.py
+++ b/tests/losses/test_dice.py
@@ -125,6 +125,8 @@ class TestDiceLoss(BaseTester):
         num_classes = 3
         logits = torch.rand(2, num_classes, 3, 2, device=device, dtype=torch.float64)
         labels = torch.randint(0, num_classes, (2, 3, 2), device=device)
+        ignore = torch.rand(2, 3, 2, device=device) > 0.8
+        labels[ignore] = -100
         self.gradcheck(kornia.losses.dice_loss, (logits, labels), dtypes=[torch.float64, torch.int64])
 
     def test_dynamo(self, device, dtype, torch_optimizer):

--- a/tests/losses/test_focal_loss.py
+++ b/tests/losses/test_focal_loss.py
@@ -97,6 +97,16 @@ class TestBinaryFocalLossWithLogits(BaseTester):
         op = kornia.losses.binary_focal_loss_with_logits
         self.gradcheck(op, (logits, labels, *args))
 
+    def test_gradcheck_ignore_index(self, device):
+        logits = torch.rand(2, 3, 2, device=device, dtype=torch.float64)
+        labels = torch.rand(2, 3, 2, device=device, dtype=torch.float64)
+        ignore = torch.rand(2, 3, 2, device=device) > 0.8
+        labels[ignore] = -100
+
+        args = (0.25, 2.0)
+        op = kornia.losses.binary_focal_loss_with_logits
+        self.gradcheck(op, (logits, labels, *args), requires_grad=[True, False, False, False])
+
     def test_module(self, device, dtype):
         logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
@@ -206,6 +216,8 @@ class TestFocalLoss(BaseTester):
         num_classes = 3
         logits = torch.rand(2, num_classes, 3, 2, device=device, dtype=torch.float64)
         labels = torch.randint(num_classes, (2, 3, 2), device=device).long()
+        ignore = torch.rand(2, 3, 2, device=device) > 0.8
+        labels[ignore] = -100
 
         self.gradcheck(
             kornia.losses.focal_loss, (logits, labels, 0.25, 2.0), dtypes=[torch.float64, torch.int64, None, None]

--- a/tests/losses/test_focal_loss.py
+++ b/tests/losses/test_focal_loss.py
@@ -9,12 +9,13 @@ from testing.base import BaseTester
 
 class TestBinaryFocalLossWithLogits(BaseTester):
     @pytest.mark.parametrize("reduction", ["none", "mean", "sum"])
-    def test_value_same_as_torch_bce_loss(self, device, dtype, reduction):
+    @pytest.mark.parametrize("ignore_index", [-100, None])
+    def test_value_same_as_torch_bce_loss(self, device, dtype, reduction, ignore_index):
         logits = torch.rand(2, 3, 2, dtype=dtype, device=device)
         labels = torch.rand(2, 3, 2, dtype=dtype, device=device)
 
         focal_equivalent_bce_loss = kornia.losses.binary_focal_loss_with_logits(
-            logits, labels, alpha=None, gamma=0, reduction=reduction
+            logits, labels, alpha=None, gamma=0, reduction=reduction, ignore_index=ignore_index
         )
         torch_bce_loss = F.binary_cross_entropy_with_logits(logits, labels, reduction=reduction)
         self.assert_close(focal_equivalent_bce_loss, torch_bce_loss)

--- a/tests/losses/test_tversky.py
+++ b/tests/losses/test_tversky.py
@@ -67,6 +67,8 @@ class TestTverskyLoss(BaseTester):
         alpha, beta = 0.5, 0.5  # for tversky loss
         logits = torch.rand(2, num_classes, 3, 2, device=device, dtype=torch.float64)
         labels = torch.randint(0, num_classes, (2, 3, 2), device=device)
+        ignore = torch.rand(2, 3, 2, device=device) > 0.8
+        labels[ignore] = -100
 
         self.gradcheck(
             kornia.losses.tversky_loss, (logits, labels, alpha, beta), dtypes=[torch.float64, torch.int64, None, None]

--- a/tests/losses/test_tversky.py
+++ b/tests/losses/test_tversky.py
@@ -47,6 +47,21 @@ class TestTverskyLoss(BaseTester):
         loss = criterion(logits, labels)
         self.assert_close(loss, torch.zeros_like(loss), atol=1e-3, rtol=1e-3)
 
+    @pytest.mark.parametrize("ignore_index", [-100, 255])
+    def test_ignore_index(self, device, dtype, ignore_index):
+        num_classes = 2
+
+        logits = torch.zeros(2, num_classes, 1, 4, device=device, dtype=dtype)
+        logits[:, 0, :, 0] = 100.0
+        logits[:, 1, :, 1:] = 100.0
+        labels = torch.zeros(2, 1, 4, device=device, dtype=torch.int64)
+
+        labels[..., 2:] = ignore_index
+        expected_loss = torch.tensor([1.0 / 2.0], device=device, dtype=dtype).squeeze()
+        criterion = kornia.losses.TverskyLoss(alpha=0.5, beta=0.5, ignore_index=ignore_index)
+        loss = criterion(logits, labels)
+        self.assert_close(loss, expected_loss, rtol=1e-3, atol=1e-3)
+
     def test_gradcheck(self, device):
         num_classes = 3
         alpha, beta = 0.5, 0.5  # for tversky loss

--- a/tests/losses/test_tversky.py
+++ b/tests/losses/test_tversky.py
@@ -35,7 +35,8 @@ class TestTverskyLoss(BaseTester):
             criterion(torch.rand(1, 1, 1, 1), torch.rand(1, 1, 1, 1, device="meta"))
         assert "pred and target must be in the same device. Got:" in str(errinfo)
 
-    def test_all_zeros(self, device, dtype):
+    @pytest.mark.parametrize("ignore_index", [-100, None])
+    def test_all_zeros(self, device, dtype, ignore_index):
         num_classes = 3
         logits = torch.zeros(2, num_classes, 1, 2, device=device, dtype=dtype)
         logits[:, 0] = 10.0
@@ -43,7 +44,7 @@ class TestTverskyLoss(BaseTester):
         logits[:, 2] = 1.0
         labels = torch.zeros(2, 1, 2, device=device, dtype=torch.int64)
 
-        criterion = kornia.losses.TverskyLoss(alpha=0.5, beta=0.5)
+        criterion = kornia.losses.TverskyLoss(alpha=0.5, beta=0.5, ignore_index=ignore_index)
         loss = criterion(logits, labels)
         self.assert_close(loss, torch.zeros_like(loss), atol=1e-3, rtol=1e-3)
 


### PR DESCRIPTION
#### Changes
* adds `ignore_index` argument to dice and tversky losses. 
* a second commit also adds code to the focal loss, but without tests. I couldn't easily extend an existing test case to properly test the new parameter. IMHO, I would drop this second commit for now.

fixes #839

#### Type of change
- [x] 🧪 Tests Cases
- [x] 🔬 New feature (non-breaking change which adds functionality)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
