### PR TITLE
chore(tests): remove unused grad/jit/nn pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,9 +242,6 @@ max-statements = 64  # Recommended: 50
 addopts = "--color=yes -v"
 testpaths = ["tests"]
 markers = [
-  "grad: mark a test as gradcheck test",
-  "jit: mark a test as torchscript test",
-  "nn: mark a test as module test",
   "slow: mark test as slow to run",
   "tf32: mark a test as sensitive to TF32 (TensorFloat-32) CUDA matmul precision; xfail by default, run with --tf32 to activate",
 ]

--- a/tests/augmentation/container/test_augmentation_sequential.py
+++ b/tests/augmentation/container/test_augmentation_sequential.py
@@ -510,7 +510,6 @@ class TestAugmentationSequential:
         if random_apply is False:
             reproducibility_test((inp, mask, bbox, keypoints, bbox_2, bbox_wh, bbox_wh_2), aug)
 
-    @pytest.mark.jit()
     @pytest.mark.skip(reason="turn off due to Union Type")
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4

--- a/tests/augmentation/container/test_video_sequential.py
+++ b/tests/augmentation/container/test_video_sequential.py
@@ -141,7 +141,6 @@ class TestVideoSequential:
             output_2 = output_2.transpose(1, 2)
         assert_close(output_1, output_2)
 
-    @pytest.mark.jit()
     @pytest.mark.skip(reason="turn off due to Union Type")
     def test_jit(self, device, dtype):
         B, C, D, H, W = 2, 3, 5, 4, 4

--- a/tests/color/test_gray.py
+++ b/tests/color/test_gray.py
@@ -101,7 +101,6 @@ class TestGrayscaleToRgb(BaseTester):
         img_rgb = kornia.color.grayscale_to_rgb(data)
         assert_close(img_rgb, expected)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
@@ -223,7 +222,6 @@ class TestRgbToGrayscale(BaseTester):
         assert img_gray.device == device
         assert img_gray.dtype == dtype
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
@@ -319,7 +317,6 @@ class TestBgrToGrayscale(BaseTester):
         img_gray = kornia.color.bgr_to_grayscale(data)
         assert_close(img_gray, expected)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)

--- a/tests/color/test_hls.py
+++ b/tests/color/test_hls.py
@@ -130,13 +130,11 @@ class TestRgbToHls(BaseTester):
         ext_rand_slice = (torch.rand((1, 3, 32, 32), dtype=dtype, device=device) >= 0.5).float()
         assert not kornia.color.rgb_to_hls(ext_rand_slice).isnan().any()
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_hls, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -248,13 +246,11 @@ class TestHlsToRgb(BaseTester):
         data[:, 0] -= 4 * math.pi
         self.assert_close(f(data), expected, low_tolerance=True)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.hls_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_hsv.py
+++ b/tests/color/test_hsv.py
@@ -231,13 +231,11 @@ class TestHsvToRgb(BaseTester):
         data[:, 0] -= 4 * math.pi
         self.assert_close(f(data), expected, low_tolerance=True)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.hsv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_lab.py
+++ b/tests/color/test_lab.py
@@ -115,13 +115,11 @@ class TestRgbToLab(BaseTester):
         data_out = lab(rgb(data, clip=False))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_lab, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -260,14 +258,12 @@ class TestLabToRgb(BaseTester):
         unclipped_data_out = rgb(lab(data), clip=False)
         self.assert_close(unclipped_data_out, data)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         img = kornia.color.rgb_to_lab(img)
         assert gradcheck(kornia.color.lab_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_luv.py
+++ b/tests/color/test_luv.py
@@ -117,13 +117,11 @@ class TestRgbToLuv(BaseTester):
         data_out = luv(rgb(data))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_luv, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -236,14 +234,12 @@ class TestLuvToRgb(BaseTester):
         data_out = rgb(luv(data))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         img = kornia.color.rgb_to_luv(img)
         assert gradcheck(kornia.color.luv_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_raw.py
+++ b/tests/color/test_raw.py
@@ -136,13 +136,11 @@ class TestRawToRgb(BaseTester):
         assert_close(bgres[:, :, 1:5, 1:5], grres[:, :, 2:6, 1:5])
         assert_close(bgres[:, :, 1:5, 1:5], rgres[:, :, 2:6, 2:6])
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.raw_to_rgb, (img, kornia.color.raw.CFA.BG), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -179,13 +177,11 @@ class TestRgbToRaw(BaseTester):
 
         # Reverse test in rawtorgb is sufficient functional test
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_raw, (img, kornia.color.raw.CFA.BG), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_rgb.py
+++ b/tests/color/test_rgb.py
@@ -88,13 +88,11 @@ class TestRgbToBgr(BaseTester):
         f = kornia.color.rgb_to_bgr
         self.assert_close(f(data), expected)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_bgr, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -236,13 +234,11 @@ class TestRgbToRgba(BaseTester):
         aval = torch.full_like(data[:, :1], aval)  # Bx1xHxW
         self.assert_close(kornia.color.rgb_to_rgba(data, aval), expected)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_rgba, (img, 1.0), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.grad()
     def test_gradcheck_th(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
@@ -250,7 +246,6 @@ class TestRgbToRgba(BaseTester):
         assert gradcheck(kornia.color.rgb_to_rgba, (img, aval), raise_exception=True, fast_mode=True)
 
     @pytest.mark.skip(reason="unsupported Union type")
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -395,14 +390,12 @@ class TestLinearRgb(BaseTester):
         f = kornia.color.linear_rgb_to_rgb
         self.assert_close(f(data), expected)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_linear_rgb, (img,), raise_exception=True, fast_mode=True)
         assert gradcheck(kornia.color.linear_rgb_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -410,7 +403,6 @@ class TestLinearRgb(BaseTester):
         op_jit = torch.jit.script(op)
         self.assert_close(op(img), op_jit(img))
 
-    @pytest.mark.jit()
     def test_jit_linear(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -464,7 +456,6 @@ class TestRgb255Normals(BaseTester):
         normals_restored = kornia.color.rgb255_to_normals(rgb255_normals)
         torch.testing.assert_close(data_normals, normals_restored, atol=1e-4, rtol=1e-4)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.full((B, C, H, W), 0.5, device=device, dtype=torch.float64, requires_grad=True)
@@ -473,7 +464,6 @@ class TestRgb255Normals(BaseTester):
         assert gradcheck(kornia.color.normals_to_rgb255, (img,), raise_exception=True, fast_mode=True)
         assert gradcheck(kornia.color.rgb255_to_normals, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_xyz.py
+++ b/tests/color/test_xyz.py
@@ -115,13 +115,11 @@ class TestRgbToXyz(BaseTester):
         data_out = xyz(rgb(data))
         self.assert_close(data_out, data)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_xyz, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -228,13 +226,11 @@ class TestXyzToRgb(BaseTester):
         data_out = rgb(xyz(data))
         self.assert_close(data_out, data, low_tolerance=True)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.xyz_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_ycbcr.py
+++ b/tests/color/test_ycbcr.py
@@ -122,13 +122,11 @@ class TestRgbToYcbcr(BaseTester):
     # def test_forth_and_back(self, device, dtype):
     #    pass
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.rgb_to_ycbcr, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -235,13 +233,11 @@ class TestYcbcrToRgb(BaseTester):
     # def test_forth_and_back(self, device, dtype):
     #    pass
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         assert gradcheck(kornia.color.ycbcr_to_rgb, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/color/test_yuv.py
+++ b/tests/color/test_yuv.py
@@ -27,85 +27,514 @@ from testing.base import BaseTester
 
 class TestRgbToYuv(BaseTester):
     def test_smoke(self, device, dtype):
-        img = torch.rand(3, 4, 5, device=device, dtype=dtype)
-        out = kornia.color.rgb_to_yuv(img)
-        assert isinstance(out, torch.Tensor)
+        C, H, W = 3, 4, 5
+        img = torch.rand(C, H, W, device=device, dtype=dtype)
+        assert isinstance(kornia.color.rgb_to_yuv(img)[0], torch.Tensor)
+        assert isinstance(kornia.color.rgb_to_yuv(img)[1], torch.Tensor)
 
-    @pytest.mark.parametrize(
-        "shape",
-        [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 1)],
-    )
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 1), (3, 2, 1)])
     def test_cardinality(self, device, dtype, shape):
         img = torch.ones(shape, device=device, dtype=dtype)
-        out = kornia.color.rgb_to_yuv(img)
-        assert out.shape == shape
+        assert kornia.color.rgb_to_yuv(img).shape == shape
 
     def test_exception(self, device, dtype):
         with pytest.raises((TypeError, AttributeError)):
-            kornia.color.rgb_to_yuv([0.0])
+            assert kornia.color.rgb_to_yuv([0.0])
 
         with pytest.raises(ShapeError):
-            kornia.color.rgb_to_yuv(torch.ones(1, 1, device=device, dtype=dtype))
+            img = torch.ones(1, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv(img)
 
         with pytest.raises(ShapeError):
-            kornia.color.rgb_to_yuv(torch.ones(2, 1, 1, device=device, dtype=dtype))
+            img = torch.ones(2, 1, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv(img)
 
-    def test_unit_invariants(self, device, dtype):
-        rgb = torch.tensor(
-            [
-                [1.0, 0.0, 0.0],  # red
-                [0.0, 1.0, 0.0],  # green
-                [0.0, 0.0, 1.0],  # blue
-                [1.0, 1.0, 1.0],  # white
-                [0.0, 0.0, 0.0],  # black
-            ],
-            device=device,
-            dtype=dtype,
-        ).view(5, 3, 1, 1)
+    # TODO: investigate and implement me
+    # def test_unit(self, device, dtype):
+    #    pass
 
-        yuv = kornia.color.rgb_to_yuv(rgb)
+    # TODO: improve accuracy
+    def test_forth_and_back(self, device, dtype):
+        data = torch.rand(3, 4, 5, device=device, dtype=dtype)
+        yuv = kornia.color.rgb_to_yuv
+        rgb = kornia.color.yuv_to_rgb
 
-        # shape preserved
-        assert yuv.shape == rgb.shape
+        data_out = rgb(yuv(data))
+        self.assert_close(data_out, data, low_tolerance=True)
 
-        Y = yuv[:, 0, 0, 0]
-
-        # basic luminance ordering invariants
-        assert Y[3] > Y[4]  # white > black
-        assert Y[1] > Y[2]  # green generally brighter than blue
-
-        # neutral colors have near-zero chroma
-        self.assert_close(yuv[3, 1:], torch.zeros_like(yuv[3, 1:]), atol=1e-4, rtol=1e-4)
-        self.assert_close(yuv[4], torch.zeros_like(yuv[4]), atol=1e-4, rtol=1e-4)
-
-    def test_round_trip_rgb_yuv_rgb(self, device, dtype):
-        rgb = torch.rand(3, 4, 5, device=device, dtype=dtype)
-
-        yuv = kornia.color.rgb_to_yuv(rgb)
-        rgb_back = kornia.color.yuv_to_rgb(yuv)
-
-        atol = 1e-3 if dtype in (torch.float32, torch.float64) else 1e-2
-
-        self.assert_close(rgb_back, rgb, atol=atol, rtol=1e-3)
-
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
-        img = torch.rand(2, 3, 4, 4, device=device, dtype=torch.float64, requires_grad=True)
-        assert gradcheck(
-            kornia.color.rgb_to_yuv,
-            (img,),
-            raise_exception=True,
-            fast_mode=True,
-        )
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
+        assert gradcheck(kornia.color.rgb_to_yuv, (img,), raise_exception=True, fast_mode=True)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
-        img = torch.ones(2, 3, 4, 4, device=device, dtype=dtype)
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
         op = kornia.color.rgb_to_yuv
         op_jit = torch.jit.script(op)
         self.assert_close(op(img), op_jit(img))
 
     def test_module(self, device, dtype):
-        img = torch.ones(2, 3, 4, 4, device=device, dtype=dtype)
-        module = kornia.color.RgbToYuv().to(device, dtype)
-        self.assert_close(module(img), kornia.color.rgb_to_yuv(img))
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        ops = kornia.color.RgbToYuv().to(device, dtype)
+        fcn = kornia.color.rgb_to_yuv
+        self.assert_close(ops(img), fcn(img))
+
+
+class TestRgbToYuv420(BaseTester):
+    def test_smoke(self, device, dtype):
+        C, H, W = 3, 4, 6
+        img = torch.rand(C, H, W, device=device, dtype=dtype)
+        assert isinstance(kornia.color.rgb_to_yuv420(img)[0], torch.Tensor)
+        assert isinstance(kornia.color.rgb_to_yuv420(img)[1], torch.Tensor)
+
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2), (3, 3, 3, 4, 4)])
+    def test_cardinality(self, device, dtype, shape):
+        img = torch.ones(shape, device=device, dtype=dtype)
+        shapey = list(shape)
+        shapey[-3] = 1
+        shapeuv = list(shape)
+        shapeuv[-3] = 2
+        shapeuv[-2] /= 2
+        shapeuv[-1] /= 2
+        assert kornia.color.rgb_to_yuv420(img)[0].shape == tuple(shapey)
+        assert kornia.color.rgb_to_yuv420(img)[1].shape == tuple(shapeuv)
+
+    def test_exception(self, device, dtype):
+        with pytest.raises((TypeError, AttributeError)):
+            assert kornia.color.rgb_to_yuv420([0.0])
+
+        with pytest.raises(ShapeError):
+            img = torch.ones(1, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv420(img)
+
+        with pytest.raises(ShapeError):
+            img = torch.ones(2, 1, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv420(img)
+
+        # dimensionality tests
+        with pytest.raises(ShapeError):
+            img = torch.ones(3, 2, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv420(img)
+
+        with pytest.raises(ShapeError):
+            img = torch.ones(3, 1, 2, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv420(img)
+
+    # Test max/min values. This is essentially testing the transform rather than the subsampling
+    # ref values manually checked vs rec 601
+    def test_unit_white(self, device, dtype):  # skipcq: PYL-R0201
+        rgb = (
+            torch.tensor(
+                [[[255, 255], [255, 255]], [[255, 255], [255, 255]], [[255, 255], [255, 255]]],
+                device=device,
+                dtype=torch.uint8,
+            ).type(dtype)
+            / 255.0
+        )
+        refy = torch.tensor([[[255, 255], [255, 255]]], device=device, dtype=torch.uint8)
+        refuv = torch.tensor([[[0]], [[0]]], device=device, dtype=torch.int8)
+
+        resy = (kornia.color.rgb_to_yuv420(rgb)[0] * 255.0).round().type(torch.uint8)
+        resuv = (kornia.color.rgb_to_yuv420(rgb)[1] * 255.0).round().clamp(-128, 127).type(torch.int8)
+        self.assert_close(refy, resy)
+        self.assert_close(refuv, resuv)
+
+    def test_unit_black(self, device, dtype):  # skipcq: PYL-R0201
+        rgb = (
+            torch.tensor([[[0, 0], [0, 0]], [[0, 0], [0, 0]], [[0, 0], [0, 0]]], device=device, dtype=torch.uint8).type(
+                dtype
+            )
+            / 255.0
+        )
+        refy = torch.tensor([[[0, 0], [0, 0]]], device=device, dtype=torch.uint8)
+        refuv = torch.tensor([[[0]], [[0]]], device=device, dtype=torch.int8)
+
+        resy = (kornia.color.rgb_to_yuv420(rgb)[0] * 255.0).round().type(torch.uint8)
+        resuv = (kornia.color.rgb_to_yuv420(rgb)[1] * 255.0).round().clamp(-128, 127).type(torch.int8)
+        self.assert_close(refy, resy)
+        self.assert_close(refuv, resuv)
+
+    def test_unit_gray(self, device, dtype):  # skipcq: PYL-R0201
+        rgb = (
+            torch.tensor(
+                [[[127, 127], [127, 127]], [[127, 127], [127, 127]], [[127, 127], [127, 127]]],
+                device=device,
+                dtype=torch.uint8,
+            ).type(dtype)
+            / 255.0
+        )
+        refy = torch.tensor([[[127, 127], [127, 127]]], device=device, dtype=torch.uint8)
+        refuv = torch.tensor([[[0]], [[0]]], device=device, dtype=torch.int8)
+
+        resy = (kornia.color.rgb_to_yuv420(rgb)[0] * 255.0).round().type(torch.uint8)
+        resuv = (kornia.color.rgb_to_yuv420(rgb)[1] * 255.0).round().clamp(-128, 127).type(torch.int8)
+        self.assert_close(refy, resy)
+        self.assert_close(refuv, resuv)
+
+    def test_unit_red(self, device, dtype):  # skipcq: PYL-R0201
+        rgb = (
+            torch.tensor(
+                [[[255, 255], [255, 255]], [[0, 0], [0, 0]], [[0, 0], [0, 0]]], device=device, dtype=torch.uint8
+            ).type(dtype)
+            / 255.0
+        )
+        refy = torch.tensor([[[76, 76], [76, 76]]], device=device, dtype=torch.uint8)
+        refuv = torch.tensor([[[-37]], [[127]]], device=device, dtype=torch.int8)
+
+        resy = (kornia.color.rgb_to_yuv420(rgb)[0] * 255.0).round().type(torch.uint8)
+        resuv = (kornia.color.rgb_to_yuv420(rgb)[1] * 255.0).round().clamp(-128, 127).type(torch.int8)
+        self.assert_close(refy, resy)
+        self.assert_close(refuv, resuv)
+
+    def test_unit_blue(self, device, dtype):  # skipcq: PYL-R0201
+        rgb = (
+            torch.tensor(
+                [[[0, 0], [0, 0]], [[0, 0], [0, 0]], [[255, 255], [255, 255]]], device=device, dtype=torch.uint8
+            ).type(dtype)
+            / 255.0
+        )
+        refy = torch.tensor([[[29, 29], [29, 29]]], device=device, dtype=torch.uint8)
+        refuv = torch.tensor([[[111]], [[-25]]], device=device, dtype=torch.int8)
+
+        resy = (kornia.color.rgb_to_yuv420(rgb)[0] * 255.0).type(torch.uint8)
+        resuv = (kornia.color.rgb_to_yuv420(rgb)[1] * 255.0).clamp(-128, 127).type(torch.int8)
+        self.assert_close(refy, resy)
+        self.assert_close(refuv, resuv)
+
+    # This measures accuracy, given the impact of the subsampling we will avoid the issue by
+    # repeating a 2x2 pattern for which mean will match what we get from upscaling again
+    def test_forth_and_back(self, device, dtype):  # skipcq: PYL-R0201
+        data = torch.rand(3, 4, 5, device=device, dtype=dtype).repeat_interleave(2, dim=2).repeat_interleave(2, dim=1)
+
+        yuv = kornia.color.rgb_to_yuv420
+        rgb = kornia.color.yuv420_to_rgb
+        (a, b) = yuv(data)
+        data_out = rgb(a, b)
+        self.assert_close(data_out, data, low_tolerance=True)
+
+    def test_gradcheck(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
+        assert gradcheck(kornia.color.rgb_to_yuv420, (img,), raise_exception=True, fast_mode=True)
+
+    def test_jit(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        op = kornia.color.rgb_to_yuv420
+        op_jit = torch.jit.script(op)
+        self.assert_close(op(img)[0], op_jit(img)[0])
+        self.assert_close(op(img)[1], op_jit(img)[1])
+
+    def test_module(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        ops = kornia.color.RgbToYuv420().to(device, dtype)
+        fcn = kornia.color.rgb_to_yuv420
+        self.assert_close(ops(img)[0], fcn(img)[0])
+        self.assert_close(ops(img)[1], fcn(img)[1])
+
+
+class TestRgbToYuv422(BaseTester):
+    def test_smoke(self, device, dtype):
+        C, H, W = 3, 4, 6
+        img = torch.rand(C, H, W, device=device, dtype=dtype)
+        assert isinstance(kornia.color.rgb_to_yuv422(img)[0], torch.Tensor)
+        assert isinstance(kornia.color.rgb_to_yuv422(img)[1], torch.Tensor)
+
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2), (3, 3, 3, 4, 4)])
+    def test_cardinality(self, device, dtype, shape):
+        img = torch.ones(shape, device=device, dtype=dtype)
+        shapey = list(shape)
+        shapey[-3] = 1
+        shapeuv = list(shape)
+        shapeuv[-3] = 2
+        shapeuv[-1] /= 2
+        assert kornia.color.rgb_to_yuv422(img)[0].shape == tuple(shapey)
+        assert kornia.color.rgb_to_yuv422(img)[1].shape == tuple(shapeuv)
+
+    def test_exception(self, device, dtype):
+        with pytest.raises((TypeError, AttributeError)):
+            assert kornia.color.rgb_to_yuv422([0.0])
+
+        with pytest.raises(ShapeError):
+            img = torch.ones(1, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv422(img)
+
+        with pytest.raises(ShapeError):
+            img = torch.ones(2, 1, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv422(img)
+
+        # dimensionality test
+        with pytest.raises(ShapeError):
+            img = torch.ones(3, 2, 1, device=device, dtype=dtype)
+            assert kornia.color.rgb_to_yuv422(img)
+
+    # This measures accuracy, given the impact of the subsampling we will avoid the issue by
+    # repeating a 2x2 pattern for which mena will match what we get from upscaling again
+    def test_forth_and_back(self, device, dtype):  # skipcq: PYL-R0201
+        data = torch.rand(3, 4, 5, device=device, dtype=dtype).repeat_interleave(2, dim=2).repeat_interleave(2, dim=1)
+
+        yuv = kornia.color.rgb_to_yuv422
+        rgb = kornia.color.yuv422_to_rgb
+        (a, b) = yuv(data)
+        data_out = rgb(a, b)
+        self.assert_close(data_out, data, low_tolerance=True)
+
+    def test_gradcheck(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
+        assert gradcheck(kornia.color.rgb_to_yuv422, (img,), raise_exception=True, fast_mode=True)
+
+    def test_jit(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        op = kornia.color.rgb_to_yuv422
+        op_jit = torch.jit.script(op)
+        self.assert_close(op(img)[0], op_jit(img)[0])
+        self.assert_close(op(img)[1], op_jit(img)[1])
+
+    def test_module(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        ops = kornia.color.RgbToYuv422().to(device, dtype)
+        fcn = kornia.color.rgb_to_yuv422
+        self.assert_close(ops(img)[0], fcn(img)[0])
+        self.assert_close(ops(img)[1], fcn(img)[1])
+
+
+class TestYuvToRgb(BaseTester):
+    def test_smoke(self, device, dtype):
+        C, H, W = 3, 4, 5
+        img = torch.rand(C, H, W, device=device, dtype=dtype)
+        assert isinstance(kornia.color.yuv_to_rgb(img), torch.Tensor)
+
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 1), (3, 2, 1)])
+    def test_cardinality(self, device, dtype, shape):
+        img = torch.ones(shape, device=device, dtype=dtype)
+        assert kornia.color.yuv_to_rgb(img).shape == shape
+
+    def test_exception(self, device, dtype):
+        with pytest.raises((TypeError, AttributeError)):
+            assert kornia.color.yuv_to_rgb([0.0])
+
+        with pytest.raises(ShapeError):
+            img = torch.ones(1, 1, device=device, dtype=dtype)
+            assert kornia.color.yuv_to_rgb(img)
+
+        with pytest.raises(ShapeError):
+            img = torch.ones(2, 1, 1, device=device, dtype=dtype)
+            assert kornia.color.yuv_to_rgb(img)
+
+    # TODO: investigate and implement me
+    # def test_unit(self, device, dtype):
+    #    pass
+
+    # TODO: improve accuracy
+    def test_forth_and_back(self, device, dtype):  # skipcq: PYL-R0201
+        data = torch.rand(3, 4, 5, device=device, dtype=dtype)
+        rgb = kornia.color.yuv_to_rgb
+        yuv = kornia.color.rgb_to_yuv
+
+        data_out = rgb(yuv(data))
+        self.assert_close(data_out, data, low_tolerance=True)
+
+    def test_gradcheck(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.rand(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
+        assert gradcheck(kornia.color.yuv_to_rgb, (img,), raise_exception=True, fast_mode=True)
+
+    def test_jit(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        op = kornia.color.yuv_to_rgb
+        op_jit = torch.jit.script(op)
+        self.assert_close(op(img), op_jit(img))
+
+    def test_module(self, device, dtype):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        ops = kornia.color.YuvToRgb().to(device, dtype)
+        fcn = kornia.color.yuv_to_rgb
+        self.assert_close(ops(img), fcn(img))
+
+
+class TestYuv420ToRgb(BaseTester):
+    def test_smoke(self, device, dtype):
+        H, W = 4, 6
+        imgy = torch.rand(1, H, W, device=device, dtype=dtype)
+        imguv = torch.rand(2, int(H / 2), int(W / 2), device=device, dtype=dtype)
+        assert isinstance(kornia.color.yuv420_to_rgb(imgy, imguv), torch.Tensor)
+
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2)])
+    def test_cardinality(self, device, dtype, shape):
+        shapey = list(shape)
+        shapey[-3] = 1
+        shapeuv = list(shape)
+        shapeuv[-3] = 2
+        shapeuv[-2] = int(shapeuv[-2] / 2)
+        shapeuv[-1] = int(shapeuv[-1] / 2)
+
+        imgy = torch.ones(shapey, device=device, dtype=dtype)
+        imguv = torch.ones(shapeuv, device=device, dtype=dtype)
+        assert kornia.color.yuv420_to_rgb(imgy, imguv).shape == shape
+
+    def test_exception(self, device, dtype):
+        with pytest.raises((TypeError, AttributeError)):
+            assert kornia.color.yuv420_to_rgb([0.0], [0.0])
+
+        with pytest.raises(ShapeError):
+            imguv = torch.ones(1, 1, device=device, dtype=dtype)
+            imgy = torch.ones(1, 1, device=device, dtype=dtype)
+            assert kornia.color.yuv420_to_rgb(imgy, imguv)
+
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(2, 2, 2, device=device, dtype=dtype)
+            imguv = torch.ones(2, 1, 1, device=device, dtype=dtype)
+            assert kornia.color.yuv420_to_rgb(imgy, imguv)
+
+        # dimensionality tests
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(3, 2, 1, device=device, dtype=dtype)
+            imguv = torch.ones(3, 1, 0, device=device, dtype=dtype)
+            assert kornia.color.yuv420_to_rgb(imgy, imguv)
+
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(3, 1, 2, device=device, dtype=dtype)
+            imguv = torch.ones(3, 0, 1, device=device, dtype=dtype)
+            assert kornia.color.yuv420_to_rgb(imgy, imguv)
+
+    # Test max/min values. This is essentially testing the transform rather than the subsampling
+    # ref values manually checked vs rec 601
+    def test_unit_white(self, device, dtype):  # skipcq: PYL-R0201
+        refrgb = torch.tensor(
+            [[[255, 255], [255, 255]], [[255, 255], [255, 255]], [[255, 255], [255, 255]]],
+            device=device,
+            dtype=torch.uint8,
+        )
+        y = torch.tensor([[[255, 255], [255, 255]]], device=device, dtype=torch.uint8).type(dtype) / 255.0
+        uv = torch.tensor([[[0]], [[0]]], device=device, dtype=torch.int8).type(torch.float) / 255.0
+
+        resrgb = (kornia.color.yuv420_to_rgb(y, uv) * 255.0).round().type(torch.uint8)
+        self.assert_close(refrgb, resrgb)
+
+    def test_unit_red(self, device, dtype):  # skipcq: PYL-R0201
+        refrgb = torch.tensor(
+            [[[221, 221], [221, 221]], [[17, 17], [17, 17]], [[1, 1], [1, 1]]], device=device, dtype=torch.uint8
+        )
+        y = torch.tensor([[[76, 76], [76, 76]]], device=device, dtype=torch.uint8).type(dtype) / 255.0
+        uv = torch.tensor([[[-37]], [[127]]], device=device, dtype=torch.int8).type(torch.float) / 255.0
+
+        resrgb = (kornia.color.yuv420_to_rgb(y, uv) * 255.0).round().type(torch.uint8)
+        self.assert_close(refrgb, resrgb)
+
+    # TODO: improve accuracy
+    def test_forth_and_back(self, device, dtype):  # skipcq: PYL-R0201
+        datay = torch.rand(1, 4, 6, device=device, dtype=dtype)
+        datauv = torch.rand(2, 2, 3, device=device, dtype=dtype)
+        rgb = kornia.color.yuv420_to_rgb
+        yuv = kornia.color.rgb_to_yuv420
+
+        (data_outy, data_outuv) = yuv(rgb(datay, datauv))
+        self.assert_close(data_outy, datay, low_tolerance=True)
+        self.assert_close(data_outuv, datauv, low_tolerance=True)
+
+    def test_gradcheck(self, device, dtype):
+        B, H, W = 2, 4, 4
+        imgy = torch.rand(B, 1, H, W, device=device, dtype=torch.float64, requires_grad=True)
+        imguv = torch.rand(B, 2, int(H / 2), int(W / 2), device=device, dtype=torch.float64, requires_grad=True)
+        assert gradcheck(kornia.color.yuv420_to_rgb, (imgy, imguv), raise_exception=True, fast_mode=True)
+
+    def test_jit(self, device, dtype):
+        B, H, W = 2, 4, 4
+        imgy = torch.ones(B, 1, H, W, device=device, dtype=dtype)
+        imguv = torch.ones(B, 2, int(H / 2), int(W / 2), device=device, dtype=dtype)
+        op = kornia.color.yuv420_to_rgb
+        op_jit = torch.jit.script(op)
+        self.assert_close(op(imgy, imguv), op_jit(imgy, imguv))
+
+    def test_module(self, device, dtype):
+        B, H, W = 2, 4, 4
+        imgy = torch.ones(B, 1, H, W, device=device, dtype=dtype)
+        imguv = torch.ones(B, 2, int(H / 2), int(W / 2), device=device, dtype=dtype)
+        ops = kornia.color.Yuv420ToRgb().to(device, dtype)
+        fcn = kornia.color.yuv420_to_rgb
+        self.assert_close(ops(imgy, imguv), fcn(imgy, imguv))
+
+
+class TestYuv422ToRgb(BaseTester):
+    def test_smoke(self, device, dtype):
+        H, W = 4, 6
+        imgy = torch.rand(1, H, W, device=device, dtype=dtype)
+        imguv = torch.rand(2, H, int(W / 2), device=device, dtype=dtype)
+        assert isinstance(kornia.color.yuv422_to_rgb(imgy, imguv), torch.Tensor)
+
+    @pytest.mark.parametrize("shape", [(1, 3, 4, 4), (2, 3, 2, 4), (3, 3, 4, 2), (3, 2, 2)])
+    def test_cardinality(self, device, dtype, shape):
+        shapey = list(shape)
+        shapey[-3] = 1
+        shapeuv = list(shape)
+        shapeuv[-3] = 2
+        shapeuv[-1] = int(shapeuv[-1] / 2)
+
+        imgy = torch.ones(shapey, device=device, dtype=dtype)
+        imguv = torch.ones(shapeuv, device=device, dtype=dtype)
+        assert kornia.color.yuv422_to_rgb(imgy, imguv).shape == shape
+
+    def test_exception(self, device, dtype):
+        with pytest.raises((TypeError, AttributeError)):
+            assert kornia.color.yuv422_to_rgb([0.0], [0.0])
+
+        with pytest.raises(ShapeError):
+            imguv = torch.ones(1, 1, device=device, dtype=dtype)
+            imgy = torch.ones(1, 1, device=device, dtype=dtype)
+            assert kornia.color.yuv422_to_rgb(imgy, imguv)
+
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(2, 2, 2, device=device, dtype=dtype)
+            imguv = torch.ones(2, 1, 1, device=device, dtype=dtype)
+            assert kornia.color.yuv422_to_rgb(imgy, imguv)
+
+        # dimensionality test
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(3, 2, 1, device=device, dtype=dtype)
+            imguv = torch.ones(3, 1, 0, device=device, dtype=dtype)
+            assert kornia.color.yuv422_to_rgb(imgy, imguv)
+
+    # TODO: investigate and implement me
+    # def test_unit(self, device, dtype):
+    #    pass
+
+    # TODO: improve accuracy
+    def test_forth_and_back(self, device, dtype):  # skipcq: PYL-R0201
+        datay = torch.rand(1, 4, 6, device=device, dtype=dtype)
+        datauv = torch.rand(2, 4, 3, device=device, dtype=dtype)
+        rgb = kornia.color.yuv422_to_rgb
+        yuv = kornia.color.rgb_to_yuv422
+
+        (data_outy, data_outuv) = yuv(rgb(datay, datauv))
+        self.assert_close(data_outy, datay, low_tolerance=True)
+        self.assert_close(data_outuv, datauv, low_tolerance=True)
+
+    def test_gradcheck(self, device, dtype):
+        B, H, W = 2, 4, 4
+        imgy = torch.rand(B, 1, H, W, device=device, dtype=torch.float64, requires_grad=True)
+        imguv = torch.rand(B, 2, H, int(W / 2), device=device, dtype=torch.float64, requires_grad=True)
+        assert gradcheck(kornia.color.yuv422_to_rgb, (imgy, imguv), raise_exception=True, fast_mode=True)
+
+    def test_jit(self, device, dtype):
+        B, H, W = 2, 4, 4
+        imgy = torch.ones(B, 1, H, W, device=device, dtype=dtype)
+        imguv = torch.ones(B, 2, H, int(W / 2), device=device, dtype=dtype)
+        op = kornia.color.yuv422_to_rgb
+        op_jit = torch.jit.script(op)
+        self.assert_close(op(imgy, imguv), op_jit(imgy, imguv))
+
+    def test_module(self, device, dtype):
+        B, H, W = 2, 4, 4
+        imgy = torch.ones(B, 1, H, W, device=device, dtype=dtype)
+        imguv = torch.ones(B, 2, H, int(W / 2), device=device, dtype=dtype)
+        ops = kornia.color.Yuv422ToRgb().to(device, dtype)
+        fcn = kornia.color.yuv422_to_rgb
+        self.assert_close(ops(imgy, imguv), fcn(imgy, imguv))

--- a/tests/enhance/test_adjust.py
+++ b/tests/enhance/test_adjust.py
@@ -46,14 +46,12 @@ class TestInvert(BaseTester):
         out = kornia.enhance.invert(img, torch.tensor(255.0))
         self.assert_close(out, torch.zeros_like(out))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 1, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=torch.float64, requires_grad=True)
         max_val = torch.tensor(1.0, device=device, dtype=torch.float64, requires_grad=True)
         self.gradcheck(kornia.enhance.invert, (img, max_val))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
         img = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -696,7 +694,6 @@ class TestAdjustSigmoid(BaseTester):
         op_optimized = torch_optimizer(op)
         self.assert_close(op(img), op_optimized(img))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         bs, channels, height, width = 1, 2, 3, 3
         inputs = torch.ones(bs, channels, height, width, device=device, dtype=torch.float64)
@@ -749,7 +746,6 @@ class TestAdjustLog(BaseTester):
         op_optimized = torch_optimizer(op)
         self.assert_close(op(img), op_optimized(img))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         bs, channels, height, width = 1, 2, 3, 3
         inputs = torch.ones(bs, channels, height, width, device=device, dtype=torch.float64)
@@ -1031,14 +1027,12 @@ class TestSharpness(BaseTester):
         self.assert_close(TestSharpness.f(inputs, 0.8), expected_08, low_tolerance=True)
         self.assert_close(TestSharpness.f(inputs, torch.tensor([0.8, 1.3])), expected_08_13, low_tolerance=True)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(TestSharpness.f, (inputs, 0.8))
 
     @pytest.mark.skip(reason="union type input")
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = TestSharpness.f
         op_script = torch.jit.script(TestSharpness.f)
@@ -1112,7 +1106,6 @@ class TestSolarize(BaseTester):
         # TODO(jian): precision is very bad compared to PIL
         self.assert_close(TestSolarize.f(inputs, 0.5), expected, rtol=1e-2, atol=1e-2)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=torch.float64)
@@ -1120,7 +1113,6 @@ class TestSolarize(BaseTester):
 
     # TODO: implement me
     @pytest.mark.skip(reason="union type input")
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = TestSolarize.f
         op_script = torch.jit.script(op)
@@ -1184,7 +1176,6 @@ class TestPosterize(BaseTester):
         self.assert_close(TestPosterize.f(inputs, 8), inputs)
 
     @pytest.mark.skip(reason="IndexError: tuple index out of range")
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         bs, channels, height, width = 2, 3, 4, 5
         inputs = torch.rand(bs, channels, height, width, device=device, dtype=torch.float64)
@@ -1192,7 +1183,6 @@ class TestPosterize(BaseTester):
 
     # TODO: implement me
     @pytest.mark.skip(reason="union type input")
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = TestPosterize.f
         op_script = torch.jit.script(op)

--- a/tests/enhance/test_normalize.py
+++ b/tests/enhance/test_normalize.py
@@ -324,7 +324,6 @@ class TestNormalizeMinMax(BaseTester):
         op_jit = torch.jit.script(op)
         self.assert_close(op(x), op_jit(x))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         x = torch.ones(1, 1, 1, 1, device=device, dtype=torch.float64, requires_grad=True)
         self.gradcheck(kornia.enhance.normalize_min_max, (x,))

--- a/tests/feature/test_defmo.py
+++ b/tests/feature/test_defmo.py
@@ -41,14 +41,12 @@ class TestDeFMO(BaseTester):
             assert out.shape == (2, 24, 4, 128, 160)
 
     @pytest.mark.slow
-    @pytest.mark.grad
     def test_gradcheck(self, device):
         patches = torch.rand(2, 6, 64, 64, device=device, dtype=torch.float64)
         defmo = DeFMO().to(patches.device, patches.dtype)
         self.gradcheck(defmo, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8)
 
     @pytest.mark.slow
-    @pytest.mark.jit
     def test_jit(self, device, dtype):
         B, C, H, W = 1, 6, 128, 160
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)

--- a/tests/feature/test_hardnet.py
+++ b/tests/feature/test_hardnet.py
@@ -44,7 +44,6 @@ class TestHardNet(BaseTester):
         hardnet = HardNet().to(patches.device, patches.dtype)
         self.gradcheck(hardnet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)
@@ -73,7 +72,6 @@ class TestHardNet8(BaseTester):
         hardnet = HardNet8().to(patches.device, patches.dtype)
         self.gradcheck(hardnet, (patches,), eps=1e-4, atol=1e-4)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/feature/test_hynet.py
+++ b/tests/feature/test_hynet.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-import pytest
 import torch
 
 from kornia.feature import HyNet

--- a/tests/feature/test_hynet.py
+++ b/tests/feature/test_hynet.py
@@ -41,7 +41,6 @@ class TestHyNet(BaseTester):
         hynet = HyNet().to(patches.device, patches.dtype)
         self.gradcheck(hynet, (patches,), eps=1e-4, atol=1e-4, nondet_tol=1e-8)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -42,7 +42,6 @@ class TestAngleToRotationMatrix(BaseTester):
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.geometry.transform.imgwarp.angle_to_rotation_matrix, (img,))
 
-    @pytest.mark.jit()
     @pytest.mark.skip("Problems with kornia.pi")
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
@@ -70,7 +69,6 @@ class TestGetLAFScale(BaseTester):
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.get_laf_scale, (img,))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width, device=device)
@@ -97,7 +95,6 @@ class TestGetLAFCenter(BaseTester):
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.get_laf_center, (img,))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
         img = torch.rand(batch_size, channels, height, width, device=device)
@@ -124,7 +121,6 @@ class TestGetLAFOri(BaseTester):
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.get_laf_orientation, (img,))
 
-    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -159,7 +155,6 @@ class TestScaleLAF(BaseTester):
         scale = torch.rand(batch_size, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.scale_laf, (laf, scale), atol=1e-4)
 
-    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -190,7 +185,6 @@ class TestSetLAFOri(BaseTester):
         ori = torch.rand(batch_size, channels, 1, 1, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.set_laf_orientation, (laf, ori), atol=1e-4)
 
-    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -232,7 +226,6 @@ class TestMakeUpright(BaseTester):
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.make_upright, (img,))
 
-    @pytest.mark.jit()
     @pytest.mark.skip("Union")
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
@@ -265,7 +258,6 @@ class TestELL2LAF(BaseTester):
         # assure it is positive definite
         self.gradcheck(kornia.feature.ellipse_to_laf, (img,))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height = 1, 2, 5
         img = torch.rand(batch_size, channels, height, device=device).abs()
@@ -315,7 +307,6 @@ class TestNormalizeLAF(BaseTester):
         img = torch.rand(batch_size, 3, 10, 32, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.normalize_laf, (laf, img))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
 
@@ -345,7 +336,6 @@ class TestLAF2pts(BaseTester):
         laf = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.laf_to_boundary_points, (laf))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 3, 2, 2, 3
         laf = torch.rand(batch_size, channels, height, width, device=device)
@@ -376,7 +366,6 @@ class TestDenormalizeLAF(BaseTester):
         img = torch.rand(batch_size, 3, 10, 32, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.denormalize_laf, (laf, img))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 1, 2, 2, 3
 
@@ -525,7 +514,6 @@ class TestLAFIsTouchingBoundary(BaseTester):
         expected = torch.tensor([[False, True]], device=device)
         assert torch.all(kornia.feature.laf_is_inside_image(laf, img) == expected).item()
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         w, h = 10, 5
         img = torch.rand(1, 3, h, w, device=device)
@@ -578,7 +566,6 @@ class TestGetCreateLAF(BaseTester):
         self.gradcheck(kornia.feature.laf_from_center_scale_ori, (xy, scale, ori))
 
     @pytest.mark.skip("Depends on angle-to-rotation-matric")
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels = 3, 2
         xy = torch.rand(batch_size, channels, 2, device=device)
@@ -611,7 +598,6 @@ class TestGetLAF3pts(BaseTester):
         inp = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.laf_to_three_points, (inp,))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 3, 2, 2, 3
         inp = torch.rand(batch_size, channels, height, width, device=device)
@@ -649,7 +635,6 @@ class TestGetLAFFrom3pts(BaseTester):
         inp = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.feature.laf_from_three_points, (inp,))
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, height, width = 3, 2, 2, 3
         inp = torch.rand(batch_size, channels, height, width, device=device)

--- a/tests/feature/test_local_features_orientation.py
+++ b/tests/feature/test_local_features_orientation.py
@@ -88,7 +88,6 @@ class TestPatchDominantGradientOrientation(BaseTester):
         patches = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(ori, (patches,))
 
-    @pytest.mark.jit()
     @pytest.mark.skip(" Compiled functions can't take variable number")
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 13, 13
@@ -136,7 +135,6 @@ class TestOriNet(BaseTester):
         ori = OriNet().to(device=device, dtype=patches.dtype)
         self.gradcheck(ori, (patches,), fast_mode=False)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/feature/test_matching.py
+++ b/tests/feature/test_matching.py
@@ -235,7 +235,6 @@ class TestMatchSMNN(BaseTester):
         self.gradcheck(match_smnn, (desc1, desc2, 0.8), nondet_tol=1e-4)
         self.gradcheck(matcher, (desc1, desc2), nondet_tol=1e-4)
 
-    @pytest.mark.jit()
     @pytest.mark.parametrize("match_type", ["nn", "snn", "mnn", "smnn"])
     def test_jit(self, match_type, device, dtype):
         desc1 = torch.rand(5, 8, device=device, dtype=dtype)
@@ -341,7 +340,6 @@ class TestMatchFGINN(BaseTester):
         lafs2 = laf_from_center_scale_ori(center2)
         self.gradcheck(match_fginn, (desc1, desc2, lafs1, lafs2, 0.8, 0.05), nondet_tol=1e-4)
 
-    @pytest.mark.jit()
     @pytest.mark.skip("keyword-arg expansion is not supported")
     def test_jit(self, device, dtype):
         desc1 = torch.rand(5, 8, device=device, dtype=dtype)

--- a/tests/feature/test_mkd.py
+++ b/tests/feature/test_mkd.py
@@ -199,7 +199,6 @@ class TestVonMisesKernel(BaseTester):
 
         self.gradcheck(vm_describe, (patches, ps), nondet_tol=1e-4)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 13, 13
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
@@ -251,7 +250,6 @@ class TestEmbedGradients(BaseTester):
 
         self.gradcheck(emb_grads_describe, (patches, ps), nondet_tol=1e-4)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 2, 13, 13
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
@@ -322,7 +320,6 @@ class TestExplicitSpacialEncoding(BaseTester):
 
         self.gradcheck(explicit_spatial_describe, (patches, ps), nondet_tol=1e-4)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 2, 13, 13
         patches = torch.rand(B, C, H, W, device=device, dtype=dtype)
@@ -383,7 +380,6 @@ class TestWhitening(BaseTester):
 
         self.gradcheck(whitening_describe, (patches, in_dims), nondet_tol=1e-4)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, in_dims = 1, 175
         patches = torch.rand(batch_size, in_dims).to(device)
@@ -457,7 +453,6 @@ class TestMKDDescriptor(BaseTester):
         self.gradcheck(mkd_describe, (patches, ps), nondet_tol=1e-4)
 
     @pytest.mark.skip("neither dict, nor nn.ModuleDict works")
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         batch_size, channels, ps = 1, 1, 19
         patches = torch.rand(batch_size, channels, ps, ps).to(device)

--- a/tests/feature/test_sosnet.py
+++ b/tests/feature/test_sosnet.py
@@ -43,7 +43,6 @@ class TestSOSNet(BaseTester):
         sosnet = SOSNet(pretrained=False).to(patches.device, patches.dtype)
         self.gradcheck(sosnet, (patches,), eps=1e-4, atol=1e-4)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/feature/test_tfeat.py
+++ b/tests/feature/test_tfeat.py
@@ -52,7 +52,6 @@ class TestTFeat(BaseTester):
         self.gradcheck(tfeat, (patches,), eps=1e-2, atol=1e-2)
 
     @pytest.mark.slow
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         B, C, H, W = 2, 1, 32, 32
         patches = torch.ones(B, C, H, W, device=device, dtype=dtype)

--- a/tests/geometry/test_homography.py
+++ b/tests/geometry/test_homography.py
@@ -258,7 +258,6 @@ class TestFindHomographyDLT(BaseTester):
             atol = 2e-3
         self.assert_close(kornia.geometry.transform_points(dst_homo_src, points_src), points_dst, rtol=rtol, atol=atol)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         points_src = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
         points_dst = torch.rand_like(points_src)
@@ -266,7 +265,6 @@ class TestFindHomographyDLT(BaseTester):
 
         self.gradcheck(find_homography_dlt, (points_src, points_dst, weights), rtol=1e-6, atol=1e-6)
 
-    @pytest.mark.grad()
     def test_gradcheck_lu(self, device):
         points_src = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
 
@@ -410,7 +408,6 @@ class TestFindHomographyFromLinesDLT(BaseTester):
             kornia.geometry.transform_points(dst_homo_src, points_src_st), points_dst_st, rtol=rtol, atol=atol
         )
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         points_src_st = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
         points_src_end = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
@@ -461,7 +458,6 @@ class TestFindHomographyDLTIter(BaseTester):
         atol = 2e-3 if (device.type == "cuda" and dtype == torch.float32) else 1e-4
         self.assert_close(kornia.geometry.transform_points(dst_homo_src, points_src), points_dst, rtol=1e-3, atol=atol)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device):
         torch.manual_seed(0)
         points_src = torch.rand(1, 10, 2, device=device, dtype=torch.float64, requires_grad=True)
@@ -469,7 +465,6 @@ class TestFindHomographyDLTIter(BaseTester):
         weights = torch.ones_like(points_src)[..., 0]
         self.gradcheck(find_homography_dlt_iterated, (points_src, points_dst, weights), rtol=1e-6, atol=1e-6)
 
-    @pytest.mark.grad()
     @pytest.mark.parametrize("batch_size", [1, 2])
     def test_dirty_points_and_gradcheck(self, batch_size, device, dtype):
         # generate input data

--- a/tests/geometry/transform/test_pyramid.py
+++ b/tests/geometry/transform/test_pyramid.py
@@ -183,3 +183,104 @@ class TestBuildLaplacianPyramid(BaseTester):
         batch_size, channels, height, width = 1, 2, 7, 9
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.geometry.transform.build_laplacian_pyramid, (img, max_level), nondet_tol=1e-8)
+
+
+class TestUpscaleDouble(BaseTester):
+    @pytest.mark.parametrize("shape", ((5, 5), (2, 5, 5), (1, 2, 5, 5)))
+    def test_smoke(self, shape, device, dtype):
+        x = self.prepare_data(shape, device, dtype)
+        assert kornia.geometry.transform.upscale_double(x) is not None
+
+    def test_exception(self):
+        from kornia.core.exceptions import TypeCheckError
+
+        with pytest.raises(TypeCheckError):
+            kornia.geometry.transform.upscale_double(None)
+
+    @pytest.mark.parametrize("shape", ((5, 5), (2, 5, 5), (1, 2, 5, 5)))
+    def test_cardinality(self, shape, device, dtype):
+        x = self.prepare_data(shape, device, dtype)
+        actual = kornia.geometry.transform.upscale_double(x)
+
+        h, w = shape[-2:]
+        expected = (*shape[:-2], h * 2, w * 2)
+
+        assert tuple(actual.shape) == expected
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        img = self.prepare_data((1, 2, 5, 5), device, dtype)
+        op = kornia.geometry.transform.upscale_double
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(img), op_optimized(img))
+
+    def test_gradcheck(self, device):
+        x = self.prepare_data((1, 2, 5, 5), device)
+        self.gradcheck(kornia.geometry.transform.upscale_double, (x,), rtol=5e-2)
+
+    @pytest.mark.parametrize("shape", ((5, 5), (2, 5, 5), (1, 2, 5, 5)))
+    def test_upscale_double_and_back(self, shape, device, dtype):
+        x = self.prepare_data(shape, device, dtype)
+        upscaled = kornia.geometry.transform.upscale_double(x)
+
+        expected = torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
+                    [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    [1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5],
+                    [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0],
+                    [2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5],
+                    [3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0],
+                    [3.5, 3.5, 3.5, 3.5, 3.5, 3.5, 3.5, 3.5, 3.5, 3.5],
+                    [4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0],
+                    [4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0],
+                ],
+                [
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                    [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.0],
+                ],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+
+        if len(shape) == 2:
+            expected = expected[0]
+        elif len(shape) == 4:
+            expected = expected[None]
+
+        self.assert_close(upscaled, expected)
+
+        downscaled_back = upscaled[..., ::2, ::2]
+        self.assert_close(x, downscaled_back)
+
+    @staticmethod
+    def prepare_data(shape, device, dtype=torch.float32):
+        xm = torch.tensor(
+            [[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3], [4, 4, 4, 4, 4]],
+            device=device,
+            dtype=dtype,
+        )
+        ym = torch.tensor(
+            [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
+            device=device,
+            dtype=dtype,
+        )
+
+        x = torch.zeros(shape, device=device, dtype=dtype)
+        if len(shape) == 2:
+            x = xm
+        else:
+            x[..., 0, :, :] = xm
+            x[..., 1, :, :] = ym
+
+        return x

--- a/tests/geometry/transform/test_thin_plate_spline.py
+++ b/tests/geometry/transform/test_thin_plate_spline.py
@@ -66,7 +66,6 @@ class TestTransformParameters(BaseTester):
             src = torch.rand(batch_size, 5)
             assert kornia.geometry.transform.get_tps_transform(src, src)
 
-    @pytest.mark.grad()
     @pytest.mark.parametrize("batch_size", [1, 3])
     @pytest.mark.parametrize("requires_grad", [True, False])
     def test_gradcheck(self, batch_size, device, dtype, requires_grad):
@@ -78,7 +77,6 @@ class TestTransformParameters(BaseTester):
             kornia.geometry.transform.get_tps_transform, (src, dst), raise_exception=True, fast_mode=True
         )
 
-    @pytest.mark.jit()
     @pytest.mark.parametrize("batch_size", [1, 3])
     def test_jit(self, batch_size, device, dtype):
         src, dst = _sample_points(batch_size, device)
@@ -139,7 +137,6 @@ class TestWarpPoints(BaseTester):
             affine_bad = torch.rand(batch_size, 3)
             assert kornia.geometry.transform.warp_points_tps(src, src, kernel, affine_bad)
 
-    @pytest.mark.grad()
     @pytest.mark.parametrize("batch_size", [1, 3])
     @pytest.mark.parametrize("requires_grad", [True, False])
     def test_gradcheck(self, batch_size, device, dtype, requires_grad):
@@ -152,7 +149,6 @@ class TestWarpPoints(BaseTester):
             kornia.geometry.transform.warp_points_tps, (src, dst, kernel, affine), raise_exception=True, fast_mode=True
         )
 
-    @pytest.mark.jit()
     @pytest.mark.parametrize("batch_size", [1, 3])
     def test_jit(self, batch_size, device, dtype):
         src, dst = _sample_points(batch_size, device)
@@ -225,7 +221,6 @@ class TestWarpImage(BaseTester):
             affine_bad = torch.rand(batch_size, 3)
             assert kornia.geometry.transform.warp_image_tps(image, dst, kernel, affine_bad)
 
-    @pytest.mark.grad()
     @pytest.mark.parametrize("batch_size", [1, 3])
     def test_gradcheck(self, batch_size, device, dtype):
         if device.type != "cpu":
@@ -253,7 +248,6 @@ class TestWarpImage(BaseTester):
             fast_mode=True,
         )
 
-    @pytest.mark.jit()
     @pytest.mark.parametrize("batch_size", [1, 3])
     def test_jit(self, batch_size, device, dtype):
         src, dst = _sample_points(batch_size, device)

--- a/tests/losses/test_cauchy.py
+++ b/tests/losses/test_cauchy.py
@@ -74,7 +74,6 @@ class TestCauchyLoss(BaseTester):
         actual = kornia.losses.cauchy_loss(img, img, reduction="mean")
         assert actual.shape == ()
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         img1 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)
         img2 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)

--- a/tests/losses/test_charbonnier.py
+++ b/tests/losses/test_charbonnier.py
@@ -74,7 +74,6 @@ class TestCharbonnierLoss(BaseTester):
         actual = kornia.losses.charbonnier_loss(img, img, reduction="mean")
         assert actual.shape == ()
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         img1 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)
         img2 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)

--- a/tests/losses/test_depth_smoothness.py
+++ b/tests/losses/test_depth_smoothness.py
@@ -81,7 +81,6 @@ class TestDepthSmoothnessLoss(BaseTester):
 
         self.assert_close(op(image, depth), op_module(image, depth))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         image = torch.rand(1, 2, 3, 4, device=device, dtype=torch.float64)
         depth = torch.rand(1, 2, 3, 4, device=device, dtype=torch.float64)

--- a/tests/losses/test_dice.py
+++ b/tests/losses/test_dice.py
@@ -194,7 +194,6 @@ class TestDiceLoss(BaseTester):
         loss = criterion(logits, labels)
         self.assert_close(loss, expected_loss, rtol=1e-3, atol=1e-3)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         num_classes = 3
         logits = torch.rand(2, num_classes, 3, 2, device=device, dtype=torch.float64)

--- a/tests/losses/test_divergence.py
+++ b/tests/losses/test_divergence.py
@@ -99,7 +99,6 @@ class TestDivergenceLoss(BaseTester):
         expected = torch.tensor(expected).to(device, dtype)
         self.assert_close(actual, expected)
 
-    @pytest.mark.grad()
     def test_gradcheck_kl(self, device, dtype):
         dtype = torch.float64
         pred = torch.rand(1, 1, 10, 16, device=device, dtype=dtype)
@@ -108,7 +107,6 @@ class TestDivergenceLoss(BaseTester):
         # evaluate function gradient
         self.gradcheck(kornia.losses.kl_div_loss_2d, (pred, target))
 
-    @pytest.mark.grad()
     def test_gradcheck_js(self, device, dtype):
         dtype = torch.float64
         pred = torch.rand(1, 1, 10, 16, device=device, dtype=dtype)

--- a/tests/losses/test_focal_loss.py
+++ b/tests/losses/test_focal_loss.py
@@ -107,7 +107,6 @@ class TestBinaryFocalLossWithLogits(BaseTester):
         expected = op(logits, labels, *args)
         self.assert_close(actual, expected)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         logits = torch.rand(2, 3, 2, device=device, dtype=torch.float64)
         labels = torch.rand(2, 3, 2, device=device, dtype=torch.float64)
@@ -116,7 +115,6 @@ class TestBinaryFocalLossWithLogits(BaseTester):
         op = kornia.losses.binary_focal_loss_with_logits
         self.gradcheck(op, (logits, labels, *args))
 
-    @pytest.mark.grad()
     def test_gradcheck_ignore_index(self, device, dtype):
         logits = torch.rand(2, 3, 2, device=device, dtype=torch.float64)
         labels = torch.rand(2, 3, 2, device=device, dtype=torch.float64)
@@ -232,7 +230,6 @@ class TestFocalLoss(BaseTester):
         expected = op(logits, labels, *args)
         self.assert_close(actual, expected)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         num_classes = 3
         logits = torch.rand(2, num_classes, 3, 2, device=device, dtype=torch.float64)

--- a/tests/losses/test_geman_macclure.py
+++ b/tests/losses/test_geman_macclure.py
@@ -74,7 +74,6 @@ class TestGemanMcclureLossLoss(BaseTester):
         actual = kornia.losses.geman_mcclure_loss(img, img, reduction="mean")
         assert actual.shape == ()
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         img1 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)
         img2 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)

--- a/tests/losses/test_hd.py
+++ b/tests/losses/test_hd.py
@@ -92,7 +92,6 @@ class TestHausdorffLoss(BaseTester):
     @pytest.mark.parametrize(
         "hd,shape", [[kornia.losses.HausdorffERLoss, (5, 5)], [kornia.losses.HausdorffERLoss3D, (5, 5, 5)]]
     )
-    @pytest.mark.grad()
     def test_gradcheck(self, hd, shape, device, dtype):
         num_classes = 3
         logits = torch.rand(2, num_classes, *shape, device=device)

--- a/tests/losses/test_lovaz_hinge.py
+++ b/tests/losses/test_lovaz_hinge.py
@@ -63,7 +63,6 @@ class TestLovaszHingeLoss(BaseTester):
         loss = criterion(prediction, labels)
         self.assert_close(loss, torch.zeros_like(loss), rtol=1e-3, atol=1e-3)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         dtype = torch.float64
         num_classes = 1

--- a/tests/losses/test_lovaz_softmax.py
+++ b/tests/losses/test_lovaz_softmax.py
@@ -94,7 +94,6 @@ class TestLovaszSoftmaxLoss(BaseTester):
 
         self.assert_close(loss, 0.5 * torch.ones_like(loss), rtol=1e-3, atol=1e-3)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         num_classes = 4
         logits = torch.rand(2, num_classes, 3, 2, device=device, dtype=torch.float64)

--- a/tests/losses/test_psnr.py
+++ b/tests/losses/test_psnr.py
@@ -75,7 +75,6 @@ class TestPSNRLoss(BaseTester):
 
         self.assert_close(op(*args), op_module(pred, target))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         dtype = torch.float64
         pred = torch.rand(2, 3, 3, 2, device=device, dtype=dtype)

--- a/tests/losses/test_ssim.py
+++ b/tests/losses/test_ssim.py
@@ -65,7 +65,6 @@ class TestSSIMLoss(BaseTester):
 
         self.assert_close(op(*args), op_module(*args[:2]))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         # input data
         window_size = 3
@@ -117,7 +116,6 @@ class TestMS_SSIMLoss(BaseTester):
 
         self.assert_close(loss.sum().item(), 0.0)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         # input data
         dtype = torch.float64
@@ -196,7 +194,6 @@ class TestSSIM3DLoss(BaseTester):
 
         self.assert_close(op(*args), op_module(*args[:2]))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         # input data
         img = torch.rand(1, 1, 5, 4, 3, device=device)

--- a/tests/losses/test_total_variation.py
+++ b/tests/losses/test_total_variation.py
@@ -164,7 +164,6 @@ class TestTotalVariation(BaseTester):
 
         self.assert_close(op(image), op_module(image))
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         dtype = torch.float64
         image = torch.rand(1, 2, 3, 4, device=device, dtype=dtype)

--- a/tests/losses/test_tversky.py
+++ b/tests/losses/test_tversky.py
@@ -80,7 +80,6 @@ class TestTverskyLoss(BaseTester):
         loss = criterion(logits, labels)
         self.assert_close(loss, expected_loss, rtol=1e-3, atol=1e-3)
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         num_classes = 3
         alpha, beta = 0.5, 0.5  # for tversky loss

--- a/tests/losses/test_welcsh.py
+++ b/tests/losses/test_welcsh.py
@@ -42,7 +42,6 @@ class TestWelschLoss(BaseTester):
         actual = kornia.losses.WelschLoss(reduction="mean")(img, img)
         assert actual.shape == ()
 
-    @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         img1 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)
         img2 = torch.rand(2, 3, 3, 3, device=device, dtype=torch.float64)

--- a/tests/morphology/test_bottom_hat.py
+++ b/tests/morphology/test_bottom_hat.py
@@ -113,7 +113,6 @@ class TestBottomHat(BaseTester):
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert bottom_hat(sample, test)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = bottom_hat
         op_script = torch.jit.script(op)

--- a/tests/morphology/test_closing.py
+++ b/tests/morphology/test_closing.py
@@ -113,7 +113,6 @@ class TestClosing(BaseTester):
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert closing(tensor, test)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = closing
         op_script = torch.jit.script(op)

--- a/tests/morphology/test_dilation.py
+++ b/tests/morphology/test_dilation.py
@@ -153,7 +153,6 @@ class TestDilate(BaseTester):
         # Results should differ when the anchor point changes
         assert not torch.equal(out_default, out_custom)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = dilation
         op_script = torch.jit.script(op)

--- a/tests/morphology/test_erosion.py
+++ b/tests/morphology/test_erosion.py
@@ -136,7 +136,6 @@ class TestErode(BaseTester):
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert erosion(tensor, test)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = erosion
         op_script = torch.jit.script(op)

--- a/tests/morphology/test_gradient.py
+++ b/tests/morphology/test_gradient.py
@@ -113,7 +113,6 @@ class TestGradient(BaseTester):
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert gradient(tensor, test)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = gradient
         op_script = torch.jit.script(op)

--- a/tests/morphology/test_opening.py
+++ b/tests/morphology/test_opening.py
@@ -113,7 +113,6 @@ class TestOpening(BaseTester):
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert opening(tensor, test)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = opening
         op_script = torch.jit.script(op)

--- a/tests/morphology/test_top_hat.py
+++ b/tests/morphology/test_top_hat.py
@@ -113,7 +113,6 @@ class TestTopHat(BaseTester):
             test = torch.ones(2, 3, 4, device=device, dtype=dtype)
             assert top_hat(sample, test)
 
-    @pytest.mark.jit()
     def test_jit(self, device, dtype):
         op = top_hat
         op_script = torch.jit.script(op)


### PR DESCRIPTION
## Summary

Remove deprecated `@pytest.mark.grad`, `@pytest.mark.jit`, and `@pytest.mark.nn` markers from all test files and their registration in `pyproject.toml`.

## Motivation

These markers were originally introduced to categorize tests by type (gradient checks, TorchScript, module tests), but they are not used anywhere in CI configuration to select or filter tests. They add noise to the test code without providing any functional value.

## Changes

- Removed 134 marker decorators across 48 test files
- Removed 3 marker registrations from `pyproject.toml` (keeping `slow` which is still relevant)

Closes #2601