### PR TITLE
refactor(tests): Add parametrization to smoke, shape, and gradcheck t…

### DIFF
--- a/tests/augmentation/_3d/test_random_horizontal_flip_3d.py
+++ b/tests/augmentation/_3d/test_random_horizontal_flip_3d.py
@@ -30,7 +30,7 @@ class TestRandomHorizontalFlip3D(BaseTester):
     # TODO: improve and implement more meaningful smoke tests e.g check for a consistent
     # return values such a torch.Tensor variable.
     @pytest.mark.xfail(reason="might fail under windows OS due to printing preicision.")
-    def test_smoke(self):
+    def test_smoke(self, device):
         f = RandomHorizontalFlip3D(0.5)
         repr = "RandomHorizontalFlip3D(p=0.5, p_batch=1.0, same_on_batch=False, return_transform=None)"
         assert str(f) == repr
@@ -123,5 +123,5 @@ class TestRandomHorizontalFlip3D(BaseTester):
         self.assert_close(f.transform_matrix, expected_transform_1)
 
     def test_gradcheck(self, device):
-        input_tensor = torch.rand((1, 3, 3)).to(device)  # 3 x 3
+        input_tensor = torch.rand((1, 3, 3), dtype=torch.float64, device=device)  # 3 x 3
         self.gradcheck(RandomHorizontalFlip3D(p=1.0), (input_tensor,))

--- a/tests/feature/test_steerer.py
+++ b/tests/feature/test_steerer.py
@@ -25,9 +25,9 @@ from testing.base import BaseTester
 
 class TestDiscreteSteerer(BaseTester):
     @pytest.mark.parametrize("num_desc, desc_dim, steerer_power", [(1, 4, 1), (2, 128, 7), (32, 128, 11)])
-    def test_shape(self, num_desc, desc_dim, steerer_power, device):
-        desc = torch.rand(num_desc, desc_dim, device=device)
-        generator = torch.rand(desc_dim, desc_dim, device=device)
+    def test_shape(self, num_desc, desc_dim, steerer_power, device, dtype):
+        desc = torch.rand(num_desc, desc_dim, device=device, dtype=dtype)
+        generator = torch.rand(desc_dim, desc_dim, device=device, dtype=dtype)
         steerer = DiscreteSteerer(generator)
         desc = steerer.steer_descriptions(desc, steerer_power=steerer_power)
         assert desc.shape == (num_desc, desc_dim)

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import torch
+
 from kornia.core import tensor
 from kornia.utils.misc import (
     differentiable_clipping,
@@ -34,7 +36,7 @@ class TestDifferentiableClipping(BaseTester):
         self.assert_close(y, y_expected)
 
     def test_gradcheck(self, device):
-        x = tensor([1.0, 6.0, 11.0, 12.0], device=device)
+        x = tensor([1.0, 6.0, 11.0, 12.0], device=device, dtype=torch.float64)
         self.gradcheck(differentiable_clipping, (x, 5.0, 10.0))
 
 
@@ -47,7 +49,7 @@ class TestDifferentiablePolynomialRounding(BaseTester):
         self.assert_close(y, y_expected)
 
     def test_gradcheck(self, device):
-        x = tensor([1.0, 6.0, 10.0, 12.0], device=device)
+        x = tensor([1.0, 6.0, 10.0, 12.0], device=device, dtype=torch.float64)
         self.gradcheck(differentiable_polynomial_rounding, (x))
 
 
@@ -60,5 +62,5 @@ class TestDifferentiablePolynomialFloor(BaseTester):
         self.assert_close(y, y_expected)
 
     def test_gradcheck(self, device):
-        x = tensor([1.5, 3.1, 5.9, 6.6], device=device)
+        x = tensor([1.5, 3.1, 5.9, 6.6], device=device, dtype=torch.float64)
         self.gradcheck(differentiable_polynomial_floor, (x))


### PR DESCRIPTION
## Overview
This PR adds pytest parametrization to 6 test methods across 3 test files to enable 
automatic test execution across multiple device and dtype configurations via the 
conftest.py parametrization framework.

## Changes
- **tests/feature/test_steerer.py**: Added `dtype` parameter to `test_shape` method
- **tests/augmentation/_3d/test_random_horizontal_flip_3d.py**: 
  - Added `device` parameter to `test_smoke` method
  - Enforced `torch.float64` in `test_gradcheck` for numerical gradient accuracy
- **tests/utils/test_misc.py**: 
  - Enforced `torch.float64` in 3 `test_gradcheck` methods
  - Added `import torch` for float64 reference

## Scope
- **3 files** modified
- **6 test methods** parametrized
- **Smoke tests**: Device parametrization
- **Shape/Cardinality tests**: Device + dtype parametrization
- **Gradcheck tests**: Device parametrization + hardcoded float64 (critical for numerical stability)

## Testing
All modified tests pass and properly parametrize across conftest.py configurations:

```bash
pytest tests/feature/test_steerer.py::TestDiscreteSteerer::test_shape -v
pytest tests/augmentation/_3d/test_random_horizontal_flip_3d.py::TestRandomHorizontalFlip3D::test_smoke -v
pytest tests/augmentation/_3d/test_random_horizontal_flip_3d.py::TestRandomHorizontalFlip3D::test_gradcheck -v
pytest tests/utils/test_misc.py -k "test_gradcheck" -v