### PR TITLE
optimized needleman_wunsch by 1772.46%

### DIFF
--- a/kornia/feature/sold2/sold2.py
+++ b/kornia/feature/sold2/sold2.py
@@ -317,16 +317,16 @@ class WunschLineMatcher(Module):
         # Recalibrate the scores to get a gap score of 0
         gap = 0.1
         B, N, M = scores.shape
-        dp = torch.zeros(B, N+1, M+1, device=scores.device)
-        S  = scores - gap
-        for k in range(2, N+M+1):
+        dp = torch.zeros(B, N + 1, M + 1, device=scores.device)
+        S = scores - gap
+        for k in range(2, N + M + 1):
             i_min = max(1, k - M)
             i_max = min(N, k - 1)
-            i = torch.arange(i_min, i_max+1, device=scores.device)
+            i = torch.arange(i_min, i_max + 1, device=scores.device)
             j = k - i
-            up   = dp[:, i-1, j    ]
-            left = dp[:, i,   j-1  ]
-            diag = dp[:, i-1, j-1] + S[:, i-1, j-1]
+            up = dp[:, i - 1, j]
+            left = dp[:, i, j - 1]
+            diag = dp[:, i - 1, j - 1] + S[:, i - 1, j - 1]
             dp[:, i, j] = torch.max(torch.max(up, left), diag)
         return dp[:, -1, -1]
 

--- a/kornia/feature/sold2/sold2.py
+++ b/kornia/feature/sold2/sold2.py
@@ -314,21 +314,21 @@ class WunschLineMatcher(Module):
                     of the elements to match.
         """
         KORNIA_CHECK_SHAPE(scores, ["B", "N", "M"])
-        b, n, m = scores.shape
-
         # Recalibrate the scores to get a gap score of 0
         gap = 0.1
-        nw_scores = scores - gap
-        dev = scores.device
-        # Run the dynamic programming algorithm
-        nw_grid = torch.zeros(b, n + 1, m + 1, dtype=torch.float, device=dev)
-        for i in range(n):
-            for j in range(m):
-                nw_grid[:, i + 1, j + 1] = torch.maximum(
-                    torch.maximum(nw_grid[:, i + 1, j], nw_grid[:, i, j + 1]), nw_grid[:, i, j] + nw_scores[:, i, j]
-                )
-
-        return nw_grid[:, -1, -1]
+        B, N, M = scores.shape
+        dp = torch.zeros(B, N+1, M+1, device=scores.device)
+        S  = scores - gap
+        for k in range(2, N+M+1):
+            i_min = max(1, k - M)
+            i_max = min(N, k - 1)
+            i = torch.arange(i_min, i_max+1, device=scores.device)
+            j = k - i
+            up   = dp[:, i-1, j    ]
+            left = dp[:, i,   j-1  ]
+            diag = dp[:, i-1, j-1] + S[:, i-1, j-1]
+            dp[:, i, j] = torch.max(torch.max(up, left), diag)
+        return dp[:, -1, -1]
 
 
 def keypoints_to_grid(keypoints: Tensor, img_size: Tuple[int, int]) -> Tensor:


### PR DESCRIPTION
used a wavefront order (iterate over anti-diagonals) to iterate through the dp table instead of serial order, leading to more efficient tensor ops. The actual algorithm is exactly the same, so the outputs don't differ

Benchmark Results:
Naive     : Time = 3.183107 s, Speedup = 1.00x,    Matches Naive = True
Wavefront : Time = 0.179587 s, Speedup = 1772.46%, Matches Naive = True

https://colab.research.google.com/drive/1aExLMZbRayVwGyf5nJhuUFfXsVSk5OWg?usp=sharing
here's the benchmark colab file