### PR TITLE
optimized add_weighted

### DIFF
--- a/kornia/enhance/core.py
+++ b/kornia/enhance/core.py
@@ -16,6 +16,7 @@
 #
 
 from typing import Union
+
 import torch
 
 from kornia.core import ImageModule as Module
@@ -77,14 +78,13 @@ def add_weighted(
 
     out = torch.empty_like(src1)
     # out = src1 * alpha  -> torch.mul(src1, alpha, out=out)
-    torch.mul(src1, alpha, out=out)          
+    torch.mul(src1, alpha, out=out)
     # out = out + src2 * beta  -> compute src2*beta into a temporary then add in-place
     tmp = torch.empty_like(src1)
-    torch.mul(src2, beta, out=tmp)    
-    out.add_(tmp)                            # out += tmp
-    out.add_(gamma)                          # out += gamma (broadcasts)
+    torch.mul(src2, beta, out=tmp)
+    out.add_(tmp)  # out += tmp
+    out.add_(gamma)  # out += gamma (broadcasts)
     return out
-
 
 
 class AddWeighted(Module):


### PR DESCRIPTION
Reduced the number of temporary variables to optimize the weighted sum


Device: cpu

=== Shape: (8, 3, 64, 64) ===
Scalar params -> max abs diff = 0.000e+00
Per-element params -> max abs diff = 0.000e+00
Scalar params: Original: 0.103 ms | Optimized: 0.080 ms | Speedup: 1.285x
Per-element:    Original: 0.104 ms | Optimized: 0.090 ms | Speedup: 1.145x

=== Shape: (16, 3, 514, 514) ===
Scalar params -> max abs diff = 0.000e+00
Per-element params -> max abs diff = 0.000e+00
Scalar params: Original: 77.331 ms | Optimized: 44.450 ms | Speedup: 1.740x
Per-element:    Original: 83.215 ms | Optimized: 51.482 ms | Speedup: 1.616x

https://colab.research.google.com/drive/1DzmpICYS5QJd09ZMMiKecFN65DIv_DMp?usp=sharing