### PR TITLE
optimized bbox_to_mask3d by vectorizing loop by 5526.89%

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -284,7 +284,7 @@ def bbox_to_mask3d(boxes: torch.Tensor, size: tuple[int, int, int]) -> torch.Ten
 
     """
     validate_bbox3d(boxes)
-    D0, D1, D2 = size # get depth, height, width
+    D0, D1, D2 = size  # get depth, height, width
 
     z_min = boxes[:, 0, 2].long()
     z_max = boxes[:, 4, 2].long()

--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 import torch
 
-from kornia.core import arange, ones_like, stack, where, zeros
+from kornia.core import arange, stack, where, zeros
 
 from .linalg import transform_points
 
@@ -288,10 +288,10 @@ def bbox_to_mask3d(boxes: torch.Tensor, size: tuple[int, int, int]) -> torch.Ten
 
     z_min = boxes[:, 0, 2].long()
     z_max = boxes[:, 4, 2].long()
-    y_min = boxes[:, 1, 1].long()  
-    y_max = boxes[:, 2, 1].long() 
-    x_min = boxes[:, 0, 0].long()  
-    x_max = boxes[:, 1, 0].long()  
+    y_min = boxes[:, 1, 1].long()
+    y_max = boxes[:, 2, 1].long()
+    x_min = boxes[:, 0, 0].long()
+    x_max = boxes[:, 1, 0].long()
 
     z = arange(D0, device=boxes.device, dtype=torch.long)
     y = arange(D1, device=boxes.device, dtype=torch.long)
@@ -299,15 +299,15 @@ def bbox_to_mask3d(boxes: torch.Tensor, size: tuple[int, int, int]) -> torch.Ten
 
     # Compute mask as union of planes in one step
     m = (
-        ((z[None, :] >= z_min[:, None]) & (z[None, :] <= z_max[:, None]))[:, None, :, None, None] |
-        ((y[None, :] >= y_min[:, None]) & (y[None, :] <= y_max[:, None]))[:, None, None, :, None] |
-        ((x[None, :] >= x_min[:, None]) & (x[None, :] <= x_max[:, None]))[:, None, None, None, :]
+        ((z[None, :] >= z_min[:, None]) & (z[None, :] <= z_max[:, None]))[:, None, :, None, None]
+        | ((y[None, :] >= y_min[:, None]) & (y[None, :] <= y_max[:, None]))[:, None, None, :, None]
+        | ((x[None, :] >= x_min[:, None]) & (x[None, :] <= x_max[:, None]))[:, None, None, None, :]
     ).float()  # Shape: (N, 1, D0, D1, D2)
 
     # Compute conditions
-    cond1 = m.all(dim=3, keepdim=True).all(dim=2, keepdim=True)  
-    cond2 = m.all(dim=4, keepdim=True).all(dim=2, keepdim=True)  
-    cond3 = m.all(dim=3, keepdim=True).all(dim=4, keepdim=True)  
+    cond1 = m.all(dim=3, keepdim=True).all(dim=2, keepdim=True)
+    cond2 = m.all(dim=4, keepdim=True).all(dim=2, keepdim=True)
+    cond3 = m.all(dim=3, keepdim=True).all(dim=4, keepdim=True)
 
     m_out = cond1 * cond2 * cond3  # Broadcasting to (N, 1, D0, D1, D2)
     return m_out.float()

--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -247,7 +247,7 @@ def bbox_to_mask3d(boxes: torch.Tensor, size: tuple[int, int, int]) -> torch.Ten
         the output mask tensor.
 
     Examples:
-        >>> boxes = torch.tensor([[[
+        >>> boxes = torch.tensor([[
         ...     [1., 1., 1.],
         ...     [2., 1., 1.],
         ...     [2., 2., 1.],
@@ -256,27 +256,46 @@ def bbox_to_mask3d(boxes: torch.Tensor, size: tuple[int, int, int]) -> torch.Ten
         ...     [2., 1., 2.],
         ...     [2., 2., 2.],
         ...     [1., 2., 2.],
-        ... ]]])
-        >>> bbox_to_mask3d(boxes, (4, 5, 5)).shape
-        torch.Size([1, 4, 5, 5])
+        ... ]])  # 1x8x3
+        >>> bbox_to_mask3d(boxes, (4, 5, 5))
+        tensor([[[[[0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                  [[0., 0., 0., 0., 0.],
+                   [0., 1., 1., 0., 0.],
+                   [0., 1., 1., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                  [[0., 0., 0., 0., 0.],
+                   [0., 1., 1., 0., 0.],
+                   [0., 1., 1., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.]],
+        <BLANKLINE>
+                  [[0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.],
+                   [0., 0., 0., 0., 0.]]]]])
+
     """
     validate_bbox3d(boxes)
-    
-    device = boxes.device
-    dtype = boxes.dtype
-    N, D0, D1, D2 = boxes.shape[0], *size  # Batch size, depth, height, width
+    D0, D1, D2 = size  # Batch size, depth, height, width
 
-    
-    z_min = boxes[:, 0, 2].long()  
-    z_max = boxes[:, 4, 2].long()  
+    z_min = boxes[:, 0, 2].long()
+    z_max = boxes[:, 4, 2].long()
     y_min = boxes[:, 1, 1].long()  
     y_max = boxes[:, 2, 1].long() 
     x_min = boxes[:, 0, 0].long()  
     x_max = boxes[:, 1, 0].long()  
 
-    z = arange(D0, device=device, dtype=torch.long)
-    y = arange(D1, device=device, dtype=torch.long)
-    x = arange(D2, device=device, dtype=torch.long)
+    z = arange(D0, device=boxes.device, dtype=torch.long)
+    y = arange(D1, device=boxes.device, dtype=torch.long)
+    x = arange(D2, device=boxes.device, dtype=torch.long)
 
     # Compute mask as union of planes in one step
     m = (

--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -284,7 +284,7 @@ def bbox_to_mask3d(boxes: torch.Tensor, size: tuple[int, int, int]) -> torch.Ten
 
     """
     validate_bbox3d(boxes)
-    D0, D1, D2 = size  # Batch size, depth, height, width
+    D0, D1, D2 = size # get depth, height, width
 
     z_min = boxes[:, 0, 2].long()
     z_max = boxes[:, 4, 2].long()


### PR DESCRIPTION
completed todo by vectorizing the main loop in bbox_to_mask3d(), leading to speed improvements of up to 5526.89 percent on average on CUDA

Benchmarking on device: CPU, B=128, shape=(32, 32, 32)
Original Time: 0.116394 s
Vectorized Time: 0.058965 s
percentage improvement = **197.39%**

Benchmarking on device: CUDA, B=128, shape=(32, 32, 32)
Original Time: 0.090199 s
Vectorized Time: 0.001632 s
percentage speedup = **5526.89%**

https://colab.research.google.com/drive/1BgU0yma9UkThbegWORgId-CM_uGSu0aQ?usp=sharing

Here's a Colab notebook with the original and the vectorized version. This also checks and proves that both versions are identical in terms of output

- [x] optimization of previously written code

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
