### PR TITLE
Update affwarp.py correcting class Affine documentation

### DIFF
--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -774,9 +774,9 @@ class Affine(Module):
             must have a shape of (B), where B is the batch size.
         translation: Amount of pixels for translation in x- and y-direction. The tensor must
             have a shape of (B, 2), where B is the batch size and the last dimension contains dx and dy.
-        scale_factor: Factor for scaling. The tensor must have a shape of (B), where B is the
-            batch size.
-        shear: Angles in degrees for shearing in x- and y-direction around the center. The
+        scale_factor: Factor for scaling. The tensor must have a shape of (B,2), where B is the
+            batch size and the last dimension contains scale factors for x and y direction.
+        shear: Factor for shearing in x- and y-direction around the center. The
             tensor must have a shape of (B, 2), where B is the batch size and the last dimension contains sx and sy.
         center: Transformation center in pixels. The tensor must have a shape of (B, 2), where
             B is the batch size and the last dimension contains cx and cy. Defaults to the center of image to be


### PR DESCRIPTION
The documentation of the class Affine was false. Class Affine uses intern the get_affine_matrix2d method and the documentation of the class was inconsistent with the documentation of the method. The changes try to fix this inconsistency. 


#### Changes

the scale factor has dimension 2 not 1 for scaling in x and y direction 

the shear is not given in angle it is a factor in x and y 

the used the method for a university assignment and had problems with bugs when using the documentation for coding

dependencies: i think None we only changed documentation


Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update



#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
