### PR TITLE
Speed up function `torch_version` by 34%

### DIFF
--- a/kornia/utils/_compat.py
+++ b/kornia/utils/_compat.py
@@ -24,7 +24,9 @@ from torch import Tensor
 
 def torch_version() -> str:
     """Parse the `torch.__version__` variable and removes +cu*/cpu."""
-    return torch.__version__.partition("+")[0]
+    v = torch.__version__
+    i = v.find("+")
+    return v[:i] if i != -1 else v
 
 
 def torch_version_lt(major: int, minor: int, patch: int) -> bool:


### PR DESCRIPTION
<!-- CODEFLASH_OPTIMIZATION: {"function":"torch_version","file":"kornia/utils/_compat.py","speedup_pct":"34%","speedup_x":"0.34x","original_runtime":"1.05 milliseconds","best_runtime":"784 microseconds","optimization_type":"memory","timestamp":"2025-08-09T09:27:00.095Z","version":"1.0"} -->
### 📄 34% (0.34x) speedup for ***`torch_version` in `kornia/utils/_compat.py`***

⏱️ Runtime :   **`1.05 milliseconds`**  **→** **`784 microseconds`** (best of `70` runs)
### 📝 Explanation and details

I've rewritten `torch_version()` to avoid unnecessary string method calls and temporary objects by using a more direct and faster approach (search and slice rather than partition, which is slower and creates an extra tuple).



**Optimization notes:**
- String search and slice is faster than `partition`, and avoids building tuple objects. This reduces memory use and speeds up the function.  
- Return value is exactly the same as before for all expected torch `__version__` formats.  
- All comments remain unchanged except where relevant.


✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | ✅ **56 Passed** |
| 🌀 Generated Regression Tests | ✅ **3027 Passed** |
| ⏪ Replay Tests | ✅ **3 Passed** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>⚙️ Existing Unit Tests and Runtime</summary>

| Test File::Test Function                                                                                                        | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:--------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `test_Usersmisanmeggisonkorniakorniaaugmentation_2dgeometriccrop_py__replay_test_0.py::test_kornia_utils__compat_torch_version` | 2.00μs        | 1.54μs         | ✅29.7%   |

</details>

<details>
<summary>🌀 Generated Regression Tests and Runtime</summary>

```python
from typing import TYPE_CHECKING, Any, Callable

# imports
import pytest  # used for our unit tests
import torch
from kornia.utils._compat import torch_version

# --- Basic Test Cases ---

def test_standard_release_version():
    # Standard release version string, no '+'
    torch.__version__ = "1.13.1"
    codeflash_output = torch_version() # 708ns -> 583ns (21.4% faster)

def test_version_with_cuda_suffix():
    # Version string with '+cu' CUDA suffix
    torch.__version__ = "1.13.1+cu117"
    codeflash_output = torch_version() # 833ns -> 833ns (0.000% faster)

def test_version_with_cpu_suffix():
    # Version string with '+cpu' suffix
    torch.__version__ = "1.13.1+cpu"
    codeflash_output = torch_version() # 833ns -> 750ns (11.1% faster)

def test_version_with_dev_tag():
    # Version string with dev tag, no '+'
    torch.__version__ = "2.0.0.dev20221212"
    codeflash_output = torch_version() # 750ns -> 542ns (38.4% faster)

def test_version_with_cuda_and_dev_tag():
    # Version string with both dev tag and '+cu' suffix
    torch.__version__ = "2.0.0.dev20221212+cu117"
    codeflash_output = torch_version() # 750ns -> 750ns (0.000% faster)

def test_version_with_cpu_and_dev_tag():
    # Version string with both dev tag and '+cpu' suffix
    torch.__version__ = "2.0.0.dev20221212+cpu"
    codeflash_output = torch_version() # 792ns -> 708ns (11.9% faster)

# --- Edge Test Cases ---

def test_version_with_multiple_plus_signs():
    # Version string with multiple '+' signs
    torch.__version__ = "1.13.1+cu117+extra"
    # Should only split at the first '+'
    codeflash_output = torch_version() # 792ns -> 750ns (5.60% faster)

def test_version_with_empty_string():
    # Edge: empty version string
    torch.__version__ = ""
    codeflash_output = torch_version() # 791ns -> 500ns (58.2% faster)

def test_version_with_only_plus():
    # Edge: version string is just '+'
    torch.__version__ = "+"
    # partition returns ('', '+', ''), so should return ''
    codeflash_output = torch_version() # 708ns -> 792ns (10.6% slower)

def test_version_with_leading_plus():
    # Edge: version string starts with '+'
    torch.__version__ = "+cu117"
    codeflash_output = torch_version() # 709ns -> 625ns (13.4% faster)

def test_version_with_trailing_plus():
    # Edge: version string ends with '+'
    torch.__version__ = "1.13.1+"
    codeflash_output = torch_version() # 667ns -> 709ns (5.92% slower)

def test_version_with_no_digits():
    # Edge: version string with no digits
    torch.__version__ = "abc+cu117"
    codeflash_output = torch_version() # 708ns -> 666ns (6.31% faster)

def test_version_with_spaces():
    # Edge: version string with spaces
    torch.__version__ = " 1.13.1 +cu117"
    codeflash_output = torch_version() # 709ns -> 667ns (6.30% faster)

def test_version_with_unicode_characters():
    # Edge: version string with unicode characters
    torch.__version__ = "2.0.0α+cu117"
    codeflash_output = torch_version() # 1.29μs -> 917ns (40.8% faster)

def test_version_with_long_unusual_suffix():
    # Edge: version string with a long, unusual suffix
    torch.__version__ = "1.13.1+thisisaverylongsuffixfortesting"
    codeflash_output = torch_version() # 792ns -> 708ns (11.9% faster)

def test_version_with_dash_in_version():
    # Edge: version string with dash in version
    torch.__version__ = "1.13.1-rc1+cu117"
    codeflash_output = torch_version() # 750ns -> 709ns (5.78% faster)

def test_version_with_multiple_plus_and_dev():
    # Edge: multiple pluses and dev tag
    torch.__version__ = "2.0.0.dev20221212+cu117+nightly"
    codeflash_output = torch_version() # 750ns -> 708ns (5.93% faster)

# --- Large Scale Test Cases ---

@pytest.mark.parametrize("base_version", [
    "1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.6.0",
    "1.7.0", "1.8.0", "1.9.0", "1.10.0", "1.11.0", "1.12.0", "1.13.0",
    "2.0.0", "2.1.0", "2.2.0", "2.3.0"
])
def test_many_cuda_versions(base_version):
    # Test a large number of different CUDA suffixes for different versions
    for cuda_minor in range(100, 110):  # 10 CUDA versions
        torch.__version__ = f"{base_version}+cu{cuda_minor}"
        codeflash_output = torch_version() # 71.8μs -> 54.5μs (31.8% faster)

def test_large_number_of_random_versions():
    # Test 100 different version strings with varying suffixes
    for i in range(100):
        base = f"{i}.{i%10}.{i%7}"
        suffix = f"+cu{i:03d}" if i % 2 == 0 else f"+cpu"
        torch.__version__ = base + suffix
        codeflash_output = torch_version() # 35.7μs -> 26.0μs (37.6% faster)

def test_large_number_of_dev_versions():
    # Test 100 dev versions with and without suffixes
    for i in range(100):
        base = f"2.0.0.dev2022{i:04d}"
        suffix = f"+cu{i%120}" if i % 2 == 0 else ""
        torch.__version__ = base + suffix
        codeflash_output = torch_version() # 34.5μs -> 24.9μs (38.5% faster)

def test_performance_on_long_version_string():
    # Test performance/scalability with a long version string (but still <1000 chars)
    base = "2.0.0" + "a" * 900
    torch.__version__ = base + "+cu117"
    codeflash_output = torch_version() # 959ns -> 1.12μs (14.8% slower)

def test_performance_on_long_suffix():
    # Test with a long suffix (but still <1000 chars)
    base = "2.0.0"
    suffix = "+cu" + "x" * 900
    torch.__version__ = base + suffix
    codeflash_output = torch_version() # 1.25μs -> 709ns (76.3% faster)

def test_large_scale_with_various_edge_cases():
    # Mix of edge and large scale: many different weird version strings
    for i in range(50):
        base = f"{i}.{i%10}.{i%7}-rc{i%5}"
        suffix = "+cpu" if i % 3 == 0 else "+cu" + str(i*3)
        torch.__version__ = base + suffix
        codeflash_output = torch_version() # 18.5μs -> 13.2μs (39.7% faster)
    for i in range(50):
        base = f"{i}.{i%10}.{i%7}-dev{i%5}"
        suffix = ""  # no suffix
        torch.__version__ = base + suffix
        codeflash_output = torch_version() # 14.8μs -> 10.7μs (38.5% faster)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.

import pytest  # used for our unit tests
import torch
from kornia.utils._compat import torch_version

# unit tests

@pytest.mark.basic
def test_torch_version_no_plus():
    """Test torch_version with a standard version string (no '+')."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "2.0.1"
        codeflash_output = torch_version()
        torch.__version__ = "1.12.0"
        codeflash_output = torch_version()
        torch.__version__ = "0.4.0"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.basic
def test_torch_version_with_plus_cu():
    """Test torch_version with '+cu' (CUDA) suffixes."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "2.0.1+cu118"
        codeflash_output = torch_version()
        torch.__version__ = "1.10.0+cu113"
        codeflash_output = torch_version()
        torch.__version__ = "1.7.1+cu102"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.basic
def test_torch_version_with_plus_cpu():
    """Test torch_version with '+cpu' suffixes."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "1.9.0+cpu"
        codeflash_output = torch_version()
        torch.__version__ = "1.8.1+cpu"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.basic
def test_torch_version_with_plus_other():
    """Test torch_version with other '+...' suffixes."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "1.7.1+someother"
        codeflash_output = torch_version()
        torch.__version__ = "2.2.0+mybuild"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_multiple_plus():
    """Test torch_version with multiple '+' characters in the string."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "1.7.1+cu113+extra"
        codeflash_output = torch_version()
        torch.__version__ = "2.0.0+cu117+test+foo"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_pre_release():
    """Test torch_version with pre-release or dev suffixes."""
    orig_version = torch.__version__
    try:
        # Pre-release with plus
        torch.__version__ = "1.8.0rc1+cu102"
        codeflash_output = torch_version()
        torch.__version__ = "1.9.0a0+gitabc123"
        codeflash_output = torch_version()
        # Pre-release without plus
        torch.__version__ = "1.10.0rc2"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_empty_string():
    """Test torch_version with an empty string."""
    orig_version = torch.__version__
    try:
        torch.__version__ = ""
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_plus_at_start():
    """Test torch_version with '+' at the start of the string."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "+cu118"
        codeflash_output = torch_version()
        torch.__version__ = "+cpu"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_plus_at_end():
    """Test torch_version with '+' at the end of the string."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "1.10.0+"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_no_digits():
    """Test torch_version with no digits in the version string."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "abc+cu118"
        codeflash_output = torch_version()
        torch.__version__ = "foo"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_whitespace():
    """Test torch_version with whitespace in the version string."""
    orig_version = torch.__version__
    try:
        torch.__version__ = " 1.10.0 +cu118 "
        # The partition will split at the first '+', so leading/trailing spaces remain
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.large
def test_torch_version_large_scale_unique_versions():
    """Test torch_version with a large number of unique version strings."""
    orig_version = torch.__version__
    try:
        # Generate 1000 unique version strings with '+cu' and '+cpu' suffixes
        for i in range(500):
            torch.__version__ = f"{i}.{i+1}.{i+2}+cu{i%120}"
            codeflash_output = torch_version()
            torch.__version__ = f"{i}.{i+1}.{i+2}+cpu"
            codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.large
def test_torch_version_large_scale_pre_release_and_custom():
    """Test torch_version with a large number of pre-release and custom build strings."""
    orig_version = torch.__version__
    try:
        for i in range(500):
            torch.__version__ = f"{i}.{i+1}.{i+2}rc{i%5}+cu{i%120}"
            codeflash_output = torch_version()
            torch.__version__ = f"{i}.{i+1}.{i+2}a{i%5}+mybuild{i%10}"
            codeflash_output = torch_version()
            torch.__version__ = f"{i}.{i+1}.{i+2}b{i%5}"
            codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.large
def test_torch_version_large_scale_long_strings():
    """Test torch_version with very long version strings (but <1000 chars)."""
    orig_version = torch.__version__
    try:
        base = "1.10.0"
        suffix = "+cu" + "1"*990  # total length < 1000
        torch.__version__ = base + suffix
        codeflash_output = torch_version()
        # Also test with long base
        base2 = "1." + "1"*995
        torch.__version__ = base2 + "+cpu"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_with_unicode():
    """Test torch_version with unicode characters in the version string."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "1.10.0+cu💻"
        codeflash_output = torch_version()
        torch.__version__ = "版本1.10.0+cpu"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_only_plus():
    """Test torch_version with only a '+' character."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "+"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version

@pytest.mark.edge
def test_torch_version_plus_in_middle_of_version():
    """Test torch_version with a '+' in the middle of the version string (unusual)."""
    orig_version = torch.__version__
    try:
        torch.__version__ = "1.10+0.1"
        codeflash_output = torch_version()
    finally:
        torch.__version__ = orig_version
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>

<details>
<summary>⏪ Replay Tests and Runtime</summary>

| Test File::Test Function                                                                                                        | Original ⏱️   | Optimized ⏱️   | Speedup   |
|:--------------------------------------------------------------------------------------------------------------------------------|:--------------|:---------------|:----------|
| `test_Usersmisanmeggisonkorniakorniaaugmentation_2dgeometriccrop_py__replay_test_0.py::test_kornia_utils__compat_torch_version` | 2.00μs        | 1.54μs         | ✅29.7%   |

</details>
