### PR TITLE
fix: handle empty batch in median_blur

### DIFF
--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -57,6 +57,12 @@ def median_blur(input: torch.Tensor, kernel_size: tuple[int, int] | int) -> torc
     KORNIA_CHECK_IS_TENSOR(input)
     KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
 
+    # NOTE: torch.nn.functional.conv2d does not accept a zero batch size.
+    # Keep behavior consistent with other Kornia filters by returning an empty,
+    # contiguous tensor with the same shape/dtype/device.
+    if input.shape[0] == 0:
+        return input.contiguous()
+
     padding = _compute_zero_padding(kernel_size)
 
     # prepare kernel

--- a/tests/filters/test_median.py
+++ b/tests/filters/test_median.py
@@ -29,12 +29,14 @@ class TestMedianBlur(BaseTester):
         actual = median_blur(inp, 3)
         assert isinstance(actual, torch.Tensor)
 
-    @pytest.mark.parametrize("batch_size", [1, 2])
+    @pytest.mark.parametrize("batch_size", [0, 1, 2])
     @pytest.mark.parametrize("kernel_size", [3, (5, 7)])
     def test_cardinality(self, batch_size, kernel_size, device, dtype):
         inp = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)
         actual = median_blur(inp, kernel_size)
         assert actual.shape == (batch_size, 3, 4, 4)
+        if batch_size == 0:
+            assert actual.is_contiguous()
 
     def test_exception(self, device, dtype):
         from kornia.core.exceptions import ShapeError, TypeCheckError


### PR DESCRIPTION
Closes #3580

### Problem
`median_blur` crashes when called with an empty batch (`B=0`), since `torch.nn.functional.conv2d` does not accept a zero batch size.

### Solution
Early-return an empty contiguous tensor with the same shape/dtype/device for `B==0`.

### Tests
- Added a cardinality test case for `batch_size=0` (CI will run full suite).