### PR TITLE
docs: add interactive image equalization demo reference

### DIFF
--- a/docs/source/enhance.rst
+++ b/docs/source/enhance.rst
@@ -40,6 +40,7 @@ Equalization
 .. autofunction:: equalize
 .. autofunction:: equalize_clahe
 .. autofunction:: equalize3d
+
 Interactive Demo
 
 .. raw:: html


### PR DESCRIPTION
Hi maintainers,
In my previous attempt I added the demo reference, but I mistakenly didn’t place it next to the related functions/examples.
This PR fixes that by adding the interactive Gradio demo reference under the Equalization section in docs/source/enhance.rst, following the same formatting used for other Kornia demos.

Demo: https://huggingface.co/spaces/Iamabhipandat/kornia-image-equalization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an interactive demo reference for equalization in the docs.
> 
> - Inserts an "Interactive Demo" block under `Equalization` in `docs/source/enhance.rst`, embedding a Gradio app (`<gradio-app src="Iamabhipandat/kornia-image-equalization">`) and linking to its Hugging Face Space.
> - Documentation-only change; no code or API modifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee0bb4e5f4576df795ae33b65858c3c422d3c18d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->