### PR TITLE
optimized strip_hash with 1.96x (196%) speedup

### DIFF
--- a/kornia/utils/image_print.py
+++ b/kornia/utils/image_print.py
@@ -303,8 +303,10 @@ RGB2SHORT_DICT = {v: k for k, v in SHORT2RGB_DICT.items()}
 def _str2hex(hexstr: str) -> int:
     return int(hexstr, 16)
 
+
 def _strip_hash(rgb: str) -> str:
     return rgb.removeprefix("#")
+
 
 def short2rgb(short: str) -> str:
     """Convert short to RGB code."""


### PR DESCRIPTION
used inbuilt removeprefix function instead of an unnecessary check and lstrip

✅ Validation passed for 10000 test cases.
Original total:  0.198657 sec
Optimized total: 0.101296 sec
Speedup: 1.96x

https://colab.research.google.com/drive/1A0Rw5sU1r_pjTNO8ndZXcrMv4DXrblqy?usp=sharing

here's benchmark and validation