### PR TITLE
optimized build_attention_bias by 6.37x (637%)

### DIFF
--- a/kornia/contrib/models/tiny_vit.py
+++ b/kornia/contrib/models/tiny_vit.py
@@ -192,20 +192,19 @@ class Attention(Module):
 
     @staticmethod
     def build_attention_bias(resolution: tuple[int, int]) -> tuple[Tensor, int]:
-        points = list(itertools.product(range(resolution[0]), range(resolution[1])))
-        attention_offsets: dict[tuple[int, int], int] = {}
-        idxs: list[int] = []
-        for p1 in points:
-            for p2 in points:
-                offset = (abs(p1[0] - p2[0]), abs(p1[1] - p2[1]))
-                if offset not in attention_offsets:
-                    attention_offsets[offset] = len(attention_offsets)
-                idxs.append(attention_offsets[offset])
-
-        N = len(points)
-        indices = torch.LongTensor(idxs).view(N, N)
-        attn_offset_size = len(attention_offsets)
+        H, W = resolution
+        rows = torch.arange(H)
+        cols = torch.arange(W)
+        rr = rows.repeat_interleave(W)
+        cc = cols.repeat(H)
+        dr = (rr[:, None] - rr[None, :]).abs()
+        dc = (cc[:, None] - cc[None, :]).abs()
+        keys = dr * W + dc
+        unique_keys, inverse = torch.unique(keys, return_inverse=True)
+        indices = inverse.view(H * W, H * W)
+        attn_offset_size = unique_keys.numel()
         return indices, attn_offset_size
+
 
     # is this really necessary?
     @torch.no_grad()


### PR DESCRIPTION
vectorized the nested loops

Resolution (10, 10):
  Original:  0.002841 sec
  Optimized: 0.000555 sec
  Speedup:   5.12x
Resolution (20, 20):
  Original:  0.043811 sec
  Optimized: 0.007248 sec
  Speedup:   6.04x
Resolution (30, 30):
  Original:  0.350406 sec
  Optimized: 0.054987 sec
  Speedup:   6.37x
Resolution (40, 40):
  Original:  0.850569 sec
  Optimized: 0.177181 sec
  Speedup:   4.80x

https://colab.research.google.com/drive/15dW1I_L_gDuwm70ekF7mRdNFQeqPYfhF?usp=sharing
Here's the benchmarking and validation script
