### PR TITLE
optimized make_grid by 2.82x

### DIFF
--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -262,8 +262,7 @@ def make_grid(tensor: Tensor, n_row: Optional[int] = None, padding: int = 2) -> 
 
     total = n_row * n_col
     if total > B:
-        pad_tiles = torch.zeros((total - B, C, padded_H, padded_W),
-                                dtype=tensor.dtype, device=tensor.device)
+        pad_tiles = torch.zeros((total - B, C, padded_H, padded_W), dtype=tensor.dtype, device=tensor.device)
         tensor_padded = torch.cat((tensor_padded, pad_tiles), dim=0)
 
     # ensure contiguous memory layout before reshaping / permuting
@@ -282,7 +281,6 @@ def make_grid(tensor: Tensor, n_row: Optional[int] = None, padding: int = 2) -> 
     combined = combined[:, :combined_H, :combined_W]
 
     return combined
-
 
 
 def perform_keep_shape_image(f: Callable[..., Tensor]) -> Callable[..., Tensor]:


### PR DESCRIPTION
=== Device: cpu ===
B=13 | shape=torch.Size([4, 51, 79]) | orig=  0.1952 ms/call | fast=  0.0911 ms/call | speedup= 2.14x | padding=5
B=16 | shape=torch.Size([4, 77, 101]) | orig=  0.2319 ms/call | fast=  0.0889 ms/call | speedup= 2.61x | padding=3
B=19 | shape=torch.Size([2, 132, 57]) | orig=  0.3572 ms/call | fast=  0.0990 ms/call | speedup= 3.61x | padding=3
B= 5 | shape=torch.Size([1, 91, 37]) | orig=  0.0824 ms/call | fast=  0.0715 ms/call | speedup= 1.15x | padding=5
B=20 | shape=torch.Size([2, 89, 47]) | orig=  0.2800 ms/call | fast=  0.0675 ms/call | speedup= 4.15x | padding=1
B=11 | shape=torch.Size([4, 109, 39]) | orig=  0.1958 ms/call | fast=  0.1361 ms/call | speedup= 1.44x | padding=3
B=14 | shape=torch.Size([3, 114, 118]) | orig=  0.2320 ms/call | fast=  0.1279 ms/call | speedup= 1.81x | padding=2
B=18 | shape=torch.Size([4, 122, 105]) | orig=  0.2479 ms/call | fast=  0.1611 ms/call | speedup= 1.54x | padding=3

Average speedup on cpu: 2.31x

=== Device: cuda ===
B=13 | shape=torch.Size([4, 51, 79]) | orig=  0.2944 ms/call | fast=  0.1286 ms/call | speedup= 2.29x | padding=5
B=16 | shape=torch.Size([4, 77, 101]) | orig=  0.3692 ms/call | fast=  0.0823 ms/call | speedup= 4.49x | padding=3
B=19 | shape=torch.Size([2, 132, 57]) | orig=  0.4049 ms/call | fast=  0.1295 ms/call | speedup= 3.13x | padding=3
B= 5 | shape=torch.Size([1, 91, 37]) | orig=  0.1357 ms/call | fast=  0.1313 ms/call | speedup= 1.03x | padding=5
B=20 | shape=torch.Size([2, 89, 47]) | orig=  0.4353 ms/call | fast=  0.0851 ms/call | speedup= 5.11x | padding=1
B=11 | shape=torch.Size([4, 109, 39]) | orig=  0.2521 ms/call | fast=  0.1422 ms/call | speedup= 1.77x | padding=3
B=14 | shape=torch.Size([3, 114, 118]) | orig=  0.3100 ms/call | fast=  0.1885 ms/call | speedup= 1.64x | padding=2
B=18 | shape=torch.Size([4, 122, 105]) | orig=  0.4156 ms/call | fast=  0.1327 ms/call | speedup= 3.13x | padding=3

Average speedup on cuda: 2.82x

here's the benchmarking and validation script for the same, it works just a little slower for B = 1 or 2 case, but after that the speedup by vectorizing kicks in, if need be there could be a fast path for those cases but the slow down is pretty small so I don't think that's necessary

https://colab.research.google.com/drive/1fX5lwqQT0uffichqQ9HfNhQ0lAQb54ZS?usp=sharing