### PR TITLE
optimized bbox_to_mask by 200x

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -228,14 +228,14 @@ def bbox_to_mask(boxes: torch.Tensor, width: int, height: int) -> torch.Tensor:
     """
     validate_bbox(boxes)
     # zero padding the surroundings
-    mask = zeros((len(boxes), height + 2, width + 2), dtype=boxes.dtype, device=boxes.device)
-    # push all points one pixel off
-    # in order to zero-out the fully filled rows or columns
-    box_i = (boxes + 1).long()
-    # set all pixels within box to 1
-    for msk, bx in zip(mask, box_i):
-        msk[bx[0, 1] : bx[2, 1] + 1, bx[0, 0] : bx[1, 0] + 1] = 1.0
-    return mask[:, 1:-1, 1:-1]
+    yy = torch.arange(height, device=boxes.device, dtype=boxes.dtype).view(height, 1)
+    xx = torch.arange(width, device=boxes.device, dtype=boxes.dtype).view(1, width)
+    x_min = boxes[:, 0, 0].view(-1, 1, 1)
+    y_min = boxes[:, 0, 1].view(-1, 1, 1)
+    x_max = boxes[:, 2, 0].view(-1, 1, 1)
+    y_max = boxes[:, 2, 1].view(-1, 1, 1)
+    mask = (xx >= x_min) & (xx <= x_max) & (yy >= y_min) & (yy <= y_max)
+    return mask.to(boxes.dtype)
 
 
 def bbox_to_mask3d(boxes: torch.Tensor, size: tuple[int, int, int]) -> torch.Tensor:


### PR DESCRIPTION
vectorized the loop over all boxes to optimize the function by 100-200x

https://colab.research.google.com/drive/1IRrpnE9GbCOBRgY3zf44ktELmM_s_YM1?usp=sharing
here's the benchmark + validation script for the optimization 


--- 📊 Benchmark Summary ---
+---------------------------------------------------------------------------------------------------------------+
| Scenario                  | Batch Size   | Mask Size      | Original (ms)   | Optimized (ms)   | Speedup (x)  |
+---------------------------------------------------------------------------------------------------------------+
| Micro Batch (MobileNet)   | 4            | 224x224        | 1.98            | 0.243            | 8.2          |
| Single Image Inference    | 8            | 480x640        | 3.35            | 0.256            | 13.1         |
| Instance Segmentation     | 16           | 256x256        | 4.70            | 0.243            | 19.4         |
| Webcam Detection (HD)     | 64           | 720x1280       | 19.89           | 0.175            | 113.7        |
| Batch Processing (FHD)    | 128          | 1080x1920      | 40.88           | 0.193            | 212.2        |
| Stress Test (Many Boxes)  | 2048         | 512x512        | 650.63          | 0.230            | 2828.9       |
+---------------------------------------------------------------------------------------------------------------+
