### PR TITLE
fixed docstring issue

### DIFF
--- a/kornia/contrib/models/rt_detr/post_processor.py
+++ b/kornia/contrib/models/rt_detr/post_processor.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import numbers
 from typing import Optional, Union
 
 import torch


### PR DESCRIPTION
also since remainder works with floats too and the errors weren't caused by the mod function I've removed the unnecessary check