### PR TITLE
Fix dedode when calling detect() with padding correctly handled

### DIFF
--- a/kornia/feature/dedode/dedode.py
+++ b/kornia/feature/dedode/dedode.py
@@ -84,7 +84,7 @@ class DeDoDe(Module):
         images: Tensor,
         n: Optional[int] = 10_000,
         apply_imagenet_normalization: bool = True,
-        pad_if_not_divisible: bool = True,
+        pad_if_not_divisible: bool = False,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """Detect and describe keypoints in the input images.
 
@@ -120,7 +120,7 @@ class DeDoDe(Module):
         images: Tensor,
         n: Optional[int] = 10_000,
         apply_imagenet_normalization: bool = True,
-        pad_if_not_divisible: bool = True,
+        pad_if_not_divisible: bool = False,
         crop_h: Optional[int] = None,
         crop_w: Optional[int] = None,
     ) -> Tuple[Tensor, Tensor]:

--- a/kornia/feature/dedode/dedode.py
+++ b/kornia/feature/dedode/dedode.py
@@ -105,8 +105,8 @@ class DeDoDe(Module):
         if apply_imagenet_normalization:
             images = self.normalizer(images)
         B, C, H, W = images.shape
+        h, w = images.shape[2:]
         if pad_if_not_divisible:
-            h, w = images.shape[2:]
             pd_h = 14 - h % 14 if h % 14 > 0 else 0
             pd_w = 14 - w % 14 if w % 14 > 0 else 0
             images = torch.nn.functional.pad(images, (0, pd_w, 0, pd_h), value=0.0)


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
The image into dedode detector is padded to be divisible by 14 by default. However, the output keypoints locations did not handle the padding if the user call detect() only, causing unwanted offset. The forward() did handle the padding. This means the users have to be careful and handle the padding themself if they use detect() only, for example only using the dedode detectors with other matchers such as RoMA or HardNet descriptors. This is pretty error prone if the input image cannot be divided by 14. 

The padding part in detect(), which H,W is image after padding:
https://github.com/kornia/kornia/blob/57296883b1500e87c2a5c92ad76d3708f65dac8b/kornia/feature/dedode/dedode.py#L145-L159

And if one sets the pad_if_not_divisible to false in forward(), the h,w will be assigned which raises an error and crash in L113
https://github.com/kornia/kornia/blob/57296883b1500e87c2a5c92ad76d3708f65dac8b/kornia/feature/dedode/dedode.py#L105-L113

<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->
No.
Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x]  🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
