### PR TITLE
Fix dedode forward with description padding removed.

### DIFF
--- a/kornia/feature/dedode/dedode.py
+++ b/kornia/feature/dedode/dedode.py
@@ -111,7 +111,7 @@ class DeDoDe(Module):
             pd_w = 14 - w % 14 if w % 14 > 0 else 0
             images = torch.nn.functional.pad(images, (0, pd_w, 0, pd_h), value=0.0)
         keypoints, scores = self.detect(images, n=n, apply_imagenet_normalization=False, crop_h=h, crop_w=w)
-        descriptions = self.describe(images, keypoints, apply_imagenet_normalization=False)
+        descriptions = self.describe(images, keypoints, apply_imagenet_normalization=False, crop_h=h, crop_w=w)
         return dedode_denormalize_pixel_coordinates(keypoints, H, W), scores, descriptions
 
     @torch.inference_mode()
@@ -162,7 +162,9 @@ class DeDoDe(Module):
 
     @torch.inference_mode()
     def describe(
-        self, images: Tensor, keypoints: Optional[Tensor] = None, apply_imagenet_normalization: bool = True
+        self, images: Tensor, keypoints: Optional[Tensor] = None, apply_imagenet_normalization: bool = True,
+        crop_h: Optional[int] = None,
+        crop_w: Optional[int] = None,
     ) -> Tensor:
         """Describe keypoints in the input images. If keypoints are not provided, returns the dense descriptors.
 
@@ -184,6 +186,10 @@ class DeDoDe(Module):
             images = self.normalizer(images)
         self.train(False)
         descriptions = self.descriptor.forward(images)
+        if crop_h is not None and crop_w is not None:
+            descriptions = descriptions[..., :crop_h, :crop_w]
+            H, W = crop_h, crop_w
+
         if keypoints is not None:
             described_keypoints = F.grid_sample(
                 descriptions.float(), keypoints[:, None], mode="bilinear", align_corners=False


### PR DESCRIPTION
During the forward() of dedode, the padded regions are removed for detectors but the descriptions are computed with the padded images.

https://github.com/kornia/kornia/blob/9f5d204c1046ae06b9cb0927f841fc366808ff88/kornia/feature/dedode/dedode.py#L112-L116
To show the important of the fix, I have run @ducha-aiki [notebook on kaggle ](https://www.kaggle.com/code/oldufo/dedode-example-with-and-without-lightglue)

**Before** the fix, the number of inliers with dedode-b and lightglue is ~440. **After** the fix, the number of inliers are increased to **613**.

Before the fix
![before_fix](https://github.com/user-attachments/assets/bcbc1333-6161-42ea-872c-5c63b3bdebdd)

After the fix
![fix_desc](https://github.com/user-attachments/assets/166db618-8724-4721-83dd-60065bb36b3d)


#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
During the forward() of dedode, the padded regions are removed for detectors but the descriptions are computed with the padded images.

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
