### PR TITLE
Adding Otsu thresholding for automatic image segmentation

### DIFF
--- a/kornia/filters/otsu_thresholding.py
+++ b/kornia/filters/otsu_thresholding.py
@@ -1,0 +1,280 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from typing import Any, Union, Tuple, Optional
+
+import torch
+
+from kornia.utils.image import perform_keep_shape_image
+
+
+class ThreshOtsu(torch.nn.Module):
+    """Otsu thresholding module for PyTorch tensors."""
+
+    def __init__(self, nbins: Optional[int] = 256) -> None:
+        """
+        Initialize the ThreshOtsu module.
+
+        Args:
+            nbins (int, optional): Number of bins for histogram computation. Default is 256.
+
+        Attributes:
+            nbins (int): Number of bins for histogram computation.
+            _threshold (float): Otsu-computed threshold, initialized to -1.
+            _early_stop (float): Fraction of max iterations without improvement before early stopping.
+        """
+        super().__init__()
+        self.nbins: int = nbins
+
+        self._threshold: float = -1
+        self._early_stop: float = 0.1
+
+    @staticmethod
+    def __rfill(x: torch.Tensor, length: int, dim: int = 0) -> torch.Tensor:
+        """
+        Right-fill a tensor with zeros to reach a given length along a dimension.
+
+        Args:
+            x (torch.Tensor): Tensor to pad.
+            length (int): Target length.
+            dim (int): Dimension to pad.
+
+        Returns:
+            torch.Tensor: Padded tensor.
+        """
+        return torch.cat([x, torch.zeros(max(length - x.shape[dim], 0), device=x.device, dtype=x.dtype)], dim=dim)
+
+    @staticmethod
+    def __histogram(xs: torch.Tensor, bins: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Compute a histogram for each row of xs, CUDA compatible.
+
+        Args:
+            xs (torch.Tensor): 2D tensor (n, N) with values to histogram.
+            bins (int): Number of bins.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: Histograms and bin edges.
+        """
+        min_val, max_val = xs.min(), xs.max()
+        counts = []
+        boundaries = []
+        for lx in xs:
+            counts.append(
+                ThreshOtsu.__rfill(
+                    torch.histc(
+                        input=lx,
+                        bins=bins,
+                        min=min_val.item(),
+                        max=max_val.item()
+                    ),
+                    length=max_val - min_val
+                )
+            )
+            boundaries.append(
+                ThreshOtsu.__rfill(
+                    torch.linspace(
+                        min_val.item(), max_val.item(), bins + 1),
+                    length=max_val - min_val + 1
+                )
+            )
+        return torch.stack(counts).to(xs.device), torch.stack(boundaries).to(xs.device)
+
+    @property
+    def threshold(self) -> float:
+        """Return the Otsu-computed threshold."""
+        return self._threshold
+
+    @threshold.setter
+    def threshold(self, value: float) -> None:
+        """Manually set the threshold."""
+        self._threshold = value
+
+    def transform_input(
+        self, x: torch.Tensor, original_shape: Optional[torch.Size] = None
+    ) -> Tuple[torch.Tensor, torch.Size]:
+        """
+        Flatten the input to make it compatible with threshold computation.
+
+        Args:
+            x (torch.Tensor): Image or batch of images.
+            original_shape (Optional[torch.Size]): Shape to preserve.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Size]: Flattened tensor, original shape.
+        """
+        if original_shape is None:
+            original_shape = x.shape
+        dimensionality: int = x.dim()
+
+        if dimensionality <= 2:
+            return x.flatten().unsqueeze(0), original_shape
+        elif dimensionality == 3:
+            return x.flatten(start_dim=1), original_shape
+        elif dimensionality == 4:
+            b, c, h, w = x.shape
+            return self.transform_input(x.reshape(b * c, h, w), original_shape=original_shape)
+        elif dimensionality == 5:
+            f, b, c, h, w = x.shape
+            return self.transform_input(x.reshape(f * b * c, h, w), original_shape=original_shape)
+        else:
+            raise ValueError(
+                "Unsupported tensor dimensionality: {}".format(dimensionality))
+
+    def forward(self, x: torch.Tensor, use_thresh: bool = False) -> torch.Tensor:
+        """
+        Apply Otsu thresholding to the input x.
+
+        Args:
+            x (torch.Tensor): Image or batch of images to threshold.
+            use_thresh (bool): If True, use the already computed threshold.
+
+        Returns:
+            torch.Tensor: Thresholded image.
+        """
+        x, orig_shape = self.transform_input(x)
+
+        if use_thresh and self._threshold > 0:
+            features = x.to(torch.float64)
+            features[features < self._threshold] = 0
+            return features.reshape(orig_shape)
+
+        # Check tensor type compatibility
+        if x.device.type == 'cpu':
+            # Error of torch.histc on CPU with int and uint types
+            assert any([x.dtype is std_dtype for std_dtype in [
+                torch.float32, torch.float64, torch.float16, torch.bfloat16
+            ]]), "Tensor dtype not supported for Otsu thresholding: only float types are supported on CPU."
+        else:
+            assert any([x.dtype is std_dtype for std_dtype in [
+                torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64,
+                torch.float32, torch.float64, torch.float16, torch.bfloat16
+            ]]), "Tensor dtype not supported for Otsu thresholding."
+
+        min_value = x.min(dim=-1)[0]
+        x = (x.T - min_value).T  # Shift values to start at 0
+        max_val = torch.max(x, dim=-1)[0]
+
+        histogram, bin_edges = ThreshOtsu.__histogram(x, bins=self.nbins)
+        nb_px = x[0, :].numel()
+
+        # Initialize Otsu variables
+        px_bellow = torch.zeros(
+            (x.shape[0]), device=x.device, requires_grad=False)
+        best_thresh = torch.zeros(
+            (x.shape[0]), device=x.device, requires_grad=False)
+        max_intra_class_var = torch.zeros(
+            (x.shape[0]), device=x.device, requires_grad=False)
+
+        # Initialize mean variables
+        mu0 = torch.zeros((x.shape[0]), device=x.device, requires_grad=False)
+        mu1 = torch.zeros((x.shape[0]), device=x.device, requires_grad=False)
+
+        x = x.to(torch.float64)
+
+        max_try = int(self.nbins * self._early_stop)
+        no_update = 0
+
+        # Iterate over each bin to find the best threshold
+        for bin_num in range(self.nbins):
+            px_bellow += histogram[:, bin_num]
+
+            w0 = px_bellow / nb_px
+            w1 = 1 - w0
+
+            thresh = bin_edges[:, bin_num + 1]
+            condition = x <= thresh.repeat(1, nb_px).reshape(x.shape)
+
+            for idx, (x_, cond) in enumerate(zip(x, condition)):
+                mu0[idx] = torch.var(x_[cond])
+                mu1[idx] = torch.var(x_[~cond])
+
+            intra_class_var = w0 * w1 * torch.pow(mu0 - mu1, 2)
+
+            update_condition = intra_class_var > max_intra_class_var
+            max_intra_class_var[update_condition] = intra_class_var[update_condition]
+            best_thresh[update_condition] = thresh[update_condition]
+
+            if torch.all(~update_condition):
+                no_update += 1
+                if no_update >= max_try:
+                    break
+            else:
+                no_update = 0
+
+        # Apply the found threshold
+        x = (x.T + min_value).T
+        x[x < (best_thresh + min_value).repeat(1, nb_px).reshape(x.shape)] = 0
+        self._threshold = (best_thresh + min_value)
+
+        return x.reshape(orig_shape)
+
+
+@perform_keep_shape_image
+def otsu_threshold(
+    x: torch.Tensor,
+    nbins: Optional[int] = 256,
+    use_thresh: bool = False,
+    threshold: Optional[Union[float, torch.Tensor]] = None
+) -> torch.Tensor:
+    """
+    Apply automatic image thresholding using Otsu algorithm to the input tensor.
+
+    Args:
+        x (Tensor): Input tensor (image or batch of images).
+        nbins (Optional[int]): Number of bins for histogram computation, default is 256.
+        use_thresh (bool): If True, use the already computed threshold.
+        threshold (Optional[Union[float, Tensor]]): Manually set threshold value.
+
+    Returns:
+        Tensor: Thresholded image.
+
+    Raises:
+        ValueError: If the input tensor has unsupported dimensionality or dtype.
+
+    .. note::
+        - The input tensor should be of type `torch.uint8`, `torch.int8`, `torch.int16`, `torch.int32`, or `torch.int64`.
+        - If `use_thresh` is True, the threshold must have been computed previously and set in the module.
+        - If `threshold` is provided, it overrides the computed threshold.
+
+    .. note::
+        You may found more information about the Otsu algorithm here: https://en.wikipedia.org/wiki/Otsu's_method
+
+    Example:
+        >>> import torch
+        >>> from kornia.filters.otsu_thresholding import otsu_threshold
+        >>> image = (torch.rand(1, 4, 6, 1)) # Example image tensor
+        >>> image
+        tensor([[[0.3242, 0.9274, 0.2698, 0.6051, 0.5593, 0.9046],
+                [0.5523, 0.3117, 0.9998, 0.8168, 0.6106, 0.8170],
+                [0.6732, 0.2573, 0.8742, 0.6480, 0.6437, 0.4655],
+                [0.9192, 0.7064, 0.8363, 0.0825, 0.3442, 0.8216]]])
+        >>> otsu_threshold(image, nbins=3)
+        tensor([[[0.0000, 0.9274, 0.0000, 0.0000, 0.0000, 0.9046],
+                [0.0000, 0.0000, 0.9998, 0.8168, 0.0000, 0.8170],
+                [0.0000, 0.0000, 0.8742, 0.0000, 0.0000, 0.0000],
+                [0.9192, 0.7064, 0.8363, 0.0000, 0.0000, 0.8216]]],
+            dtype=torch.float64)
+    """
+
+    module = ThreshOtsu(nbins=nbins)
+    if threshold is not None:
+        module.threshold = threshold
+
+    return module(x, use_thresh=use_thresh)

--- a/tests/filters/test_otsu_thresholding.py
+++ b/tests/filters/test_otsu_thresholding.py
@@ -1,0 +1,82 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import torch
+
+from kornia.filters.otsu_thresholding import ThreshOtsu, otsu_threshold
+from testing.base import BaseTester, assert_close
+
+
+class TestThreshOtsu(BaseTester):
+    def test_smoke(self, device, dtype):
+        img = torch.rand(1, 3, 5, 5, device=device, dtype=dtype)
+        op = ThreshOtsu(nbins=4)
+        out = op(img)
+        assert out.shape == img.shape
+
+    @pytest.mark.parametrize("input_shape", [(3, 3), (1, 3, 3), (1, 1, 3, 3), (2, 1, 1, 3, 3)])
+    def test_transform_input_shapes(self, input_shape, device, dtype):
+        img = torch.rand(input_shape, device=device, dtype=dtype)
+        op = ThreshOtsu()
+        flat, orig_shape = op.transform_input(img)
+        assert orig_shape == img.shape
+        assert flat.ndim == 2
+
+    def test_threshold_property(self, device, dtype):
+        op = ThreshOtsu()
+        op.threshold = 5.5
+        assert op.threshold == 5.5
+
+    def test_manual_threshold(self, device, dtype):
+        img = torch.rand(1, 5, 5, device=device, dtype=dtype)
+        op = ThreshOtsu()
+        op.threshold = img.mean().item()
+        out = op(img, use_thresh=True)
+        assert out.shape == img.shape
+
+    def test_otsu_threshold_consistency(self, device, dtype):
+        torch.manual_seed(0)
+        img = torch.rand(1, 4, 6, 1, device=device, dtype=dtype)
+        out_func = otsu_threshold(img, nbins=3)
+        out_class = ThreshOtsu(nbins=3)(img)
+        assert_close(out_func, out_class, rtol=1e-4, atol=1e-4)
+
+    def test_invalid_dim(self, device, dtype):
+        img = torch.rand(1, 1, 1, 1, 3, 3, device=device, dtype=dtype)
+        op = ThreshOtsu()
+        with pytest.raises(ValueError, match="Unsupported tensor dimensionality"):
+            op.transform_input(img)
+
+    def test_dtype_validation_cpu(self):
+        img = torch.randint(0, 255, (1, 4, 4), dtype=torch.int32)
+        op = ThreshOtsu()
+        if img.device.type == "cpu":
+            with pytest.raises(AssertionError, match="Tensor dtype not supported"):
+                op(img)
+
+    def test_gradcheck(self, device):
+        img = torch.rand(1, 1, 5, 5, device=device,
+                         dtype=torch.float64, requires_grad=True)
+        self.gradcheck(otsu_threshold, (img, 3, False, None))
+
+
+@pytest.mark.parametrize("shape", [(1, 3, 5, 5), (2, 1, 10, 10)])
+def test_otsu_threshold_basic(shape, device, dtype):
+    img = torch.rand(shape, device=device, dtype=dtype)
+    out = otsu_threshold(img)
+    assert out.shape == img.shape


### PR DESCRIPTION
#### Changes
This PR add Otsu thresholding algorithm for automatic image segmentation. This aims to complete the existing _in\_range_ function that segment based on range value.

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?

Some commentary needs to be updated as well as documentation. I would like to have some reviews and if this addition could be added in future to kornia. Despite the remaining work on documentation the code is fully working on different device. I will update quickly the code to add the necessary comments and documentation update. 