### PR TITLE
Perf: optimized unsharp by using lerp

### DIFF
--- a/kornia/filters/unsharp.py
+++ b/kornia/filters/unsharp.py
@@ -17,9 +17,10 @@
 
 from __future__ import annotations
 
+import torch
+
 from kornia.core import ImageModule as Module
 from kornia.core import Tensor
-import torch
 
 from .gaussian import gaussian_blur2d
 
@@ -51,6 +52,7 @@ def unsharp_mask(
     """
     data_blur: Tensor = gaussian_blur2d(input, kernel_size, sigma, border_type)
     return torch.lerp(data_blur, input, weight=2.0)
+
 
 class UnsharpMask(Module):
     r"""Create an operator that sharpens image with: out = 2 * image - gaussian_blur2d(image).


### PR DESCRIPTION
Replaced the `input + (input - data_blur)` with `torch.lerp(data_blur, input, weight=2.0)` which effectively does the same thing, but without the memory allocation and separate kernels for all the operations. I did not think it would affect the speed of the function this much but these were the results of a benchmark run on Colab

--- Benchmarking on CPU ---
Input: torch.Size([16, 3, 512, 512]), Device: cpu
Original             | 380.4911 ms per call
Optimized (lerp)     | 354.2562 ms per call

--- Benchmarking on CUDA ---
Input: torch.Size([16, 3, 512, 512]), Device: cuda
Original             | 6.4617 ms per call
Optimized (lerp)     | 5.2504 ms per call

https://colab.research.google.com/drive/1V-oc1MvRd_MZBmIcYd9e8PrUn5pOV0px?usp=sharing

heres the colab file with the benchmarking script, still feels weird to see this much of a speedup with this small of a change, if there's anything wrong with the benchmarking lemme know