### PR TITLE
optimized _modified_bessel_i and finished todo

### DIFF
--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -238,7 +238,7 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
         out_nz = torch.where(x_nz < 0.0, -out_nz, out_nz)
 
     out = torch.zeros_like(x)
-    out[~is_zero] = out_nz
+    out[~is_zero_mask] = out_nz
     return out
 
 

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -206,39 +206,40 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
     """Adapted from: https://github.com/Project-MONAI/MONAI/blob/master/monai/networks/layers/convutils.py."""
     KORNIA_CHECK(n >= 2, "n must be greater than 1.99")
 
-    if (x == 0.0).all():
-        return x
+    is_zero = (x == 0.0)
+    if is_zero.all():
+        return torch.zeros_like(x)
 
-    batch_size = x.shape[0]
+    x_nz = x[~is_zero]
 
-    tox = 2.0 / x.abs()
-    ans = zeros(batch_size, 1, device=x.device, dtype=x.dtype)
-    bip = zeros(batch_size, 1, device=x.device, dtype=x.dtype)
-    bi = torch.ones(batch_size, 1, device=x.device, dtype=x.dtype)
+    batch_size = x_nz.shape[0]
+    tox = 2.0 / x_nz.abs()
 
-    m = int(2 * (n + int(sqrt(40.0 * n))))
+    ans = torch.zeros(batch_size, device=x.device, dtype=x.dtype)
+    bip = torch.zeros(batch_size, device=x.device, dtype=x.dtype)
+    bi  = torch.ones(batch_size, device=x.device, dtype=x.dtype)
+
+    m = int(2 * (n + int(math.sqrt(40.0 * n))))
     for j in range(m, 0, -1):
-        bim = bip + float(j) * tox * bi
-        bip = bi
-        bi = bim
-        idx = bi.abs() > 1.0e10
+        bim = torch.addcmul(bip, tox, bi, value=j)
+        bip, bi = bi, bim
 
-        if idx.any():
-            ans[idx] = ans[idx] * 1.0e-10
-            bi[idx] = bi[idx] * 1.0e-10
-            bip[idx] = bip[idx] * 1.0e-10
+        scale_mask = bi.abs() > 1.0e10
+        if scale_mask.any():
+            factor = torch.where(scale_mask, 1e-10, 1.0)
+            ans *= factor
+            bi  *= factor
+            bip *= factor
 
         if j == n:
             ans = bip
 
-    out = ans * _modified_bessel_0(x) / bi
-
+    out_nz = ans * _modified_bessel_0(x_nz) / bi
     if (n % 2) == 1:
-        out = where(x < 0.0, -out, out)
+        out_nz = torch.where(x_nz < 0.0, -out_nz, out_nz)
 
-    # TODO: skip the previous computation for x == 0, instead of forcing here
-    out = where(x == 0.0, x, out)
-
+    out = torch.zeros_like(x)
+    out[~is_zero] = out_nz
     return out
 
 

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -205,11 +205,11 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
     """Adapted from: https://github.com/Project-MONAI/MONAI/blob/master/monai/networks/layers/convutils.py."""
     KORNIA_CHECK(n >= 2, "n must be greater than 1.99")
 
-    is_zero = x == 0.0
-    if is_zero.all():
-        return torch.zeros_like(x)
+    is_zero_mask = torch.isclose(x, torch.tensor(0.0, device=x.device, dtype=x.dtype))
+    if is_zero_mask.all():
+        return x
 
-    x_nz = x[~is_zero]
+    x_nz = x[~is_zero_mask]
 
     batch_size = x_nz.shape[0]
     tox = 2.0 / x_nz.abs()

--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import math
-from math import sqrt
 from typing import Any, Optional, Union
 
 import torch
@@ -206,7 +205,7 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
     """Adapted from: https://github.com/Project-MONAI/MONAI/blob/master/monai/networks/layers/convutils.py."""
     KORNIA_CHECK(n >= 2, "n must be greater than 1.99")
 
-    is_zero = (x == 0.0)
+    is_zero = x == 0.0
     if is_zero.all():
         return torch.zeros_like(x)
 
@@ -217,7 +216,7 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
 
     ans = torch.zeros(batch_size, device=x.device, dtype=x.dtype)
     bip = torch.zeros(batch_size, device=x.device, dtype=x.dtype)
-    bi  = torch.ones(batch_size, device=x.device, dtype=x.dtype)
+    bi = torch.ones(batch_size, device=x.device, dtype=x.dtype)
 
     m = int(2 * (n + int(math.sqrt(40.0 * n))))
     for j in range(m, 0, -1):
@@ -228,7 +227,7 @@ def _modified_bessel_i(n: int, x: Tensor) -> Tensor:
         if scale_mask.any():
             factor = torch.where(scale_mask, 1e-10, 1.0)
             ans *= factor
-            bi  *= factor
+            bi *= factor
             bip *= factor
 
         if j == n:


### PR DESCRIPTION
did as the todo said, moved the filtering of the zero values to the top of the loop to prevent redundant operations, also used PyTorch's fused arithmetic operations to optimize the function further

https://colab.research.google.com/drive/1jNVehlZJ2AXn0XVqV5Ij9SMZ_XPMOfxB?usp=sharing
Here's the benchmarking+validation script

[Benchmark 1] DENSE tensor (size: 10000, 0% zeros)
--------------------------------------------------
Compute-then-Mask    : 10.2011 ms per run
Filter-then-Compute  : 3.0826 ms per run
🏆 Verdict: Filter-then-Compute is 3.31x faster on dense data.

[Benchmark 2] SPARSE tensor (size: 10000, 50% zeros)
--------------------------------------------------
Compute-then-Mask    : 22.1584 ms per run
Filter-then-Compute  : 1.8892 ms per run
🏆 Verdict: Filter-then-Compute is 11.73x faster on sparse data.
