### PR TITLE
Feat/codeflash/optimize-torch_version-utils

### DIFF
--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -24,7 +24,8 @@ from torch import Tensor
 
 def torch_version() -> str:
     """Parse the `torch.__version__` variable and removes +cu*/cpu."""
-    return torch.__version__.split("+")[0]
+    # Use partition to avoid allocating a list as in split; faster for a single delimiter search.
+    return torch.__version__.partition("+")[0]
 
 
 def torch_version_lt(major: int, minor: int, patch: int) -> bool:


### PR DESCRIPTION
### 📄 7% (0.07x) speedup for ***`torch_version` in `kornia/utils/_compat.py`***

⏱️ Runtime :   **`602 microseconds`**  **→** **`561 microseconds`** (best of `131` runs)
### 📝 Explanation and details

Uses partition over split, which is faster for such use-cases because it avoids producing a list of all splits. This saves both time and memory in practice for common torch version strings.


This gives the exact same result but is faster for this common string filtering idiom. No additional packages or functions are needed.


✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | ✅ **56 Passed** |
| 🌀 Generated Regression Tests | ✅ **4158 Passed** |
| ⏪ Replay Tests | ✅ **3 Passed** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>⚙️ Existing Unit Tests and Runtime</summary>

| Test File::Test Function                                                                       | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:-----------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `test_korniaaugmentation_2dbase_py__replay_test_0.py::test_kornia_utils__compat_torch_version` | 874ns         | 791ns          | ✅10.5%   |

</details>

<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
import pytest  # used for our unit tests
import torch
from kornia.utils._compat import torch_version

# unit tests

@pytest.mark.parametrize(
    "version_str,expected",
    [
        # Basic cases: just major.minor.patch
        ("1.13.1", "1.13.1"),
        ("2.0.0", "2.0.0"),
        ("0.4.1", "0.4.1"),
        # Basic case: major.minor (no patch)
        ("1.8", "1.8"),
        # Basic case: major only
        ("1", "1"),
        # Basic case: with pre-release tags
        ("2.0.0a0", "2.0.0a0"),
        ("1.9.0rc3", "1.9.0rc3"),
        ("1.10.0b1", "1.10.0b1"),
        # Basic case: dev tags
        ("2.1.0.dev20230501", "2.1.0.dev20230501"),
        # Basic case: with local build identifier but no '+'
        ("1.13.1.dev20221212", "1.13.1.dev20221212"),
    ]
)
def test_torch_version_basic(monkeypatch, version_str, expected):
    """Basic functionality: should return the version string up to, but not including, any '+' and its suffix."""
    # Patch torch.__version__ to the test string
    monkeypatch.setattr(torch, "__version__", version_str)
    codeflash_output = torch_version() # 3.33μs -> 2.92μs (14.3% faster)

@pytest.mark.parametrize(
    "version_str,expected",
    [
        # Edge: with CUDA version
        ("1.13.1+cu117", "1.13.1"),
        ("2.0.0+cu118", "2.0.0"),
        ("1.9.0+cu102", "1.9.0"),
        # Edge: with cpu
        ("1.13.1+cpu", "1.13.1"),
        ("2.0.0+cpu", "2.0.0"),
        # Edge: with long CUDA version
        ("1.13.1+cu117.1", "1.13.1"),
        # Edge: with multiple '+'
        ("1.13.1+cu117+extra", "1.13.1"),
        # Edge: with pre-release and CUDA
        ("2.0.0a0+cu118", "2.0.0a0"),
        ("1.9.0rc3+cpu", "1.9.0rc3"),
        # Edge: with dev and CUDA
        ("2.1.0.dev20230501+cu118", "2.1.0.dev20230501"),
        # Edge: with unknown suffix after '+'
        ("1.13.1+foobar", "1.13.1"),
        # Edge: with empty string after '+'
        ("1.13.1+", "1.13.1"),
        # Edge: with only '+'
        ("+", ""),
        # Edge: only '+cpu'
        ("+cpu", ""),
        # Edge: empty string
        ("", ""),
    ]
)
def test_torch_version_edge(monkeypatch, version_str, expected):
    """Edge cases: test with CUDA, cpu, multiple '+', empty, or malformed version strings."""
    monkeypatch.setattr(torch, "__version__", version_str)
    codeflash_output = torch_version() # 5.66μs -> 4.75μs (19.2% faster)

def test_torch_version_large_scale(monkeypatch):
    """Large scale: test with a very long version string (simulate long dev/build metadata)."""
    # Construct a version string with a very long dev tag and a long CUDA tag
    base_version = "1.13.1"
    long_dev = ".dev" + "1234567890" * 50  # 500 chars
    long_cuda = "+cu" + "1" * 500          # 503 chars
    version_str = base_version + long_dev + long_cuda
    expected = base_version + long_dev
    monkeypatch.setattr(torch, "__version__", version_str)
    codeflash_output = torch_version() # 1.08μs -> 708ns (53.0% faster)

def test_torch_version_large_scale_many_plus(monkeypatch):
    """Large scale: version string with many '+' characters, only the first should be used."""
    version_str = "2.0.0+cu118+cpu+extra+reallylong"  # Only the first '+' matters
    expected = "2.0.0"
    monkeypatch.setattr(torch, "__version__", version_str)
    codeflash_output = torch_version() # 458ns -> 292ns (56.8% faster)

def test_torch_version_large_scale_many_versions(monkeypatch):
    """Large scale: test many different version strings in a loop (simulate stress)."""
    # We'll test 1000 different version strings, all should return the correct part before '+'
    for i in range(1000):
        v = f"{i}.{i%10}.{i%100}"
        cuda = f"+cu{i%120}"
        version_str = v + cuda
        monkeypatch.setattr(torch, "__version__", version_str)
        codeflash_output = torch_version() # 148μs -> 136μs (8.79% faster)

def test_torch_version_large_scale_randomized(monkeypatch):
    """Large scale: test with randomized but valid version strings."""
    import random
    import string

    def random_version():
        # Random major.minor.patch
        maj = random.randint(0, 99)
        minr = random.randint(0, 99)
        pat = random.randint(0, 99)
        # Optionally add pre-release or dev tags
        tag = random.choice(["", "a0", "rc1", "b2", ".dev20230601"])
        # Optionally add CUDA/cpu or random suffix
        suffix = ""
        if random.choice([True, False]):
            suffix = "+" + random.choice(["cu117", "cu118", "cpu", "foobar", "cu" + ''.join(random.choices(string.digits, k=3))])
        return f"{maj}.{minr}.{pat}{tag}{suffix}"

    for _ in range(100):
        version_str = random_version()
        # The expected result is everything before the first '+'
        expected = version_str.split("+")[0]
        monkeypatch.setattr(torch, "__version__", version_str)
        codeflash_output = torch_version() # 14.9μs -> 14.9μs (0.254% slower)

def test_torch_version_does_not_mutate(monkeypatch):
    """Ensure torch_version does not mutate torch.__version__."""
    original = "1.13.1+cu117"
    monkeypatch.setattr(torch, "__version__", original)
    codeflash_output = torch_version(); _ = codeflash_output # 416ns -> 375ns (10.9% faster)

def test_torch_version_type(monkeypatch):
    """torch_version should always return a string."""
    monkeypatch.setattr(torch, "__version__", "1.13.1+cu117")
    codeflash_output = torch_version(); result = codeflash_output # 334ns -> 333ns (0.300% faster)
    monkeypatch.setattr(torch, "__version__", "1.13.1")
    codeflash_output = torch_version(); result = codeflash_output # 208ns -> 166ns (25.3% faster)
    monkeypatch.setattr(torch, "__version__", "")
    codeflash_output = torch_version(); result = codeflash_output # 167ns -> 208ns (19.7% slower)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

import types

# imports
import pytest  # used for our unit tests
import torch
from kornia.utils._compat import torch_version

# ------------------- BASIC TEST CASES -------------------

@pytest.mark.parametrize(
    "version_str,expected",
    [
        # Standard release
        ("1.12.1", "1.12.1"),
        # Pre-release (alpha, beta, rc)
        ("2.0.0a0", "2.0.0a0"),
        ("2.0.0b1", "2.0.0b1"),
        ("2.0.0rc2", "2.0.0rc2"),
        # Post-release
        ("1.10.0.post2", "1.10.0.post2"),
        # With CUDA suffix
        ("1.12.1+cu113", "1.12.1"),
        ("2.0.0+cu118", "2.0.0"),
        # With cpu suffix
        ("1.13.0+cpu", "1.13.0"),
        # With CUDA and build metadata
        ("1.13.1+cu117.gitabcdef", "1.13.1"),
        # With cpu and build metadata
        ("2.0.1+cpu.gitabcdef", "2.0.1"),
    ]
)
def test_torch_version_basic(version_str, expected):
    """Test torch_version with typical version strings."""
    torch.__version__ = version_str
    codeflash_output = torch_version() # 3.46μs -> 2.96μs (16.9% faster)

# ------------------- EDGE TEST CASES -------------------

@pytest.mark.parametrize(
    "version_str,expected",
    [
        # Empty version string
        ("", ""),
        # Only CUDA suffix
        ("+cu113", ""),
        # Only cpu suffix
        ("+cpu", ""),
        # Only build metadata
        ("+gitabcdef", ""),
        # Multiple pluses (should split at the first '+')
        ("1.12.1+cu113+gitabcdef", "1.12.1"),
        ("2.0.0+cpu+gitabcdef", "2.0.0"),
        # Leading/trailing whitespace
        (" 1.12.1+cu113 ", " 1.12.1"),
        # No digits, just text
        ("foo+bar", "foo"),
        # No plus, but weird chars
        ("1.2.3rc1.post2", "1.2.3rc1.post2"),
        # Unicode in version string
        ("2.0.0+cu🐍", "2.0.0"),
        ("🐍2.0.0+cu113", "🐍2.0.0"),
        # Version string is just a plus
        ("+", ""),
    ]
)
def test_torch_version_edge(version_str, expected):
    """Test torch_version with edge-case version strings."""
    torch.__version__ = version_str
    codeflash_output = torch_version() # 5.33μs -> 4.33μs (23.0% faster)

def test_torch_version_does_not_mutate_version():
    """Ensure torch_version does not modify torch.__version__."""
    orig_version = "1.12.1+cu113"
    torch.__version__ = orig_version
    codeflash_output = torch_version(); _ = codeflash_output # 375ns -> 292ns (28.4% faster)

def test_torch_version_with_non_str_version():
    """Test behavior if torch.__version__ is not a string (should raise)."""
    torch.__version__ = None
    with pytest.raises(AttributeError):
        torch_version() # 1.12μs -> 1.08μs (3.78% faster)
    torch.__version__ = 123
    with pytest.raises(AttributeError):
        torch_version() # 750ns -> 833ns (9.96% slower)
    torch.__version__ = object()
    with pytest.raises(AttributeError):
        torch_version() # 625ns -> 708ns (11.7% slower)

# ------------------- LARGE SCALE TEST CASES -------------------

def test_torch_version_large_batch():
    """Test torch_version with a large number of unique version strings."""
    # Generate 1000 version strings of the form "{major}.{minor}.{patch}+cu{cuda}"
    for i in range(1000):
        major = i % 10
        minor = (i // 10) % 10
        patch = (i // 100) % 10
        cuda = 100 + (i % 20)
        version_str = f"{major}.{minor}.{patch}+cu{cuda}"
        torch.__version__ = version_str
        expected = f"{major}.{minor}.{patch}"
        codeflash_output = torch_version() # 152μs -> 137μs (11.0% faster)

def test_torch_version_large_batch_no_plus():
    """Test torch_version with a large number of version strings with no '+'."""
    for i in range(1000):
        major = i % 10
        minor = (i // 10) % 10
        patch = (i // 100) % 10
        version_str = f"{major}.{minor}.{patch}"
        torch.__version__ = version_str
        codeflash_output = torch_version() # 123μs -> 122μs (0.878% faster)

def test_torch_version_performance_large():
    """Performance test: ensure torch_version is fast for large version strings."""
    # Version string of length ~1000 (still <100MB)
    long_version = "1.2.3" + "+cu" + "a"*990
    torch.__version__ = long_version
    expected = "1.2.3"
    codeflash_output = torch_version() # 917ns -> 500ns (83.4% faster)

def test_torch_version_performance_many_calls():
    """Performance test: many repeated calls do not degrade or mutate state."""
    torch.__version__ = "2.0.0+cu118"
    for _ in range(1000):
        codeflash_output = torch_version() # 136μs -> 128μs (6.74% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>

<details>
<summary>⏪ Replay Tests and Runtime</summary>

| Test File::Test Function                                                                       | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:-----------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `test_korniaaugmentation_2dbase_py__replay_test_0.py::test_kornia_utils__compat_torch_version` | 874ns         | 791ns          | ✅10.5%   |

</details>