### PR TITLE
fix: handle empty batch in median_blur

### DIFF
--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -62,10 +62,11 @@ def median_blur(input: torch.Tensor, kernel_size: tuple[int, int] | int) -> torc
     # prepare kernel
     kernel: torch.Tensor = get_binary_kernel2d(kernel_size, device=input.device, dtype=input.dtype)
     b, c, h, w = input.shape
+    ky, kx = _unpack_2d_ks(kernel_size)
 
     # map the local window to single vector
     features: torch.Tensor = F.conv2d(input.reshape(b * c, 1, h, w), kernel, padding=padding, stride=1)
-    features = features.view(b, c, -1, h, w)  # BxCx(K_h * K_w)xHxW
+    features = features.view(b, c, ky * kx, h, w)  # BxCx(K_h * K_w)xHxW
 
     # compute the median along the feature axis
     return features.median(dim=2)[0]

--- a/tests/filters/test_median.py
+++ b/tests/filters/test_median.py
@@ -29,6 +29,11 @@ class TestMedianBlur(BaseTester):
         actual = median_blur(inp, 3)
         assert isinstance(actual, torch.Tensor)
 
+    def test_empty_batch(self, device, dtype):
+        inp = torch.zeros(0, 3, 4, 4, device=device, dtype=dtype)
+        actual = median_blur(inp, (3, 5))
+        assert actual.shape == (0, 3, 4, 4)
+
     @pytest.mark.parametrize("batch_size", [1, 2])
     @pytest.mark.parametrize("kernel_size", [3, (5, 7)])
     def test_cardinality(self, batch_size, kernel_size, device, dtype):


### PR DESCRIPTION
## Summary
Fixes #3580.
**Root cause:** `features.view(b, c, -1, h, w)` is ambiguous when b=0 since total elements are 0.
**Fix:** Use explicit kernel dimensions instead of -1 in the reshape.
## Changes
- `kornia/filters/median.py`: replace -1 with ky*kx in view call
## Testing
- Added test for batch_size=0 input
- Verified other batch sizes still work