### PR TITLE
Enable grouping for GitHub Actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
       prefix: ⬆️
     open-pull-requests-limit: 5
     # this will group all dependencies together into single PRs for all github-actions
-    #groups:
-    #  github-actions:
-    #    patterns:
-    #      - "*"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 📝 Description

This pull request enables grouping for GitHub Actions dependencies in the Dependabot configuration, which will consolidate updates for all GitHub Actions into single pull requests instead of separate ones.

* Dependabot configuration: Enabled the `groups` feature for `github-actions` dependencies in `.github/dependabot.yml`, allowing all GitHub Actions updates to be grouped together in single PRs.

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** (List new/updated tests)
- [ ] **Manual Verification:** (Describe the steps you took)
- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [x] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [ ] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
