### PR TITLE
optimized rgb2short by about 27% (138% speedup)

### DIFF
--- a/kornia/utils/image_print.py
+++ b/kornia/utils/image_print.py
@@ -352,7 +352,8 @@ def rgb2short(rgb: str) -> Tuple[str, str]:
         parts_match = _RE_RGB_SPLIT.match(rgb)
         if not parts_match:
             raise ValueError(f"Invalid RGB hex string: {rgb}") from None
-        parts = tuple(int(val, 16) for val in parts_match.groups())
+        r, g, b = (int(val, 16) for val in parts_match.groups())
+        parts = (r, g, b)
 
     res = []
     for part in parts:

--- a/kornia/utils/image_print.py
+++ b/kornia/utils/image_print.py
@@ -345,13 +345,13 @@ def rgb2short(rgb: str) -> Tuple[str, str]:
         except ValueError:
             parts_match = _RE_RGB_SPLIT.match(rgb)
             if not parts_match:
-                raise ValueError(f"Invalid RGB hex string: {rgb}")
+                raise ValueError(f"Invalid RGB hex string: {rgb}") from None
             r, g, b = (int(val, 16) for val in parts_match.groups())
         parts = (r, g, b)
     else:
         parts_match = _RE_RGB_SPLIT.match(rgb)
         if not parts_match:
-            raise ValueError(f"Invalid RGB hex string: {rgb}")
+            raise ValueError(f"Invalid RGB hex string: {rgb}") from None
         parts = tuple(int(val, 16) for val in parts_match.groups())
 
     res = []


### PR DESCRIPTION
It avoids regex and uses early-exit linear search.

Total time for 1000 samples:
  new version: 0.004085 sec
  old version : 0.005631 sec

Raw Speedup: 1.38x faster
Speedup Percentage: 27.45% faster


https://colab.research.google.com/drive/14dZo3CBHVTJ4QVToQTb9LN3RX6fVQg7m?usp=sharing

here's a basic benchmark script for the optimization which shows that its faster and also has identical output
