### PR TITLE
Updating CONTRIBUTING.md with correct dev env setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ repository under your GitHub account.
 
     ```bash
     $ source ./path.bash.inc
-    $ python setup.py develop
+    $ pip install -e .[dev]
     $ python -c "import kornia; print(kornia.__version__)"
     ```
 


### PR DESCRIPTION
#### Changes
since `setup.py` was removed from the repo, the old command `python setup.py develop` no longer works.
this update replaces the outdated instruction with the correct sequence of commands to set up the development environment:

```bash
source ./path.bash.inc
pip install -e .[dev]
python -c "import kornia; print(kornia.__version__)"
```

#### Type of change
- [x] 📚  Documentation Update