### PR TITLE
fix(geometry): propagate NaN from w-component in quaternion_to_axis_a…

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -662,6 +662,11 @@ def quaternion_to_axis_angle(quaternion: torch.Tensor) -> torch.Tensor:
     axis_angle[..., 0] += q1 * k
     axis_angle[..., 1] += q2 * k
     axis_angle[..., 2] += q3 * k
+    # When sin_squared_theta == 0 (xyz all zero), the small-angle branch uses
+    # k_neg = 2.0 and multiplies by q1/q2/q3 = 0, so the result is 0.0 even
+    # if w is NaN.  A NaN in w means the rotation is undefined; propagate it.
+    # Using cos_theta * 0.0 exploits IEEE 754: finite * 0 = 0, NaN * 0 = NaN.
+    axis_angle = axis_angle + (cos_theta * 0.0)[..., None]
     return axis_angle
 
 


### PR DESCRIPTION
When `sin_squared_theta == 0` (xyz all zero), `k_neg = 2.0` and `axis_angle[i] = q_i * 2.0 = 0.0`, silently discarding NaN in w. Fix using IEEE 754: `(cos_theta * 0.0)` adds 0 for finite w, NaN for NaN w.

## 📝 Description

**Fixes/Relates to:** #3629

The `quaternion_to_axis_angle` function silently swallows NaN values in the w (cos_theta) component. When the xyz components are all zero, the small-angle branch uses k = 2.0 and computes `axis_angle[i] = q_i * 2.0 = 0 * 2.0 = 0.0`, which returns a zero axis-angle even when w is NaN. This masks invalid quaternions instead of surfacing the error.

**Important:**
- This PR is linked to issue #3629
- The fix strictly implements the linked issue

---

## 🔀 Changes Made

- [x] Added one line to `kornia/geometry/conversions.py`: `axis_angle = axis_angle + (cos_theta * 0.0)[..., None]` after the axis-angle components are computed. IEEE 754 guarantees NaN * 0.0 = NaN and finite * 0.0 = 0.0, so valid inputs are unchanged while NaN w-components propagate.

---

## ✅ How Was This Tested?

- [x] **Unit Tests:** Added three regression tests in `tests/geometry/test_conversions.py`: NaN w with zero xyz, NaN in xyz (existing behavior), and a batch case verifying NaN does not corrupt a valid row.
- [x] **Manual Verification:** Verified IEEE 754 behavior: `float('nan') * 0.0 == nan` and `1.0 * 0.0 == 0.0` in Python.
- [x] **Performance/Edge Cases:** The fix adds a single floating-point operation with no branches, negligible cost, and no impact on valid inputs.

---

## 🤖 AI Usage Disclosure
*Check one of the following:*
- [x] 🟢 **No AI used.**

---

## ✅ Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or 'hallucinations').
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added screenshots/recordings for UI changes.