### PR TITLE
Add unit tests for generate_examples helper functions

### DIFF
--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -36,6 +36,36 @@ import kornia as K
 
 mpl.use("Agg")
 
+def handle_special_cases(aug_name, img_in):
+    if aug_name == "RandomJigsaw":
+        img_in = K.geometry.resize(img_in, (1020, 500))
+    elif aug_name == "RandomJPEG":
+        img_in = img_in[..., :176, :]
+    return img_in
+
+def apply_augmentation(mod, aug_name, args, seed, img_in):
+    cls = getattr(mod, aug_name)
+
+    try:
+        aug = cls(*args, p=1.0)
+    except TypeError:
+        aug = cls(*args)
+
+    torch.manual_seed(seed)
+    return aug(img_in)
+
+def postprocess_output(aug_name, ori, out, img1, img_in):
+    if aug_name == "CenterCrop":
+        out = transparent_pad(out, tuple(img1[-2:].shape))
+        ori = K.color.rgb_to_rgba(ori, 1.0)
+    elif aug_name == "PadTo":
+        ori = transparent_pad(img_in[0], tuple(out.shape[-2:]))
+        out = K.color.rgb_to_rgba(out, 1.0)
+    return ori, out
+
+def save_output_image(out, output_path, aug_name):
+    out_np = K.image.tensor_to_image((out * 255.0).byte())
+    cv2.imwrite(str(output_path / f"{aug_name}.png"), out_np)
 
 def download_tutorials_examples(download_infos: dict[str, str], directory: Path):
     URL_BASE = "https://raw.githubusercontent.com/kornia/tutorials/master/"
@@ -189,40 +219,29 @@ def main():
 
     # ITERATE OVER THE TRANSFORMS
     for aug_name, (args, num_samples, seed) in augmentations_list.items():
-        img_in = img1.repeat(num_samples, 1, 1, 1)
-        # dynamically create the class instance
-        cls = getattr(mod, aug_name)
-        try:
-            aug = cls(*args, p=1.0)
-        except TypeError:
-            aug = cls(*args)
 
-        # set seed
-        torch.manual_seed(seed)
-        if aug_name == "RandomJigsaw":  # make sure the image is dividable
-            img_in = K.geometry.resize(img_in, (1020, 500))
-        elif aug_name == "RandomJPEG":
-            img_in = img_in[..., :176, :]
-        # apply the augmentation to the image and concat
-        out = aug(img_in)
+       # prepare input
+       img_in = img1.repeat(num_samples, 1, 1, 1)
+       img_in = handle_special_cases(aug_name, img_in)
 
-        # save ori image to concatenate into the out image
-        ori = img_in[0]
-        if aug_name == "CenterCrop":
-            # Convert to RGBA, and center the output image with transparent pad
-            out = transparent_pad(out, tuple(img1[-2:].shape))
-            ori = K.color.rgb_to_rgba(ori, 1.0)  # To match the dims
-        elif aug_name == "PadTo":
-            # Convert to RGBA, and center the original image with transparent pad
-            ori = transparent_pad(img_in[0], tuple(out.shape[-2:]))
-            out = K.color.rgb_to_rgba(out, 1.0)  # To match the dims
+       # apply augmentation
+       augmented = apply_augmentation(mod, aug_name, args, seed, img_in)
 
-        out = torch.cat([ori, *(out[i] for i in range(out.size(0)))], dim=-1)
-        # save the output image
-        out_np = K.image.tensor_to_image((out * 255.0).byte())
-        cv2.imwrite(str(OUTPUT_PATH / f"{aug_name}.png"), out_np)
-        sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
-        print(f"Generated image example for {aug_name}. {sig}")
+       # original image
+       ori = img_in[0]
+
+       # postprocess
+       ori, augmented = postprocess_output(aug_name, ori, augmented, img1, img_in)
+
+       # concatenate outputs
+       out = torch.cat([ori, *list(augmented)], dim=-1)
+
+       # save image
+       save_output_image(out, OUTPUT_PATH, aug_name)
+
+       # logging (same as original)
+       sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
+       print(f"Generated image example for {aug_name}: {sig}")
 
     mix_augmentations_list = {"RandomMixUpV2": ((), 2, 20), "RandomCutMixV2": ((), 2, 2019)}
     # ITERATE OVER THE TRANSFORMS

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -221,9 +221,9 @@ def main():
         "RandomThinPlateSpline": ((), 1, 2020),
         "RandomJigsaw": ((), 2, 2020),
     }
-
-    # ITERATE OVER THE TRANSFORMS
+    
     for aug_name, (args, num_samples, seed) in augmentations_list.items():
+
         # prepare input
         img_in = img1.repeat(num_samples, 1, 1, 1)
         img_in = handle_special_cases(aug_name, img_in)
@@ -243,7 +243,7 @@ def main():
         # save image
         save_output_image(out, OUTPUT_PATH, aug_name)
 
-        # logging (same as original)
+        # logging
         sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
         print(f"Generated image example for {aug_name}: {sig}")
 

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -36,12 +36,14 @@ import kornia as K
 
 mpl.use("Agg")
 
+
 def handle_special_cases(aug_name, img_in):
     if aug_name == "RandomJigsaw":
         img_in = K.geometry.resize(img_in, (1020, 500))
     elif aug_name == "RandomJPEG":
         img_in = img_in[..., :176, :]
     return img_in
+
 
 def apply_augmentation(mod, aug_name, args, seed, img_in):
     cls = getattr(mod, aug_name)
@@ -54,6 +56,7 @@ def apply_augmentation(mod, aug_name, args, seed, img_in):
     torch.manual_seed(seed)
     return aug(img_in)
 
+
 def postprocess_output(aug_name, ori, out, img1, img_in):
     if aug_name == "CenterCrop":
         out = transparent_pad(out, tuple(img1[-2:].shape))
@@ -63,9 +66,11 @@ def postprocess_output(aug_name, ori, out, img1, img_in):
         out = K.color.rgb_to_rgba(out, 1.0)
     return ori, out
 
+
 def save_output_image(out, output_path, aug_name):
     out_np = K.image.tensor_to_image((out * 255.0).byte())
     cv2.imwrite(str(output_path / f"{aug_name}.png"), out_np)
+
 
 def download_tutorials_examples(download_infos: dict[str, str], directory: Path):
     URL_BASE = "https://raw.githubusercontent.com/kornia/tutorials/master/"
@@ -219,29 +224,28 @@ def main():
 
     # ITERATE OVER THE TRANSFORMS
     for aug_name, (args, num_samples, seed) in augmentations_list.items():
+        # prepare input
+        img_in = img1.repeat(num_samples, 1, 1, 1)
+        img_in = handle_special_cases(aug_name, img_in)
 
-       # prepare input
-       img_in = img1.repeat(num_samples, 1, 1, 1)
-       img_in = handle_special_cases(aug_name, img_in)
+        # apply augmentation
+        augmented = apply_augmentation(mod, aug_name, args, seed, img_in)
 
-       # apply augmentation
-       augmented = apply_augmentation(mod, aug_name, args, seed, img_in)
+        # original image
+        ori = img_in[0]
 
-       # original image
-       ori = img_in[0]
+        # postprocess
+        ori, augmented = postprocess_output(aug_name, ori, augmented, img1, img_in)
 
-       # postprocess
-       ori, augmented = postprocess_output(aug_name, ori, augmented, img1, img_in)
+        # concatenate outputs
+        out = torch.cat([ori, *list(augmented)], dim=-1)
 
-       # concatenate outputs
-       out = torch.cat([ori, *list(augmented)], dim=-1)
+        # save image
+        save_output_image(out, OUTPUT_PATH, aug_name)
 
-       # save image
-       save_output_image(out, OUTPUT_PATH, aug_name)
-
-       # logging (same as original)
-       sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
-       print(f"Generated image example for {aug_name}: {sig}")
+        # logging (same as original)
+        sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
+        print(f"Generated image example for {aug_name}: {sig}")
 
     mix_augmentations_list = {"RandomMixUpV2": ((), 2, 20), "RandomCutMixV2": ((), 2, 2019)}
     # ITERATE OVER THE TRANSFORMS

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -221,9 +221,8 @@ def main():
         "RandomThinPlateSpline": ((), 1, 2020),
         "RandomJigsaw": ((), 2, 2020),
     }
-    
-    for aug_name, (args, num_samples, seed) in augmentations_list.items():
 
+    for aug_name, (args, num_samples, seed) in augmentations_list.items():
         # prepare input
         img_in = img1.repeat(num_samples, 1, 1, 1)
         img_in = handle_special_cases(aug_name, img_in)

--- a/tests/test_generate_examples.py
+++ b/tests/test_generate_examples.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # LICENSE HEADER MANAGED BY add-license-header
 #
 # Copyright 2018 Kornia Team
@@ -19,6 +20,14 @@ import torch
 
 import kornia as K
 from docs.generate_examples import apply_augmentation, handle_special_cases
+=======
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "docs"))
+
+from generate_examples import handle_special_cases, apply_augmentation
+>>>>>>> e60527ff (Remove __main__ block from text file)
 
 
 def test_handle_special_cases_jigsaw():
@@ -38,9 +47,12 @@ def test_apply_augmentation_runs():
     out = apply_augmentation(K.augmentation, "RandomHorizontalFlip", (), 42, img)
     assert out.shape == img.shape
 
+<<<<<<< HEAD
 
 if __name__ == "__main__":
     test_handle_special_cases_jigsaw()
     test_handle_special_cases_jpeg()
     test_apply_augmentation_runs()
     print("All tests passed!")
+=======
+>>>>>>> e60527ff (Remove __main__ block from text file)

--- a/tests/test_generate_examples.py
+++ b/tests/test_generate_examples.py
@@ -1,0 +1,28 @@
+import torch
+import kornia as K
+
+from docs.generate_examples import handle_special_cases, apply_augmentation
+
+
+def test_handle_special_cases_jigsaw():
+    img = torch.randn(1, 3, 100, 100)
+    out = handle_special_cases("RandomJigsaw", img)
+    assert out.shape[-2:] == (1020, 500)
+
+
+def test_handle_special_cases_jpeg():
+    img = torch.randn(1, 3, 200, 200)
+    out = handle_special_cases("RandomJPEG", img)
+    assert out.shape[-2] == 176
+
+
+def test_apply_augmentation_runs():
+    img = torch.randn(2, 3, 64, 64)
+    out = apply_augmentation(K.augmentation, "RandomHorizontalFlip", (), 42, img)
+    assert out.shape == img.shape
+
+if __name__ == "__main__":
+    test_handle_special_cases_jigsaw()
+    test_handle_special_cases_jpeg()
+    test_apply_augmentation_runs()
+    print("All tests passed!")

--- a/tests/test_generate_examples.py
+++ b/tests/test_generate_examples.py
@@ -1,7 +1,24 @@
-import torch
-import kornia as K
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-from docs.generate_examples import handle_special_cases, apply_augmentation
+import torch
+
+import kornia as K
+from docs.generate_examples import apply_augmentation, handle_special_cases
 
 
 def test_handle_special_cases_jigsaw():
@@ -20,6 +37,7 @@ def test_apply_augmentation_runs():
     img = torch.randn(2, 3, 64, 64)
     out = apply_augmentation(K.augmentation, "RandomHorizontalFlip", (), 42, img)
     assert out.shape == img.shape
+
 
 if __name__ == "__main__":
     test_handle_special_cases_jigsaw()


### PR DESCRIPTION
This PR adds unit tests for helper functions introduced in generate_examples.py.

#### Tests added:
- handle_special_cases (RandomJigsaw, RandomJPEG)
- apply_augmentation basic execution

#### Benefits:
- Ensures correctness of refactored logic
- Improves reliability and maintainability