### PR TITLE
optimized find_next_powerof_two by 3.71x (371% speedup)

### DIFF
--- a/kornia/geometry/transform/pyramid.py
+++ b/kornia/geometry/transform/pyramid.py
@@ -373,10 +373,7 @@ def is_powerof_two(x: int) -> bool:
 
 
 def find_next_powerof_two(x: int) -> int:
-    # return the nearest power of 2
-    n = math.ceil(math.log(x) / math.log(2))
-    return 2**n
-
+    return 1 << (x - 1).bit_length()
 
 def build_laplacian_pyramid(
     input: Tensor, max_level: int, border_type: str = "reflect", align_corners: bool = False


### PR DESCRIPTION
replaced the use of logs and ciels with efficient bitwise operations

Validation passed: find_next_powerof_two_original and find_next_powerof_two_optimized produce identical results.

Benchmarking with 100000 random numbers (1 to 10^12) over 10 runs...
Original took: 0.627989 seconds
Optimized took: 0.169169 seconds
Speedup: 371.22%

https://colab.research.google.com/drive/1zY0iAmZ-Ryx7W1XN1P8cRFUTPbzSgRfY?usp=sharing
