### PR TITLE
Docs: fix remaining D401 docstring violations

### DIFF
--- a/kornia/augmentation/presets/ada.py
+++ b/kornia/augmentation/presets/ada.py
@@ -178,7 +178,7 @@ class AdaptiveDiscriminatorAugmentation(AugmentationSequential):
         )
 
     def update(self, real_acc: float) -> None:
-        r"""Updates internal params `p` once every `update_every` calls based on discriminator accuracy.
+        r"""Update internal params `p` once every `update_every` calls based on discriminator accuracy.
 
         the update is based on an exponential moving average of `real_acc`
         `p` is updated by adding or subtracting `adjustment_speed` from it and clamp it at [0, `max_p`]

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -127,7 +127,7 @@ def KORNIA_CHECK(condition: bool, msg: Optional[str] = None, raises: bool = True
 
 
 def KORNIA_UNWRAP(maybe_obj: object, typ: Any) -> Any:
-    """Unwraps an optional contained value that may or not be present.
+    """Unwrap an optional contained value that may or not be present.
 
     Args:
         maybe_obj: the object to unwrap.
@@ -461,7 +461,7 @@ def KORNIA_CHECK_LAF(laf: Tensor, raises: bool = True) -> bool:
 
 
 def _handle_invalid_range(msg: Optional[str], raises: bool, min_val: float | Tensor, max_val: float | Tensor) -> bool:
-    """Helper function to handle invalid range cases."""
+    """Handle invalid range cases."""
     err_msg = f"Invalid image value range. Expect [0, 1] but got [{min_val}, {max_val}]."
     if msg is not None:
         err_msg += f"\n{msg}"

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -190,7 +190,7 @@ class OriNet(nn.Module):
 
     @staticmethod
     def _normalize_input(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-        """Utility function that normalizes the input by batch."""
+        """Normalize the input by batch."""
         sp, mp = torch.std_mean(x, dim=(-3, -2, -1), keepdim=True)
         # WARNING: we need to .detach() input, otherwise the gradients produced by
         # the patches extractor with F.grid_sample are very noisy, making the detector

--- a/kornia/geometry/camera/utils.py
+++ b/kornia/geometry/camera/utils.py
@@ -226,7 +226,7 @@ def create_four_cameras(device: Device, dtype: torch.dtype) -> PinholeCamera:
 
 
 def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
-    """Creates random images for a given set of cameras."""
+    """Create random images for a given set of cameras."""
     torch.manual_seed(112)
     imgs: list[Tensor] = []
     for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
@@ -236,7 +236,7 @@ def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
 
 
 def create_red_images_for_cameras(cameras: PinholeCamera, device: Device) -> list[Tensor]:
-    """Creates red images for a given set of cameras."""
+    """Create red images for a given set of cameras."""
     imgs: list[Tensor] = []
     for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
         image_data = torch.zeros(3, int(height), int(width), dtype=torch.uint8)  # (C, H, W)

--- a/kornia/image/image.py
+++ b/kornia/image/image.py
@@ -188,7 +188,7 @@ class Image:
         return self
 
     def to_gray(self) -> Image:
-        """Converts the image to grayscale."""
+        """Convert the image to grayscale."""
         src = self._pixel_format.color_space
         data = self._data
 
@@ -220,7 +220,7 @@ class Image:
         return Image(out, new_pf, new_layout)
 
     def to_rgb(self) -> Image:
-        """Converts the image to RGB."""
+        """Convert the image to RGB."""
         src = self._pixel_format.color_space
         data = self._data
 
@@ -246,7 +246,7 @@ class Image:
         return Image(out, new_pf, new_layout)
 
     def to_bgr(self) -> Image:
-        """Converts the image to BGR."""
+        """Convert the image to BGR."""
         src = self._pixel_format.color_space
         data = self._data
 


### PR DESCRIPTION
This PR fixes the remaining Ruff D401 docstring violations after syncing with `main`,
so the rule can be enabled cleanly in CI.
