### PR TITLE
Implement color space conversion in Image and add tests

### DIFF
--- a/kornia/image/image.py
+++ b/kornia/image/image.py
@@ -23,12 +23,12 @@ from typing import Any
 import torch
 from torch.utils.dlpack import from_dlpack, to_dlpack
 
+import kornia.color
 from kornia.core import Device, Dtype, Tensor
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 from kornia.image.base import ChannelsOrder, ColorSpace, ImageLayout, ImageSize, PixelFormat
 from kornia.io.io import ImageLoadType, load_image, write_image
 from kornia.utils.image_print import image_to_string
-import kornia.color
 
 # placeholder for numpy
 np_ndarray = Any
@@ -191,9 +191,9 @@ class Image:
         """Converts the image to grayscale."""
         src = self._pixel_format.color_space
         data = self._data
-        
+
         if src == ColorSpace.GRAY:
-            return self 
+            return self
 
         is_channels_last = self._layout.channels_order == ChannelsOrder.CHANNELS_LAST
         if is_channels_last:
@@ -209,9 +209,9 @@ class Image:
 
         if is_channels_last:
             if out.ndim == 4:
-                out = out.permute(0, 2, 3, 1)  
+                out = out.permute(0, 2, 3, 1)
             elif out.ndim == 3:
-                out = out.permute(1, 2, 0)   
+                out = out.permute(1, 2, 0)
             else:
                 raise ValueError(f"Unexpected shape after grayscale conversion: {out.shape}")
 

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -27,6 +27,7 @@ from kornia.utils._compat import torch_version_le
 
 from testing.base import assert_close
 
+
 class TestImage:
     def test_smoke(self, device):
         data = torch.randint(0, 255, (3, 4, 5), device=device, dtype=torch.uint8)
@@ -98,6 +99,7 @@ class TestImage:
         img = Image.from_numpy(data, color_space=ColorSpace.RGB, channels_order=ChannelsOrder.CHANNELS_LAST)
         img.write(tmp_path / "image.jpg")
 
+
 def make_image(data: torch.Tensor, cs: ColorSpace, order: ChannelsOrder) -> Image:
     if order not in [ChannelsOrder.CHANNELS_FIRST, ChannelsOrder.CHANNELS_LAST]:
         pytest.skip(f"Skipping unsupported channels_order: {order}")
@@ -116,11 +118,11 @@ def test_color_space_conversions(order):
     bgr_val = rgb_val.flip(0)
 
     if order == ChannelsOrder.CHANNELS_FIRST:
-        rgb_data = rgb_val.view(3,1,1)
-        bgr_data = bgr_val.view(3,1,1)
+        rgb_data = rgb_val.view(3, 1, 1)
+        bgr_data = bgr_val.view(3, 1, 1)
     else:
-        rgb_data = rgb_val.view(1,1,3)
-        bgr_data = bgr_val.view(1,1,3)
+        rgb_data = rgb_val.view(1, 1, 3)
+        bgr_data = bgr_val.view(1, 1, 3)
 
     # Create images
     img_rgb = make_image(rgb_data, ColorSpace.RGB, order)


### PR DESCRIPTION
- Implemented Image.to_color_space() to support RGB, BGR, and GRAY conversions
- Added unit tests for identity, RGB↔BGR flip, RGB→GRAY, and GRAY→RGB/BGR

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
