### PR TITLE
Fix registrator code typo in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ within the context of an Open Source community.
 
    >>> import kornia.geometry as K
    >>> registrator = K.ImageRegistrator('similarity')
-   >>> model = registrator(img1, img2)
+   >>> model = registrator.register(img1, img2)
 
 Ready to use with state-of-the art Deep Learning models:
 


### PR DESCRIPTION
The code example using registrator misses the call for its register() method.