### PR TITLE
perf: vectorize sepia with device-aware dispatch (einsum/conv2d)

### DIFF
--- a/benchmarks/color/sepia_test.py
+++ b/benchmarks/color/sepia_test.py
@@ -20,16 +20,16 @@ import torch
 
 from kornia.color import sepia_from_rgb
 
+
 @pytest.mark.parametrize("B", [1, 8, 32])
 @pytest.mark.parametrize("C", [3])
 @pytest.mark.parametrize("H", [128, 256, 512])
 @pytest.mark.parametrize("W", [128, 256, 512])
 def test_sepia_from_rgb(benchmark, device, dtype, torch_optimizer, B, C, H, W):
-    
     data = torch.rand(B, C, H, W, device=device, dtype=dtype)
-    
+
     op = torch_optimizer(sepia_from_rgb)
 
-    actual = benchmark(op,data)
+    actual = benchmark(op, data)
 
     assert actual.shape == (B, 3, H, W)

--- a/kornia/color/sepia.py
+++ b/kornia/color/sepia.py
@@ -16,9 +16,10 @@
 #
 
 import torch
-from torch import nn
 import torch.nn.functional as F
-from kornia.core.check import KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+from torch import nn
+
+from kornia.core.check import KORNIA_CHECK_SHAPE
 
 
 def sepia_from_rgb(input: torch.Tensor, rescale: bool = True, eps: float = 1e-6) -> torch.Tensor:
@@ -43,11 +44,11 @@ def sepia_from_rgb(input: torch.Tensor, rescale: bool = True, eps: float = 1e-6)
                 [[0.9370]]])
     """
     # Safety Checks
-    KORNIA_CHECK_SHAPE(input, ["*", "3", "H", "W"])    
+    KORNIA_CHECK_SHAPE(input, ["*", "3", "H", "W"])
 
     image_compute = input if input.is_floating_point() else input.float()
     input_shape = image_compute.shape
-    
+
     # Standard Sepia Matrix
     kernel = torch.tensor(
         [
@@ -73,9 +74,9 @@ def sepia_from_rgb(input: torch.Tensor, rescale: bool = True, eps: float = 1e-6)
 
         # Reshape kernel: (3, 3) -> (3, 3, 1, 1)
         weight = kernel.view(3, 3, 1, 1)
-        
+
         out_flat = F.conv2d(input_flat, weight)
-        
+
         # Unflatten back to original shape
         out = out_flat.reshape(input_shape)
 

--- a/tests/color/test_sepia.py
+++ b/tests/color/test_sepia.py
@@ -57,7 +57,7 @@ class TestSepia(BaseTester):
 
     def test_exception(self, device, dtype):
         from kornia.core.exceptions import ShapeError
-        
+
         with pytest.raises(ShapeError):
             kornia.color.sepia(torch.rand(size=(4, 1, 1), dtype=dtype, device=device))
 


### PR DESCRIPTION
## 📝 Description

**⚠️ Issue Link Required**: #3314 
**Fixes/Relates to:** #3314 

**Summary:**
This PR optimizes the sepia_from_rgb function by replacing the legacy serial element-wise operations with vectorized linear algebra operations. It introduces a device-aware dispatch strategy to maximize throughput on both CPU and GPU hardwares, significantly improving batch processing speeds.

---

## 🛠️ Changes Made
- [x] Vectorization: Replaced manual channel extraction and element-wise addition/multiplication with matrix operations.
- [x] Device Dispatch: Implemented a branching strategy:
    - **CPU:** Uses torch.einsum for memory-efficient matrix multiplication.
    - **GPU:** Uses torch.nn.functional.conv2d (1x1 convolution) to leverage optimized CUDA kernels.
- [x] Type Safety: Added explicit dtype and device casting for the kernel tensor to match the input image.

---

## 🧪 How Was This Tested?
- [x] Unit Tests: Verified against existing Kornia tests (pytest kornia/color/test_sepia.py).
- [x] Numerical Equivalence: Validated that torch.allclose(old_impl, new_impl) returns True for random tensors.
- [x] Performance Benchmarking: Created a script to compare throughput on CPU vs. GPU (Laptop RTX 4060).

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Benchmarking was conducted on an NVIDIA RTX 4060 (Laptop) and CPU. The optimization removes Python loop overhead and leverages hardware intrinsics.
<img width="994" height="522" alt="PR(Sepia)" src="https://github.com/user-attachments/assets/36d0cd44-f72b-4c9b-9e82-c4e408c0b4cb" />

