### PR TITLE
Add explicit dev dependency on setuptools

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -9,4 +9,5 @@ pre-commit>=2
 pytest==8.3.3
 pytest-timeout
 requests
+setuptools>=61.2  # needed by pytorch dynamo / triton
 transformers


### PR DESCRIPTION
#### Changes

Fixes #3035

Add explicit dev dependency on `setuptools`. This is needed to run torch dynamo tests when setting up the environment manually with uv. The lower version bound is copied from the build_requirements of kornia itself.

#### Type of change
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
