### PR TITLE
optimized heatmap_to_keypoints

### DIFF
--- a/kornia/feature/disk/detector.py
+++ b/kornia/feature/disk/detector.py
@@ -46,7 +46,8 @@ def nms(signal: Tensor, window_size: int = 5, cutoff: float = 0.0) -> Tensor:
 
 def heatmap_to_keypoints(
     heatmap: Tensor, n: Optional[int] = None, window_size: int = 5, score_threshold: float = 0.0
-) -> List[Keypoints]:
+) -> list[Keypoints]:
+    """Inference-time nms-based detection protocol."""
     heatmap = heatmap.squeeze(1)  # (B, H, W)
     B, H, W = heatmap.shape
     device = heatmap.device


### PR DESCRIPTION
partially vectorized the loop as well as added tests to check functionality

https://colab.research.google.com/drive/1ey7hEol_dpGYC6ap3-qnhygKylsEh7V8?usp=sharing

here's a simple benchmark to show optimization aswell as prove similarity

Benchmarking on heatmap shape: torch.Size([100, 1, 128, 128])

Original Time      : 0.030025 s
Optimized Time     : 0.019378 s
Speedup            : 35.46%
Output match?      : ✅

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
