### PR TITLE
docs: added docstring to the detach tensor to gpu

### DIFF
--- a/kornia/core/module.py
+++ b/kornia/core/module.py
@@ -197,7 +197,7 @@ class ImageModuleMixIn:
             output_image (Union[Tensor, list[Tensor], tuple[Tensor]]): The input tensor(s) to be moved.
 
         Returns:
-            Union[Tensor, list[Tensor], tuple[Tensor]]: The tensor(s) moved to the CPU and detached from 
+            Union[Tensor, list[Tensor], tuple[Tensor]]: The tensor(s) moved to the CPU and detached from
             the computational graph.
         """
         if isinstance(output_image, (Tensor,)):

--- a/kornia/core/module.py
+++ b/kornia/core/module.py
@@ -191,6 +191,15 @@ class ImageModuleMixIn:
     def _detach_tensor_to_cpu(
         self, output_image: Union[Tensor, list[Tensor], tuple[Tensor]]
     ) -> Union[Tensor, list[Tensor], tuple[Tensor]]:
+        """
+        Detach the input tensor (or list/tuple of tensors) from the GPU and move it to the CPU.
+
+        Args:
+            output_image (Union[Tensor, list[Tensor], tuple[Tensor]]): The input tensor(s) to be moved.
+
+        Returns:
+            Union[Tensor, list[Tensor], tuple[Tensor]]: The tensor(s) moved to the CPU and detached from the computational graph.
+        """
         if isinstance(output_image, (Tensor,)):
             return output_image.detach().cpu()
         if isinstance(

--- a/kornia/core/module.py
+++ b/kornia/core/module.py
@@ -197,7 +197,8 @@ class ImageModuleMixIn:
             output_image (Union[Tensor, list[Tensor], tuple[Tensor]]): The input tensor(s) to be moved.
 
         Returns:
-            Union[Tensor, list[Tensor], tuple[Tensor]]: The tensor(s) moved to the CPU and detached from the computational graph.
+            Union[Tensor, list[Tensor], tuple[Tensor]]: The tensor(s) moved to the CPU and detached from 
+            the computational graph.
         """
         if isinstance(output_image, (Tensor,)):
             return output_image.detach().cpu()

--- a/kornia/core/module.py
+++ b/kornia/core/module.py
@@ -191,8 +191,7 @@ class ImageModuleMixIn:
     def _detach_tensor_to_cpu(
         self, output_image: Union[Tensor, list[Tensor], tuple[Tensor]]
     ) -> Union[Tensor, list[Tensor], tuple[Tensor]]:
-        """
-        Detach the input tensor (or list/tuple of tensors) from the GPU and move it to the CPU.
+        """Detach the input tensor (or list/tuple of tensors) from the GPU and move it to the CPU.
 
         Args:
             output_image (Union[Tensor, list[Tensor], tuple[Tensor]]): The input tensor(s) to be moved.


### PR DESCRIPTION
#### Changes

Added a docstring to the `_detach_tensor_to_cpu` function to explain its purpose, parameters, and return type. This improves the understanding of the function's behavior and usage.

Fixes #3130 

#### Type of change
- [x] 📚  Documentation Update

#### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
