### PR TITLE
(todo completed) optimized posterize() by 1.65x and made it differentiable 

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -766,7 +766,7 @@ def posterize(input: Tensor, bits: Union[int, Tensor],
 
     .. image:: _static/img/posterize.png
 
-    Non-differentiable function, ``torch.uint8`` involved.
+    Non-differentiable function, ``torch.uint8`` involved. but allows gradient flow using STE.
 
     Args:
         input: image tensor with shape :math:`(*, C, H, W)` to posterize.


### PR DESCRIPTION
The forward pass performs true posterization using uint8 and bit masking. The backward pass uses a straight-through estimator (STE), passing gradients as if the function were identity. This allows gradients to flow during training, enabling optimization despite non-differentiable operations.

https://colab.research.google.com/drive/10A13lay8GFLrTvl11j0Gzuhgsq3TzCAq?usp=sharing

here's a benchmark that shows speed improvement, as well as shows that gradients pass through the function

- [x] 🔬 New feature (non-breaking change which adds functionality)
- [x] optimization

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Did you update CHANGELOG in case of a major change?
