### PR TITLE
Fix LightGlue normalize_keypoints with torch.Size input

### DIFF
--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -45,7 +45,7 @@ def math_clamp(x, min_, max_):  # type: ignore
 @custom_fwd(cast_inputs=torch.float32)
 def normalize_keypoints(kpts: Tensor, size: Tensor) -> Tensor:
     if isinstance(size, torch.Size):
-        size = Tensor(size)[None]
+        size = torch.tensor(size)[None]
     shift = size.float().to(kpts) / 2
     scale = size.max(1).values.float().to(kpts) / 2
     kpts = (kpts - shift[:, None]) / scale[:, None, None]


### PR DESCRIPTION
#### Changes
```python3
size = image.shape # [1064, 688]
size = Tensor(size)[None]  # [1, 1064, 688]
```
torch.Torch(size_tensor) creates a tensor with that size, instead of converting the variable from torch.Size to tensor.
Resulting in the following error:

```
File "/home/dawars/miniconda3/envs/imw/lib/python3.10/site-packages/kornia/feature/lightglue.py", line 51, in normalize_keypoints
    kpts = (kpts - shift[:, None]) / scale[:, None, None]
RuntimeError: The size of tensor a (2) must match the size of tensor b (688) at non-singleton dimension 3
```

The proposed change fixes this case, which is analogous with the original LG code: https://github.com/cvg/LightGlue/blob/main/lightglue/lightglue.py#L30
Also, in line with the integrated LightGlueMatcher implementation: https://github.com/kornia/kornia/blob/main/kornia/feature/integrated.py#L464

Tested pytorch version: 2.4.0

#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
