### PR TITLE
Fix gradient check in `convert_points_from_homogeneous`

### DIFF
--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -737,13 +737,12 @@ class TestConvertPointsFromHomogeneous(BaseTester):
         # evaluate function gradient
         self.gradcheck(kornia.geometry.conversions.convert_points_from_homogeneous, (points_h,))
 
-    @pytest.mark.skip("RuntimeError: Jacobian mismatch for output 0 with respect to input 0,")
     def test_gradcheck_zvec_zeros(self, device):
         # generate input data
         points_h = torch.tensor([[1.0, 2.0, 0.0], [0.0, 1.0, 0.1], [2.0, 1.0, 0.1]], device=device, dtype=torch.float64)
 
         # evaluate function gradient
-        self.gradcheck(kornia.geometry.conversions.convert_points_from_homogeneous, (points_h,))
+        self.gradcheck(kornia.geometry.conversions.convert_points_from_homogeneous, (points_h,), eps=1e-8)
 
     def test_dynamo(self, device, dtype, torch_optimizer):
         points_h = torch.zeros(1, 2, 3, device=device, dtype=dtype)


### PR DESCRIPTION
* `convert_points_from_homogeneous` avoids dividing by the last component (`z`) if z<=1e-8 while Pytorch `gradcheck` computes finite differences with eps=1e-6.

* By setting `gradcheck`'s eps to 1e-8, z==0 evaluates correctly. Then, the numerical and analytical gradient match and the test passes.

#### Changes

Fixes #893 

#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
