### PR TITLE
docs: fix output shape comment in RawToRgb example

### DIFF
--- a/kornia/color/raw.py
+++ b/kornia/color/raw.py
@@ -305,7 +305,7 @@ class RawToRgb(nn.Module):
     Example:
         >>> rawinput = torch.rand(2, 1, 4, 6)
         >>> rgb = RawToRgb(CFA.RG)
-        >>> output = rgb(rawinput)  # 2x3x4x5
+        >>> output = rgb(rawinput)  # 2x3x4x6
 
     """
 


### PR DESCRIPTION
Correct the output shape comment from 2x3x4x5 to 2x3x4x6 to match the actual input dimensions.

## 📝 Description

**Fixes/Relates to:** #3526 

---

## 🛠️ Changes Made
Fix wrong shape "output = rgb(rawinput)  # 2x3x4x5" to "output = rgb(rawinput)  # 2x3x4x6".
Code is right, just documentation error.

