### PR TITLE
fix: use StrEnum instead of string and enum

### DIFF
--- a/kornia/config.py
+++ b/kornia/config.py
@@ -17,12 +17,12 @@
 
 import os
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 __all__ = ["InstallationMode", "kornia_config"]
 
 
-class InstallationMode(str, Enum):
+class InstallationMode(StrEnum):
     """Represent the installation mode for external dependencies."""
 
     # Ask the user if to install the dependencies


### PR DESCRIPTION
## Refactor: Update InstallationMode to use StrEnum (UP042)

This PR modernizes the `InstallationMode` configuration class by migrating from a manual `(str, Enum)` mixin to the native `enum.StrEnum` introduced in Python 3.11.

### Changes:

* Updated `InstallationMode` to inherit from `StrEnum`.
* Resolved linter warning **UP042** (pyupgrade).
* Maintained custom `__eq__` logic to support existing case-insensitive string comparisons.

### Impact:

* **No breaking changes** for Python 3.11+ environments.
* Improves native string serialization (e.g., `str(Mode.ASK)` now returns `"ASK"` instead of `"InstallationMode.ASK"`).
* Better type-hinting support for string-based operations.
