### PR TITLE
Introducing Kornia Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ English | [简体中文](README_zh-CN.md)
 [![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=white)](https://join.slack.com/t/kornia/shared_invite/zt-csobk21g-2AQRi~X9Uu6PLMuUZdvfjA)
 [![Twitter](https://img.shields.io/twitter/follow/kornia_foss?style=social)](https://twitter.com/kornia_foss)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENCE)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Kornia%20Guru-006BFF)](https://gurubase.io/g/kornia)
 
 </p>
 </div>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Kornia Guru](https://gurubase.io/g/kornia) to Gurubase. Kornia Guru uses the data from this repo and data from the [docs](https://kornia.readthedocs.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Kornia Guru", which highlights that Kornia now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Kornia Guru in Gurubase, just let me know that's totally fine.
