### PR TITLE
chore: skip dissolving tests

### DIFF
--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -79,7 +79,7 @@ from kornia.augmentation._2d.base import AugmentationBase2D
 from kornia.constants import Resample, pi
 from kornia.geometry import transform_points
 from kornia.utils import create_meshgrid
-from kornia.utils._compat import torch_version
+from kornia.utils._compat import torch_version, torch_version_le
 from kornia.utils.helpers import _torch_inverse_cast
 
 from testing.augmentation.datasets import DummyMPDataset
@@ -5239,6 +5239,7 @@ class TestRandomJPEG(BaseTester):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="transformers clip model needs distributed tensor.")
 class TestRandomDissolving(BaseTester):
     torch.manual_seed(0)  # for random reproductibility
 

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5239,7 +5239,7 @@ class TestRandomJPEG(BaseTester):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="transformers clip model needs distributed tensor.")
+@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="Test requires distributed tensor support introduced in PyTorch > 2.0.1 for transformers clip model.")
 class TestRandomDissolving(BaseTester):
     torch.manual_seed(0)  # for random reproductibility
 

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5239,7 +5239,10 @@ class TestRandomJPEG(BaseTester):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="Test requires distributed tensor support introduced in PyTorch > 2.0.1 for transformers clip model.")
+@pytest.mark.skipif(
+    torch_version_le(2, 0, 1),
+    reason="Test requires distributed tensor support introduced in PyTorch > 2.0.1 for transformers clip model.",
+)
 class TestRandomDissolving(BaseTester):
     torch.manual_seed(0)  # for random reproductibility
 

--- a/tests/filters/test_dissolving.py
+++ b/tests/filters/test_dissolving.py
@@ -26,7 +26,7 @@ WEIGHTS_CACHE_DIR = "weights/"
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="transformers clip model needs distributed tensor.")
+@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="Skipped for torch versions <= 2.0.1: transformers clip model needs distributed tensor.")
 class TestStableDiffusionDissolving:
     @pytest.fixture(scope="class")
     def sdm_2_1(self):

--- a/tests/filters/test_dissolving.py
+++ b/tests/filters/test_dissolving.py
@@ -20,11 +20,13 @@ import torch
 
 from kornia.core import Tensor
 from kornia.filters.dissolving import StableDiffusionDissolving
+from kornia.utils._compat import torch_version_le
 
 WEIGHTS_CACHE_DIR = "weights/"
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="transformers clip model needs distributed tensor.")
 class TestStableDiffusionDissolving:
     @pytest.fixture(scope="class")
     def sdm_2_1(self):

--- a/tests/filters/test_dissolving.py
+++ b/tests/filters/test_dissolving.py
@@ -26,7 +26,10 @@ WEIGHTS_CACHE_DIR = "weights/"
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(torch_version_le(2, 0, 1), reason="Skipped for torch versions <= 2.0.1: transformers clip model needs distributed tensor.")
+@pytest.mark.skipif(
+    torch_version_le(2, 0, 1),
+    reason="Skipped for torch versions <= 2.0.1: transformers clip model needs distributed tensor.",
+)
 class TestStableDiffusionDissolving:
     @pytest.fixture(scope="class")
     def sdm_2_1(self):


### PR DESCRIPTION
dissolving filter uses the tranformers clip model, that underlying uses torch.distributed.tensors, which is only available on newer torch versions
