### PR TITLE
Moved NeRF test helpers into kornia.testing (part of tests reorg) + run pre-commit fixes

### DIFF
--- a/testing/nerf.py
+++ b/testing/nerf.py
@@ -1,0 +1,167 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+from kornia.core import Device
+from kornia.geometry.camera import PinholeCamera
+
+
+def create_camera_dimensions(device, dtype):
+    n_cams1 = 3
+    n_cams2 = 2
+    heights: torch.Tensor = torch.cat(
+        (
+            torch.tensor([200] * n_cams1, device=device, dtype=dtype),
+            torch.tensor([100] * n_cams2, device=device, dtype=dtype),
+        )
+    )
+    widths: torch.Tensor = torch.cat(
+        (
+            torch.tensor([300] * n_cams1, device=device, dtype=dtype),
+            torch.tensor([400] * n_cams2, device=device, dtype=dtype),
+        )
+    )
+    num_img_rays: torch.Tensor = torch.cat(
+        (
+            torch.tensor([10] * n_cams1, device=device, dtype=dtype),
+            torch.tensor([15] * n_cams2, device=device, dtype=dtype),
+        )
+    )
+    return heights, widths, num_img_rays
+
+
+def create_intrinsics(fxs, fys, cxs, cys, device, dtype):
+    intrinsics_batch = []
+    for fx, fy, cx, cy in zip(fxs, fys, cxs, cys):
+        intrinsics = torch.eye(4, device=device, dtype=dtype)
+        intrinsics[0, 0] = fx
+        intrinsics[1, 1] = fy
+        intrinsics[0, 2] = cx
+        intrinsics[1, 2] = cy
+        intrinsics_batch.append(intrinsics)
+    return torch.stack(intrinsics_batch)
+
+
+def create_extrinsics_with_rotation(alphas, betas, gammas, txs, tys, tzs, device, dtype):
+    extrinsics_batch = []
+    for alpha, beta, gamma, tx, ty, tz in zip(alphas, betas, gammas, txs, tys, tzs):
+        Rx = torch.eye(3, device=device, dtype=dtype)
+        Rx[1, 1] = math.cos(alpha)
+        Rx[1, 2] = math.sin(alpha)
+        Rx[2, 1] = -Rx[1, 2]
+        Rx[2, 2] = Rx[1, 1]
+
+        Ry = torch.eye(3, device=device, dtype=dtype)
+        Ry[0, 0] = math.cos(beta)
+        Ry[0, 2] = -math.sin(beta)
+        Ry[2, 0] = -Ry[0, 2]
+        Ry[2, 2] = Ry[0, 0]
+
+        Rz = torch.eye(3, device=device, dtype=dtype)
+        Rz[0, 0] = math.cos(gamma)
+        Rz[0, 1] = math.sin(gamma)
+        Rz[1, 0] = -Rz[0, 1]
+        Rz[1, 1] = Rz[0, 0]
+
+        Ryz = torch.matmul(Ry, Rz)
+        R = torch.matmul(Rx, Ryz)
+
+        extrinsics = torch.eye(4, device=device, dtype=dtype)
+        extrinsics[..., 0, -1] = tx
+        extrinsics[..., 1, -1] = ty
+        extrinsics[..., 2, -1] = tz
+        extrinsics[:3, :3] = R
+
+        extrinsics_batch.append(extrinsics)
+    return torch.stack(extrinsics_batch)
+
+
+def create_one_camera(height, width, device: Device, dtype: torch.dtype) -> PinholeCamera:
+    fx = width
+    fy = height
+    cx = (width - 1.0) / 2.0
+    cy = (height - 1.0) / 2.0
+
+    tx = 0.0
+    ty = 0.0
+    tz = 1.0
+
+    alpha = math.pi / 2.0
+    beta = 0.0
+    gamma = -math.pi / 2.0
+
+    intrinsics = create_intrinsics([fx], [fy], [cx], [cy], device=device, dtype=dtype)
+    extrinsics = create_extrinsics_with_rotation([alpha], [beta], [gamma], [tx], [ty], [tz], device=device, dtype=dtype)
+
+    return PinholeCamera(
+        intrinsics,
+        extrinsics,
+        torch.tensor([height], device=device, dtype=dtype),
+        torch.tensor([width], device=device, dtype=dtype),
+    )
+
+
+def create_four_cameras(device, dtype) -> PinholeCamera:
+    height = torch.tensor([5, 4, 4, 4], device=device, dtype=dtype)
+    width = torch.tensor([9, 7, 7, 7], device=device, dtype=dtype)
+
+    fx = width.tolist()
+    fy = height.tolist()
+
+    cx = (width - 1.0) / 2.0
+    cy = (height - 1.0) / 2.0
+
+    tx = [0.0, 0.0, 0.0, 0.0]
+    ty = [0.0, 0.0, 0.0, 0.0]
+    tz = [11.0, 11.0, 11.0, 5.0]
+
+    pi = math.pi
+    alpha = [pi / 2.0, pi / 2.0, pi / 2.0, 0.0]
+    beta = [0.0, 0.0, 0.0, pi]
+    gamma = [-pi / 2.0, 0.0, pi / 2.0, 0.0]
+
+    intrinsics = create_intrinsics(fx, fy, cx, cy, device=device, dtype=dtype)
+    extrinsics = create_extrinsics_with_rotation(alpha, beta, gamma, tx, ty, tz, device=device, dtype=dtype)
+
+    cameras = PinholeCamera(intrinsics, extrinsics, height, width)
+    return cameras
+
+
+def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
+    """Creates random images for a given set of cameras."""
+    torch.manual_seed(112)
+    imgs: list[Tensor] = []
+    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
+        image_data = torch.randint(0, 255, (3, int(height), int(width)), dtype=torch.uint8)  # (C, H, W)
+        imgs.append(image_data)  # (C, H, W)
+    return imgs
+
+
+def create_red_images_for_cameras(cameras: PinholeCamera, device: Device) -> list[Tensor]:
+    """Creates red images for a given set of cameras."""
+    imgs: list[Tensor] = []
+    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
+        image_data = torch.zeros(3, int(height), int(width), dtype=torch.uint8)  # (C, H, W)
+        image_data[0, ...] = 255  # Red channel
+        imgs.append(image_data.to(device=device))
+    return imgs

--- a/tests/nerf/test_data_utils.py
+++ b/tests/nerf/test_data_utils.py
@@ -17,35 +17,10 @@
 
 from __future__ import annotations
 
-import torch
-
-from kornia.core import Device, Tensor
-from kornia.geometry.camera import PinholeCamera
 from kornia.nerf.data_utils import RayDataset, instantiate_ray_dataloader
 
 from testing.base import assert_close
-
-from tests.nerf.test_rays import create_four_cameras
-
-
-def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
-    """Creates random images for a given set of cameras."""
-    torch.manual_seed(112)
-    imgs: list[Tensor] = []
-    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
-        image_data = torch.randint(0, 255, (3, int(height), int(width)), dtype=torch.uint8)  # (C, H, W)
-        imgs.append(image_data)  # (C, H, W)
-    return imgs
-
-
-def create_red_images_for_cameras(cameras: PinholeCamera, device: Device) -> list[Tensor]:
-    """Creates red images for a given set of cameras."""
-    imgs: list[Tensor] = []
-    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
-        image_data = torch.zeros(3, int(height), int(width), dtype=torch.uint8)  # (C, H, W)
-        image_data[0, ...] = 255  # Red channel
-        imgs.append(image_data.to(device=device))
-    return imgs
+from testing.nerf import create_four_cameras, create_random_images_for_cameras
 
 
 class TestDataset:

--- a/tests/nerf/test_nerf_solver.py
+++ b/tests/nerf/test_nerf_solver.py
@@ -24,9 +24,12 @@ from kornia.nerf.nerf_model import NerfModelRenderer
 from kornia.nerf.nerf_solver import NerfSolver
 
 from testing.base import assert_close
-
-from tests.nerf.test_data_utils import create_random_images_for_cameras, create_red_images_for_cameras
-from tests.nerf.test_rays import create_four_cameras, create_one_camera
+from testing.nerf import (
+    create_four_cameras,
+    create_one_camera,
+    create_random_images_for_cameras,
+    create_red_images_for_cameras,
+)
 
 
 class TestNerfSolver:

--- a/tests/nerf/test_rays.py
+++ b/tests/nerf/test_rays.py
@@ -15,12 +15,7 @@
 # limitations under the License.
 #
 
-import math
 
-import torch
-
-from kornia.core import Device
-from kornia.geometry.camera import PinholeCamera
 from kornia.nerf.samplers import (
     RandomGridRaySampler,
     RandomRaySampler,
@@ -32,30 +27,7 @@ from kornia.nerf.samplers import (
 )
 
 from testing.base import assert_close
-
-
-def create_camera_dimensions(device, dtype):
-    n_cams1 = 3
-    n_cams2 = 2
-    heights: torch.Tensor = torch.cat(
-        (
-            torch.tensor([200] * n_cams1, device=device, dtype=dtype),
-            torch.tensor([100] * n_cams2, device=device, dtype=dtype),
-        )
-    )
-    widths: torch.Tensor = torch.cat(
-        (
-            torch.tensor([300] * n_cams1, device=device, dtype=dtype),
-            torch.tensor([400] * n_cams2, device=device, dtype=dtype),
-        )
-    )
-    num_img_rays: torch.Tensor = torch.cat(
-        (
-            torch.tensor([10] * n_cams1, device=device, dtype=dtype),
-            torch.tensor([15] * n_cams2, device=device, dtype=dtype),
-        )
-    )
-    return heights, widths, num_img_rays
+from testing.nerf import create_camera_dimensions, create_four_cameras
 
 
 class TestRaySampler_2DPoints:
@@ -81,103 +53,6 @@ class TestRaySampler_2DPoints:
         points_2d_camera = sampler.sample_points_2d(heights, widths, num_img_rays)
         assert len(points_2d_camera) == 1
         assert points_2d_camera[9].points_2d.shape == (5, 9, 2)
-
-
-def create_intrinsics(fxs, fys, cxs, cys, device, dtype):
-    intrinsics_batch = []
-    for fx, fy, cx, cy in zip(fxs, fys, cxs, cys):
-        intrinsics = torch.eye(4, device=device, dtype=dtype)
-        intrinsics[0, 0] = fx
-        intrinsics[1, 1] = fy
-        intrinsics[0, 2] = cx
-        intrinsics[1, 2] = cy
-        intrinsics_batch.append(intrinsics)
-    return torch.stack(intrinsics_batch)
-
-
-def create_extrinsics_with_rotation(alphas, betas, gammas, txs, tys, tzs, device, dtype):
-    extrinsics_batch = []
-    for alpha, beta, gamma, tx, ty, tz in zip(alphas, betas, gammas, txs, tys, tzs):
-        Rx = torch.eye(3, device=device, dtype=dtype)
-        Rx[1, 1] = math.cos(alpha)
-        Rx[1, 2] = math.sin(alpha)
-        Rx[2, 1] = -Rx[1, 2]
-        Rx[2, 2] = Rx[1, 1]
-
-        Ry = torch.eye(3, device=device, dtype=dtype)
-        Ry[0, 0] = math.cos(beta)
-        Ry[0, 2] = -math.sin(beta)
-        Ry[2, 0] = -Ry[0, 2]
-        Ry[2, 2] = Ry[0, 0]
-
-        Rz = torch.eye(3, device=device, dtype=dtype)
-        Rz[0, 0] = math.cos(gamma)
-        Rz[0, 1] = math.sin(gamma)
-        Rz[1, 0] = -Rz[0, 1]
-        Rz[1, 1] = Rz[0, 0]
-
-        Ryz = torch.matmul(Ry, Rz)
-        R = torch.matmul(Rx, Ryz)
-
-        extrinsics = torch.eye(4, device=device, dtype=dtype)
-        extrinsics[..., 0, -1] = tx
-        extrinsics[..., 1, -1] = ty
-        extrinsics[..., 2, -1] = tz
-        extrinsics[:3, :3] = R
-
-        extrinsics_batch.append(extrinsics)
-    return torch.stack(extrinsics_batch)
-
-
-def create_one_camera(height, width, device: Device, dtype: torch.dtype) -> PinholeCamera:
-    fx = width
-    fy = height
-    cx = (width - 1.0) / 2.0
-    cy = (height - 1.0) / 2.0
-
-    tx = 0.0
-    ty = 0.0
-    tz = 1.0
-
-    alpha = math.pi / 2.0
-    beta = 0.0
-    gamma = -math.pi / 2.0
-
-    intrinsics = create_intrinsics([fx], [fy], [cx], [cy], device=device, dtype=dtype)
-    extrinsics = create_extrinsics_with_rotation([alpha], [beta], [gamma], [tx], [ty], [tz], device=device, dtype=dtype)
-
-    return PinholeCamera(
-        intrinsics,
-        extrinsics,
-        torch.tensor([height], device=device, dtype=dtype),
-        torch.tensor([width], device=device, dtype=dtype),
-    )
-
-
-def create_four_cameras(device, dtype) -> PinholeCamera:
-    height = torch.tensor([5, 4, 4, 4], device=device, dtype=dtype)
-    width = torch.tensor([9, 7, 7, 7], device=device, dtype=dtype)
-
-    fx = width.tolist()
-    fy = height.tolist()
-
-    cx = (width - 1.0) / 2.0
-    cy = (height - 1.0) / 2.0
-
-    tx = [0.0, 0.0, 0.0, 0.0]
-    ty = [0.0, 0.0, 0.0, 0.0]
-    tz = [11.0, 11.0, 11.0, 5.0]
-
-    pi = math.pi
-    alpha = [pi / 2.0, pi / 2.0, pi / 2.0, 0.0]
-    beta = [0.0, 0.0, 0.0, pi]
-    gamma = [-pi / 2.0, 0.0, pi / 2.0, 0.0]
-
-    intrinsics = create_intrinsics(fx, fy, cx, cy, device=device, dtype=dtype)
-    extrinsics = create_extrinsics_with_rotation(alpha, beta, gamma, tx, ty, tz, device=device, dtype=dtype)
-
-    cameras = PinholeCamera(intrinsics, extrinsics, height, width)
-    return cameras
 
 
 class TestRaySampler_3DPoints:


### PR DESCRIPTION
…un pre-commit fixes

#### Changes
This PR centralizes reusable NeRF test utilities into a dedicated testing module and updates tests to import those helpers, improving test code health and reducing duplication.

Specifically:
- Added `kornia/testing/nerf.py` containing:
  - `create_camera_dimensions`
  - `create_intrinsics`
  - `create_extrinsics_with_rotation`
  - `create_one_camera`
  - `create_four_cameras`
  - `create_random_images_for_cameras`
  - `create_red_images_for_cameras`
- Removed the above helper definitions from:
  - `tests/nerf/test_rays.py`
  - `tests/nerf/test_data_utils.py`
- Updated `tests/nerf/test_rays.py`, `tests/nerf/test_data_utils.py`, and `tests/nerf/test_nerf_solver.py` to import helpers from `kornia.testing.nerf`.
- Ran pre-commit (ruff) and included the formatting fixes in this PR.

Related: closes part of tracker issue #2745

#### Testing / Local environment
I ran the NeRF test subset locally:

```
pytest -q tests/nerf
# 22 passed, 1 skipped
```

Environment:
- Python: `python -V` → **paste your version here**
- PyTorch: `python -c "import torch; print(torch.__version__)"` → **paste version**
- OS: Windows 10
