### PR TITLE
fix(core): enable weights_only=False for TensorWrapper serialization

### DIFF
--- a/tests/core/test_tensor_wrapper.py
+++ b/tests/core/test_tensor_wrapper.py
@@ -43,7 +43,7 @@ class TestTensorWrapper(BaseTester):
         torch.save(tensor, file_path)
         file_path.is_file()
 
-        loaded_tensor: TensorWrapper = torch.load(file_path)
+        loaded_tensor: TensorWrapper = torch.load(file_path, weights_only=False)
         assert isinstance(loaded_tensor, TensorWrapper)
 
         self.assert_close(loaded_tensor.unwrap(), tensor.unwrap())


### PR DESCRIPTION
## Description
This PR fixes a failure in `test_serialization` caused by the recent PyTorch `weights_only=True` default security setting.

The `TensorWrapper` test attempts to save and load a full Python object. PyTorch's new default restricts `torch.load` to weights only, causing `_pickle.UnpicklingError`. This fix explicitly sets `weights_only=False` for this specific test case to allow the wrapper object to be loaded.

## Testing
- [x] Ran `pytest tests/core/test_tensor_wrapper.py` locally on Apple Silicon (M-series).
- [x] Verified that the previously failing test now passes.

#### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings