### PR TITLE
GPU support for `create_meshgrid` inside `depth_to_3d` function

### DIFF
--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -172,11 +172,8 @@ def depth_to_3d(depth: Tensor, camera_matrix: Tensor, normalize_points: bool = F
     # create base coordinates grid
     _, _, height, width = depth.shape
     points_2d: Tensor = create_meshgrid(
-        height,
-        width,
-        normalized_coordinates=False,
-        device=depth.device,
-        dtype=depth.dtype)  # 1xHxWx2
+        height, width, normalized_coordinates=False, device=depth.device, dtype=depth.dtype
+    )  # 1xHxWx2
 
     # depth should come in Bx1xHxW
     points_depth: Tensor = depth.permute(0, 2, 3, 1)  # 1xHxWx1


### PR DESCRIPTION
#### Changes

Before this change, `depth_to_3d` always created the meshgrid on the CPU and then transferred it to the GPU.

This caused two issues:
1. Creating high-resolution meshgrids on the CPU is slow.
2. It forces a CPU-GPU synchronization, which can significantly hurt performance in typical ML optimization loops or other performance-sensitive scenarios.

All the necessary GPU support already existed but wasn't being used. This PR simply enables it.

Fixes # (issue)

#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [ ] 🧪 Tests Cases
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
