### PR TITLE
removed depreciated torch.cross for torch.linalg.cross and fixed #2822

### DIFF
--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -219,7 +219,7 @@ def depth_to_normals(depth: Tensor, camera_matrix: Tensor, normalize_points: boo
     # compute normals
     a, b = gradients[:, :, 0], gradients[:, :, 1]  # Bx3xHxW
 
-    normals: Tensor = torch.cross(a, b, dim=1)  # Bx3xHxW
+    normals: Tensor = torch.linalg.cross(a, b, dim=1)
     return kornia_ops.normalize(normals, dim=1, p=2)
 
 

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -369,11 +369,10 @@ def decompose_essential_matrix_no_svd(E_mat: torch.Tensor) -> Tuple[torch.Tensor
     scale_factor = torch.sqrt(0.5 * torch.diagonal(E_mat @ E_mat.transpose(-1, -2), dim1=-1, dim2=-2).sum(-1))
 
     # B, 3, 3
-    cross_products = torch.stack([
-        torch.linalg.cross(e1, e2, dim=-1),
-        torch.linalg.cross(e2, e3, dim=-1),
-        torch.linalg.cross(e3, e1, dim=-1)
-    ], dim=1)
+    cross_products = torch.stack(
+        [torch.linalg.cross(e1, e2, dim=-1), torch.linalg.cross(e2, e3, dim=-1), torch.linalg.cross(e3, e1, dim=-1)],
+        dim=1,
+    )
 
     # B, 3, 1
     norms = torch.norm(cross_products, dim=-1, keepdim=True)

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -240,7 +240,7 @@ def null_to_Nister_solution(X: torch.Tensor, batch_size: int) -> torch.Tensor:
         .unsqueeze(-1)
     )
 
-    xzs = torch.matmul(torch.inverse(Bs[:, :, 0:2, 0:2]), bs[:, :, 0:2])
+    xzs = torch.matmul(torch.linalg.inv(Bs[:, :, 0:2, 0:2]), bs[:, :, 0:2])
 
     mask = (abs(Bs[:, 2].unsqueeze(1) @ xzs - bs[:, 2].unsqueeze(1)) > 1e-3).flatten()
 
@@ -369,7 +369,12 @@ def decompose_essential_matrix_no_svd(E_mat: torch.Tensor) -> Tuple[torch.Tensor
     scale_factor = torch.sqrt(0.5 * torch.diagonal(E_mat @ E_mat.transpose(-1, -2), dim1=-1, dim2=-2).sum(-1))
 
     # B, 3, 3
-    cross_products = torch.stack([torch.cross(e1, e2), torch.cross(e2, e3), torch.cross(e3, e1)], dim=1)
+    cross_products = torch.stack([
+        torch.linalg.cross(e1, e2, dim=-1),
+        torch.linalg.cross(e2, e3, dim=-1),
+        torch.linalg.cross(e3, e1, dim=-1)
+    ], dim=1)
+
     # B, 3, 1
     norms = torch.norm(cross_products, dim=-1, keepdim=True)
 

--- a/kornia/geometry/epipolar/fundamental.py
+++ b/kornia/geometry/epipolar/fundamental.py
@@ -327,7 +327,7 @@ def get_perpendicular(lines: Tensor, points: Tensor) -> Tensor:
     else:
         raise AssertionError(points.shape)
     infinity_point = lines * torch.tensor([1, 1, 0], dtype=lines.dtype, device=lines.device).view(1, 1, 3)
-    perp: Tensor = points_h.cross(infinity_point, dim=2)
+    perp: Tensor = torch.linalg.cross(points_h, infinity_point, dim=2)
     return perp
 
 
@@ -355,7 +355,10 @@ def get_closest_point_on_epipolar_line(pts1: Tensor, pts2: Tensor, Fm: Tensor) -
         pts2 = convert_points_to_homogeneous(pts2)
     line1in2 = compute_correspond_epilines(pts1, Fm)
     perp = get_perpendicular(line1in2, pts2)
-    points1_in_2 = convert_points_from_homogeneous(line1in2.cross(perp, dim=2))
+    points1_in_2 = convert_points_from_homogeneous(
+        torch.linalg.cross(line1in2, perp, dim=2)
+    )
+
     return points1_in_2
 
 

--- a/kornia/geometry/epipolar/fundamental.py
+++ b/kornia/geometry/epipolar/fundamental.py
@@ -355,9 +355,7 @@ def get_closest_point_on_epipolar_line(pts1: Tensor, pts2: Tensor, Fm: Tensor) -
         pts2 = convert_points_to_homogeneous(pts2)
     line1in2 = compute_correspond_epilines(pts1, Fm)
     perp = get_perpendicular(line1in2, pts2)
-    points1_in_2 = convert_points_from_homogeneous(
-        torch.linalg.cross(line1in2, perp, dim=2)
-    )
+    points1_in_2 = convert_points_from_homogeneous(torch.linalg.cross(line1in2, perp, dim=2))
 
     return points1_in_2
 

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -128,7 +128,7 @@ def line_segment_transfer_error_one_way(ls1: Tensor, ls2: Tensor, H: Tensor, squ
     ps2, pe2 = torch.chunk(ls2, dim=2, chunks=2)
     ps2_h = convert_points_to_homogeneous(ps2)
     pe2_h = convert_points_to_homogeneous(pe2)
-    ln2 = ps2_h.cross(pe2_h, dim=3)
+    ln2 = torch.linalg.cross(ps2_h, pe2_h, dim=3)
     ps1_in2 = convert_points_to_homogeneous(transform_points(H, ps1))
     pe1_in2 = convert_points_to_homogeneous(transform_points(H, pe1))
     er_st1 = (ln2 @ ps1_in2.transpose(-2, -1)).view(B, N).abs()
@@ -259,10 +259,13 @@ def sample_is_valid_for_homography(points1: Tensor, points2: Tensor) -> Tensor:
     src_perm = points_src_h[:, idx_perm]
     dst_perm = points_dst_h[:, idx_perm]
     left_sign = (
-        torch.cross(src_perm[..., 1:2, :], src_perm[..., 2:3, :]) @ src_perm[..., 0:1, :].permute(0, 1, 3, 2)
+        torch.linalg.cross(src_perm[..., 1:2, :], src_perm[..., 2:3, :], dim=-1)
+        @ src_perm[..., 0:1, :].permute(0, 1, 3, 2)
     ).sign()
+
     right_sign = (
-        torch.cross(dst_perm[..., 1:2, :], dst_perm[..., 2:3, :]) @ dst_perm[..., 0:1, :].permute(0, 1, 3, 2)
+        torch.linalg.cross(dst_perm[..., 1:2, :], dst_perm[..., 2:3, :], dim=-1)
+        @ dst_perm[..., 0:1, :].permute(0, 1, 3, 2)
     ).sign()
     sample_is_valid = (left_sign == right_sign).view(-1, 4).min(dim=1)[0]
     return sample_is_valid

--- a/kornia/geometry/plane.py
+++ b/kornia/geometry/plane.py
@@ -19,7 +19,7 @@
 # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/Hyperplane.h
 
 from typing import Optional
-
+import torch
 from kornia.core import Module, Tensor, stack, where
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
 from kornia.core.tensor_wrapper import unwrap, wrap  # type: ignore[attr-defined]
@@ -103,7 +103,7 @@ class Hyperplane(Module):
         KORNIA_CHECK(p0.shape == p1.shape)
         KORNIA_CHECK(p1.shape == p2.shape)
         v0, v1 = (p2 - p0), (p1 - p0)
-        normal = v0.cross(v1)
+        normal = torch.linalg.cross(v0,v1, dim = -1)
         norm = normal.norm(-1)
 
         # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/Hyperplane.h#L108

--- a/kornia/geometry/plane.py
+++ b/kornia/geometry/plane.py
@@ -19,7 +19,9 @@
 # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/Hyperplane.h
 
 from typing import Optional
+
 import torch
+
 from kornia.core import Module, Tensor, stack, where
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE, KORNIA_CHECK_TYPE
 from kornia.core.tensor_wrapper import unwrap, wrap  # type: ignore[attr-defined]
@@ -103,7 +105,7 @@ class Hyperplane(Module):
         KORNIA_CHECK(p0.shape == p1.shape)
         KORNIA_CHECK(p1.shape == p2.shape)
         v0, v1 = (p2 - p0), (p1 - p0)
-        normal = torch.linalg.cross(v0,v1, dim = -1)
+        normal = torch.linalg.cross(v0, v1, dim=-1)
         norm = normal.norm(-1)
 
         # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/Hyperplane.h#L108

--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -21,6 +21,7 @@
 # https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Geometry/Quaternion.h
 from math import pi
 from typing import Optional, Tuple, Union
+
 import torch
 
 from kornia.core import Device, Dtype, Module, Parameter, Tensor, concatenate, rand, stack, tensor, where

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -1329,7 +1329,7 @@ def _transform_warp_impl3d(
     """Compute the transform in normalized coordinates and perform the warping."""
     dst_norm_trans_src_norm: Tensor = normalize_homography3d(dst_pix_trans_src_pix, dsize_src, dsize_dst)
 
-    src_norm_trans_dst_norm = torch.inverse(dst_norm_trans_src_norm)
+    src_norm_trans_dst_norm = torch.linalg.inv(dst_norm_trans_src_norm)
     return homography_warp3d(src, src_norm_trans_dst_norm, dsize_dst, grid_mode, padding_mode, align_corners, True)
 
 


### PR DESCRIPTION
The following changes fix https://github.com/kornia/kornia/issues/2822 by removing torch.cross for torch.linalg.cross, also removing the deprecated torch.inverse for torch.linalg.inv, this should also reduce the number of warnings as well as reduce unwanted bugs which may not have been recorded, like issue #2822 

https://colab.research.google.com/drive/1dNce3y-jAIIeJTrDypeHmw4aASgd8Qap?usp=sharing

Here's a script to show that it indeed fixes the bug in #2822 