### PR TITLE
removed output.clone() in _transform_output_shape()

### DIFF
--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -239,7 +239,7 @@ def _transform_output_shape(
         torch.Tensor
 
     """
-    out_tensor = output.detach()
+    out_tensor = output
 
     for dim in range(len(out_tensor.shape) - len(shape)):
         idx = 0


### PR DESCRIPTION
## 📝 Description
Fixes #3494 

The _transform_output_shape() function is called whenever transform_input() is called with keepdim =True. Within this helper function, the entire output torch.Tensor is cloned. The idea, I believe, is that the change of dimensionality within that function does not overwrite the original Tensor.

The _transform_output_shape() function is only ever called like this:
`output = _transform_output_shape(output, ori_shape) if self.keepdim else output`
(e.g. in kornia.augmentation.base.py, line 336)

This renders the cloning useless, since the output tensor is overwritten at the end.

Based on #3494, I removed the .clone() call in the _transform_output_shape() function to prevent excessive GPU memory consumption when processing large 3D images with numerous augmentations, as each augmentation call clones the input torch tensor.

Whether the .clone() should be replaced with .detach() or be removed entirely is an open question. I put in .detach() since it avoids carrying over computation graphs, which are not required in transformations. Are there cases where users want to retain their graphs while applying transformations? If yes, I will remove the .detach() call.
UPDATE: Based on copilot review, I looked into the code, and yes, .detach() is wrong here, hence I removed the call entirely.

---

## 🛠️ Changes Made
- in kornia.augmentation.utils.helpers.py, removed the .clone() in line 242

---

## 🧪 How Was This Tested?
- [x ] **Unit Tests:** There are no new tests; the current ones run locally based on pixi run lint/test/typecheck.
- [x ] **Manual Verification:** I ran a lot of custom augmentations on large 3D images and verified that in both code-bases, the results are identical, while prior to the code-change, the GPU memory consumption explodes for each transform_input() call, since it it will call the _transform_output_shape() function if self.keepdim is set to true. An example can be found in #3494 .
- [ ] **Performance/Edge Cases:** TBD, although I currently don't see relevance regarding edge cases. I did not run performance benchmarks beyond measuring GPU memory consumption and comparing that, as shown in #3494.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [x ] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x ] I am assigned to the linked issue (required before PR submission)
- [x ] The linked issue has been approved by a maintainer
- [x ] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x ] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
