### PR TITLE
Add regression test for SigLip2 logit_scale numerical stability

### DIFF
--- a/tests/models/test_siglip2.py
+++ b/tests/models/test_siglip2.py
@@ -26,7 +26,6 @@ from kornia.models.siglip2.config import SigLip2TextConfig, SigLip2VisionConfig
 from kornia.models.siglip2.preprocessor import SigLip2ImagePreprocessor
 from kornia.models.siglip2.text_encoder import SigLip2TextEmbeddings, SigLip2TextEncoder, SigLip2TextModel
 from kornia.models.siglip2.vision_encoder import SigLip2VisionEmbeddings, SigLip2VisionEncoder, SigLip2VisionModel
-from kornia.models.siglip2 import SigLip2Model, SigLip2Config
 
 from testing.base import BaseTester
 
@@ -53,7 +52,8 @@ class TestSigLip2Model(BaseTester):
 
     def test_siglip2_logit_scale_no_nan(self):
         import torch
-        from kornia.models.siglip2 import SigLip2Model, SigLip2Config
+
+        from kornia.models.siglip2 import SigLip2Config, SigLip2Model
 
         config = SigLip2Config()
         model = SigLip2Model(config)
@@ -68,7 +68,7 @@ class TestSigLip2Model(BaseTester):
 
         assert torch.isfinite(output.logits_per_image).all()
         assert torch.isfinite(output.logits_per_text).all()
-        
+
     def test_smoke(self, device, dtype, config):
         """Test basic model instantiation."""
         model = SigLip2Model(config).to(device, dtype)


### PR DESCRIPTION
### Summary
Adds a regression test to ensure numerical stability of `SigLip2Model` when
`logit_scale` grows to large values during training.

### Motivation
An issue reported NaNs caused by exponential overflow when `logit_scale` becomes
large. The current implementation clamps the value before exponentiation; this
test ensures that behavior remains stable and prevents future regressions.

### Changes
- Added regression test validating finite logits for large `logit_scale`.

### Related Issue
Fixes #3481 
