### PR TITLE
chore (ci): tests on torch `2.5.1`

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       hash: ${{ steps.hashid.outputs.weights-hash }}
     steps:
-    - uses: kornia/workflows/.github/actions/env@v1.12.1
+    - uses: kornia/workflows/.github/actions/env@v1.13.0
     - uses: actions/cache@v4
       id: cache-weights
       with:
@@ -43,11 +43,11 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.13.0
     with:
       os: ${{ matrix.os }}
       python-version: '["3.9", "3.12"]'
-      pytorch-version: '["1.9.1", "2.4.0"]'
+      pytorch-version: '["1.9.1", "2.5.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
@@ -57,7 +57,7 @@ jobs:
 
   tests-cpu-macos:
     needs: [pre-tests]
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.13.0
     with:
       os: 'MacOS-latest'
       python-version: '["3.9", "3.12"]'
@@ -71,7 +71,7 @@ jobs:
 
   coverage:
     needs: [pre-tests]
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.13.0
     with:
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
@@ -80,14 +80,14 @@ jobs:
         model-weights-
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.13.0
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.13.0
 
   docs:
     needs: [pre-tests]
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.13.0
     with:
       python-version: '["3.11"]'
       cache-path: weights/
@@ -116,7 +116,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest'] #, 'MacOS-latest'] add it when https://github.com/pytorch/pytorch/pull/89262 be merged
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.13.0
     with:
       os: ${{ matrix.os }}
       pytorch-version: '["nightly"]'

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       hash: ${{ steps.hashid.outputs.weights-hash }}
     steps:
-    - uses: kornia/workflows/.github/actions/env@v1.12.1
+    - uses: kornia/workflows/.github/actions/env@v1.13.0
     - uses: actions/cache@v4
       id: cache-weights
       with:
@@ -41,11 +41,11 @@ jobs:
         # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.13.0
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.9", "3.10", "3.11", "3.12"]'
-      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.2", "2.3.1", "2.4.0"]'
+      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.2", "2.3.1", "2.4.0", "2.5.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       pytest-extra: '--runslow'
       cache-path: weights/
@@ -61,11 +61,11 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.13.0
     with:
       os: 'Windows-latest'
       python-version: '["3.12"]'
-      pytorch-version: '["1.9.1", "2.4.0"]'
+      pytorch-version: '["1.9.1", "2.5.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
@@ -80,7 +80,7 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.13.0
     with:
       os: 'MacOS-latest'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
@@ -92,7 +92,7 @@ jobs:
 
   coverage:
     needs: [pre-tests]
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.13.0
     with:
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
@@ -101,14 +101,14 @@ jobs:
         model-weights-
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.13.0
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.13.0
 
   docs:
     needs: [pre-tests]
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.12.1
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.13.0
     with:
       python-version: '["3.11"]'
       cache-path: weights/

--- a/kornia/core/mixin/onnx.py
+++ b/kornia/core/mixin/onnx.py
@@ -111,9 +111,9 @@ class ONNXExportMixin:
 
         onnx_buffer = io.BytesIO()
         torch.onnx.export(
-            model or self,  # type: ignore
-            dummy_input,
-            onnx_buffer,
+            model or self,  # type: ignore[arg-type]
+            dummy_input,  # type: ignore[arg-type]
+            onnx_buffer,  # type: ignore[arg-type]
             **default_args,
         )
         onnx_buffer.seek(0)

--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -468,7 +468,7 @@ class LightGlue(Module):
             )
 
         for i in range(self.conf.n_layers):
-            self.transformers[i].masked_forward = torch.compile(
+            self.transformers[i].masked_forward = torch.compile(  # type: ignore[assignment]
                 self.transformers[i].masked_forward, mode=mode, fullgraph=True
             )
 

--- a/kornia/feature/sold2/backbones.py
+++ b/kornia/feature/sold2/backbones.py
@@ -131,15 +131,15 @@ class Hourglass(Module):
         return nn.ModuleList(hgl)
 
     def _hour_glass_forward(self, n: int, x: Tensor) -> Tensor:
-        up1 = self.hg[n - 1][0](x)
+        up1 = self.hg[n - 1][0](x)  # type: ignore[index]
         low1 = F.max_pool2d(x, 2, stride=2)
-        low1 = self.hg[n - 1][1](low1)
+        low1 = self.hg[n - 1][1](low1)  # type: ignore[index]
 
         if n > 1:
             low2 = self._hour_glass_forward(n - 1, low1)
         else:
-            low2 = self.hg[n - 1][3](low1)
-        low3 = self.hg[n - 1][2](low2)
+            low2 = self.hg[n - 1][3](low1)  # type: ignore[index]
+        low3 = self.hg[n - 1][2](low2)  # type: ignore[index]
         up2 = F.interpolate(low3, size=up1.shape[2:])
         out = up1 + up2
         return out


### PR DESCRIPTION
replaces torch 2.4.0
bump workflow jobs
