### PR TITLE
Add requires_grad parameter to Quaternion class

### DIFF
--- a/kornia/geometry/quaternion.py
+++ b/kornia/geometry/quaternion.py
@@ -99,7 +99,7 @@ class Quaternion(Module):
         if not isinstance(data, (Tensor, Parameter)):
             raise TypeError(f"Expected Tensor or Parameter, got {type(data)}")
         # KORNIA_CHECK_SHAPE(data, ["B", "4"])  # FIXME: resolve shape bugs. @edgarriba
-        if requires_grad is not None and isinstance(data, Tensor):
+        if requires_grad is not None and not isinstance(data, Parameter):
             data = data.requires_grad_(requires_grad)
         self._data = data
 
@@ -496,7 +496,7 @@ class Quaternion(Module):
         batch_size: Optional[int] = None,
         device: Optional[Device] = None,
         dtype: Dtype = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> "Quaternion":
         """Create a quaternion representing an identity rotation.
 
@@ -504,7 +504,8 @@ class Quaternion(Module):
             batch_size: the batch size of the underlying data.
             device: device to place the result on.
             dtype: dtype of the result.
-            requires_grad: If True, the quaternion will track gradients.
+            requires_grad: If specified, sets the requires_grad flag on the quaternion.
+                If None, defaults to False (no gradient tracking).
 
         Example:
             >>> q = Quaternion.identity()
@@ -518,7 +519,7 @@ class Quaternion(Module):
         return cls(data, requires_grad=requires_grad)
 
     @classmethod
-    def from_coeffs(cls, w: float, x: float, y: float, z: float, requires_grad: bool = False) -> "Quaternion":
+    def from_coeffs(cls, w: float, x: float, y: float, z: float, requires_grad: Optional[bool] = None) -> "Quaternion":
         """Create a quaternion from the data coefficients.
 
         Args:
@@ -526,7 +527,8 @@ class Quaternion(Module):
             x: a float representing the :math:`q_x` component.
             y: a float representing the :math:`q_y` component.
             z: a float representing the :math:`q_z` component.
-            requires_grad: If True, the quaternion will track gradients.
+            requires_grad: If specified, sets the requires_grad flag on the quaternion.
+                If None, defaults to False (no gradient tracking).
 
         Example:
             >>> q = Quaternion.from_coeffs(1., 0., 0., 0.)
@@ -544,7 +546,7 @@ class Quaternion(Module):
         batch_size: Optional[int] = None,
         device: Optional[Device] = None,
         dtype: Dtype = None,
-        requires_grad: bool = False,
+        requires_grad: Optional[bool] = None,
     ) -> "Quaternion":
         """Create a random unit quaternion of shape :math:`(B, 4)`.
 
@@ -554,7 +556,8 @@ class Quaternion(Module):
             batch_size: the batch size of the underlying data.
             device: device to place the result on.
             dtype: dtype of the result.
-            requires_grad: If True, the quaternion will track gradients.
+            requires_grad: If specified, sets the requires_grad flag on the quaternion.
+                If None, defaults to False (no gradient tracking).
 
         Example:
             >>> q = Quaternion.random()


### PR DESCRIPTION
This commit addresses issue #3291 by adding support for explicit gradient tracking control in the Quaternion class, making its behavior consistent with PyTorch tensors.

Changes:
- Added optional `requires_grad` parameter to Quaternion.__init__()
  - When None (default), preserves the requires_grad flag from input data
  - When specified, explicitly sets the requires_grad flag on the tensor

- Added `requires_grad` parameter to all class factory methods:
  - identity(): defaults to False
  - from_coeffs(): defaults to False
  - from_matrix(): defaults to None (inherits from matrix)
  - from_euler(): defaults to None (inherits from input angles)
  - from_axis_angle(): defaults to None (inherits from axis_angle)
  - random(): defaults to False

- Mathematical operations already preserve requires_grad correctly through PyTorch's automatic gradient propagation

The implementation ensures backward compatibility - all existing code will continue to work as the new parameter has sensible defaults.

Fixes #3291

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update
