### PR TITLE
fix(io): ensure grayscale images are saved with channel dim (HxWx1) (#3280)

### DIFF
--- a/kornia/io/io.py
+++ b/kornia/io/io.py
@@ -202,7 +202,8 @@ def write_image(path_file: str | Path, image: Tensor, quality: int = 80) -> None
     KORNIA_CHECK(image.dim() >= 2, f"Invalid image shape: {image.shape}. Must be at least 2D.")
 
     img_np = tensor_to_image(image, keepdim=True, force_contiguous=True)  # HxWxC
-
+    if img_np.ndim == 2:
+        img_np = img_np[..., None]  # ensures channel dimension
     if image.dtype == torch.uint8:
         _write_uint8_image(path_file, img_np, quality)
     elif image.dtype == torch.uint16:


### PR DESCRIPTION
### Problem
Calling `kornia.io.write_image` with grayscale images (shape `(H, W)` or `(1, H, W)`, dtype `uint8`) raised the following error:

`TypeError: argument 'image': 'ndarray' object cannot be converted to 'PyArray<T, D>'`

Root cause: `tensor_to_image` returned a 2D array `(H, W)` for grayscale images, 
but `kornia_rs.write_image_png_u8` expects a 3D array `(H, W, C)` (even for mono images).

### Fix
Added a post-processing step in `kornia.io.write_image` to ensure that if the output
array is 2D, it is expanded to 3D by adding a singleton channel dimension:

```python
if img_np.ndim == 2:
    img_np = img_np[..., None]  # (H, W) -> (H, W, 1)
```
This ensures grayscale images are saved correctly.