### PR TITLE
Link in docs AND on RTD?

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -281,6 +281,7 @@ def linkcode_resolve(domain, info):
     end = start + len(src) - 1
     return f"{code_url}/{file_rel}#L{start}-L{end}"
 
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {


### PR DESCRIPTION
## 📝 Description

Previous one works locally

<img width="793" height="391" alt="image" src="https://github.com/user-attachments/assets/1736457c-1a0c-43dd-ae59-fa1ed26aa1dc" />


but somehow not on readthedocs.
<img width="650" height="256" alt="image" src="https://github.com/user-attachments/assets/b6014bfb-dd74-44f4-9643-d414d99bbe13" />


 So I am trying to debug that in prod. Also apply the code review comment I missed from previous :)

https://github.com/kornia/kornia/pull/3466