### PR TITLE
fix: propagate device and dtype in get_shear_matrix2d and get_shear_matrix3d

### DIFF
--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -696,8 +696,8 @@ def get_shear_matrix2d(
         This function is often used in conjunction with :func:`warp_affine`, :func:`warp_perspective`.
 
     """
-    sx = torch.tensor([0.0]).repeat(center.size(0)) if sx is None else sx
-    sy = torch.tensor([0.0]).repeat(center.size(0)) if sy is None else sy
+    sx = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sx is None else sx
+    sy = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sy is None else sy
 
     x, y = torch.split(center, 1, dim=-1)
     x, y = x.view(-1), y.view(-1)
@@ -818,12 +818,12 @@ def get_shear_matrix3d(
         This function is often used in conjunction with :func:`warp_perspective3d`.
 
     """
-    sxy = torch.tensor([0.0]).repeat(center.size(0)) if sxy is None else sxy
-    sxz = torch.tensor([0.0]).repeat(center.size(0)) if sxz is None else sxz
-    syx = torch.tensor([0.0]).repeat(center.size(0)) if syx is None else syx
-    syz = torch.tensor([0.0]).repeat(center.size(0)) if syz is None else syz
-    szx = torch.tensor([0.0]).repeat(center.size(0)) if szx is None else szx
-    szy = torch.tensor([0.0]).repeat(center.size(0)) if szy is None else szy
+    sxy = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sxy is None else sxy
+    sxz = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sxz is None else sxz
+    syx = torch.tensor([0.0]).to(center).repeat(center.size(0)) if syx is None else syx
+    syz = torch.tensor([0.0]).to(center).repeat(center.size(0)) if syz is None else syz
+    szx = torch.tensor([0.0]).to(center).repeat(center.size(0)) if szx is None else szx
+    szy = torch.tensor([0.0]).to(center).repeat(center.size(0)) if szy is None else szy
 
     x, y, z = torch.split(center, 1, dim=-1)
     x, y, z = x.view(-1), y.view(-1), z.view(-1)

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -696,8 +696,8 @@ def get_shear_matrix2d(
         This function is often used in conjunction with :func:`warp_affine`, :func:`warp_perspective`.
 
     """
-    sx = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sx is None else sx
-    sy = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sy is None else sy
+    sx = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if sx is None else sx
+    sy = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if sy is None else sy
 
     x, y = torch.split(center, 1, dim=-1)
     x, y = x.view(-1), y.view(-1)
@@ -818,12 +818,12 @@ def get_shear_matrix3d(
         This function is often used in conjunction with :func:`warp_perspective3d`.
 
     """
-    sxy = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sxy is None else sxy
-    sxz = torch.tensor([0.0]).to(center).repeat(center.size(0)) if sxz is None else sxz
-    syx = torch.tensor([0.0]).to(center).repeat(center.size(0)) if syx is None else syx
-    syz = torch.tensor([0.0]).to(center).repeat(center.size(0)) if syz is None else syz
-    szx = torch.tensor([0.0]).to(center).repeat(center.size(0)) if szx is None else szx
-    szy = torch.tensor([0.0]).to(center).repeat(center.size(0)) if szy is None else szy
+    sxy = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if sxy is None else sxy
+    sxz = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if sxz is None else sxz
+    syx = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if syx is None else syx
+    syz = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if syz is None else syz
+    szx = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if szx is None else szx
+    szy = torch.zeros(center.size(0), device=center.device, dtype=center.dtype) if szy is None else szy
 
     x, y, z = torch.split(center, 1, dim=-1)
     x, y, z = x.view(-1), y.view(-1), z.view(-1)

--- a/tests/geometry/transform/test_affine.py
+++ b/tests/geometry/transform/test_affine.py
@@ -785,3 +785,19 @@ class TestGetShearMatrix(BaseTester):
         )
 
         self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
+    def test_get_shear_matrix2d_default_params_device_dtype(self, device, dtype):
+        # When sx and sy are None, the defaults should inherit device and dtype from center.
+        center = torch.tensor([[128.0, 128.0]], device=device, dtype=dtype)
+        out = kornia.geometry.transform.get_shear_matrix2d(center, sx=None, sy=None)
+        assert out.device.type == center.device.type, "Output device must match center device"
+        assert out.dtype == center.dtype, "Output dtype must match center dtype"
+
+    def test_get_shear_matrix3d_default_params_device_dtype(self, device, dtype):
+        # When shear params are None, the defaults should inherit device and dtype from center.
+        center = torch.tensor([[64.0, 64.0, 32.0]], device=device, dtype=dtype)
+        out = kornia.geometry.transform.get_shear_matrix3d(
+            center, sxy=None, sxz=None, syx=None, syz=None, szx=None, szy=None
+        )
+        assert out.device.type == center.device.type, "Output device must match center device"
+        assert out.dtype == center.dtype, "Output dtype must match center dtype"


### PR DESCRIPTION
## 📝 Description

**Fixes** #3562

`torch.tensor([0.0])` in both `get_shear_matrix2d` and `get_shear_matrix3d` always creates a CPU float32 tensor, regardless of the device or dtype of `center`. This causes a device mismatch error when `center` is on GPU and `sx`/`sy` (or the 3D equivalents) are left as `None`.

Replace with `torch.zeros(center.size(0), device=center.device, dtype=center.dtype)` so the default shear values inherit device and dtype from `center`.

---

## 🛠️ Changes Made
- [x] `get_shear_matrix2d`: replace `torch.tensor([0.0]).repeat(...)` with `torch.zeros(..., device=center.device, dtype=center.dtype)` for `sx` and `sy` (2 lines)
- [x] `get_shear_matrix3d`: same fix for `sxy`, `sxz`, `syx`, `syz`, `szx`, `szy` (6 lines)

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** Added `test_get_shear_matrix2d_default_params_device_dtype` and `test_get_shear_matrix3d_default_params_device_dtype` to `TestGetShearMatrix` in `tests/geometry/transform/test_affine.py`
- [x] **Manual Verification:** Confirmed device and dtype match on CPU and float16 inputs

---

## 🕵️ AI Usage Disclosure
- [x] 🟡 **AI-assisted:** I used AI for assistance but have manually reviewed and tested every line of the fix.

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (approved by @shijianjian)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a self-review of my code
- [x] My code follows the existing style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works