### PR TITLE
Opti kb undistort by 2.69x

### DIFF
--- a/kornia/geometry/camera/distortion_kannala_brandt.py
+++ b/kornia/geometry/camera/distortion_kannala_brandt.py
@@ -117,7 +117,7 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: Tensor, params: 
     KORNIA_CHECK_SHAPE(distorted_points_in_camera, ["*", "2"])
     KORNIA_CHECK_SHAPE(params, ["*", "8"])
 
-    iters = 20
+    iters = 10
     eps = 1e-8
     device = distorted_points_in_camera.device
     out_dtype = distorted_points_in_camera.dtype
@@ -144,7 +144,7 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: Tensor, params: 
     rth = rth2.sqrt()
 
     th = rth.clamp(min=1e-16).sqrt()
-    
+
     # gauss-newton
     for _ in range(iters):
         th2 = th * th         

--- a/kornia/geometry/camera/distortion_kannala_brandt.py
+++ b/kornia/geometry/camera/distortion_kannala_brandt.py
@@ -21,6 +21,7 @@ import kornia.core as ops
 from kornia.core import Tensor
 from kornia.core.check import KORNIA_CHECK_SHAPE
 from kornia.geometry.camera.distortion_affine import distort_points_affine
+import torch
 
 
 def _distort_points_kannala_brandt_impl(
@@ -116,80 +117,52 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: Tensor, params: 
     KORNIA_CHECK_SHAPE(distorted_points_in_camera, ["*", "2"])
     KORNIA_CHECK_SHAPE(params, ["*", "8"])
 
-    x = distorted_points_in_camera[..., 0]
-    y = distorted_points_in_camera[..., 1]
+    iters = 20
+    eps = 1e-8
+    device = distorted_points_in_camera.device
+    out_dtype = distorted_points_in_camera.dtype
 
-    fx, fy = params[..., 0], params[..., 1]
-    cx, cy = params[..., 2], params[..., 3]
+    pts = distorted_points_in_camera.to(device=device, dtype=params.dtype)
+    p = params.to(device=device, dtype=params.dtype)
 
-    k0 = params[..., 4]
-    k1 = params[..., 5]
-    k2 = params[..., 6]
-    k3 = params[..., 7]
+    x = pts[..., 0]
+    y = pts[..., 1]
+
+    fx = p[..., 0]
+    fy = p[..., 1]
+    cx = p[..., 2]
+    cy = p[..., 3]
+    k0 = p[..., 4]
+    k1 = p[..., 5]
+    k2 = p[..., 6]
+    k3 = p[..., 7]
 
     un = (x - cx) / fx
     vn = (y - cy) / fy
-    rth2 = un**2 + vn**2
 
-    # TODO: explore stop condition (won't work with pytorch with batched inputs)
-    # Additionally, with this stop condition we can avoid adding 1e-8 to the denominator
-    # in the return statement of the function.
-
-    # if rth2.abs() < 1e-8:
-    #     return distorted_points_in_camera
-
+    rth2 = un * un + vn * vn
     rth = rth2.sqrt()
 
-    th = rth.sqrt()
-
-    iters = 0
-
+    th = rth.clamp(min=1e-16).sqrt()
+    
     # gauss-newton
-
-    while True:
-        th2 = th**2
-        th4 = th2**2
-        th6 = th2 * th4
-        th8 = th4**2
-
-        thd = th * (1.0 + k0 * th2 + k1 * th4 + k2 * th6 + k3 * th8)
-        d_thd_wtr_th = 1.0 + 3.0 * k0 * th2 + 5.0 * k1 * th4 + 7.0 * k2 * th6 + 9.0 * k3 * th8
-
-        step = (thd - rth) / d_thd_wtr_th
+    for _ in range(iters):
+        th2 = th * th         
+        th4 = th2 * th2      
+        th6 = th2 * th4       
+        th8 = th4 * th4       
+        inner = k0 + th2 * (k1 + th2 * (k2 + th2 * k3))
+        thd = th * (1.0 + th2 * inner)
+        d_thd = 1.0 + th2 * (3.0 * k0 + th2 * (5.0 * k1 + th2 * (7.0 * k2 + 9.0 * k3 * th2)))
+        step = (thd - rth) / (d_thd + 1e-12)
         th = th - step
 
-        iters += 1
-
-        # TODO: improve stop condition by masking only the elements that have converged
-        th_abs_mask = th.abs() < 1e-8
-
-        if th_abs_mask.all():
-            break
-
-        if iters >= 20:
-            break
-
     radius_undistorted = th.tan()
+    denom = rth + eps
+    mag = radius_undistorted.abs() / denom
+    undistorted = torch.stack([mag * un, mag * vn], dim=-1)
 
-    undistorted_points = ops.where(
-        radius_undistorted[..., None] < 0.0,
-        ops.stack(
-            [
-                -radius_undistorted * un / (rth + 1e-8),
-                -radius_undistorted * vn / (rth + 1e-8),
-            ],
-            dim=-1,
-        ),
-        ops.stack(
-            [
-                radius_undistorted * un / (rth + 1e-8),
-                radius_undistorted * vn / (rth + 1e-8),
-            ],
-            dim=-1,
-        ),
-    )
-
-    return undistorted_points
+    return undistorted.to(device=device, dtype=out_dtype)
 
 
 def dx_distort_points_kannala_brandt(projected_points_in_camera_z1_plane: Tensor, params: Tensor) -> Tensor:

--- a/kornia/geometry/camera/distortion_kannala_brandt.py
+++ b/kornia/geometry/camera/distortion_kannala_brandt.py
@@ -17,11 +17,12 @@
 
 # inspired by: shttps://github.com/farm-ng/sophus-rs/blob/main/src/sensor/kannala_brandt.rs
 
+import torch
+
 import kornia.core as ops
 from kornia.core import Tensor
 from kornia.core.check import KORNIA_CHECK_SHAPE
 from kornia.geometry.camera.distortion_affine import distort_points_affine
-import torch
 
 
 def _distort_points_kannala_brandt_impl(
@@ -147,10 +148,10 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: Tensor, params: 
 
     # gauss-newton
     for _ in range(iters):
-        th2 = th * th         
-        th4 = th2 * th2      
-        th6 = th2 * th4       
-        th8 = th4 * th4       
+        th2 = th * th
+        th4 = th2 * th2
+        th6 = th2 * th4
+        th8 = th4 * th4
         inner = k0 + th2 * (k1 + th2 * (k2 + th2 * k3))
         thd = th * (1.0 + th2 * inner)
         d_thd = 1.0 + th2 * (3.0 * k0 + th2 * (5.0 * k1 + th2 * (7.0 * k2 + 9.0 * k3 * th2)))

--- a/kornia/geometry/camera/distortion_kannala_brandt.py
+++ b/kornia/geometry/camera/distortion_kannala_brandt.py
@@ -149,9 +149,6 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: Tensor, params: 
     # gauss-newton
     for _ in range(iters):
         th2 = th * th
-        th4 = th2 * th2
-        th6 = th2 * th4
-        th8 = th4 * th4
         inner = k0 + th2 * (k1 + th2 * (k2 + th2 * k3))
         thd = th * (1.0 + th2 * inner)
         d_thd = 1.0 + th2 * (3.0 * k0 + th2 * (5.0 * k1 + th2 * (7.0 * k2 + 9.0 * k3 * th2)))


### PR DESCRIPTION
removed the early stop and branching from the Gauss-Newton loop and fixed it to 10 iterations, as even on strong distortions it provides a very accurate output. Here's a benchmarking and validation script

https://colab.research.google.com/drive/1pRUp9NkMWCz34Ba2QCEH_psABExz0r1Q?usp=sharing

Benchmarking on device: cuda
Points:   10000 | Orig time:    6.314 ms | Opt time:    2.497 ms | Speedup:  2.53x
  Max abs diff: 2.235e-08, Mean abs diff: 3.227e-10, Max rel diff: 3.337e-07


Points:   30000 | Orig time:    6.602 ms | Opt time:    2.456 ms | Speedup:  2.69x
  Max abs diff: 2.235e-08, Mean abs diff: 3.195e-10, Max rel diff: 3.456e-07
