### PR TITLE
corrects lint command for pixi

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -45,7 +45,7 @@ test-slow = { cmd = "uv run pytest -v tests/", env = { KORNIA_TEST_RUNSLOW = "tr
 test-quick = { cmd = "uv run pytest -v -m 'not (jit or grad or nn)' tests/" }
 test-module = { cmd = "uv run pytest -v", description = "Run tests for a specific module (usage: pixi run test-module tests/<module_path>, e.g., pixi run test-module tests/contrib/)" }
 # Quality
-lint = { cmd = "uv run pre-commit run ruff --all-files" }
+lint = { cmd = "uv run pre-commit run ruff-check --all-files && uv run pre-commit run ruff-format --all-files" }
 typecheck = { cmd = "ty check kornia" }
 doctest = { cmd = "uv run pytest -v --doctest-modules kornia/" }
 toml-fmt = { cmd = "tombi format", description = "Format TOML files" }


### PR DESCRIPTION
The `pixi run lint` task fails with `No hook with id 'ruff'` because the hook was renamed to `ruff-check` in `.pre-commit-config.yaml` but `pixi.toml` still references the old `ruff` hook ID.

## 🛠️ Changes Made

Updated the `lint` task in `pixi.toml` from:

```toml
lint = { cmd = "uv run pre-commit run ruff --all-files" }
```

to:

```toml
lint = { cmd = "uv run pre-commit run ruff-check --all-files" }
```

This aligns the task with the actual hook ID defined in `.pre-commit-config.yaml`.

## 🧪 How Was This Tested?

- [x] Manual Verification: Ran `pixi run lint` before (fails with hook not found) and after (runs successfully).