### PR TITLE
Remove deprecation decorator from depth_to_3d function

### DIFF
--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -28,7 +28,6 @@ from kornia.core import Module, Tensor, tensor
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
 from kornia.filters.sobel import spatial_gradient
 from kornia.utils import create_meshgrid
-from kornia.utils.helpers import deprecated
 
 from .camera import PinholeCamera, cam2pixel, pixel2cam, project_points, unproject_points
 from .conversions import normalize_pixel_coordinates, normalize_points_with_intrinsics
@@ -134,7 +133,6 @@ def depth_to_3d_v2(
     KORNIA_CHECK_SHAPE(points_xyz, ["*", "H", "W", "3"])
 
     return points_xyz * depth[..., None]  # HxWx3
-
 
 
 def depth_to_3d(depth: Tensor, camera_matrix: Tensor, normalize_points: bool = False) -> Tensor:

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -136,14 +136,7 @@ def depth_to_3d_v2(
     return points_xyz * depth[..., None]  # HxWx3
 
 
-@deprecated(
-    replace_with="depth_to_3d_v2",
-    version="0.8.0",
-    extra_reason=(
-        " This function will be replaced with the `depth_to_3d_v2` behaviour, where the that does not require the"
-        " creation of a meshgrid. The return shape can be not backward compatible between these implementations."
-    ),
-)
+
 def depth_to_3d(depth: Tensor, camera_matrix: Tensor, normalize_points: bool = False) -> Tensor:
     """Compute a 3d point per pixel given its depth value and the camera intrinsics.
 


### PR DESCRIPTION
#### Changes
This PR removes the deprecation decorator from the depth_to_3d function to address issue #3015. Currently, depth_to_normals uses depth_to_3d, which is marked as deprecated, causing users to see deprecation warnings when using depth_to_normals. Since depth_to_3d_v2 is not a direct replacement due to different tensor dimension ordering, this PR removes the deprecation warning until a proper transition can be implemented.
Fixes #3015 


#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)



#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
