### PR TITLE
fix: preserve align_corners from extra_args in inverse_masks (fixes #3400)

### DIFF
--- a/kornia/augmentation/_2d/geometric/base.py
+++ b/kornia/augmentation/_2d/geometric/base.py
@@ -102,28 +102,27 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         align_corners_was_none: bool = False
         original_align_corners: Optional[bool] = None
 
-        # Check resample mode before modifying it
-        is_nearest_mode = False
         if "resample" in flags:
             resample_method = flags["resample"]
-            # Check if we're setting it to nearest (masks always use nearest)
-            is_nearest_mode = True
             flags["resample"] = Resample.get("nearest")
 
         # When align_corners=None is in flags (from extra_args), use the module's default
         # This ensures masks use the same align_corners value as inputs for consistency
-        # However, for 'nearest' mode, align_corners must be None (PyTorch requirement)
+        # However, for 'slice' cropping_mode with 'nearest' mode, align_corners must be None
+        # because crop_by_indices -> resize -> interpolate doesn't accept align_corners with nearest
+        # For 'resample' cropping_mode, warp_affine/grid_sample accepts align_corners with nearest
         if "align_corners" in flags and flags["align_corners"] is None:
             align_corners_was_none = True
             original_align_corners = None
-            # For 'nearest' resample mode, align_corners must be None
-            # For other modes, use the module's default align_corners value
-            if is_nearest_mode:
-                # Keep align_corners=None for nearest mode (PyTorch requirement)
+            # Check if we're using 'slice' cropping_mode which uses interpolate
+            # interpolate doesn't accept align_corners with nearest mode
+            if flags.get("cropping_mode") == "slice":
+                # Keep align_corners=None for slice mode with nearest (interpolate requirement)
                 pass
             else:
                 # Use the module's default align_corners value from self.flags
                 # This ensures masks use the same align_corners as inputs
+                # For 'resample' mode, warp_affine/grid_sample accepts align_corners with nearest
                 flags["align_corners"] = self.flags.get("align_corners", False)
 
         output = self.apply_transform(input, params, flags, transform)
@@ -256,12 +255,8 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         resample_method: Optional[Resample] = None
         align_corners_value: Optional[bool] = None
         align_corners_was_none_in_kwargs: bool = False
-        # Check resample mode before modifying it
-        is_nearest_mode = False
         if "resample" in flags:
             resample_method = flags["resample"]
-            # Check if we're setting it to nearest (masks always use nearest)
-            is_nearest_mode = True
             flags["resample"] = Resample.get("nearest")
         # Preserve align_corners from extra_args (kwargs) if provided
         # This ensures masks use the same align_corners setting in inverse as in forward
@@ -269,18 +264,23 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             align_corners_value = flags.get("align_corners")
             # When align_corners=None is in kwargs, use the module's default
             # This ensures masks use the same align_corners value as inputs for consistency
-            # However, for 'nearest' mode, align_corners must be None (PyTorch requirement)
+            # However, for 'slice' cropping_mode with 'nearest' mode, align_corners must be None
+            # because crop_by_indices -> resize -> interpolate doesn't accept align_corners with nearest
+            # For 'resample' cropping_mode, warp_affine/grid_sample accepts align_corners with nearest
             # We need to normalize it in kwargs too, because inverse_inputs will call
             # _process_kwargs_to_params_and_flags which merges kwargs into flags
             if kwargs["align_corners"] is None:
                 align_corners_was_none_in_kwargs = True
-                # For 'nearest' resample mode, align_corners must be None
-                # For other modes, use the module's default align_corners value
-                if is_nearest_mode:
-                    # Keep align_corners=None for nearest mode (PyTorch requirement)
+                # Check if we're using 'slice' cropping_mode which uses interpolate
+                # interpolate doesn't accept align_corners with nearest mode
+                if flags.get("cropping_mode") == "slice":
+                    # Keep align_corners=None for slice mode with nearest (interpolate requirement)
                     # Don't modify flags or kwargs
                     pass
                 else:
+                    # Use the module's default align_corners value
+                    # This ensures masks use the same align_corners as inputs
+                    # For 'resample' mode, warp_affine/grid_sample accepts align_corners with nearest
                     normalized_align_corners = self.flags.get("align_corners", False)
                     flags["align_corners"] = normalized_align_corners
                     # Also update kwargs to prevent _process_kwargs_to_params_and_flags from overwriting


### PR DESCRIPTION
## Description

This PR fixes an issue where `inverse_masks` was not preserving `align_corners` from `extra_args` (kwargs), causing mismatched results between input and mask inverses when `align_corners=None` was specified for masks.

## Changes

- Updated `inverse_masks` in `GeometricAugmentationBase2D` to preserve `align_corners` from `extra_args`, similar to how `resample` is handled
- This ensures masks use the same `align_corners` setting in the inverse as they did in the forward pass

## Testing

- Fixed failing test `test_random_crops[cpu-float64]` which was failing due to this issue
- Test now passes for both float32 and float64 with the original tolerance (1e-4)

## Related Issue

Fixes #3400