### PR TITLE
potential fix to #3104 issue

### DIFF
--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -682,7 +682,7 @@ class JPEGCodecDifferentiable(Module):
         device = image_rgb.device
         dtype = image_rgb.dtype
         # Move quantization tables to the same device and dtype as input
-        # and store it in the local variables craeted in init
+        # and store it in the local variables created in init
         quantization_table_y = self.quantization_table_y.to(device, dtype)
         quantization_table_c = self.quantization_table_c.to(device, dtype)
         # Perform encoding-decoding

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -555,6 +555,8 @@ def jpeg_codec_differentiable(
             f"Batch dimensions do not match. "
             f"Got {image_rgb.shape[0]} images and {jpeg_quality.shape[0]} JPEG qualities.",
         )
+    # keep jpeg_quality same device as input tensor
+    jpeg_quality = jpeg_quality.to(device, dtype)
     # Quantization tables to same device and dtype as input image
     quantization_table_y = quantization_table_y.to(device, dtype)
     quantization_table_c = quantization_table_c.to(device, dtype)
@@ -677,11 +679,17 @@ class JPEGCodecDifferentiable(Module):
         image_rgb: Tensor,
         jpeg_quality: Tensor,
     ) -> Tensor:
+        device = image_rgb.device
+        dtype = image_rgb.dtype
+        # Move quantization tables to the same device and dtype as input
+        # and store it in the local variables craeted in init
+        quantization_table_y = self.quantization_table_y.to(device, dtype)
+        quantization_table_c = self.quantization_table_c.to(device, dtype)
         # Perform encoding-decoding
         image_rgb_jpeg: Tensor = jpeg_codec_differentiable(
             image_rgb,
             jpeg_quality=jpeg_quality,
-            quantization_table_c=self.quantization_table_c,
-            quantization_table_y=self.quantization_table_y,
+            quantization_table_c=quantization_table_c,
+            quantization_table_y=quantization_table_y,
         )
         return image_rgb_jpeg


### PR DESCRIPTION
#### Changes
Potential fix for the issue #3104.
Using the Reproduction code, mentioned in the issue was giving the following error,
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```
I found out that the issue was in the `jpeg.py`, below are the potential fixes.


Fixes # (issue)
- Added handling to ensure `jpeg_quality` is also on the correct device [link](https://github.com/soumya997/kornia/blob/somusan_dev/kornia/enhance/jpeg.py#L559).
- Modified the forward pass to move quantization tables to the correct device and dtype based on the input tensor [Link](https://github.com/soumya997/kornia/blob/somusan_dev/kornia/enhance/jpeg.py#L686).

#### Type of change
- [x] :lady_beetle: Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?