### PR TITLE
optimized random_intrinsics by 36.74%

### DIFF
--- a/kornia/geometry/epipolar/projection.py
+++ b/kornia/geometry/epipolar/projection.py
@@ -73,11 +73,7 @@ def random_intrinsics(low: Union[float, Tensor], high: Union[float, Tensor]) -> 
     sampler = torch.distributions.Uniform(low, high)
     params = sampler.sample((4,))
     fx, fy, cx, cy = params[0], params[1], params[2], params[3]
-    camera_matrix = torch.tensor([
-        [fx, 0.0, cx],
-        [0.0, fy, cy],
-        [0.0, 0.0, 1.0]
-    ], dtype=fx.dtype, device=fx.device)
+    camera_matrix = torch.tensor([[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], dtype=fx.dtype, device=fx.device)
     return camera_matrix.unsqueeze(0)
 
 

--- a/kornia/geometry/epipolar/projection.py
+++ b/kornia/geometry/epipolar/projection.py
@@ -71,10 +71,14 @@ def random_intrinsics(low: Union[float, Tensor], high: Union[float, Tensor]) -> 
 
     """
     sampler = torch.distributions.Uniform(low, high)
-    fx, fy, cx, cy = (sampler.sample(torch.Size((1,))) for _ in range(4))
-    zeros, ones = zeros_like(fx), ones_like(fx)
-    camera_matrix = concatenate([fx, zeros, cx, zeros, fy, cy, zeros, zeros, ones])
-    return camera_matrix.view(1, 3, 3)
+    params = sampler.sample((4,))
+    fx, fy, cx, cy = params[0], params[1], params[2], params[3]
+    camera_matrix = torch.tensor([
+        [fx, 0.0, cx],
+        [0.0, fy, cy],
+        [0.0, 0.0, 1.0]
+    ], dtype=fx.dtype, device=fx.device)
+    return camera_matrix.unsqueeze(0), (fx.item(), fy.item(), cx.item(), cy.item())
 
 
 def scale_intrinsics(camera_matrix: Tensor, scale_factor: Union[float, Tensor]) -> Tensor:

--- a/kornia/geometry/epipolar/projection.py
+++ b/kornia/geometry/epipolar/projection.py
@@ -78,7 +78,7 @@ def random_intrinsics(low: Union[float, Tensor], high: Union[float, Tensor]) -> 
         [0.0, fy, cy],
         [0.0, 0.0, 1.0]
     ], dtype=fx.dtype, device=fx.device)
-    return camera_matrix.unsqueeze(0), (fx.item(), fy.item(), cx.item(), cy.item())
+    return camera_matrix.unsqueeze(0)
 
 
 def scale_intrinsics(camera_matrix: Tensor, scale_factor: Union[float, Tensor]) -> Tensor:


### PR DESCRIPTION
The optimized version is faster because it samples all parameters at once and constructs the camera matrix in a single tensor creation without multiple small tensor operations or concatenations, minimizing function calls and memory overhead.
 
original_camera_matrix: 1.796077 seconds for 10000 iterations
optimized_camera_matrix: 1.136175 seconds for 10000 iterations
Optimization: 36.74% faster

https://colab.research.google.com/drive/1jSUj0pXWa9lGQCfC35hs4kNQQjwXqvCL?usp=sharing