### PR TITLE
drop support `torch<2.0.0`

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -47,7 +47,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: '["3.9", "3.12"]'
-      pytorch-version: '["1.9.1", "2.5.1"]'
+      pytorch-version: '["2.0.1", "2.5.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -45,7 +45,7 @@ jobs:
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.9", "3.10", "3.11", "3.12"]'
-      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.2", "2.3.1", "2.4.0", "2.5.1"]'
+      pytorch-version: '["2.0.1", "2.1.2", "2.2.2", "2.3.1", "2.4.0", "2.5.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       pytest-extra: '--runslow'
       cache-path: weights/
@@ -65,7 +65,7 @@ jobs:
     with:
       os: 'Windows-latest'
       python-version: '["3.12"]'
-      pytorch-version: '["1.9.1", "2.5.1"]'
+      pytorch-version: '["2.0.1", "2.5.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 kornia_rs>=0.1.9
 packaging
-torch>=1.9.1
+torch>=2.0.0


### PR DESCRIPTION
This PR drops support to old torch versions. By updating the requirements to torch >=2.0.0 and updating the CI