### PR TITLE
optimized one_hot by changing order of operations

### DIFF
--- a/kornia/feature/sold2/sold2.py
+++ b/kornia/feature/sold2/sold2.py
@@ -50,7 +50,7 @@ class SOLD2(Module):
         as well as the list of detected line segments (ij coordinates convention).
 
     Example:
-        >>> images = torch.rand(2, 1, 512, 512)
+        >>> images = torch.rand(2, 1, 64, 64)
         >>> sold2 = SOLD2()
         >>> outputs = sold2(images)
         >>> line_seg1 = outputs["line_segments"][0]

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, cast, Tuple
+from typing import Optional, Tuple, cast
 
 import torch
 from torch import Size

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, cast
+from typing import Optional, cast, Tuple
 
 import torch
 from torch import Size
@@ -622,12 +622,13 @@ class Boxes:
         # -----------------
         # GPU Hotpath (vectorized)
         # -----------------
+        out_shape: Tuple[int, ...]
         if is_batched:
             out_shape = (self.shape[0], self.shape[1], height, width)
         else:
             out_shape = (self.shape[0], height, width)
 
-        clipped_boxes_xyxy = self.to_tensor("xyxy", as_padded_sequence=True)
+        clipped_boxes_xyxy = cast(Tensor, self.to_tensor("xyxy", as_padded_sequence=True))
         clipped_boxes_xyxy[..., ::2].clamp_(0, width)
         clipped_boxes_xyxy[..., 1::2].clamp_(0, height)
 

--- a/kornia/utils/image.py
+++ b/kornia/utils/image.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, List, Optional
 
 import torch
 from torch import nn
+from torch.nn import functional as F
 
 from kornia.core import Tensor
 
@@ -265,7 +266,7 @@ def make_grid(tensor: Tensor, n_row: Optional[int] = None, padding: int = 2) -> 
     padded_W = W + padding
 
     # pad each image on right and bottom with `padding` zeros
-    tensor_padded = torch.pad(tensor, (0, padding, 0, padding))
+    tensor_padded = F.pad(tensor, (0, padding, 0, padding))
 
     total = n_row * n_col
     if total > B:

--- a/kornia/utils/one_hot.py
+++ b/kornia/utils/one_hot.py
@@ -57,6 +57,5 @@ def one_hot(labels: Tensor, num_classes: int, device: torch.device, dtype: torch
         raise ValueError(f"The number of classes must be bigger than one. Got: {num_classes}")
 
     shape = labels.shape
-    one_hot = zeros((shape[0], num_classes) + shape[1:], device=device, dtype=dtype)
-
-    return one_hot.scatter_(1, labels.unsqueeze(1), 1.0) + eps
+    one_hot = torch.full((shape[0], num_classes) + shape[1:], eps, device=device, dtype=dtype)
+    return one_hot.scatter_(1, labels.unsqueeze(1), 1.0)

--- a/kornia/utils/one_hot.py
+++ b/kornia/utils/one_hot.py
@@ -36,7 +36,7 @@ def one_hot(labels: Tensor, num_classes: int, device: torch.device, dtype: torch
 
     Examples:
         >>> labels = torch.LongTensor([[[0, 1], [2, 0]]])
-        >>> one_hot(labels, num_classes=3, device=torch.device('cpu'), dtype=torch.int64)
+        >>> one_hot(labels, num_classes=3, device=torch.device('cpu'), dtype=torch.float32)
         tensor([[[[1.0000e+00, 1.0000e-06],
                   [1.0000e-06, 1.0000e+00]],
         <BLANKLINE>


### PR DESCRIPTION
This version makes the code start with an array filled with all eps and then scatter adds ones to the correct places, instead of starting with zeroes, adding ones, and then adding eps to all elements. This does change the final output a bit

```
Method	|  background values Becomes	Hot Value Becomes
Original|  eps	                        1.0 + eps 
optimized|  eps	                        1.0 
```
which I feel would work as the point of the eps was to avoid zero values, which this one does too

https://colab.research.google.com/drive/1RECgW-D5IJjuLKRrOxUiZZhdxjfcDNr9?usp=sharing

heres the benchmarking script, about 2x as fast on CPU and 1.5x faster on CUDA