### PR TITLE
optimized mod function by using inbuilt torch.remainder by 336% ?? (not sure pls check)

### DIFF
--- a/kornia/contrib/models/rt_detr/post_processor.py
+++ b/kornia/contrib/models/rt_detr/post_processor.py
@@ -45,7 +45,7 @@ def mod(a: Tensor, b: int) -> Tensor:
         1
 
     """
-    return a - (a // b) * b
+    return torch.remainder(a, b)
 
 
 # TODO: deprecate the confidence threshold and add the num_top_queries as a parameter and num_classes as a parameter


### PR DESCRIPTION
Running benchmark on CUDA
✅ custom_mod == torch.remainder: PASS
✅ custom_mod == a % b         : PASS

⏱ Average time per call (over 100 runs):
custom_mod       : 38.88 µs
torch.remainder  : 11.55 µs
a % b            : 11.73 µs

⚡ Speedup over custom:
torch.remainder  : 3.37x
a % b            : 3.31x

ngl I don't really understand why this works so well in the benchmarks, even CodeFlash said no optimization was possible, but I wrote a benchmark script just for fun, and these were the results. if anyone knows what's happening and if my benchmarking code is wrong, please do explain

