### PR TITLE
fix ARKitQTVects_to_COLMAPQTVecs docstring

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -1518,7 +1518,7 @@ def ARKitQTVecs_to_ColmapQTVecs(qvec: Tensor, tvec: Tensor) -> tuple[Tensor, Ten
     Both poses in quaternion representation.
 
     Args:
-        qvec: ARKit rotation quaternion :math:`(B, 4)`, [x, y, z, w] format.
+        qvec: ARKit rotation quaternion :math:`(B, 4)`, [w, x, y, z] format.
         tvec: translation vector :math:`(B, 3, 1)`, [x, y, z]
 
     Returns:


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

In ARKitQTVecs_to_ColmapQTVecs, the first function it calls is quaternion_to_rotation_matrix, which expects the quaternion in (w, x, y, z) format, so this fixes the docstring to reflect that.

Fixes # 3184


#### Type of change
<!-- Please delete options that are not relevant. -->
- [] 📚  Documentation Update



#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
