### PR TITLE
Updated the Batch functionality for depth_to_3d_v2 function

### DIFF
--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -83,7 +83,7 @@ def unproject_meshgrid(
 
     # project pixels to camera frame
     camera_matrix_tmp: Tensor = camera_matrix[:, None, None]  # Bx1x1x3x3
-    
+
     points_xy = normalize_points_with_intrinsics(points_uv, camera_matrix_tmp)  # HxWx2
 
     # unproject pixels to camera frame

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -74,14 +74,17 @@ def unproject_meshgrid(
         tensor with a 3d point per pixel of the same resolution as the input :math:`(*, H, W, 3)`.
 
     """
-    KORNIA_CHECK_SHAPE(camera_matrix, ["3", "3"])
+    KORNIA_CHECK_SHAPE(camera_matrix, ["*", "3", "3"])
 
     # create base coordinates grid
     points_uv: Tensor = create_meshgrid(
         height, width, normalized_coordinates=False, device=device, dtype=dtype
     ).squeeze()  # HxWx2
 
-    points_xy = normalize_points_with_intrinsics(points_uv, camera_matrix)  # HxWx2
+    # project pixels to camera frame
+    camera_matrix_tmp: Tensor = camera_matrix[:, None, None]  # Bx1x1x3x3
+    
+    points_xy = normalize_points_with_intrinsics(points_uv, camera_matrix_tmp)  # HxWx2
 
     # unproject pixels to camera frame
     points_xyz = convert_points_to_homogeneous(points_xy)  # HxWx3

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -119,9 +119,9 @@ def depth_to_3d_v2(
 
     Example:
         >>> depth = torch.rand(4, 4)
-        >>> K = torch.eye(3)
+        >>> K = torch.eye(3).repeat(2,1,1)
         >>> depth_to_3d_v2(depth, K).shape
-        torch.Size([4, 4, 3])
+        torch.Size([2, 4, 4, 3])
 
     """
     KORNIA_CHECK_SHAPE(depth, ["*", "H", "W"])

--- a/tests/geometry/test_depth.py
+++ b/tests/geometry/test_depth.py
@@ -57,6 +57,7 @@ class TestDepthTo3d(BaseTester):
         # Permute the depth tensor to match the expected input shape for depth_to_3d_v2.
         depth = torch.permute(depth, (1, 0, 2, 3))
         points3d_v2 = kornia.geometry.depth.depth_to_3d_v2(depth[0], camera_matrix)
+        # Align the output format of depth_to_3d with depth_to_3d_v2 by reordering dimensions.
         self.assert_close(points3d.permute(0, 2, 3, 1), points3d_v2)
 
     def test_unproject_meshgrid(self, device, dtype):

--- a/tests/geometry/test_depth.py
+++ b/tests/geometry/test_depth.py
@@ -48,20 +48,21 @@ class TestDepthTo3d(BaseTester):
         assert points3d.shape == (batch_size, 3, 3, 4)
 
     def test_depth_to_3d_v2(self, device, dtype):
-        depth = torch.rand(1, 1, 3, 4, device=device, dtype=dtype)
-        camera_matrix = torch.rand(1, 3, 3, device=device, dtype=dtype)
+        depth = torch.rand(5, 1, 3, 4, device=device, dtype=dtype)
+        camera_matrix = torch.rand(5, 3, 3, device=device, dtype=dtype)
 
         points3d = kornia.geometry.depth.depth_to_3d(depth, camera_matrix)
 
         # TODO: implement me with batch
-        points3d_v2 = kornia.geometry.depth.depth_to_3d_v2(depth[0, 0], camera_matrix[0])
-        self.assert_close(points3d[0].permute(1, 2, 0), points3d_v2)
+        depth = torch.permute(depth, (1, 0, 2, 3))
+        points3d_v2 = kornia.geometry.depth.depth_to_3d_v2(depth[0], camera_matrix)
+        self.assert_close(points3d.permute(0, 2, 3, 1), points3d_v2)
 
     def test_unproject_meshgrid(self, device, dtype):
         # TODO: implement me with batch
-        camera_matrix = torch.eye(3, device=device, dtype=dtype)
+        camera_matrix = torch.eye(3, device=device, dtype=dtype).repeat(2, 1, 1)
         grid = kornia.geometry.unproject_meshgrid(3, 4, camera_matrix, device=device, dtype=dtype)
-        assert grid.shape == (3, 4, 3)
+        assert grid.shape == (2, 3, 4, 3)
         # test for now that the grid is correct and have homogeneous coords
         self.assert_close(grid[..., 2], torch.ones_like(grid[..., 2]))
 

--- a/tests/geometry/test_depth.py
+++ b/tests/geometry/test_depth.py
@@ -54,6 +54,7 @@ class TestDepthTo3d(BaseTester):
         points3d = kornia.geometry.depth.depth_to_3d(depth, camera_matrix)
 
         # TODO: implement me with batch
+        # Permute the depth tensor to match the expected input shape for depth_to_3d_v2.
         depth = torch.permute(depth, (1, 0, 2, 3))
         points3d_v2 = kornia.geometry.depth.depth_to_3d_v2(depth[0], camera_matrix)
         self.assert_close(points3d.permute(0, 2, 3, 1), points3d_v2)


### PR DESCRIPTION
#### Changes
This PR fixes the issue with the depth_to_3d_v2 function when handling batched K matrices. The change ensures proper handling of batched inputs, resolving errors related to matrix dimensions.

Fixes #2709


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
