### PR TITLE
refactor(color): vectorize yuv with device-aware dispatch and safety …

### DIFF
--- a/benchmarks/color/yuv_test.py
+++ b/benchmarks/color/yuv_test.py
@@ -18,7 +18,7 @@
 import pytest
 import torch
 
-from kornia.color import yuv_to_rgb, rgb_to_yuv
+from kornia.color import rgb_to_yuv, yuv_to_rgb
 
 
 @pytest.mark.parametrize("B", [1, 8, 32])

--- a/kornia/color/utils.py
+++ b/kornia/color/utils.py
@@ -1,7 +1,27 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import torch
 from torch.nn import functional as F
 
-def _apply_linear_transformation(image: torch.Tensor, kernel: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
+
+def _apply_linear_transformation(
+    image: torch.Tensor, kernel: torch.Tensor, bias: torch.Tensor | None = None
+) -> torch.Tensor:
     """Apply a 3x3 linear color transformation with device-aware optimization.
 
     Args:
@@ -32,7 +52,7 @@ def _apply_linear_transformation(image: torch.Tensor, kernel: torch.Tensor, bias
 
         if bias is not None:
             out = out + bias.view(-1, 1, 1)
-            
+
         return out.contiguous()
 
     # BRANCH 2: GPU/Accelerators (Conv2d)

--- a/kornia/color/yuv.py
+++ b/kornia/color/yuv.py
@@ -21,11 +21,10 @@ from typing import ClassVar
 
 import torch
 from torch import nn
-from torch.nn import functional as F
 
+from kornia.color.utils import _apply_linear_transformation
 from kornia.core.check import KORNIA_CHECK_SHAPE
 from kornia.core.exceptions import ShapeError
-from kornia.color.utils import _apply_linear_transformation
 
 
 def rgb_to_yuv(image: torch.Tensor) -> torch.Tensor:
@@ -53,7 +52,7 @@ def rgb_to_yuv(image: torch.Tensor) -> torch.Tensor:
 
     """
     KORNIA_CHECK_SHAPE(image, ["*", "3", "H", "W"])
-    
+
     kernel = torch.tensor(
         [
             [0.299, 0.587, 0.114],
@@ -221,7 +220,7 @@ def yuv420_to_rgb(imagey: torch.Tensor, imageuv: torch.Tensor) -> torch.Tensor:
         [imagey, imageuv.repeat_interleave(2, dim=-1).repeat_interleave(2, dim=-2)],
         dim=-3,
     )
-    
+
     return yuv_to_rgb(yuv444image)
 
 
@@ -263,7 +262,7 @@ def yuv422_to_rgb(imagey: torch.Tensor, imageuv: torch.Tensor) -> torch.Tensor:
 
     # first upsample
     yuv444image = torch.cat([imagey, imageuv.repeat_interleave(2, dim=-1)], dim=-3)
-    
+
     return yuv_to_rgb(yuv444image)
 
 

--- a/tests/color/test_yuv.py
+++ b/tests/color/test_yuv.py
@@ -38,8 +38,7 @@ class TestRgbToYuv(BaseTester):
         assert kornia.color.rgb_to_yuv(img).shape == shape
 
     def test_exception(self, device, dtype):
-        
-        with pytest.raises((TypeError,AttributeError)):
+        with pytest.raises((TypeError, AttributeError)):
             assert kornia.color.rgb_to_yuv([0.0])
 
         with pytest.raises(ShapeError):
@@ -105,7 +104,7 @@ class TestRgbToYuv420(BaseTester):
         assert kornia.color.rgb_to_yuv420(img)[1].shape == tuple(shapeuv)
 
     def test_exception(self, device, dtype):
-        with pytest.raises((TypeError,AttributeError)):
+        with pytest.raises((TypeError, AttributeError)):
             assert kornia.color.rgb_to_yuv420([0.0])
 
         with pytest.raises(ShapeError):
@@ -260,7 +259,7 @@ class TestRgbToYuv422(BaseTester):
         assert kornia.color.rgb_to_yuv422(img)[1].shape == tuple(shapeuv)
 
     def test_exception(self, device, dtype):
-        with pytest.raises((TypeError,AttributeError)):
+        with pytest.raises((TypeError, AttributeError)):
             assert kornia.color.rgb_to_yuv422([0.0])
 
         with pytest.raises(ShapeError):
@@ -323,7 +322,7 @@ class TestYuvToRgb(BaseTester):
         assert kornia.color.yuv_to_rgb(img).shape == shape
 
     def test_exception(self, device, dtype):
-        with pytest.raises((TypeError,AttributeError)):
+        with pytest.raises((TypeError, AttributeError)):
             assert kornia.color.yuv_to_rgb([0.0])
 
         with pytest.raises(ShapeError):
@@ -390,7 +389,7 @@ class TestYuv420ToRgb(BaseTester):
         assert kornia.color.yuv420_to_rgb(imgy, imguv).shape == shape
 
     def test_exception(self, device, dtype):
-        with pytest.raises((TypeError,AttributeError)):
+        with pytest.raises((TypeError, AttributeError)):
             assert kornia.color.yuv420_to_rgb([0.0], [0.0])
 
         with pytest.raises(ShapeError):
@@ -494,7 +493,7 @@ class TestYuv422ToRgb(BaseTester):
         assert kornia.color.yuv422_to_rgb(imgy, imguv).shape == shape
 
     def test_exception(self, device, dtype):
-        with pytest.raises((TypeError,AttributeError)):
+        with pytest.raises((TypeError, AttributeError)):
             assert kornia.color.yuv422_to_rgb([0.0], [0.0])
 
         with pytest.raises(ShapeError):


### PR DESCRIPTION
## 📝 Description

**⚠️ Issue Link Required**: #3314 

**Fixes/Relates to**: #3314 

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- **Hybrid Vectorization Strategy:**
    - **RGB → YUV:** Implemented `torch.einsum` for CPU (contiguous memory optimization) and `F.conv2d` for CUDA (massive parallelism).
    - **YUV → RGB:** Implemented a **Sparse Dispatch**: uses explicit unrolled math on CPU (avoiding dense matrix multiplication overhead for sparse kernels) and `F.conv2d` on CUDA.
- **Precision Stability:** Fixed `gradcheck` instability by ensuring transformation kernels strictly sync with the input `dtype` (resolving `Float` vs `Double` mismatches in `_apply_linear_transformation`).
- **Safety Standards:** Replaced manual assertions with strict `KORNIA_CHECK_SHAPE` macros.
- **Tests:** Updated `tests/color/test_yuv.py` to handle strict type checking and proper `gradcheck` validation (enforcing `float64`).

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** `pytest tests/color/test_yuv.py` (Passed all smoke, exception, and gradcheck tests).
- [x] **Manual Verification:** Verified correctness against the old implementation and checked output contiguity.
- [x] **Performance/Edge Cases:** Benchmarked using `torch.compile` (Inductor) on CPU and CUDA.

### 🚀 Performance Summary
Significant speedups achieved on both devices, particularly for CUDA operations.

* **RGB → YUV:**
    * **CPU:** **1.86x** Speedup (1527ms → 820ms)
    * **CUDA:** **5.70x** Speedup (19.7ms → 3.4ms)
* **YUV → RGB:**
    * **CPU:** **1.17x** Speedup (1135ms → 970ms)
    * **CUDA:** **3.65x** Speedup (12.5ms → 3.4ms)

#### 📸 Comparison Screenshot
<img width="1230" height="646" alt="Screenshot 2026-01-16 145713" src="https://github.com/user-attachments/assets/0a43ca69-2520-43ae-8fea-065c1f42ab0e" />

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context

### 📊 CPU Benchmark Results
| Function | Min (ms) | Mean (ms) | StdDev (ms) |
| :--- | :--- | :--- | :--- |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-128-3-1] | 0.0732 | 0.1365 | 0.0826 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-128-3-8] | 0.1202 | 0.1914 | 0.0616 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-128-3-32] | 4.0409 | 4.2034 | 0.1551 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-256-3-1] | 0.1191 | 0.1439 | 0.0322 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-256-3-8] | 0.3184 | 0.4172 | 0.1182 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-256-3-32] | 10.7771 | 11.0931 | 0.2752 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-512-3-1] | 0.1349 | 0.1646 | 0.0426 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-512-3-8] | 0.8307 | 0.9819 | 0.1593 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-128-512-3-32] | 19.5361 | 20.4961 | 0.8089 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-128-3-1] | 0.0694 | 0.0997 | 0.0426 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-128-3-8] | 0.2396 | 0.3021 | 0.0732 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-128-3-32] | 3.8432 | 4.0514 | 0.2044 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-256-3-1] | 0.0745 | 0.0868 | 0.0188 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-256-3-8] | 0.6125 | 0.7485 | 0.1372 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-256-3-32] | 19.4734 | 20.8668 | 1.1960 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-512-3-1] | 0.1287 | 0.1752 | 0.0463 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-512-3-8] | 3.8892 | 4.1027 | 0.1862 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-256-512-3-32] | 39.3638 | 41.4907 | 1.3730 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-128-3-1] | 0.0758 | 0.0935 | 0.0194 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-128-3-8] | 0.6734 | 0.8227 | 0.1495 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-128-3-32] | 19.7268 | 20.6857 | 0.8413 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-256-3-1] | 0.1579 | 0.1945 | 0.0441 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-256-3-8] | 4.0152 | 4.1930 | 0.3024 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-256-3-32] | 39.2523 | 40.5638 | 1.1838 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-512-3-1] | 0.1381 | 0.2024 | 0.0595 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-512-3-8] | 20.1204 | 20.9848 | 0.8105 |
| `test_rgb_to_yuv_benchmark` [cpu-float32-inductor-512-512-3-32] | 77.8496 | 80.4396 | 1.8528 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-128-3-1] | 0.0626 | 0.0848 | 0.0295 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-128-3-8] | 0.1193 | 0.1873 | 0.0510 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-128-3-32] | 1.2392 | 1.6075 | 0.2736 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-256-3-1] | 0.0660 | 0.0799 | 0.0162 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-256-3-8] | 0.2097 | 0.2944 | 0.0945 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-256-3-32] | 3.8903 | 4.1752 | 0.2174 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-512-3-1] | 0.0712 | 0.0840 | 0.0194 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-512-3-8] | 0.7675 | 1.0529 | 0.1987 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-128-512-3-32] | 19.8670 | 20.8981 | 0.8449 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-128-3-1] | 0.0689 | 0.0878 | 0.0240 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-128-3-8] | 0.2399 | 0.3018 | 0.0821 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-128-3-32] | 3.8655 | 4.4734 | 0.6433 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-256-3-1] | 0.0853 | 0.1015 | 0.0210 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-256-3-8] | 0.8167 | 0.9749 | 0.1314 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-256-3-32] | 19.8680 | 20.3867 | 0.5661 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-512-3-1] | 0.0937 | 0.1302 | 0.0401 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-512-3-8] | 3.7979 | 4.0978 | 0.2136 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-256-512-3-32] | 41.2907 | 42.8408 | 0.7795 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-128-3-1] | 0.0737 | 0.0925 | 0.0228 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-128-3-8] | 0.8781 | 1.0666 | 0.1991 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-128-3-32] | 20.1758 | 21.1484 | 0.8563 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-256-3-1] | 0.1038 | 0.1285 | 0.0344 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-256-3-8] | 3.8043 | 4.0224 | 0.1761 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-256-3-32] | 39.4070 | 40.6848 | 0.9695 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-512-3-1] | 0.1161 | 0.1841 | 0.0599 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-512-3-8] | 19.6549 | 20.8449 | 0.8402 |
| `test_yuv_to_rgb_benchmark` [cpu-float32-inductor-512-512-3-32] | 78.8268 | 81.1719 | 1.7532 |

### 📊 CUDA Benchmark Results
| Function | Min (ms) | Mean (ms) | StdDev (ms) |
| :--- | :--- | :--- | :--- |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-128-3-1] | 0.2353 | 0.3373 | 0.1501 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-128-3-8] | 0.1986 | 0.2433 | 0.0910 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-128-3-32] | 0.1978 | 0.2305 | 0.0391 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-256-3-1] | 0.1989 | 0.2371 | 0.0376 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-256-3-8] | 0.1945 | 0.2332 | 0.0514 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-256-3-32] | 0.2301 | 0.2807 | 0.0473 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-512-3-1] | 0.2078 | 0.2534 | 0.0568 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-512-3-8] | 0.2028 | 0.2355 | 0.0430 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-128-512-3-32] | 0.2165 | 0.2645 | 0.0425 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-128-3-1] | 0.2068 | 0.2557 | 0.0409 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-128-3-8] | 0.2041 | 0.2477 | 0.0558 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-128-3-32] | 0.2018 | 0.2368 | 0.0426 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-256-3-1] | 0.1992 | 0.2514 | 0.0550 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-256-3-8] | 0.1954 | 0.2112 | 0.0203 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-256-3-32] | 0.1987 | 0.2275 | 0.0321 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-512-3-1] | 0.2086 | 0.2708 | 0.0714 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-512-3-8] | 0.2011 | 0.2529 | 0.0717 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-256-512-3-32] | 0.2229 | 0.2609 | 0.0400 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-128-3-1] | 0.2142 | 0.2490 | 0.0383 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-128-3-8] | 0.1987 | 0.2341 | 0.0396 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-128-3-32] | 0.1996 | 0.2314 | 0.0430 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-256-3-1] | 0.2019 | 0.2222 | 0.0212 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-256-3-8] | 0.2004 | 0.2479 | 0.0483 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-256-3-32] | 0.1955 | 0.2218 | 0.0390 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-512-3-1] | 0.1994 | 0.2321 | 0.0437 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-512-3-8] | 0.2023 | 0.2396 | 0.0474 |
| `test_rgb_to_yuv_benchmark` [cuda-float32-inductor-512-512-3-32] | 0.2271 | 0.2806 | 0.0556 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-128-3-1] | 0.2045 | 0.2561 | 0.0586 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-128-3-8] | 0.2028 | 0.2447 | 0.0399 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-128-3-32] | 0.2082 | 0.2458 | 0.0346 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-256-3-1] | 0.2120 | 0.2447 | 0.0323 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-256-3-8] | 0.1995 | 0.2340 | 0.0411 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-256-3-32] | 0.2032 | 0.2357 | 0.0404 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-512-3-1] | 0.2008 | 0.2326 | 0.0427 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-512-3-8] | 0.2027 | 0.2428 | 0.0330 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-128-512-3-32] | 0.2015 | 0.2366 | 0.0343 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-128-3-1] | 0.2075 | 0.2489 | 0.0333 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-128-3-8] | 0.2014 | 0.2612 | 0.0628 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-128-3-32] | 0.2075 | 0.2369 | 0.0348 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-256-3-1] | 0.2046 | 0.2396 | 0.0341 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-256-3-8] | 0.2009 | 0.2309 | 0.0291 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-256-3-32] | 0.2002 | 0.2357 | 0.0392 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-512-3-1] | 0.2032 | 0.2404 | 0.0428 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-512-3-8] | 0.2034 | 0.2372 | 0.0289 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-256-512-3-32] | 0.1994 | 0.2325 | 0.0262 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-128-3-1] | 0.2123 | 0.2460 | 0.0312 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-128-3-8] | 0.2005 | 0.2467 | 0.0514 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-128-3-32] | 0.1985 | 0.2401 | 0.0503 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-256-3-1] | 0.1995 | 0.2426 | 0.0529 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-256-3-8] | 0.2101 | 0.2323 | 0.0256 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-256-3-32] | 0.2041 | 0.2411 | 0.0425 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-512-3-1] | 0.2114 | 0.2497 | 0.0644 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-512-3-8] | 0.2059 | 0.2476 | 0.0425 |
| `test_yuv_to_rgb_benchmark` [cuda-float32-inductor-512-512-3-32] | 0.1983 | 0.2353 | 0.0434 |