### PR TITLE
Feat/codeflash-get_default_detector_config

### DIFF
--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -272,14 +272,8 @@ class Detector_config(TypedDict):
 
 def get_default_detector_config() -> Detector_config:
     """Return default config."""
-    return {
-        # Extraction Parameters
-        "nms_size": 15,
-        "pyramid_levels": 4,
-        "up_levels": 1,
-        "scale_factor_levels": math.sqrt(2),
-        "s_mult": 22.0,
-    }
+    # Return a shallow copy to ensure modifications outside don't affect the module-level config.
+    return _default_detector_config.copy()
 
 
 class MultiResolutionDetector(Module):
@@ -437,3 +431,13 @@ class MultiResolutionDetector(Module):
         lafs = self.aff(lafs, img)
         lafs = self.ori(lafs, img)
         return lafs, responses
+
+
+_default_detector_config = {
+    # Extraction Parameters
+    "nms_size": 15,
+    "pyramid_levels": 4,
+    "up_levels": 1,
+    "scale_factor_levels": math.sqrt(2),
+    "s_mult": 22.0,
+}


### PR DESCRIPTION
### 📄 98% (0.98x) speedup for ***`get_default_detector_config` in `kornia/feature/scale_space_detector.py`***

⏱️ Runtime :   **`10.5 microseconds`**  **→** **`5.33 microseconds`** (best of `654` runs)
### 📝 Explanation and details


**Optimization summary:**
- Avoids recreating the dictionary on each call by maintaining a cached top-level copy.
- Returns a shallow copy so external modifications don't affect the module state.
- Avoids unnecessary complexity and import cost.
- Keeps all functional and type aspects the same as the original implementation.


✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **28 Passed** |
| ⏪ Replay Tests | ✅ **1 Passed** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
import math

# imports
import pytest  # used for our unit tests
from kornia.feature.scale_space_detector import get_default_detector_config

# unit tests

# --- Basic Test Cases ---

def test_config_is_dict():
    """Test that the returned value is a dict."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 459ns -> 250ns (83.6% faster)

def test_config_has_expected_keys():
    """Test that the config contains all expected keys."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 416ns -> 208ns (100% faster)
    expected_keys = {
        "nms_size",
        "pyramid_levels",
        "up_levels",
        "scale_factor_levels",
        "s_mult",
    }

def test_config_default_values():
    """Test that the config contains the correct default values."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 167ns (125% faster)

def test_config_types():
    """Test that each config value is of the correct type."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 333ns -> 125ns (166% faster)

# --- Edge Test Cases ---

def test_config_is_not_singleton():
    """Test that each call returns a new dict (not the same object)."""
    codeflash_output = get_default_detector_config(); config1 = codeflash_output # 334ns -> 208ns (60.6% faster)
    codeflash_output = get_default_detector_config(); config2 = codeflash_output # 208ns -> 125ns (66.4% faster)

def test_config_is_not_mutated_across_calls():
    """Test that changes to one config do not affect subsequent calls."""
    codeflash_output = get_default_detector_config(); config1 = codeflash_output # 333ns -> 208ns (60.1% faster)
    config1["nms_size"] = 99
    codeflash_output = get_default_detector_config(); config2 = codeflash_output # 208ns -> 125ns (66.4% faster)

def test_config_no_extra_keys():
    """Test that no extra keys are present."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 208ns (80.3% faster)
    allowed_keys = {"nms_size", "pyramid_levels", "up_levels", "scale_factor_levels", "s_mult"}
    for key in config.keys():
        pass

def test_config_no_missing_keys():
    """Test that no expected keys are missing."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 208ns (80.3% faster)
    for key in ["nms_size", "pyramid_levels", "up_levels", "scale_factor_levels", "s_mult"]:
        pass

def test_config_values_are_not_none():
    """Test that no config value is None."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 208ns (80.3% faster)
    for key, value in config.items():
        pass

def test_config_scale_factor_is_positive():
    """Test that scale_factor_levels is positive."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 333ns -> 167ns (99.4% faster)

def test_config_nms_size_is_odd():
    """Test that nms_size is an odd integer (as is typical for NMS window sizes)."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 333ns -> 167ns (99.4% faster)

def test_config_s_mult_is_float_and_positive():
    """Test that s_mult is a positive float."""
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 208ns (80.3% faster)

# --- Large Scale Test Cases ---


def test_bulk_config_values_are_correct():
    """Test that all configs in a large batch have the correct default values."""
    configs = [get_default_detector_config() for _ in range(1000)] # 541ns -> 250ns (116% faster)
    for config in configs:
        pass

def test_bulk_config_keys_are_correct():
    """Test that all configs in a large batch have the correct keys."""
    expected_keys = {"nms_size", "pyramid_levels", "up_levels", "scale_factor_levels", "s_mult"}
    configs = [get_default_detector_config() for _ in range(1000)] # 375ns -> 167ns (125% faster)
    for config in configs:
        pass

def test_bulk_config_types_are_correct():
    """Test that all configs in a large batch have the correct types."""
    configs = [get_default_detector_config() for _ in range(1000)] # 375ns -> 167ns (125% faster)
    for config in configs:
        pass
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

import math

# imports
import pytest  # used for our unit tests
from kornia.feature.scale_space_detector import get_default_detector_config

# unit tests

# 1. Basic Test Cases

def test_default_keys_exist():
    # Test that all expected keys are present in the returned config
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 208ns (80.3% faster)
    expected_keys = {"nms_size", "pyramid_levels", "up_levels", "scale_factor_levels", "s_mult"}

def test_default_values_correct():
    # Test that the default values are as expected
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 208ns (80.3% faster)

def test_return_type_is_dict():
    # Test that the function returns a dictionary
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 167ns (125% faster)

def test_return_new_instance_each_call():
    # Test that each call returns a new dict instance (not the same object)
    codeflash_output = get_default_detector_config(); config1 = codeflash_output # 333ns -> 167ns (99.4% faster)
    codeflash_output = get_default_detector_config(); config2 = codeflash_output # 208ns -> 83ns (151% faster)
    config1["nms_size"] = 99

# 2. Edge Test Cases

def test_no_extra_keys():
    # Test that no extra keys are present in the config
    codeflash_output = get_default_detector_config(); config = codeflash_output # 333ns -> 167ns (99.4% faster)
    allowed_keys = {"nms_size", "pyramid_levels", "up_levels", "scale_factor_levels", "s_mult"}
    for key in config:
        pass

def test_types_of_values():
    # Test that the types of the values are as expected
    codeflash_output = get_default_detector_config(); config = codeflash_output # 333ns -> 208ns (60.1% faster)

def test_scale_factor_precision():
    # Test that scale_factor_levels is exactly math.sqrt(2) to high precision
    codeflash_output = get_default_detector_config(); config = codeflash_output # 333ns -> 167ns (99.4% faster)

def test_config_is_flat_dict():
    # Test that the config dict is flat (no nested dicts/lists)
    codeflash_output = get_default_detector_config(); config = codeflash_output # 333ns -> 167ns (99.4% faster)
    for v in config.values():
        pass

def test_config_is_not_callable_or_class():
    # Test that the config values are not callables or classes
    codeflash_output = get_default_detector_config(); config = codeflash_output # 375ns -> 208ns (80.3% faster)
    for v in config.values():
        pass

# 3. Large Scale Test Cases


def test_bulk_config_memory_and_performance():
    # Test that creating a large number of configs does not cause performance or memory issues
    # This is a smoke test: if it completes, it's considered a pass
    configs = [get_default_detector_config() for _ in range(999)] # 541ns -> 208ns (160% faster)
```

</details>

<details>
<summary>⏪ Replay Tests and Runtime</summary>

| Test File::Test Function                                                                                                    | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:----------------------------------------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `test_korniaaugmentation_2dbase_py__replay_test_0.py::test_kornia_feature_scale_space_detector_get_default_detector_config` | 500ns         | 208ns          | ✅140%    |

</details>