### PR TITLE
Ruff Docstring Rule D417: Fix missing arguments

### DIFF
--- a/kornia/augmentation/auto/base.py
+++ b/kornia/augmentation/auto/base.py
@@ -56,6 +56,7 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
             params: params for the sequence.
             recompute: if to recompute the transformation matrix according to the params.
                 default: False.
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
 
         """
         if params is None:

--- a/kornia/augmentation/auto/operations/policy.py
+++ b/kornia/augmentation/auto/operations/policy.py
@@ -58,6 +58,7 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
             params: params for the sequence.
             recompute: if to recompute the transformation matrix according to the params.
                 default: False.
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
 
         """
         if params is None:

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -480,8 +480,10 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         """Overwrite the __call__ function to handle various inputs.
 
         Args:
+            inputs: Inputs to operate on.
             input_names_to_handle: List of input names to convert, if None, handle all inputs.
             output_type: Desired output type ('tensor', 'numpy', or 'pil').
+            kwargs: Additional arguments.
 
         Returns:
             Callable: Decorated function with converted input and output types.

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -185,7 +185,7 @@ class ImageSequentialBase(SequentialBase):
             params: params for the sequence.
             recompute: if to recompute the transformation matrix according to the params.
                 default: False.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         raise NotImplementedError
 

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -248,7 +248,7 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
             params: params for the sequence.
             recompute: if to recompute the transformation matrix according to the params.
                 default: False.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if params is None:
             raise NotImplementedError("requires params to be provided.")
@@ -326,8 +326,10 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
         """Overwrite the __call__ function to handle various inputs.
 
         Args:
+            inputs: Inputs to operate on.
             input_names_to_handle: List of input names to convert, if None, handle all inputs.
             output_type: Desired output type ('tensor', 'numpy', or 'pil').
+            kwargs: Additional arguments.
 
         Returns:
             Callable: Decorated function with converted input and output types.

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -50,7 +50,7 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         raise NotImplementedError
 
@@ -64,7 +64,7 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         raise NotImplementedError
 
@@ -255,7 +255,7 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if extra_args is None:
             extra_args = {}
@@ -304,7 +304,7 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if extra_args is None:
             extra_args = {}
@@ -369,7 +369,7 @@ class MaskSequentialOps(SequentialOpsInterface[Tensor]):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if extra_args is None:
             extra_args = {}
@@ -417,7 +417,7 @@ class BoxSequentialOps(SequentialOpsInterface[Boxes]):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if extra_args is None:
             extra_args = {}
@@ -463,7 +463,7 @@ class BoxSequentialOps(SequentialOpsInterface[Boxes]):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if extra_args is None:
             extra_args = {}
@@ -514,7 +514,7 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if extra_args is None:
             extra_args = {}
@@ -561,7 +561,7 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
             module: any torch Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
-
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if extra_args is None:
             extra_args = {}

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -253,7 +253,8 @@ class VideoSequential(ImageSequential):
         Args:
             input: tensor with shape :math:`(B, T, N, 4, 2)`.
                 If input is a `Keypoints` type, the internal shape is :math:`(B * T, N, 4, 2)`.
-
+            params: params for the sequence.
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if isinstance(input, Tensor):
             batchsize, frame_num = input.size(0), input.size(1)
@@ -272,7 +273,8 @@ class VideoSequential(ImageSequential):
         Args:
             input: tensor with shape :math:`(B, T, N, 4, 2)`.
                 If input is a `Keypoints` type, the internal shape is :math:`(B * T, N, 4, 2)`.
-
+            params: params for the sequence.
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if isinstance(input, Tensor):
             batchsize, frame_num = input.size(0), input.size(1)
@@ -291,7 +293,8 @@ class VideoSequential(ImageSequential):
         Args:
             input: tensor with shape :math:`(B, T, N, 2)`.
                 If input is a `Keypoints` type, the internal shape is :math:`(B * T, N, 2)`.
-
+            params: params for the sequence.
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if isinstance(input, Tensor):
             batchsize, frame_num = input.size(0), input.size(1)
@@ -310,7 +313,8 @@ class VideoSequential(ImageSequential):
         Args:
             input: tensor with shape :math:`(B, T, N, 2)`.
                 If input is a `Keypoints` type, the internal shape is :math:`(B * T, N, 2)`.
-
+            params: params for the sequence.
+            extra_args: Optional dictionary of extra arguments with specific options for different input types.
         """
         if isinstance(input, Tensor):
             frame_num, batchsize = input.size(0), input.size(1)

--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -211,8 +211,9 @@ def _transform_output_shape(
     r"""Collapse the broadcasted batch dimensions an input tensor to be the specified shape.
 
     Args:
-        input: Tensor
+        output: Tensor
         shape: List/tuple of int
+        reference_shape: Tensor representation of shape to control which dimensions are collapsed.
 
     Returns:
         Tensor

--- a/kornia/contrib/extract_patches.py
+++ b/kornia/contrib/extract_patches.py
@@ -430,7 +430,7 @@ def extract_tensor_patches(
         window_size: the size of the sliding window and the output patch size.
         stride: stride of the sliding window.
         padding: Zero-padding added to both side of the input.
-        allow_auto_adding: whether to allow automatic padding if the window and stride do not fit into the image.
+        allow_auto_padding: whether to allow automatic padding if the window and stride do not fit into the image.
 
     Returns:
         the tensor with the extracted patches with shape :math:`(B, N, C, H_{out}, W_{out})`.

--- a/kornia/contrib/models/common.py
+++ b/kornia/contrib/models/common.py
@@ -128,7 +128,7 @@ def window_unpartition(windows: Tensor, window_size: int, pad_hw: tuple[int, int
     """Window unpartition into original sequences and removing padding.
 
     Args:
-        x: input tokens with [B * num_windows, window_size, window_size, C].
+        windows: input tokens with [B * num_windows, window_size, window_size, C].
         window_size: window size.
         pad_hw: padded height and width (Hp, Wp).
         hw: original height and width (H, W) before padding.

--- a/kornia/contrib/models/rt_detr/model.py
+++ b/kornia/contrib/models/rt_detr/model.py
@@ -81,6 +81,7 @@ class RTDETRConfig:
 
         Args:
             model_name: 'rtdetr_r18vd', 'rtdetr_r34vd', 'rtdetr_r50vd_m', 'rtdetr_r50vd', 'rtdetr_r101vd'.
+            num_classes: Number of classes to detect.
 
         """
         if model_name == "rtdetr_r18vd":
@@ -107,8 +108,8 @@ class RTDETR(ModelBase[RTDETRConfig]):
 
         Args:
             backbone: backbone network for feature extraction.
-            neck: neck network for feature fusion.
-            head: head network to decode features into detection results.
+            encoder: neck network for feature fusion.
+            decoder: head network to decode features into detection results.
 
         """
         super().__init__()
@@ -255,6 +256,7 @@ class RTDETR(ModelBase[RTDETRConfig]):
 
         Args:
             model_name: 'rtdetr_r18vd', 'rtdetr_r34vd', 'rtdetr_r50vd_m', 'rtdetr_r50vd', 'rtdetr_r101vd'.
+            num_classes: number of classes to detect.
 
         """
         model = RTDETR.from_config(RTDETRConfig.from_name(model_name, num_classes))

--- a/kornia/contrib/models/sam/architecture/image_encoder.py
+++ b/kornia/contrib/models/sam/architecture/image_encoder.py
@@ -49,6 +49,7 @@ class ImageEncoderViT(Module):
         depth: Depth of ViT.
         num_heads: Number of attention heads in each ViT block.
         mlp_ratio: Ratio of mlp hidden dim to embedding dim.
+        out_chans: Number of output channels.
         qkv_bias: If True, add a learnable bias to query, key, value.
         norm_layer: Normalization layer.
         act_layer: Activation layer.
@@ -194,7 +195,7 @@ class Attention(Module):
         dim: Number of input channels.
         num_heads: Number of attention heads.
         qkv_bias:  If True, add a learnable bias to query, key, value.
-        rel_pos: If True, add relative positional embeddings to the attention map.
+        use_rel_pos: If True, add relative positional embeddings to the attention map.
         rel_pos_zero_init: If True, zero initialize relative positional parameters.
         input_size: Input resolution for calculating the relative positional parameter size.
 

--- a/kornia/contrib/models/sam/architecture/transformer.py
+++ b/kornia/contrib/models/sam/architecture/transformer.py
@@ -34,6 +34,7 @@ class TwoWayTransformer(Module):
             num_heads: the number of heads for multihead attention. Must divide embedding_dim
             mlp_dim: the channel dimension internal to the MLP block
             activation: the activation to use in the MLP block
+            attention_downsample_rate: downsampling rate from embedding dimension
 
         """  # noqa: D205
         super().__init__()
@@ -117,6 +118,7 @@ class TwoWayAttentionBlock(Module):
             mlp_dim: the hidden dimension of the mlp block
             activation: the activation of the mlp block
             skip_first_layer_pe: skip the PE on the first layer
+            attention_downsample_rate: downsampling rate from embedding dimension
 
         """
         super().__init__()

--- a/kornia/contrib/visual_prompter.py
+++ b/kornia/contrib/visual_prompter.py
@@ -119,6 +119,8 @@ class VisualPrompter:
             image: RGB image. Normally images with range of [0-1], the model preprocess normalize the
                    pixel values with the mean and std defined in its initialization. Expected to be into a float32
                    dtype. Shape :math:`(3, H, W)`.
+            mean: mean value of dataset for normalization.
+            std: standard deviation of dataset for normalization.
 
         """
         KORNIA_CHECK_SHAPE(image, ["3", "H", "W"])
@@ -236,7 +238,7 @@ class VisualPrompter:
         Args:
             keypoints: Point prompts to the model. Each point is in (X,Y) in pixels. Shape :math:`(K, N, 2)`. Where
                        `N` is the number of points and `K` the number of prompts.
-            keypoint_labels: Labels for the point prompts. 1 indicates a foreground point and 0 indicates a background
+            keypoints_labels: Labels for the point prompts. 1 indicates a foreground point and 0 indicates a background
                              point. Shape :math:`(K, N)`. Where `N` is the number of points, and `K` the number of
                              prompts.
             boxes: A box prompt to the model. If a tensor, should be in a xyxy mode. Shape :math:`(K, 4)`

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -235,7 +235,7 @@ def KORNIA_CHECK_SAME_DEVICES(tensors: list[Tensor], msg: Optional[str] = None, 
     """Check whether a list provided tensors live in the same device.
 
     Args:
-        x: a list of tensors.
+        tensors: a list of tensors.
         msg: message to show in the exception.
         raises: bool indicating whether an exception should be raised upon failure.
 

--- a/kornia/core/mixin/image_module.py
+++ b/kornia/core/mixin/image_module.py
@@ -190,6 +190,7 @@ class ImageModuleMixIn:
         Args:
             n_row: Number of images displayed in each row of the grid.
             backend: visualization backend. Only PIL is supported now.
+            display: Whether or not to show the image.
 
         """
         if self._output_image is None:

--- a/kornia/core/mixin/onnx.py
+++ b/kornia/core/mixin/onnx.py
@@ -157,6 +157,7 @@ class ONNXRuntimeMixin:
         """Create an optimized ONNXRuntime InferenceSession for the combined model.
 
         Args:
+            op: Onnx operation.
             providers:
                 Execution providers for ONNXRuntime (e.g., ['CUDAExecutionProvider', 'CPUExecutionProvider']).
             session_options:
@@ -213,6 +214,7 @@ class ONNXRuntimeMixin:
 
         Args:
             device_id: Select GPU to execute.
+            kwargs: Additional arguments for cuda.
 
         """
         self._session.set_providers(["CUDAExecutionProvider"], provider_options=[{"device_id": device_id, **kwargs}])
@@ -226,6 +228,7 @@ class ONNXRuntimeMixin:
 
         Args:
             device_id: select GPU to execute.
+            kwargs: additional arguments from TensorRT.
 
         """
         self._session.set_providers(
@@ -233,7 +236,7 @@ class ONNXRuntimeMixin:
         )
 
     def as_openvino(self, device_type: str = "GPU", **kwargs: Any) -> None:
-        """Set the session to run on TensorRT.
+        """Set the session to run on OpenVINO.
 
         We set the ONNX runtime session to use OpenVINOExecutionProvider.
         For other OpenVINOExecutionProvider configurations, or CUDA/cuDNN/ONNX/TensorRT version issues,
@@ -242,6 +245,7 @@ class ONNXRuntimeMixin:
         Args:
             device_type: CPU, NPU, GPU, GPU.0, GPU.1 based on the available GPUs, NPU, Any valid Hetero combination,
                 Any valid Multi or Auto devices combination.
+            kwargs: Additional arguments for OpenVINO.
 
         """
         self._session.set_providers(
@@ -275,6 +279,7 @@ class ONNXMixin:
 
         Args:
             arg: Either an ONNX ModelProto object or a file path to an ONNX model.
+            cache_dir: Where to read onnx objects from if stored on disk.
 
         Returns:
             onnx.ModelProto: The loaded ONNX model.
@@ -297,6 +302,7 @@ class ONNXMixin:
             *args: A variable number of ONNX models (either ONNX ModelProto objects or file paths).
                 For Hugging Face-hosted models, use the format 'hf://model_name'. Valid `model_name` can be found on
                 https://huggingface.co/kornia/ONNX_models. Or a URL to the ONNX model.
+            cache_dir: Where to read operations from if stored on disk.
 
         Returns:
             list[onnx.ModelProto]: The loaded ONNX models as a list of ONNX graphs.
@@ -317,6 +323,7 @@ class ONNXMixin:
         Optionally, map inputs and outputs between operators using the `io_map`.
 
         Args:
+            args: list of onnx operations.
             io_maps:
                 A list of list of tuples representing input-output mappings for combining the models.
                 Example: [[(model1_output_name, model2_input_name)], [(model2_output_name, model3_input_name)]].
@@ -350,8 +357,10 @@ class ONNXMixin:
         """Export the combined ONNX model to a file.
 
         Args:
+            op: onnx operation.
             file_path:
                 The file path to export the combined ONNX model.
+            kwargs: Addtional arguments to save onnx model.
 
         """
         onnx.save(op, file_path, **kwargs)  # type:ignore
@@ -364,6 +373,7 @@ class ONNXMixin:
         """Add metadata to the combined ONNX model.
 
         Args:
+            op: onnx opperation.
             additional_metadata:
                 A list of tuples representing additional metadata to add to the combined ONNX model.
                 Example: [("version", 0.1)], [("date", 20240909)].
@@ -381,6 +391,7 @@ class ONNXMixin:
         """Automatic conversion of the model's IR/OPSET version to the given target version.
 
         Args:
+            op: onnx operation.
             target_ir_version: The target IR version to convert to.
             target_opset_version: The target OPSET version to convert to.
 

--- a/kornia/core/mixin/onnx.py
+++ b/kornia/core/mixin/onnx.py
@@ -360,7 +360,7 @@ class ONNXMixin:
             op: onnx operation.
             file_path:
                 The file path to export the combined ONNX model.
-            kwargs: Addtional arguments to save onnx model.
+            kwargs: Additional arguments to save onnx model.
 
         """
         onnx.save(op, file_path, **kwargs)  # type:ignore
@@ -373,7 +373,7 @@ class ONNXMixin:
         """Add metadata to the combined ONNX model.
 
         Args:
-            op: onnx opperation.
+            op: onnx operation.
             additional_metadata:
                 A list of tuples representing additional metadata to add to the combined ONNX model.
                 Example: [("version", 0.1)], [("date", 20240909)].

--- a/kornia/core/module.py
+++ b/kornia/core/module.py
@@ -192,6 +192,7 @@ class ImageModuleMixIn:
         Args:
             n_row: Number of images displayed in each row of the grid.
             backend: visualization backend. Only PIL is supported now.
+            display: whether to display the image.
 
         """
         if self._output_image is None:
@@ -267,8 +268,10 @@ class ImageModule(Module, ImageModuleMixIn, ONNXExportMixin):
         """Overwrite the __call__ function to handle various inputs.
 
         Args:
+            inputs: Inputs to operate on.
             input_names_to_handle: List of input names to convert, if None, handle all inputs.
             output_type: Desired output type ('tensor', 'numpy', or 'pil').
+            kwargs: Additional arguments.
 
         Returns:
             Callable: Decorated function with converted input and output types.
@@ -324,8 +327,10 @@ class ImageSequential(Sequential, ImageModuleMixIn, ONNXExportMixin):
         """Overwrite the __call__ function to handle various inputs.
 
         Args:
+            inputs: Inputs to operate on.
             input_names_to_handle: List of input names to convert, if None, handle all inputs.
             output_type: Desired output type ('tensor', 'numpy', or 'pil').
+            kwargs: Additional arguments.
 
         Returns:
             Callable: Decorated function with converted input and output types.

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -444,6 +444,7 @@ def adjust_brightness(image: Tensor, factor: Union[float, Tensor], clip_output: 
         factor: Brightness adjust factor per element in the batch. It's recommended to
             bound the factor by [0, 1]. 0 does not modify the input image while any other
             number modify the brightness.
+        clip_output: Whether to clip output to be in [0,1].
 
     Return:
         Adjusted tensor in the shape of :math:`(*, H, W)`.
@@ -499,6 +500,7 @@ def adjust_brightness_accumulative(image: Tensor, factor: Union[float, Tensor], 
         factor: Brightness adjust factor per element in the batch. It's recommended to
             bound the factor by [0, 1]. 0 does not modify the input image while any other
             number modify the brightness.
+        clip_output: Whether to clip output to be in [0,1].
 
     Return:
         Adjusted tensor in the shape of :math:`(*, H, W)`.
@@ -903,7 +905,7 @@ def _scale_channel(im: Tensor) -> Tensor:
     r"""Scale the data in the channel to implement equalize.
 
     Args:
-        input: image tensor with shapes like :math:`(H, W)` or :math:`(D, H, W)`.
+        im: image tensor with shapes like :math:`(H, W)` or :math:`(D, H, W)`.
 
     Returns:
         image tensor with the batch in the zero position.

--- a/kornia/enhance/histogram.py
+++ b/kornia/enhance/histogram.py
@@ -176,6 +176,7 @@ def image_histogram2d(
           each bin.
         kernel: kernel to perform kernel density estimation
           ``(`triangular`, `gaussian`, `uniform`, `epanechnikov`)``.
+        eps: epsilon for numerical stability.
 
     Returns:
         Computed histogram of shape :math:`(bins)`, :math:`(C, bins)`,

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -83,6 +83,8 @@ def _unpatchify_8x8(input: Tensor, H: int, W: int) -> Tensor:
 
     Args:
         input (Tensor): Input image of the shape :math:`(B, N, 8, 8)`.
+        H: height of resulting tensor.
+        W: width of resulting tensor.
 
     Returns:
         output (Tensor): Image patchify of the shape :math:`(B, H, W)`.

--- a/kornia/enhance/normalize.py
+++ b/kornia/enhance/normalize.py
@@ -193,7 +193,7 @@ def denormalize(data: Tensor, mean: Union[Tensor, float], std: Union[Tensor, flo
     Where `mean` is :math:`(M_1, ..., M_n)` and `std` :math:`(S_1, ..., S_n)` for `n` channels,
 
     Args:
-        input: Image tensor of size :math:`(B, C, *)`.
+        data: Image tensor of size :math:`(B, C, *)`.
         mean: Mean for each channel.
         std: Standard deviations for each channel.
 

--- a/kornia/feature/adalam/adalam.py
+++ b/kornia/feature/adalam/adalam.py
@@ -54,6 +54,9 @@ def match_adalam(
         config: dict with AdaLAM config
         dm: Tensor containing the distances from each descriptor in desc1
           to each descriptor in desc2, shape of :math:`(B1, B2)`.
+        hw1: Height/width of image.
+        hw2: Height/width of image.
+
 
     Return:
         - Descriptor distance of matching descriptors, shape of :math:`(B3, 1)`.
@@ -203,7 +206,7 @@ class AdalamFilter:
             - finds mutual nearest neighbors if required;
             - finally calls AdaLAM filtering.
 
-        Inputs:
+        Args:
             k1: keypoint locations in the source image, in pixel coordinates.
                 Expected an array with shape (num_keypoints_in_source_image, 2).
             k2: keypoint locations in the destination image, in pixel coordinates.
@@ -218,12 +221,14 @@ class AdalamFilter:
             im2shape: Shape of the destination image. If None, it is inferred from keypoints max and min, at the cost
                       of wasted runtime. So please provide it. Expected a tuple with (width, height) or (height, width)
                       of destination image
-            o1/o2: keypoint orientations in degrees. They can be None if 'orientation_difference_threshold' in config
+            o1: keypoint orientations in degrees. They can be None if 'orientation_difference_threshold' in config
                    is set to None. See documentation on 'orientation_difference_threshold' in the DEFAULT_CONFIG.
                    Expected an array with shape (num_keypoints_in_source/destination_image,)
-            s1/s2: keypoint scales. They can be None if 'scale_rate_threshold' in config is set to None.
+            o2: Same as o1 for destination.
+            s1: keypoint scales. They can be None if 'scale_rate_threshold' in config is set to None.
                    See documentation on 'scale_rate_threshold' in the DEFAULT_CONFIG.
                    Expected an array with shape (num_keypoints_in_source/destination_image,)
+            s2: Same as s1 for destination.
             return_dist: if True, inverse confidence value is also outputted.
 
         Returns:

--- a/kornia/feature/adalam/adalam.py
+++ b/kornia/feature/adalam/adalam.py
@@ -131,7 +131,7 @@ class AdalamFilter:
 
         No sanity check is performed on the inputs.
 
-        Inputs:
+        Args:
             k1: keypoint locations in the source image, in pixel coordinates.
                 Expected a float32 tensor with shape (num_keypoints_in_source_image, 2).
             k2: keypoint locations in the destination image, in pixel coordinates.
@@ -152,12 +152,14 @@ class AdalamFilter:
             im2shape: Shape of the destination image. If None, it is inferred from keypoints max and min, at the cost
                       of wasted runtime. So please provide it. Expected a tuple with (width, height) or (height, width)
                       of destination image
-            o1/o2: keypoint orientations in degrees. They can be None if 'orientation_difference_threshold' in config
+            o1: keypoint orientations in degrees. They can be None if 'orientation_difference_threshold' in config
                    is set to None. See documentation on 'orientation_difference_threshold' in the DEFAULT_CONFIG.
                    Expected a float32 tensor with shape (num_keypoints_in_source/destination_image,)
-            s1/s2: keypoint scales. They can be None if 'scale_rate_threshold' in config is set to None.
+            o2: same as o1 but for destination.
+            s1: keypoint scales. They can be None if 'scale_rate_threshold' in config is set to None.
                    See documentation on 'scale_rate_threshold' in the DEFAULT_CONFIG.
                    Expected a float32 tensor with shape (num_keypoints_in_source/destination_image,)
+            s2: same as s1 but for destination.
             return_dist: if True, inverse confidence value is also outputted.
 
         Returns:

--- a/kornia/feature/adalam/core.py
+++ b/kornia/feature/adalam/core.py
@@ -266,17 +266,18 @@ def adalam_core(
 
     No sanity check is performed on the inputs.
 
-    Inputs:
+    Args:
         k1: keypoint locations in the source image, in pixel coordinates.
             Expected a float32 tensor with shape (num_keypoints_in_source_image, 2).
         k2: keypoint locations in the destination image, in pixel coordinates.
             Expected a float32 tensor with shape (num_keypoints_in_destination_image, 2).
-        fn12: Initial set of putative matches to be filtered.
+        fnn12: Initial set of putative matches to be filtered.
               The current implementation assumes that these are unfiltered nearest neighbor matches,
               so it requires this to be a list of indices a_i such that the source keypoint i is associated to the
               destination keypoint a_i. For now to use AdaLAM on different inputs a workaround on the input format is
               required. Expected a long tensor with shape (num_keypoints_in_source_image,).
         scores1: Confidence scores on the putative_matches. Usually holds Lowe's ratio scores.
+        config: Adalam configuration.
         mnn: A mask indicating which putative matches are also mutual nearest neighbors. See documentation on
              'force_seed_mnn' in the DEFAULT_CONFIG. If None, it disables the mutual nearest neighbor filtering on seed
              point selection. Expected a bool tensor with shape (num_keypoints_in_source_image,)
@@ -286,12 +287,14 @@ def adalam_core(
         im2shape: Shape of the destination image. If None, it is inferred from keypoints max and min, at the cost of
                   wasted runtime. So please provide it. Expected a tuple with (width, height) or (height, width) of
                   destination image
-        o1/o2: keypoint orientations in degrees. They can be None if 'orientation_difference_threshold' in config is
+        o1: keypoint orientations in degrees. They can be None if 'orientation_difference_threshold' in config is
                set to None. See documentation on 'orientation_difference_threshold' in the DEFAULT_CONFIG.
                Expected a float32 tensor with shape (num_keypoints_in_source/destination_image,)
-        s1/s2: keypoint scales. They can be None if 'scale_rate_threshold' in config is set to None.
+        o2: Same as o1 but for destination.
+        s1: keypoint scales. They can be None if 'scale_rate_threshold' in config is set to None.
                See documentation on 'scale_rate_threshold' in the DEFAULT_CONFIG.
                Expected a float32 tensor with shape (num_keypoints_in_source/destination_image,)
+        s2: Same as s1 but for destination.
         return_dist: if True, inverse confidence value is also outputted. Default is False
 
     Returns:

--- a/kornia/feature/affine_shape.py
+++ b/kornia/feature/affine_shape.py
@@ -125,7 +125,7 @@ class LAFAffineShapeEstimator(nn.Module):
         """Run forward.
 
         Args:
-            LAF: :math:`(B, N, 2, 3)`
+            laf: :math:`(B, N, 2, 3)`
             img: :math:`(B, 1, H, W)`
 
         Returns:
@@ -220,7 +220,7 @@ class LAFAffNetShapeEstimator(nn.Module):
         """Run forward.
 
         Args:
-            LAF: :math:`(B, N, 2, 3)`
+            laf: :math:`(B, N, 2, 3)`
             img: :math:`(B, 1, H, W)`
 
         Returns:

--- a/kornia/feature/dedode/dedode.py
+++ b/kornia/feature/dedode/dedode.py
@@ -75,6 +75,7 @@ class DeDoDe(Module):
             images: A tensor of shape :math:`(B, 3, H, W)` containing the ImageNet-Normalized input images.
             n: The number of keypoints to detect.
             apply_imagenet_normalization: Whether to apply ImageNet normalization to the input images.
+            pad_if_not_divisible: pad image shape if not evenly divisible.
 
         Returns:
             keypoints: A tensor of shape :math:`(B, N, 2)` containing the detected keypoints in the image range,
@@ -112,6 +113,7 @@ class DeDoDe(Module):
             images: A tensor of shape :math:`(B, 3, H, W)` containing the input images.
             n: The number of keypoints to detect.
             apply_imagenet_normalization: Whether to apply ImageNet normalization to the input images.
+            pad_if_not_divisible: pad image shape if not evenly divisible.
             crop_h: The height of the crop to be used for detection. If None, the full image is used.
             crop_w: The width of the crop to be used for detection. If None, the full image is used.
 

--- a/kornia/feature/integrated.py
+++ b/kornia/feature/integrated.py
@@ -475,6 +475,8 @@ class LightGlueMatcher(GeometryAwareDescriptorMatcher):
             desc2: Batch of descriptors of a shape :math:`(B2, D)`.
             lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`.
             lafs2: LAFs of a shape :math:`(1, B2, 2, 3)`.
+            hw1: Height/width of image.
+            hw2: Height/width of image.
 
         Return:
             - Descriptor distance of matching descriptors, shape of :math:`(B3, 1)`.

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -78,7 +78,7 @@ def rotate_laf(LAF: Tensor, angles_degrees: Tensor) -> Tensor:
 
     Args:
         LAF: :math:`(B, N, 2, 3)`
-        angles: :math:`(B, N, 1)` in degrees.
+        angles_degrees: :math:`(B, N, 1)` in degrees.
 
     Returns:
         LAF oriented with angles :math:`(B, N, 2, 3)`
@@ -97,7 +97,7 @@ def set_laf_orientation(LAF: Tensor, angles_degrees: Tensor) -> Tensor:
 
     Args:
         LAF: :math:`(B, N, 2, 3)`
-        angles: :math:`(B, N, 1)` in degrees.
+        angles_degrees: :math:`(B, N, 1)` in degrees.
 
     Returns:
         LAF oriented with angles :math:`(B, N, 2, 3)`
@@ -117,7 +117,7 @@ def laf_from_center_scale_ori(xy: Tensor, scale: Optional[Tensor] = None, ori: O
     Args:
         xy: :math:`(B, N, 2)`.
         scale: :math:`(B, N, 1, 1)`. If not provided, scale = 1.0 is assumed
-        angle in degrees: :math:`(B, N, 1)`. If not provided orientation = 0 is assumed
+        ori: angle in degrees :math:`(B, N, 1)`. If not provided orientation = 0 is assumed
 
     Returns:
         LAF :math:`(B, N, 2, 3)`
@@ -144,7 +144,7 @@ def scale_laf(laf: Tensor, scale_coef: Union[float, Tensor]) -> Tensor:
     So the center, shape and orientation of the local feature stays the same, but the region area changes.
 
     Args:
-        LAF :math:`(B, N, 2, 3)`
+        laf: :math:`(B, N, 2, 3)`
         scale_coef: broadcastable tensor or float.
 
     Returns:
@@ -275,7 +275,7 @@ def get_laf_pts_to_draw(LAF: Tensor, img_idx: int = 0) -> Tuple[List[int], List[
 
     Args:
         LAF: :math:`(B, N, 2, 3)`
-        n_pts: number of points to output.
+        img_idx: which points to output.
 
     Returns:
         List of boundary points x, y`

--- a/kornia/feature/loftr/utils/coarse_matching.py
+++ b/kornia/feature/loftr/utils/coarse_matching.py
@@ -14,8 +14,8 @@ def mask_border(m: Tensor, b: int, v: Union[Tensor, float, bool]) -> None:
 
     Args:
         m (torch.Tensor): [N, H0, W0, H1, W1]
-        b (int)
-        v (m.dtype)
+        b (int): border size.
+        v (m.dtype): border value.
     """
     if b <= 0:
         return
@@ -52,7 +52,8 @@ def compute_max_candidates(p_m0: Tensor, p_m1: Tensor) -> Tensor:
     """Compute the max candidates of all pairs within a batch.
 
     Args:
-        p_m0, p_m1 (torch.Tensor): padded masks
+        p_m0: padded mask 0
+        p_m1: padded mask 1
 
     """
     h0s, w0s = p_m0.sum(1).max(-1)[0], p_m0.sum(-1).max(-1)[0]
@@ -99,8 +100,8 @@ class CoarseMatching(Module):
         """Run forward.
 
         Args:
-            feat0 (torch.Tensor): [N, L, C]
-            feat1 (torch.Tensor): [N, S, C]
+            feat_c0 (torch.Tensor): [N, L, C]
+            feat_c1 (torch.Tensor): [N, S, C]
             data (dict)
             mask_c0 (torch.Tensor): [N, L] (optional)
             mask_c1 (torch.Tensor): [N, S] (optional)

--- a/kornia/feature/loftr/utils/fine_matching.py
+++ b/kornia/feature/loftr/utils/fine_matching.py
@@ -20,8 +20,8 @@ class FineMatching(Module):
         """Run forward.
 
         Args:
-            feat0 (torch.Tensor): [M, WW, C]
-            feat1 (torch.Tensor): [M, WW, C]
+            feat_f0 (torch.Tensor): [M, WW, C]
+            feat_f1 (torch.Tensor): [M, WW, C]
             data (dict)
         Update:
             data (dict):{

--- a/kornia/feature/loftr/utils/position_encoding.py
+++ b/kornia/feature/loftr/utils/position_encoding.py
@@ -15,6 +15,7 @@ class PositionEncodingSine(Module):
         """Construct sinusoidal positional encoding.
 
         Args:
+        d_model: Dimensions of model input.
         max_shape (tuple): for 1/8 featmap, the max length of 256 corresponds to 2048 pixels
         temp_bug_fix (bool): As noted in this [issue](https://github.com/zju3dv/LoFTR/issues/41),
             the original implementation of LoFTR includes a bug in the pos-enc impl, which has little impact

--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -33,7 +33,7 @@ def _get_lazy_distance_matrix(desc1: Tensor, desc2: Tensor, dm_: Optional[Tensor
     Args:
         desc1: Batch of descriptors of a shape :math:`(B1, D)`.
         desc2: Batch of descriptors of a shape :math:`(B2, D)`.
-        dm: Tensor containing the distances from each descriptor in desc1
+        dm_: Tensor containing the distances from each descriptor in desc1
           to each descriptor in desc2, shape of :math:`(B1, B2)`.
 
     """

--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -24,6 +24,7 @@ def _scale_index_to_scale(max_coords: Tensor, sigmas: Tensor, num_levels: int) -
     Args:
         max_coords: tensor [BxNx3].
         sigmas: tensor [BxNxD], D >= 1
+        num_levels: number of levels in the scale index.
 
     Returns:
         tensor [BxNx3].

--- a/kornia/feature/sold2/sold2.py
+++ b/kornia/feature/sold2/sold2.py
@@ -115,8 +115,10 @@ class SOLD2(Module):
         """Find the best matches between two sets of line segments and their corresponding descriptors.
 
         Args:
-            line_seg1, line_seg2: list of line segments in two images, with shape [num_lines, 2, 2].
-            desc1, desc2: semi-dense descriptor maps of the images, with shape [1, 128, H/4, W/4].
+            line_seg1: list of line segments in image 1, with shape [num_lines, 2, 2].
+            line_seg2: list of line segments in image 2, with shape [num_lines, 2, 2].
+            desc1: semi-dense descriptor map of image 1, with shape [1, 128, H/4, W/4].
+            desc2: semi-dense descriptor map of image 2, with shape [1, 128, H/4, W/4].
 
         Returns:
             A np.array of size [num_lines1] indicating the index in line_seg2 of the matched line,
@@ -207,9 +209,11 @@ class WunschLineMatcher(Module):
         """Regularly sample points along each line segments, with a minimal distance between each point.
 
         Pad the remaining points.
-        Inputs:
+
+        Args:
             line_seg: an Nx2x2 Tensor.
-        Outputs:
+
+        Returns:
             line_points: an N x num_samples x 2 Tensor.
             valid_points: a boolean N x num_samples Tensor.
         """

--- a/kornia/feature/sold2/sold2.py
+++ b/kornia/feature/sold2/sold2.py
@@ -251,10 +251,11 @@ class WunschLineMatcher(Module):
 
         Compute the Needleman- Wunsch algorithm on each candidate pairs, and keep the highest score.
 
-        Inputs:
+        Args:
             scores: a (N, M, n, n) Tensor containing the pairwise scores
                     of the elements to match.
-        Outputs:
+
+        Returns:
             matches: a (N) Tensor containing the indices of the best match
         """
         KORNIA_CHECK_SHAPE(scores, ["M", "N", "n", "n"])
@@ -290,7 +291,8 @@ class WunschLineMatcher(Module):
 
         The cost of the InDel operation is set to 0 by subtracting the gap
         penalty to the scores.
-        Inputs:
+
+        Args:
             scores: a (B, N, M) Tensor containing the pairwise scores
                     of the elements to match.
         """

--- a/kornia/feature/sold2/sold2_detector.py
+++ b/kornia/feature/sold2/sold2_detector.py
@@ -33,7 +33,7 @@ class SOLD2_detector(Module):
 
     Example:
         >>> img = torch.rand(1, 1, 512, 512)
-        >>> sold2_detector = SOLD2_detector()
+        >>> sold2_detector = SOLD2_detector(pretrained=False)
         >>> line_segments = sold2_detector(img)["line_segments"]
 
     """

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -27,7 +27,7 @@ def box_blur(
         \end{bmatrix}
 
     Args:
-        image: the image to blur with shape :math:`(B,C,H,W)`.
+        input: the image to blur with shape :math:`(B,C,H,W)`.
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
           The expected modes are: ``'constant'``, ``'reflect'``, ``'replicate'`` or ``'circular'``.

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -139,8 +139,9 @@ def blur_pool2d(input: Tensor, kernel_size: tuple[int, int] | int, stride: int =
     See :cite:`zhang2019shiftinvar` for more details.
 
     Args:
-        kernel_size: the kernel size for max pooling..
-        ceil_mode: should be true to match output size of conv2d with same kernel size.
+        input: tensor to apply operation to.
+        kernel_size: the kernel size for max pooling.
+        stride: stride for pooling.
 
     Shape:
         - Input: :math:`(B, C, H, W)`
@@ -187,6 +188,7 @@ def max_blur_pool2d(
     See :class:`~kornia.filters.MaxBlurPool2D` for details.
 
     Args:
+        input: tensor to apply operation to.
         kernel_size: the kernel size for max pooling.
         stride: stride for pooling.
         max_pool_size: the kernel size for max pooling.

--- a/kornia/geometry/camera/perspective.py
+++ b/kornia/geometry/camera/perspective.py
@@ -13,7 +13,7 @@ def project_points(point_3d: torch.Tensor, camera_matrix: torch.Tensor) -> torch
     r"""Project a 3d point onto the 2d camera plane.
 
     Args:
-        point3d: tensor containing the 3d points to be projected
+        point_3d: tensor containing the 3d points to be projected
             to the camera plane. The shape of the tensor can be :math:`(*, 3)`.
         camera_matrix: tensor containing the intrinsics camera
             matrix. The tensor shape must be :math:`(*, 3, 3)`.
@@ -45,7 +45,7 @@ def unproject_points(
     Transform coordinates in the pixel frame to the camera frame.
 
     Args:
-        point2d: tensor containing the 2d to be projected to
+        point_2d: tensor containing the 2d to be projected to
             world coordinates. The shape of the tensor can be :math:`(*, 2)`.
         depth: tensor containing the depth value of each 2d
             points. The tensor shape must be equal to point2d :math:`(*, 1)`.

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -303,7 +303,7 @@ class PinholeCamera:
         r"""Project a 3d point in world coordinates onto the 2d camera plane.
 
         Args:
-            point3d: tensor containing the 3d points to be projected
+            point_3d: tensor containing the 3d points to be projected
                 to the camera plane. The shape of the tensor can be :math:`(*, 3)`.
 
         Returns:
@@ -330,7 +330,7 @@ class PinholeCamera:
         Transform coordinates in the pixel frame to the world frame.
 
         Args:
-            point2d: tensor containing the 2d to be projected to
+            point_2d: tensor containing the 2d to be projected to
                 world coordinates. The shape of the tensor can be :math:`(*, 2)`.
             depth: tensor containing the depth value of each 2d
                 points. The tensor shape must be equal to point2d :math:`(*, 1)`.
@@ -462,6 +462,7 @@ def pinhole_matrix(pinholes: Tensor, eps: float = 1e-6) -> Tensor:
 
     Args:
         pinholes: tensor of pinhole models.
+        eps: epsilon for numerical stability.
 
     Returns:
         tensor of pinhole matrices.
@@ -506,7 +507,8 @@ def inverse_pinhole_matrix(pinhole: Tensor, eps: float = 1e-6) -> Tensor:
         :attr:`kornia.PinholeCamera.intrinsics_inverse()`.
 
     Args:
-        pinholes: tensor with pinhole models.
+        pinhole: tensor with pinhole models.
+        eps: epsilon for numerical stability.
 
     Returns:
         tensor of inverted pinhole matrices.
@@ -686,7 +688,7 @@ def cam2pixel(cam_coords_src: Tensor, dst_proj_src: Tensor, eps: float = 1e-12) 
     r"""Transform coordinates in the camera frame to the pixel frame.
 
     Args:
-        cam_coords: (x, y, z) coordinates defined in the first camera coordinates system. Shape must be BxHxWx3.
+        cam_coords_src: (x, y, z) coordinates defined in the first camera coordinates system. Shape must be BxHxWx3.
         dst_proj_src: the projection matrix between the
           reference and the non reference camera frame. Shape must be Bx4x4.
         eps: small value to avoid division by zero error.

--- a/kornia/geometry/camera/stereo.py
+++ b/kornia/geometry/camera/stereo.py
@@ -15,8 +15,8 @@ class StereoException(Exception):
 
         Args:
             msg: Custom message to add to the general message.
-            *args:
-            **kwargs:
+            *args: Additional argument passthrough
+            **kwargs: Additional argument passthrough
 
         """
         doc_help = (

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1049,9 +1049,11 @@ def normal_transform_pixel(
     r"""Compute the normalization matrix from image size in pixels to [-1, 1].
 
     Args:
-        height image height.
+        height: image height.
         width: image width.
         eps: epsilon to prevent divide-by-zero errors
+        device: device to place the result on.
+        dtype: dtype of the result.
 
     Returns:
         normalized transform with shape :math:`(1, 3, 3)`.
@@ -1084,6 +1086,8 @@ def normal_transform_pixel3d(
         height: image height.
         width: image width.
         eps: epsilon to prevent divide-by-zero errors
+        device: device to place the result on.
+        dtype: dtype of the result.
 
     Returns:
         normalized transform with shape :math:`(1, 4, 4)`.
@@ -1151,7 +1155,7 @@ def normalize_homography3d(
         dst_pix_trans_src_pix: homography/ies from source to destination to be
           normalized. :math:`(B, 4, 4)`
         dsize_src: size of the source image (depth, height, width).
-        dsize_src: size of the destination image (depth, height, width).
+        dsize_dst: size of the destination image (depth, height, width).
 
     Returns:
         the normalized homography.
@@ -1315,7 +1319,7 @@ def camtoworld_graphics_to_vision_4x4(extrinsics_graphics: Tensor) -> Tensor:
     Vision convention: [+x, +y, +z] == [right, down, forwards].
 
     Args:
-        extrinsics: pose matrix :math:`(B, 4, 4)`.
+        extrinsics_graphics: pose matrix :math:`(B, 4, 4)`.
 
     Returns:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
@@ -1375,7 +1379,7 @@ def camtoworld_vision_to_graphics_4x4(extrinsics_vision: Tensor) -> Tensor:
     Vision convention: [+x, +y, +z] == [right, down, forwards].
 
     Args:
-        extrinsics: pose matrix :math:`(B, 4, 4)`.
+        extrinsics_vision: pose matrix :math:`(B, 4, 4)`.
 
     Returns:
         extrinsics: pose matrix :math:`(B, 4, 4)`.
@@ -1533,7 +1537,7 @@ def vector_to_skew_symmetric_matrix(vec: Tensor) -> Tensor:
         -v2 & v1 & 0\end{bmatrix}
 
     Args:
-        x: tensor of shape :math:`(B, 3)`.
+        vec: tensor of shape :math:`(B, 3)`.
 
     Returns:
         tensor of shape :math:`(B, 3, 3)`.

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -46,9 +46,13 @@ def unproject_meshgrid(
         the meshgrid computation when warping multiple frames with the same camera intrinsics.
 
     Args:
+        height: height of image.
+        width: width of image.
         camera_matrix: tensor containing the camera intrinsics with shape :math:`(3, 3)`.
         normalize_points: whether to normalize the pointcloud. This must be set to `True` when the depth is
           represented as the Euclidean ray length from the camera position.
+        device: device to place the result on.
+        dtype: dtype of the result.
 
     Return:
         tensor with a 3d point per pixel of the same resolution as the input :math:`(*, H, W, 3)`.
@@ -89,6 +93,7 @@ def depth_to_3d_v2(
         camera_matrix: tensor containing the camera intrinsics with shape :math:`(*, 3, 3)`.
         normalize_points: whether to normalise the pointcloud. This must be set to `True` when the depth is
           represented as the Euclidean ray length from the camera position.
+        xyz_grid: explicit xyz point values.
 
     Return:
         tensor with a 3d point per pixel of the same resolution as the input :math:`(*, H, W, 3)`.
@@ -215,6 +220,7 @@ def depth_from_plane_equation(
         plane_offsets (Tensor): Plane offsets of shape (B, 1).
         points_uv (Tensor): Pixel coordinates of shape (B, N, 2).
         camera_matrix (Tensor): Camera intrinsic matrix of shape (B, 3, 3).
+        eps: epsilon for numerical stability.
 
     Returns:
         Tensor: Computed depth values at the given pixels, shape (B, N).

--- a/kornia/geometry/epipolar/projection.py
+++ b/kornia/geometry/epipolar/projection.py
@@ -117,6 +117,7 @@ def KRt_from_projection(P: Tensor, eps: float = 1e-6) -> Tuple[Tensor, Tensor, T
 
     Args:
         P: the projection matrix with shape :math:`(B, 3, 4)`.
+        eps: epsilon for numerical stability.
 
     Returns:
         - The Camera matrix with shape :math:`(B, 3, 3)`.

--- a/kornia/geometry/liegroup/se2.py
+++ b/kornia/geometry/liegroup/se2.py
@@ -255,6 +255,8 @@ class Se2(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = Se2.identity(1)
@@ -338,6 +340,8 @@ class Se2(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = Se2.random()

--- a/kornia/geometry/liegroup/se3.py
+++ b/kornia/geometry/liegroup/se3.py
@@ -255,6 +255,8 @@ class Se3(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = Se3.identity()
@@ -362,6 +364,8 @@ class Se3(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = Se3.random()

--- a/kornia/geometry/liegroup/so2.py
+++ b/kornia/geometry/liegroup/so2.py
@@ -216,6 +216,8 @@ class So2(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = So2.identity(batch_size=2)
@@ -252,6 +254,8 @@ class So2(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = So2.random()

--- a/kornia/geometry/liegroup/so3.py
+++ b/kornia/geometry/liegroup/so3.py
@@ -36,7 +36,7 @@ class So3(Module):
         Internally represented by a unit quaternion `q`.
 
         Args:
-            data: Quaternion with the shape of :math:`(B, 4)`.
+            q: Quaternion with the shape of :math:`(B, 4)`.
 
         Example:
             >>> data = torch.ones((2, 4))
@@ -266,6 +266,8 @@ class So3(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = So3.identity()
@@ -302,6 +304,8 @@ class So3(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> s = So3.random()

--- a/kornia/geometry/line.py
+++ b/kornia/geometry/line.py
@@ -142,6 +142,7 @@ class ParametrizedLine(Module):
 
         Args:
             plane: the plane to compute the intersection point.
+            eps: epsilon for numerical stability.
 
         Return:
             - the lambda value used to compute the look at point.

--- a/kornia/geometry/pose.py
+++ b/kornia/geometry/pose.py
@@ -42,8 +42,8 @@ class NamedPose:
 
         Args:
             dst_from_src: Pose from source frame to destination frame.
-            src: Name of frame a.
-            dst: Name of frame b.
+            frame_src: Name of frame a.
+            frame_dst: Name of frame b.
 
         """
         self._dst_from_src = dst_from_src

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -344,6 +344,8 @@ class Quaternion(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> q = Quaternion.identity()
@@ -388,6 +390,8 @@ class Quaternion(Module):
 
         Args:
             batch_size: the batch size of the underlying data.
+            device: device to place the result on.
+            dtype: dtype of the result.
 
         Example:
             >>> q = Quaternion.random()

--- a/kornia/geometry/solvers/polynomial_solver.py
+++ b/kornia/geometry/solvers/polynomial_solver.py
@@ -212,7 +212,7 @@ def multiply_deg_one_poly(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 
     Args:
         a: a first order polynomial for variables :math:`(x,y,z,1)`.
-                b: a first order polynomial for variables :math:`(x,y,z,1)`.
+        b: a first order polynomial for variables :math:`(x,y,z,1)`.
 
     Returns:
         degree 2 poly with the order :math:`(x^2, x*y, x*z, x, y^2, y*z, y, z^2, z, 1)`.

--- a/kornia/geometry/subpix/spatial_soft_argmax.py
+++ b/kornia/geometry/subpix/spatial_soft_argmax.py
@@ -21,7 +21,7 @@ def _get_window_grid_kernel2d(h: int, w: int, device: Optional[torch.device] = N
 
     Args:
          h: kernel height.
-         : kernel width.
+         w: kernel width.
          device: device, on which generate.
 
     Returns:

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -543,7 +543,7 @@ def resize(
     .. image:: _static/img/resize.png
 
     Args:
-        tensor: The image tensor to be skewed with shape of :math:`(..., H, W)`.
+        input: The image tensor to be skewed with shape of :math:`(..., H, W)`.
             `...` means there can be any number of dimensions.
         size: Desired output size. If size is a sequence like (h, w),
             output size will be matched to this. If size is an int, smaller edge of the image will

--- a/kornia/geometry/transform/crop2d.py
+++ b/kornia/geometry/transform/crop2d.py
@@ -300,7 +300,7 @@ def crop_by_indices(
     """Crop tensors with naive indices.
 
     Args:
-        input: the 2D image tensor with shape (B, C, H, W).
+        input_tensor: the 2D image tensor with shape (B, C, H, W).
         src_box: a tensor with shape (B, 4, 2) containing the coordinates of the bounding boxes
             to be extracted. The tensor must have the shape of Bx4x2, where each box is defined in the clockwise
             order: top-left, top-right, bottom-right and bottom-left. The coordinates must be in x, y order.

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -700,7 +700,7 @@ def get_affine_matrix3d(
         translations: tensor containing the translation vector (dx,dy,dz) with shape :math:`(B, 3)`.
         center: tensor containing the center vector (x,y,z) with shape :math:`(B, 3)`.
         scale: tensor containing the scale factor with shape :math:`(B)`.
-        angle: axis angle vector containing the rotation angles in degrees in the form
+        angles: axis angle vector containing the rotation angles in degrees in the form
             of (rx, ry, rz) with shape :math:`(B, 3)`. Internally it calls Rodrigues to compute
             the rotation matrix from axis-angle.
         sxy: tensor containing the shear factor in the xy-direction with shape :math:`(B)`.
@@ -855,7 +855,7 @@ def warp_affine3d(
         src : input tensor of shape :math:`(B, C, D, H, W)`.
         M: projective transformation matrix of shape :math:`(B, 3, 4)`.
         dsize: size of the output image (depth, height, width).
-        mode: interpolation mode to calculate output values
+        flags: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
           ``'zeros'`` | ``'border'`` | ``'reflection'``.

--- a/kornia/image/image.py
+++ b/kornia/image/image.py
@@ -187,6 +187,7 @@ class Image:
             data: a numpy array containing the image data.
             color_space: the color space of the image.
             pixel_format: the pixel format of the image.
+            channels_order: what dimension the channels are in the image tensor.
 
         Example:
             >>> data = np.ones((4, 5, 3), dtype=np.uint8)  # HxWxC

--- a/kornia/losses/dice.py
+++ b/kornia/losses/dice.py
@@ -46,7 +46,7 @@ def dice_loss(
 
     Args:
         pred: logits tensor with shape :math:`(N, C, H, W)` where C = number of classes.
-        labels: labels tensor with shape :math:`(N, H, W)` where each value
+        target: labels tensor with shape :math:`(N, H, W)` where each value
           is :math:`0 ≤ targets[i] ≤ C-1`.
         average:
             Reduction applied in multi-class scenario:

--- a/kornia/losses/lovasz_hinge.py
+++ b/kornia/losses/lovasz_hinge.py
@@ -40,7 +40,7 @@ def lovasz_hinge_loss(pred: Tensor, target: Tensor) -> Tensor:
 
     Args:
         pred: logits tensor with shape :math:`(N, 1, H, W)`.
-        labels: labels tensor with shape :math:`(N, H, W)` with binary values.
+        target: labels tensor with shape :math:`(N, H, W)` with binary values.
 
     Return:
         a scalar with the computed loss.

--- a/kornia/losses/lovasz_softmax.py
+++ b/kornia/losses/lovasz_softmax.py
@@ -41,7 +41,7 @@ def lovasz_softmax_loss(pred: Tensor, target: Tensor, weight: Optional[Tensor] =
 
     Args:
         pred: logits tensor with shape :math:`(N, C, H, W)` where C = number of classes > 1.
-        labels: labels tensor with shape :math:`(N, H, W)` where each value
+        target: labels tensor with shape :math:`(N, H, W)` where each value
           is :math:`0 ≤ targets[i] ≤ C-1`.
         weight: weights for classes with shape :math:`(num\_of\_classes,)`.
 

--- a/kornia/losses/ms_ssim.py
+++ b/kornia/losses/ms_ssim.py
@@ -93,6 +93,8 @@ class MS_SSIMLoss(nn.Module):
         Args:
             size: the size of gauss kernel.
             sigma: sigma of normal distribution.
+            device: device to store the result on.
+            dtype: dtype of the result.
 
         Returns:
             1D kernel (size).
@@ -112,6 +114,8 @@ class MS_SSIMLoss(nn.Module):
         Args:
             size: the size of gauss kernel.
             sigma: sigma of normal distribution.
+            device: device to store the result on.
+            dtype: dtype of the result.
 
         Returns:
             2D kernel (size x size).

--- a/kornia/losses/psnr.py
+++ b/kornia/losses/psnr.py
@@ -19,7 +19,7 @@ def psnr_loss(image: torch.Tensor, target: torch.Tensor, max_val: float) -> torc
 
     Args:
         image: the input image with shape :math:`(*)`.
-        labels : the labels image with shape :math:`(*)`.
+        target : the labels image with shape :math:`(*)`.
         max_val: The maximum value in the image tensor.
 
     Return:

--- a/kornia/metrics/mean_iou.py
+++ b/kornia/metrics/mean_iou.py
@@ -17,6 +17,7 @@ def mean_iou(pred: torch.Tensor, target: torch.Tensor, num_classes: int, eps: fl
           values between 0 and K-1, where targets are assumed to be provided as
           one-hot vectors.
         num_classes: total possible number of classes in target.
+        eps: epsilon for numerical stability.
 
     Returns:
         a tensor representing the mean intersection-over union

--- a/kornia/metrics/psnr.py
+++ b/kornia/metrics/psnr.py
@@ -23,7 +23,7 @@ def psnr(image: torch.Tensor, target: torch.Tensor, max_val: float) -> torch.Ten
 
     Args:
         image: the input image with arbitrary shape :math:`(*)`.
-        labels: the labels image with arbitrary shape :math:`(*)`.
+        target: the labels image with arbitrary shape :math:`(*)`.
         max_val: The maximum value in the input tensor.
 
     Return:

--- a/kornia/models/_hf_models/hf_onnx_community.py
+++ b/kornia/models/_hf_models/hf_onnx_community.py
@@ -133,6 +133,7 @@ class HFONNXComunnityModel(ONNXSequential, ModelBaseMixin):
                 If to save the model or load it.
             additional_metadata:
                 Additional metadata to add to the ONNX model.
+            kwargs: Additional arguments to convert to onnx.
 
         """
         if onnx_name is None:

--- a/kornia/models/base.py
+++ b/kornia/models/base.py
@@ -57,6 +57,7 @@ class ModelBaseMixin:
         Args:
             outputs: output tensor.
             directory: directory to save the images.
+            suffix: filename suffix.
 
         """
         if directory is None:
@@ -84,6 +85,7 @@ class ModelBase(Module, ONNXExportMixin, ModelBaseMixin):
             model: an object detection model.
             pre_processor: a pre-processing module
             post_processor: a post-processing module.
+            name: name of a model.
 
         """
         super().__init__()

--- a/kornia/models/depth_estimation/base.py
+++ b/kornia/models/depth_estimation/base.py
@@ -55,6 +55,7 @@ class DepthEstimation(HFONNXComunnityModel):
 
         Args:
             images: input tensor.
+            depth_maps: estimated depths.
             output_type: type of the output.
             depth_type: 'metric' or 'relative' depth.
             max_depth: maximum depth value. Only valid for metric depth.
@@ -90,9 +91,11 @@ class DepthEstimation(HFONNXComunnityModel):
 
         Args:
             images: input tensor.
+            depth_maps: estimated depths.
             output_type: type of the output.
             depth_type: 'metric' or 'relative' depth.
             max_depth: maximum depth value. Only valid for metric depth.
+            directory: where to store outputs.
 
         Returns:
             output tensor.

--- a/kornia/models/detection/base.py
+++ b/kornia/models/detection/base.py
@@ -75,6 +75,7 @@ def results_from_detections(detections: Tensor, format: str | BoundingBoxDataFor
     Args:
         detections: tensor with shape :math:`(D, 6)`, where :math:`D` is the number of detections in the given image,
             :math:`6` represents class id, score, and `xywh` bounding box.
+        format: detection format.
 
     Returns:
         list of :py:class:`ObjectDetectorResult`.
@@ -185,6 +186,7 @@ class ObjectDetector(ModelBase):
                 If to save the model or load it.
             additional_metadata:
                 Additional metadata to add to the ONNX model.
+            kwargs: Additional arguments to convert to onnx.
 
         """
         if onnx_name is None:

--- a/kornia/models/detection/rtdetr.py
+++ b/kornia/models/detection/rtdetr.py
@@ -51,6 +51,9 @@ class RTDETRDetectorBuilder:
                 The size to which input images will be resized during preprocessing.
                 If None, no resizing will be inferred from config file. Recommended scales include
                 [480, 512, 544, 576, 608, 640, 672, 704, 736, 768, 800].
+            confidence_threshold: Threshold to filter results based on confidence scores.
+            confidence_filtering: Whether to filter results based on confidence scores.
+
 
         Returns:
             ObjectDetector

--- a/kornia/models/edge_detection/base.py
+++ b/kornia/models/edge_detection/base.py
@@ -44,6 +44,7 @@ class EdgeDetector(ModelBase):
 
         Args:
             images: input tensor.
+            edge_maps: detected edges.
             output_type: type of the output.
 
         Returns:
@@ -69,7 +70,9 @@ class EdgeDetector(ModelBase):
 
         Args:
             images: input tensor.
+            edge_maps: detected edges.
             output_type: type of the output.
+            directory: where to save outputs.
 
         Returns:
             output tensor.
@@ -103,6 +106,7 @@ class EdgeDetector(ModelBase):
                 If to save the model or load it.
             additional_metadata:
                 Additional metadata to add to the ONNX model.
+            kwargs: Additional arguments to convert to onnx.
 
         """
         if onnx_name is None:

--- a/kornia/models/segmentation/segmentation_models.py
+++ b/kornia/models/segmentation/segmentation_models.py
@@ -37,6 +37,7 @@ class SegmentationModelsBuilder:
             decoder_channels: Number of channels in the decoder.
             in_channels: Number of channels in the input.
             classes: Number of classes to predict.
+            activation: Type of activation layer.
             **kwargs: Additional arguments to pass to the model. Detailed arguments can be found at:
                 https://github.com/qubvel-org/segmentation_models.pytorch/tree/main/segmentation_models_pytorch/decoders
 

--- a/kornia/models/super_resolution/base.py
+++ b/kornia/models/super_resolution/base.py
@@ -58,6 +58,7 @@ class SuperResolution(ModelBase):
 
         Args:
             images: input tensor.
+            edge_maps: detected edges.
             output_type: type of the output.
 
         Returns:
@@ -83,7 +84,10 @@ class SuperResolution(ModelBase):
 
         Args:
             images: input tensor.
+            edge_maps: detected edges.
             output_type: type of the output.
+            directory: where to save outputs.
+            output_type: backend used to generate outputs.
 
         Returns:
             output tensor.
@@ -116,6 +120,7 @@ class SuperResolution(ModelBase):
                 If to save the model or load it.
             additional_metadata:
                 Additional metadata to add to the ONNX model.
+            kwargs: Additional arguments for converting to onnx.
 
         """
         if onnx_name is None:

--- a/kornia/models/tracking/boxmot_tracker.py
+++ b/kornia/models/tracking/boxmot_tracker.py
@@ -153,6 +153,8 @@ class BoxMotTracker:
 
         Args:
             image: The input image.
+            show_trajectories: Whether to visualize trajectories.
+            directory: Where to save the file(s).
 
         """
         if directory is None:

--- a/kornia/nerf/camera_utils.py
+++ b/kornia/nerf/camera_utils.py
@@ -17,6 +17,7 @@ def parse_colmap_output(
         cameras_path: Path to camera.txt Colmap file with camera intrinsics: str
         images_path: Path to images.txt Colmap file with camera extrinsics for each image: str
         device: device for created camera object: Union[str, torch.device]
+        dtype: Intrinsics and extrinsics dtype.
 
     Returns:
         image names: List[str]

--- a/kornia/nerf/nerf_solver.py
+++ b/kornia/nerf/nerf_solver.py
@@ -86,7 +86,7 @@ class NerfSolver:
             batch_size: Number of rays to sample in a batch.
             num_ray_points: Number of points to sample along rays.
             irregular_ray_sampling: Whether to sample ray points irregularly.
-            log_space: Whether frequency sampling should be log spaced.
+            log_space_encoding: Whether frequency sampling should be log spaced.
             lr: Learning rate.
 
         """

--- a/kornia/onnx/sequential.py
+++ b/kornia/onnx/sequential.py
@@ -64,6 +64,7 @@ class ONNXSequential(ONNXMixin, ONNXRuntimeMixin):
         If `target_opset_version` is not provided, the model is converted to 17 by default.
 
         Args:
+            args: List of operations to convert.
             target_ir_version: The target IR version to convert to.
             target_opset_version: The target OPSET version to convert to.
 

--- a/kornia/onnx/utils.py
+++ b/kornia/onnx/utils.py
@@ -27,6 +27,7 @@ class ONNXLoader(CachedDownloader):
         Args:
             url: The URL of the preprocessor config to load.
             download: If True, the config will be downloaded if it's not already in the local cache.
+            kwargs: Additional download arguments.
 
         Returns:
             dict[str, Any]: The loaded preprocessor config.

--- a/kornia/utils/download.py
+++ b/kornia/utils/download.py
@@ -23,6 +23,7 @@ class CachedDownloader:
             model_name: The name of the model or operator, typically in the format 'operators/model_name'.
             cache_dir: The directory where the model should be cached.
                 Defaults to None, which will use a default `kornia.config.hub_onnx_dir` directory.
+            suffix: Optional file suffix when the filename is the model name.
 
         Returns:
             str: The full local path where the model should be stored or loaded from.

--- a/kornia/utils/draw.py
+++ b/kornia/utils/draw.py
@@ -260,7 +260,7 @@ def _get_convex_edges(polygon: Tensor, h: int, w: int) -> Tuple[Tensor, Tensor]:
     r"""Get the left and right edges of a polygon for each y-coordinate y \in [0, h).
 
     Args:
-        polygons: represents polygons to draw in BxNx2
+        polygon: represents polygons to draw in BxNx2
             N is the number of points
             2 is (x, y).
         h: bottom most coordinate (top coordinate is assumed to be 0)
@@ -305,7 +305,7 @@ def _batch_polygons(polygons: List[Tensor]) -> Tensor:
     Works by repeating the last element in the tensor.
 
     Args:
-        polygon: List of variable length polygons of shape [N_1 x 2, N_2 x 2, ..., N_B x 2].
+        polygons: List of variable length polygons of shape [N_1 x 2, N_2 x 2, ..., N_B x 2].
                     B is the batch size,
                     N_i is the number of points,
                     2 is (x, y).
@@ -329,7 +329,7 @@ def draw_convex_polygon(images: Tensor, polygons: Union[Tensor, List[Tensor]], c
         polygons: represents polygons as points, either BxNx2 or List of variable length polygons.
             N is the number of points.
             2 is (x, y).
-        color: a B x 3 tensor or 3 tensor with color to fill in.
+        colors: a B x 3 tensor or 3 tensor with color to fill in.
 
     Returns:
         This operation modifies image inplace but also returns the drawn tensor for

--- a/kornia/utils/one_hot.py
+++ b/kornia/utils/one_hot.py
@@ -12,6 +12,7 @@ def one_hot(labels: Tensor, num_classes: int, device: torch.device, dtype: torch
         num_classes: number of classes in labels.
         device: the desired device of returned tensor.
         dtype: the desired data type of returned tensor.
+        eps: epsilon for numerical stability.
 
     Returns:
         the labels in one hot tensor of shape :math:`(N, C, *)`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ ignore = [
   'D104',    # TODO: Undocumented public package
   'D105',    # Allow Undocumented magic method
   'D107',    # TODO: Undocumented public init
-  'D417',    # TODO: Undocumented params
  ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Related to #3083
For any existing `Args:` in docstrings make sure it captures all arguments. I'm not sure how to get it to raise an error if no Args is added at all but there are function/method arguments.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 📚  Documentation Update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code