### PR TITLE
optimized batch_2x2_ellipse by about 3-6x 

### DIFF
--- a/kornia/feature/adalam/utils.py
+++ b/kornia/feature/adalam/utils.py
@@ -143,7 +143,7 @@ def batch_2x2_ellipse(m: Tensor, *, eps: float = 0.0) -> Tuple[Tensor, Tensor]:
     c = torch.cos(theta)
     s = torch.sin(theta)
 
-    ev1 = torch.stack([c, s], dim=-1)   # (...,2)
+    ev1 = torch.stack([c, s], dim=-1)  # (...,2)
     ev2 = torch.stack([-s, c], dim=-1)  # orthogonal (...,2)
     eigenvecs = torch.stack([ev1, ev2], dim=-1)  # (...,2,2) columns are eigenvectors
     return eigenvals, eigenvecs


### PR DESCRIPTION
It’s faster because the atan2 + cos/sin method computes orthonormal eigenvectors directly, avoiding the costly normalization and unstable division in the original.

timing avg (ms): orig = 10.201 ms  |  fast = 1.533 ms  |  speedup = 6.66x

https://colab.research.google.com/drive/1oOUzUMOKHrfUzJ7yNftolxPhvx7npA23?usp=sharing

heres a simple benchmarking and validation script