### PR TITLE
Fix/ci for prs

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -92,7 +92,7 @@ jobs:
     uses: ./.github/workflows/tutorials.yml
 
   collector:
-    needs: [tests, tutorials, typecheck]
+    needs: [tests, typecheck]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,14 +21,14 @@ repos:
         exclude: ^$|.devcontainer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.5
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
 

--- a/kornia/models/sam/architecture/mask_decoder.py
+++ b/kornia/models/sam/architecture/mask_decoder.py
@@ -105,7 +105,7 @@ class MaskDecoder(nn.Module):
             dense_prompt_embeddings=dense_prompt_embeddings,
         )
 
-        # Select the correct mask or masks for outptu
+        # Select the correct mask or masks for output
         if multimask_output:
             mask_slice = slice(1, None)
         else:


### PR DESCRIPTION
## 📝 Description

On repo setting, from the PR required jobs, should only be configured as the collector job. This job read from the states from previous job and fail if anyone of the required jobs has failed. Since we have an issue on tutorials repo/pipeline, we are removing for now the tutorials to be a required step

fixes #3566 

related to #3586 #3591 

---

## 🛠️ Changes Made
- autoupdated pre-commit hooks -- superseeds #3588
- fixed a typo into a comment
- removed tutorials job to be required in the PRs collector job


---

## 🕵️ AI Usage Disclosure

- [x] 🟢 **No AI used.**


---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.