### PR TITLE
optimized image_list_to_tensor by 2.92x (292% speedup)

### DIFF
--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -17,8 +17,6 @@
 
 from functools import wraps
 from typing import Any, Callable, List, Optional
-
-import numpy as np
 import torch
 from torch import nn
 
@@ -91,12 +89,23 @@ def image_list_to_tensor(images: List[Any]) -> Tensor:
 
     """
     if not images:
-        raise ValueError("Input list of numpy images is empty")
-    if len(images[0].shape) != 3:
-        raise ValueError("Input images must be three dimensional arrays")
+        raise ValueError("Input list of images is empty")
 
-    batch_np = np.stack(images)
-    return torch.from_numpy(batch_np).permute(0, 3, 1, 2)
+    images_t = []
+    for img in images:
+        if not torch.is_tensor(img):
+            img = torch.as_tensor(img)
+        images_t.append(img)
+
+    shape = images_t[0].shape
+    if len(shape) != 3:
+        raise ValueError("Each image must have shape (H, W, C)")
+    if any(img.shape != shape for img in images_t):
+        raise ValueError("All images must have the same shape")
+
+    # Stack into (N, H, W, C) then permute to (N, C, H, W)
+    return torch.stack(images_t, dim=0).permute(0, 3, 1, 2)
+
 
 
 def _to_bchw(tensor: Tensor) -> Tensor:

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -18,9 +18,10 @@
 from functools import wraps
 from typing import Any, Callable, List, Optional
 
+import numpy as np
 import torch
 from torch import nn
-import numpy as np
+
 from kornia.core import Tensor
 
 
@@ -94,7 +95,7 @@ def image_list_to_tensor(images: List[Any]) -> Tensor:
     if len(images[0].shape) != 3:
         raise ValueError("Input images must be three dimensional arrays")
 
-    batch_np = np.stack(images)  
+    batch_np = np.stack(images)
     return torch.from_numpy(batch_np).permute(0, 3, 1, 2)
 
 

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -17,6 +17,7 @@
 
 from functools import wraps
 from typing import Any, Callable, List, Optional
+
 import torch
 from torch import nn
 
@@ -105,7 +106,6 @@ def image_list_to_tensor(images: List[Any]) -> Tensor:
 
     # Stack into (N, H, W, C) then permute to (N, C, H, W)
     return torch.stack(images_t, dim=0).permute(0, 3, 1, 2)
-
 
 
 def _to_bchw(tensor: Tensor) -> Tensor:

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, List, Optional
 
 import torch
 from torch import nn
-
+import numpy as np
 from kornia.core import Tensor
 
 
@@ -94,11 +94,8 @@ def image_list_to_tensor(images: List[Any]) -> Tensor:
     if len(images[0].shape) != 3:
         raise ValueError("Input images must be three dimensional arrays")
 
-    list_of_tensors: List[Tensor] = []
-    for image in images:
-        list_of_tensors.append(image_to_tensor(image))
-    tensor: Tensor = torch.stack(list_of_tensors)
-    return tensor
+    batch_np = np.stack(images)  
+    return torch.from_numpy(batch_np).permute(0, 3, 1, 2)
 
 
 def _to_bchw(tensor: Tensor) -> Tensor:


### PR DESCRIPTION
Using np.stack is faster than appending tensors in a loop because it allocates memory once for the entire output array, while appending requires repeated memory reallocations and data copying. This difference significantly impacts performance, especially with large datasets.

✅ Validation passed: Outputs are identical.
Original function time (10 runs): 0.1937 seconds
Optimized function time (10 runs): 0.0663 seconds
Speedup: 2.92x

https://colab.research.google.com/drive/1MWw7Y54W_rufj647yd771SsNU23c-J29?usp=sharing

here's benchmark and validation script for the same

