### PR TITLE
optimized img_to_str by about 3.5x (350%)

### DIFF
--- a/kornia/utils/image_print.py
+++ b/kornia/utils/image_print.py
@@ -25,8 +25,8 @@ Taken from https://gist.github.com/klange/1687427
 import re
 from typing import Tuple, Union
 
-from torch import float16, float32, float64
 import torch
+from torch import float16, float32, float64
 
 import kornia
 from kornia.core import Tensor
@@ -372,7 +372,7 @@ def image_to_string(image: torch.Tensor, max_width: int = 256) -> str:
     KORNIA_CHECK_SHAPE(image, ["C", "H", "W"])
 
     if image.dtype not in [float16, float32, float64]:
-        image = image / 255.0  
+        image = image / 255.0
 
     if image.shape[-1] > max_width:
         new_h = image.size(-2) * max_width // image.size(-1)
@@ -398,6 +398,7 @@ def image_to_string(image: torch.Tensor, max_width: int = 256) -> str:
         lines.append("".join(row_parts))
 
     return "".join(lines)
+
 
 def print_image(image: Union[str, Tensor], max_width: int = 96) -> None:
     """Print an image to the terminal.


### PR DESCRIPTION
The optimized code is faster because it reduces per-pixel Python overhead by flattening the image once instead of slicing it for every pixel, caches lookups like rgb2short, and builds strings in lists before joining instead of concatenating repeatedly.
It also combines operations (scaling + clamping) and minimizes redundant function calls, cutting unnecessary allocations and lookups.

https://colab.research.google.com/drive/1fi6OFjOX3umBkAZJR9oWBVeYcLN5PliY?usp=sharing

here's code to validate and benchmark my changes

✅ Output is identical
Original avg time:  1.2716 sec
Optimized avg time: 0.3463 sec
Speedup: 3.67x
