### PR TITLE
optimized normalize() with inbuilt function to get 55.3% speedup

### DIFF
--- a/kornia/geometry/plane.py
+++ b/kornia/geometry/plane.py
@@ -19,6 +19,7 @@
 # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/Hyperplane.h
 
 from typing import Optional
+
 import torch.nn.functional as F
 
 from kornia.core import Module, Tensor, stack, where

--- a/kornia/geometry/plane.py
+++ b/kornia/geometry/plane.py
@@ -19,6 +19,7 @@
 # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/Hyperplane.h
 
 from typing import Optional
+import torch.nn.functional as F
 
 from kornia.core import Module, Tensor, stack, where
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
@@ -31,7 +32,7 @@ __all__ = ["Hyperplane", "fit_plane"]
 
 
 def normalized(v: Tensor, eps: float = 1e-6) -> Tensor:
-    return v / batched_dot_product(v, v).add(eps).sqrt()
+    return F.normalize(v, p=2, dim=-1, eps=eps)
 
 
 class Hyperplane(Module):

--- a/kornia/geometry/plane.py
+++ b/kornia/geometry/plane.py
@@ -34,6 +34,7 @@ def normalized(v: Tensor, eps: float = 1e-6) -> Tensor:
     norm_sq = (v * v).sum(dim=-1, keepdim=True) + eps
     return v * norm_sq.rsqrt()
 
+
 class Hyperplane(Module):
     def __init__(self, n: Vector3, d: Scalar) -> None:
         super().__init__()

--- a/kornia/geometry/plane.py
+++ b/kornia/geometry/plane.py
@@ -20,8 +20,6 @@
 
 from typing import Optional
 
-import torch.nn.functional as F
-
 from kornia.core import Module, Tensor, stack, where
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
 from kornia.core.tensor_wrapper import unwrap, wrap  # type: ignore[attr-defined]
@@ -33,8 +31,8 @@ __all__ = ["Hyperplane", "fit_plane"]
 
 
 def normalized(v: Tensor, eps: float = 1e-6) -> Tensor:
-    return F.normalize(v, p=2, dim=-1, eps=eps)
-
+    norm_sq = (v * v).sum(dim=-1, keepdim=True) + eps
+    return v * norm_sq.rsqrt()
 
 class Hyperplane(Module):
     def __init__(self, n: Vector3, d: Scalar) -> None:

--- a/tests/geometry/test_normalize.py
+++ b/tests/geometry/test_normalize.py
@@ -1,0 +1,77 @@
+import torch
+import torch.nn.functional as F
+import pytest
+
+# For demonstration, re-define them inline:
+def batched_dot_product(x: torch.Tensor, y: torch.Tensor, keepdim: bool = False) -> torch.Tensor:
+    return (x * y).sum(-1, keepdim)
+
+def normalized_orig(v: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    return v / batched_dot_product(v, v, keepdim=True).add(eps).sqrt()
+
+def normalized_fnorm(v: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    return F.normalize(v, p=2, dim=-1, eps=eps)
+
+
+# -- Reference normalization using explicit loops (earlier implementation) --
+def normalized_ref(v: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    # clone input and iterate over flattened vectors to preserve batch dims
+    out = v.clone()
+    flat = out.view(-1, v.size(-1))
+    for i, vec in enumerate(flat):
+        norm = torch.sqrt((vec * vec).sum() + eps)
+        flat[i] = vec / norm
+    return out
+
+@pytest.fixture(params=[(2, 3), (4, 5, 6), (10, 128)])
+def random_batch(request):
+    shape = request.param
+    torch.manual_seed(0)
+    return torch.randn(*shape, dtype=torch.float32)
+
+
+def test_batched_dot_product_shape(random_batch):
+    x = random_batch
+    y = random_batch.clone()
+    out1 = batched_dot_product(x, y)
+    out2 = batched_dot_product(x, y, keepdim=True)
+    assert out1.shape == x.shape[:-1]
+    assert out2.shape == x.shape[:-1] + (1,)
+
+@pytest.mark.parametrize("fn", [normalized_orig, normalized_fnorm])
+def test_unit_norm(random_batch, fn):
+    v = random_batch
+    out = fn(v)
+    assert out.shape == v.shape
+    norms = torch.linalg.norm(out.flatten(0, -2), dim=-1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-6)
+
+@pytest.mark.parametrize("fn", [normalized_orig, normalized_fnorm])
+def test_normalized_against_ref(fn, random_batch):
+    v = random_batch
+    out = fn(v)
+    ref = normalized_ref(v)
+    assert torch.allclose(out, ref, atol=1e-6), (
+        f"{fn.__name__} differs from reference by "
+        f"{(out - ref).abs().max().item():.3e}"
+    )
+
+@pytest.mark.parametrize("fn", [normalized_fnorm])
+def test_optimized_matches_orig(fn, random_batch):
+    v = random_batch
+    out_opt = fn(v)
+    out_orig = normalized_orig(v)
+    assert torch.allclose(out_opt, out_orig, atol=1e-6), (
+        f"{fn.__name__} differs from normalized_orig by "
+        f"{(out_opt - out_orig).abs().max().item():.3e}"
+    )
+
+
+def test_orig_matches_fnormalize(random_batch):
+    v = random_batch
+    out_orig = normalized_orig(v)
+    out_fnorm = F.normalize(v, p=2, dim=-1, eps=1e-6)
+    assert torch.allclose(out_orig, out_fnorm, atol=1e-6), (
+        f"normalized_orig differs from F.normalize by "
+        f"{(out_orig - out_fnorm).abs().max().item():.3e}"
+    )

--- a/tests/geometry/test_normalize.py
+++ b/tests/geometry/test_normalize.py
@@ -1,13 +1,33 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
 import torch
 import torch.nn.functional as F
-import pytest
+
 
 # For demonstration, re-define them inline:
 def batched_dot_product(x: torch.Tensor, y: torch.Tensor, keepdim: bool = False) -> torch.Tensor:
     return (x * y).sum(-1, keepdim)
 
+
 def normalized_orig(v: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
     return v / batched_dot_product(v, v, keepdim=True).add(eps).sqrt()
+
 
 def normalized_fnorm(v: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
     return F.normalize(v, p=2, dim=-1, eps=eps)
@@ -22,6 +42,7 @@ def normalized_ref(v: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
         norm = torch.sqrt((vec * vec).sum() + eps)
         flat[i] = vec / norm
     return out
+
 
 @pytest.fixture(params=[(2, 3), (4, 5, 6), (10, 128)])
 def random_batch(request):
@@ -38,6 +59,7 @@ def test_batched_dot_product_shape(random_batch):
     assert out1.shape == x.shape[:-1]
     assert out2.shape == x.shape[:-1] + (1,)
 
+
 @pytest.mark.parametrize("fn", [normalized_orig, normalized_fnorm])
 def test_unit_norm(random_batch, fn):
     v = random_batch
@@ -46,15 +68,16 @@ def test_unit_norm(random_batch, fn):
     norms = torch.linalg.norm(out.flatten(0, -2), dim=-1)
     assert torch.allclose(norms, torch.ones_like(norms), atol=1e-6)
 
+
 @pytest.mark.parametrize("fn", [normalized_orig, normalized_fnorm])
 def test_normalized_against_ref(fn, random_batch):
     v = random_batch
     out = fn(v)
     ref = normalized_ref(v)
     assert torch.allclose(out, ref, atol=1e-6), (
-        f"{fn.__name__} differs from reference by "
-        f"{(out - ref).abs().max().item():.3e}"
+        f"{fn.__name__} differs from reference by {(out - ref).abs().max().item():.3e}"
     )
+
 
 @pytest.mark.parametrize("fn", [normalized_fnorm])
 def test_optimized_matches_orig(fn, random_batch):
@@ -62,8 +85,7 @@ def test_optimized_matches_orig(fn, random_batch):
     out_opt = fn(v)
     out_orig = normalized_orig(v)
     assert torch.allclose(out_opt, out_orig, atol=1e-6), (
-        f"{fn.__name__} differs from normalized_orig by "
-        f"{(out_opt - out_orig).abs().max().item():.3e}"
+        f"{fn.__name__} differs from normalized_orig by {(out_opt - out_orig).abs().max().item():.3e}"
     )
 
 
@@ -72,6 +94,5 @@ def test_orig_matches_fnormalize(random_batch):
     out_orig = normalized_orig(v)
     out_fnorm = F.normalize(v, p=2, dim=-1, eps=1e-6)
     assert torch.allclose(out_orig, out_fnorm, atol=1e-6), (
-        f"normalized_orig differs from F.normalize by "
-        f"{(out_orig - out_fnorm).abs().max().item():.3e}"
+        f"normalized_orig differs from F.normalize by {(out_orig - out_fnorm).abs().max().item():.3e}"
     )

--- a/tests/geometry/test_normalize.py
+++ b/tests/geometry/test_normalize.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn.functional as F
 
 
-# For demonstration, re-define them inline:
+# Reference implementations used in the test suite:
 def batched_dot_product(x: torch.Tensor, y: torch.Tensor, keepdim: bool = False) -> torch.Tensor:
     return (x * y).sum(-1, keepdim)
 

--- a/tests/geometry/test_plane.py
+++ b/tests/geometry/test_plane.py
@@ -76,7 +76,7 @@ class TestHyperplane(BaseTester):
         torch.save(plane, file_path)
         assert file_path.is_file()
 
-        loaded_plane = torch.load(file_path)
+        loaded_plane = torch.load(file_path, weights_only=False)
         self.assert_close(plane.normal.unwrap(), loaded_plane.normal.unwrap())
 
     # TODO: implement `Vector2`


### PR DESCRIPTION
used torch function for normalization and also wrote through tests for it

method    time (µs)    % improv.
--------------------------------
  orig      1231.08             —
 fnorm       792.92        35.59%

Accuracy check (max abs error vs. orig):
  fnorm : 5.960e-08

https://colab.research.google.com/drive/1ey7hEol_dpGYC6ap3-qnhygKylsEh7V8?usp=sharing
benchmarking script

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
