### PR TITLE
Avoid 2N x 2N weight matrix allocation in find_homography_dlt

### DIFF
--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -186,8 +186,8 @@ def find_homography_dlt(
         # We should use provided weights
         if not (len(weights.shape) == 2 and weights.shape == points1.shape[:2]):
             raise AssertionError(weights.shape)
-        w_diag = torch.diag_embed(weights.unsqueeze(dim=-1).repeat(1, 1, 2).reshape(weights.shape[0], -1))
-        A = A.transpose(-2, -1) @ w_diag @ A
+        w_full = weights.repeat_interleave(2, dim=1).unsqueeze(1)
+        A = (A.transpose(-2, -1) * w_full) @ A
 
     if solver == "svd":
         try:


### PR DESCRIPTION
#### Changes

`find_homography_dlt` in `kornia.geometry.homography` allocates a 2N x 2N weight matrix when `weights` is provided. This can be a memory bottleneck when N is large. The PR replaces the matrix multiplication with a simple element-wise multiplication to reduce memory footprint and FLOPs.

#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
