### PR TITLE
removed unnecessary clamping by 59.0% (2.4x speedup)

### DIFF
--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -672,7 +672,7 @@ class LightGlue(Module):
     def confidence_threshold(self, layer_index: int) -> float:
         """Scaled confidence threshold."""
         return 0.8 + 0.1 * math.exp(-4.0 * layer_index / self.conf.n_layers)
-    
+
     def get_pruning_mask(self, confidences: Tensor, scores: Tensor, layer_index: int) -> Tensor:
         """Mask points which should be removed."""
         keep = scores > (1 - self.conf.width_confidence)

--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -671,9 +671,8 @@ class LightGlue(Module):
 
     def confidence_threshold(self, layer_index: int) -> float:
         """Scaled confidence threshold."""
-        threshold = 0.8 + 0.1 * math.exp(-4.0 * layer_index / self.conf.n_layers)
-        return min(max(threshold, 0), 1)
-
+        return 0.8 + 0.1 * math.exp(-4.0 * layer_index / self.conf.n_layers)
+    
     def get_pruning_mask(self, confidences: Tensor, scores: Tensor, layer_index: int) -> Tensor:
         """Mask points which should be removed."""
         keep = scores > (1 - self.conf.width_confidence)


### PR DESCRIPTION
the clamping is unnecessary for all values of layer index and conf layers which are positive, as it does nothing

Benchmark Results (10,000 calls per layer):
Original avg: 0.005487 sec
Optimized avg: 0.002250 sec
Improvement: 59.0%
Speedup = 2.4x

 https://colab.research.google.com/drive/1kO3aJVg6sccAJ040003Ylk42Mnq67RJu?usp=sharing