### PR TITLE
tests(image): migrate test_image to BaseTester

### DIFF
--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -173,8 +173,6 @@ class TestImage(BaseTester):
         self.assert_close(img_rgb.to_bgr().data.squeeze(), bgr_val)
         self.assert_close(img_bgr.to_rgb().data.squeeze(), rgb_val)
 
-
-
     @pytest.mark.skipif(torch_version_le(1, 9, 1), reason="dlpack is broken in torch<=1.9.1")
     @pytest.mark.xfail(reason="This may fail some time due to jpeg compression assertion")
     def test_load_write(self, tmp_path: Path) -> None:
@@ -205,5 +203,3 @@ def make_image(data: torch.Tensor, cs: ColorSpace, order: ChannelsOrder) -> Imag
     pf = PixelFormat(color_space=cs, bit_depth=data.element_size() * 8)
     layout = ImageLayout(image_size=ImageSize(H, W), channels=C, channels_order=order)
     return Image(data.clone(), pf, layout)
-
-


### PR DESCRIPTION
#### Changes
This PR migrates `tests/image/test_image.py` to use `BaseTester` as part of the ongoing test standardization effort.

Related #2752 


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] 📚  Documentation Update
- [x] 🧪 Tests Cases
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔬 New feature (non-breaking change which adds functionality)
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
