### PR TITLE
fix: fix doctest failures for ALIKED and fft_conv

### DIFF
--- a/kornia/feature/aliked/aliked.py
+++ b/kornia/feature/aliked/aliked.py
@@ -725,9 +725,9 @@ class ALIKED(nn.Module):
         nms_radius: NMS radius (kernel size ``= 2 * nms_radius + 1``).
 
     Example:
-        >>> aliked = ALIKED.from_pretrained('aliked-n16')
-        >>> images = torch.rand(1, 3, 256, 256)
-        >>> features = aliked(images)
+        >>> aliked = ALIKED.from_pretrained('aliked-n16')  # doctest: +SKIP
+        >>> images = torch.rand(1, 3, 256, 256)  # doctest: +SKIP
+        >>> features = aliked(images)  # doctest: +SKIP
     """
 
     n_limit_max: int = 20000

--- a/kornia/filters/filter.py
+++ b/kornia/filters/filter.py
@@ -371,7 +371,7 @@ def fft_conv(
         ...     [0., 0., 0., 0., 0.],
         ... ]]])
         >>> kernel = torch.ones(1, 3, 3)
-        >>> fft_conv(input, kernel, padding="same")
+        >>> fft_conv(input, kernel, padding="same").round()
         tensor([[[[0., 0., 0., 0., 0.],
                   [0., 5., 5., 5., 0.],
                   [0., 5., 5., 5., 0.],


### PR DESCRIPTION
Skip network-dependent ALIKED.from_pretrained example and round fft_conv output to suppress floating-point noise from FFT.


## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

Fix currently failing doctest 