### PR TITLE
fix: resolve two CI failures in coverage workflow

### DIFF
--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5302,3 +5302,20 @@ class TestRandomThinPlateSpline(CommonTests):
         diffs = [(params["dst"][0] - params["dst"][j]).abs().sum().item() for j in range(1, 4)]
 
         assert any(d > 0 for d in diffs)
+
+    @pytest.mark.slow
+    def _test_gradcheck_implementation(self, params):
+        # RandomThinPlateSpline generates fresh random control points on every forward call,
+        # which makes the standard gradcheck non-deterministic (numerical Jacobian sees a
+        # different warp each perturbation step).  Fix the params from a single forward pass
+        # so that gradcheck only tests gradient flow through the deterministic warp path.
+        aug = self._create_augmentation_from_params(**params, p=1.0)
+        input_tensor = torch.rand((1, 3, 5, 5), device=self.device, dtype=self.dtype)
+        torch.manual_seed(0)
+        _ = aug(input_tensor)
+        fixed_params = aug._params
+
+        def forward_with_fixed_params(x: torch.Tensor) -> torch.Tensor:
+            return aug(x, params=fixed_params)
+
+        self.gradcheck(forward_with_fixed_params, (input_tensor,))

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5309,11 +5309,15 @@ class TestRandomThinPlateSpline(CommonTests):
         # which makes the standard gradcheck non-deterministic (numerical Jacobian sees a
         # different warp each perturbation step).  Fix the params from a single forward pass
         # so that gradcheck only tests gradient flow through the deterministic warp path.
+        # fork_rng saves/restores CPU RNG state so this seed doesn't affect other tests.
+        # (generate_parameters uses rsample on CPU then .to(device), so CPU RNG governs both
+        # input_tensor and the TPS control-point sampling.)
         aug = self._create_augmentation_from_params(**params, p=1.0)
-        input_tensor = torch.rand((1, 3, 5, 5), device=self.device, dtype=self.dtype)
-        torch.manual_seed(0)
-        _ = aug(input_tensor)
-        fixed_params = aug._params
+        with torch.random.fork_rng():
+            torch.manual_seed(0)
+            input_tensor = torch.rand((1, 3, 5, 5), device=self.device, dtype=self.dtype)
+            _ = aug(input_tensor)
+            fixed_params = aug._params
 
         def forward_with_fixed_params(x: torch.Tensor) -> torch.Tensor:
             return aug(x, params=fixed_params)

--- a/tests/losses/test_mutual_information.py
+++ b/tests/losses/test_mutual_information.py
@@ -207,9 +207,9 @@ class TestMutualInformationLoss(BaseTester):
         op = mutual_information_loss
         op_optimized = torch_optimizer(op)
 
-        self.assert_close(op(*args), op_optimized(*args))
+        self.assert_close(op(*args), op_optimized(*args), low_tolerance=True)
 
         op = normalized_mutual_information_loss
         op_optimized = torch_optimizer(op)
 
-        self.assert_close(op(*args), op_optimized(*args))
+        self.assert_close(op(*args), op_optimized(*args), low_tolerance=True)


### PR DESCRIPTION
## Summary

Fixes two consistently failing tests in the `coverage.yml` CI workflow.

### Failure 1: `TestMutualInformationLoss::test_dynamo[cpu-float32-inductor]`

**Root cause:** `torch.compile` with the `inductor` backend applies operation fusion and vectorisation that produces slightly different floating-point results (~5e-5 absolute difference). The default `float32` tolerance in `BaseTester.assert_close` is `atol=1e-5`, which is too tight for compiled outputs.

**Fix:** Pass `low_tolerance=True` to `assert_close` in `test_dynamo`, raising the effective tolerance to ~3e-3 — appropriate for inductor's numerical variance while still catching real regressions.

### Failure 2: `TestRandomThinPlateSpline::test_gradcheck[cpu-float32]`

**Root cause:** `RandomThinPlateSpline.generate_parameters` calls `self.dist.rsample()` on every forward pass, so each of `gradcheck`'s ~200+ perturbation calls saw a *different* random TPS warp. The numerical Jacobian (~2e5) and analytical Jacobian (~0.4) were measuring completely different functions.

**Fix:** Override `_test_gradcheck_implementation` in `TestRandomThinPlateSpline` to capture the TPS control-point params from a single forward pass and pass them explicitly (`aug(x, params=fixed_params)`) on every subsequent call. This makes gradcheck fully deterministic while still exercising gradient flow through `get_tps_transform` → `warp_image_tps` → `grid_sample`.

Posted on behalf of @ducha-aiki by Claude (Sonnet 4.6).
