### PR TITLE
Migrate codespell config to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
@@ -31,11 +31,6 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        args:
-          - --ignore-words-list
-          - "ans,hist,laf,cofusion"
-          - --skip
-          - "*.bib,*.ipynb"
 
   - repo: https://github.com/arkinmodi/add-license-header
     rev: v2.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ exclude = ["**/*.md"]  # Exclude markdown files from wheel
 [tool.hatch.build.targets.sdist]
 include = ["kornia/", "LICENSE", "README.md"]
 
+[tool.codespell]
+ignore-words-list = "ans,hist,laf,cofusion"
+skip = "*.bib,*.ipynb"
+
 [tool.ruff]
 target-version = "py311"
 line-length = 120


### PR DESCRIPTION
This pull request updates the configuration for pre-commit hooks and moves codespell-specific settings to `pyproject.toml` for better organization and maintainability. The most important changes are grouped below:

Pre-commit hook adjustments:

* Changed the ruff hook in `.pre-commit-config.yaml` from `ruff` to `ruff-check` to reflect updated naming and deprecated id.

Configuration migration and cleanup:

* Removed codespell arguments (`ignore-words-list` and `skip`) from `.pre-commit-config.yaml` and migrated them to a new `[tool.codespell]` section in `pyproject.toml` for centralized configuration. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L26-L38) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R92-R95)