### PR TITLE
feat(geometry): add optional support for image shape mismatch 

### DIFF
--- a/kornia/geometry/transform/image_registrator.py
+++ b/kornia/geometry/transform/image_registrator.py
@@ -252,10 +252,7 @@ class ImageRegistrator(nn.Module):
         self.reset_model()
         if src_img.shape != dst_img.shape:
             if not self.allow_shape_mismatch:
-                raise ValueError(
-                    f"Cannot register images of different shapes "
-                    f"{src_img.shape} {dst_img.shape}"
-                )
+                raise ValueError(f"Cannot register images of different shapes {src_img.shape} {dst_img.shape}")
             src_img = F.interpolate(
                 src_img,
                 size=dst_img.shape[-2:],

--- a/kornia/geometry/transform/image_registrator.py
+++ b/kornia/geometry/transform/image_registrator.py
@@ -308,3 +308,4 @@ class ImageRegistrator(nn.Module):
         warper = self.warper(_height, _width)
         img_dst_to_src = warper(dst_img, self.model.forward_inverse())
         return img_dst_to_src
+    

--- a/kornia/geometry/transform/image_registrator.py
+++ b/kornia/geometry/transform/image_registrator.py
@@ -168,6 +168,7 @@ class ImageRegistrator(nn.Module):
         num_iterations: int = 100,
         tolerance: float = 1e-4,
         warper: Optional[Type[BaseWarper]] = None,
+        allow_shape_mismatch: bool = False,
     ) -> None:
         super().__init__()
         self.known_models = ["homography", "similarity", "translation", "scale", "rotation"]
@@ -201,6 +202,7 @@ class ImageRegistrator(nn.Module):
         self.loss_fn = loss_fn
         self.num_iterations = num_iterations
         self.tolerance = tolerance
+        self.allow_shape_mismatch = allow_shape_mismatch
 
     def get_single_level_loss(
         self, img_src: torch.Tensor, img_dst: torch.Tensor, transform_model: torch.Tensor
@@ -248,6 +250,18 @@ class ImageRegistrator(nn.Module):
 
         """
         self.reset_model()
+        if src_img.shape != dst_img.shape:
+            if not self.allow_shape_mismatch:
+                raise ValueError(
+                    f"Cannot register images of different shapes "
+                    f"{src_img.shape} {dst_img.shape}"
+                )
+            src_img = F.interpolate(
+                src_img,
+                size=dst_img.shape[-2:],
+                mode="bilinear",
+                align_corners=False,
+            )
         # ToDo: better parameter passing to optimizer
         _opt_args: Dict[str, Any] = {}
         _opt_args["lr"] = self.lr

--- a/kornia/geometry/transform/image_registrator.py
+++ b/kornia/geometry/transform/image_registrator.py
@@ -308,4 +308,3 @@ class ImageRegistrator(nn.Module):
         warper = self.warper(_height, _width)
         img_dst_to_src = warper(dst_img, self.model.forward_inverse())
         return img_dst_to_src
-    

--- a/kornia/geometry/transform/image_registrator.py
+++ b/kornia/geometry/transform/image_registrator.py
@@ -252,7 +252,10 @@ class ImageRegistrator(nn.Module):
         self.reset_model()
         if src_img.shape != dst_img.shape:
             if not self.allow_shape_mismatch:
-                raise ValueError(f"Cannot register images of different shapes {src_img.shape} {dst_img.shape}")
+                raise ValueError(
+                    f"Cannot register images of different shapes {src_img.shape} {dst_img.shape}. "
+                    "Consider setting `allow_shape_mismatch = True`"
+                )
             src_img = F.interpolate(
                 src_img,
                 size=dst_img.shape[-2:],

--- a/tests/geometry/transform/test_image_registrator.py
+++ b/tests/geometry/transform/test_image_registrator.py
@@ -17,7 +17,6 @@
 
 import sys
 
-
 import pytest
 import torch
 
@@ -133,7 +132,7 @@ class TestImageRegistrator(BaseTester):
         out = registrator.register(img1, img2)
 
         assert out is not None
-    
+
     def test_register_shape_mismatch_raises(self, device):
         img1 = torch.rand(1, 1, 64, 64, device=device)
         img2 = torch.rand(1, 1, 32, 32, device=device)

--- a/tests/geometry/transform/test_image_registrator.py
+++ b/tests/geometry/transform/test_image_registrator.py
@@ -17,6 +17,7 @@
 
 import sys
 
+from kornia.conftest import device
 import pytest
 import torch
 
@@ -122,3 +123,22 @@ class TestImageRegistrator(BaseTester):
         # and transformation is quite significant, so
         # 15 px  reprojection error is not super huge
         self.assert_close(bbox_in_2_gt, bbox_in_2_gt_est, atol=15, rtol=0.1)
+
+    def test_register_with_shape_mismatch(self, device):
+        img1 = torch.rand(1, 1, 64, 64, device=device)
+        img2 = torch.rand(1, 1, 32, 32, device=device)
+
+        registrator = ImageRegistrator("similarity", allow_shape_mismatch=True)
+
+        out = registrator.register(img1, img2)
+
+        assert out is not None
+    
+    def test_register_shape_mismatch_raises(self, device):
+        img1 = torch.rand(1, 1, 64, 64, device=device)
+        img2 = torch.rand(1, 1, 32, 32, device=device)
+
+        registrator = ImageRegistrator("similarity", allow_shape_mismatch=False)
+
+        with pytest.raises(ValueError):
+            registrator.register(img1, img2)

--- a/tests/geometry/transform/test_image_registrator.py
+++ b/tests/geometry/transform/test_image_registrator.py
@@ -17,7 +17,7 @@
 
 import sys
 
-from kornia.conftest import device
+
 import pytest
 import torch
 


### PR DESCRIPTION
Fixes #3593  :-

This PR introduces optional support for registering images with different spatial shapes in ImageRegistrator.

By default, the original strict behavior is preserved — a ValueError is raised when shapes mismatch.

When allow_shape_mismatch=True, the source image is resized to match the destination image using bilinear interpolation before pyramid construction, ensuring:

Backward compatibility

No change to default behavior

Clean integration with existing optimization flow

The resizing is performed inside register() after self.reset_model() and before pyramid generation to maintain architectural correctness.

🛠️ Changes Made

Added new parameter allow_shape_mismatch: bool = False

Added conditional resize logic in register() before pyramid construction

## 🧪 How Was This Tested?
Manual Verification:
Tested with:
img1 = torch.rand(1, 1, 64, 64)
img2 = torch.rand(1, 1, 32, 32)

registrator = ImageRegistrator("similarity", allow_shape_mismatch=True)
out = registrator.register(img1, img2)

Verified successful execution.
Verified that default behavior (allow_shape_mismatch=False) still raises ValueError.

## 🕵️ AI Usage Disclosure
🟡 AI-assisted: I used AI for guidance and structuring but manually implemented, reviewed, and tested every line.

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context

