### PR TITLE
docs: add missing docstrings to augmentation module

### DIFF
--- a/kornia/augmentation/auto/autoaugment/autoaugment.py
+++ b/kornia/augmentation/auto/autoaugment/autoaugment.py
@@ -156,24 +156,25 @@ class AutoAugment(PolicyAugmentBase):
         self.rand_selector = Categorical(selection_weights)
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
-        """Composes a sequential policy module from a subpolicy configuration.
+        """Build a :class:`PolicySequential` from one AutoAugment sub-policy.
 
         Args:
-            subpolicy: A list of operations containing their names, probabilities, and magnitudes.
+            subpolicy: Sequence of ``(name, probability, magnitude)`` operation tuples.
 
         Returns:
-            The composed sequential policy module.
+            A sequential container that applies the configured operations in order.
         """
         return PolicySequential(*[getattr(ops, name)(prob, mag) for name, prob, mag in subpolicy])
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
-        """Retrieves the forward sequence of operations to be applied.
+        """Return the operations to run for the current forward call.
 
         Args:
-            params: Optional parameters to fetch a specific sequence of modules.
+            params: Optional recorded parameters. When provided, the sequence is
+                reconstructed from them.
 
         Returns:
-            An iterator yielding tuples of operation names and their corresponding modules.
+            Iterator of ``(name, module)`` pairs.
         """
         if params is None:
             idx = self.rand_selector.sample((1,))

--- a/kornia/augmentation/auto/autoaugment/autoaugment.py
+++ b/kornia/augmentation/auto/autoaugment/autoaugment.py
@@ -156,9 +156,25 @@ class AutoAugment(PolicyAugmentBase):
         self.rand_selector = Categorical(selection_weights)
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
+        """Composes a sequential policy module from a subpolicy configuration.
+
+        Args:
+            subpolicy: A list of operations containing their names, probabilities, and magnitudes.
+
+        Returns:
+            The composed sequential policy module.
+        """
         return PolicySequential(*[getattr(ops, name)(prob, mag) for name, prob, mag in subpolicy])
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
+        """Retrieves the forward sequence of operations to be applied.
+
+        Args:
+            params: Optional parameters to fetch a specific sequence of modules.
+
+        Returns:
+            An iterator yielding tuples of operation names and their corresponding modules.
+        """
         if params is None:
             idx = self.rand_selector.sample((1,))
             return self.get_children_by_indices(idx)

--- a/kornia/augmentation/auto/base.py
+++ b/kornia/augmentation/auto/base.py
@@ -45,6 +45,7 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         self._transform_matrices.append(module.transform_matrix)
 
     def clear_state(self) -> None:
+        """Clears the internal state of the augmentation, including the transform matrix."""
         self._reset_transform_matrix_state()
         return super().clear_state()
 
@@ -53,6 +54,14 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         return [self.compose_subpolicy_sequential(subpolicy) for subpolicy in policy]
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
+        """Composes a sequential policy module from a subpolicy configuration.
+
+        Args:
+            subpolicy: A list of operations containing their names, probabilities, and magnitudes.
+
+        Returns:
+            The composed sequential policy module.
+        """
         raise NotImplementedError
 
     def identity_matrix(self, input: torch.Tensor) -> torch.Tensor:
@@ -91,6 +100,14 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         return res_mat
 
     def is_intensity_only(self, params: Optional[List[ParamItem]] = None) -> bool:
+        """Checks if the sequence of operations contains only intensity transformations.
+
+        Args:
+            params: Optional parameters to evaluate specific modules.
+
+        Returns:
+            True if only intensity transformations are present, False otherwise.
+        """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence(params)
         for _, module in named_modules:
             module = cast(PolicySequential, module)
@@ -99,6 +116,14 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         return True
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
+        """Generates the parameters for the forward pass based on the batch shape.
+
+        Args:
+            batch_shape: The shape of the input batch.
+
+        Returns:
+            A list of generated parameters for each module in the sequence.
+        """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
 
         params: List[ParamItem] = []
@@ -113,6 +138,16 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Transforms the input tensor using the provided parameters.
+
+        Args:
+            input: The input tensor to transform.
+            params: The list of parameters for each operation.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed input tensor.
+        """
         for param in params:
             module = self.get_submodule(param.name)
             input = InputSequentialOps.transform(input, module=module, param=param, extra_args=extra_args)
@@ -121,6 +156,16 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
     def forward(
         self, input: torch.Tensor, params: Optional[List[ParamItem]] = None, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Performs the forward pass of the policy augmentation.
+
+        Args:
+            input: The input tensor.
+            params: Optional parameters to use for the transformations.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The augmented input tensor.
+        """
         self.clear_state()
 
         if params is None:

--- a/kornia/augmentation/auto/base.py
+++ b/kornia/augmentation/auto/base.py
@@ -45,7 +45,7 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         self._transform_matrices.append(module.transform_matrix)
 
     def clear_state(self) -> None:
-        """Clears the internal state of the augmentation, including the transform matrix."""
+        """Reset cached params and transformation-matrix state."""
         self._reset_transform_matrix_state()
         return super().clear_state()
 
@@ -54,13 +54,13 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         return [self.compose_subpolicy_sequential(subpolicy) for subpolicy in policy]
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
-        """Composes a sequential policy module from a subpolicy configuration.
+        """Build a :class:`PolicySequential` from a single sub-policy spec.
 
         Args:
-            subpolicy: A list of operations containing their names, probabilities, and magnitudes.
+            subpolicy: Sub-policy definition used by the concrete augmentation.
 
         Returns:
-            The composed sequential policy module.
+            The sequential module representing that sub-policy.
         """
         raise NotImplementedError
 
@@ -100,13 +100,13 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         return res_mat
 
     def is_intensity_only(self, params: Optional[List[ParamItem]] = None) -> bool:
-        """Checks if the sequence of operations contains only intensity transformations.
+        """Check whether all selected sub-policies are intensity-only.
 
         Args:
-            params: Optional parameters to evaluate specific modules.
+            params: Optional parameters that define which sub-policies to inspect.
 
         Returns:
-            True if only intensity transformations are present, False otherwise.
+            ``True`` if no geometric transform is selected, ``False`` otherwise.
         """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence(params)
         for _, module in named_modules:
@@ -116,13 +116,13 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
         return True
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
-        """Generates the parameters for the forward pass based on the batch shape.
+        """Generate per-module parameters for one policy forward pass.
 
         Args:
-            batch_shape: The shape of the input batch.
+            batch_shape: Input shape used to sample operation parameters.
 
         Returns:
-            A list of generated parameters for each module in the sequence.
+            Parameters for each selected child module, in execution order.
         """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
 
@@ -138,15 +138,15 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Transforms the input tensor using the provided parameters.
+        """Apply a prepared parameter list to the input tensor.
 
         Args:
-            input: The input tensor to transform.
-            params: The list of parameters for each operation.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input tensor.
+            params: Parameters produced by :meth:`forward_parameters`.
+            extra_args: Optional overrides forwarded to child transforms.
 
         Returns:
-            The transformed input tensor.
+            Transformed tensor.
         """
         for param in params:
             module = self.get_submodule(param.name)
@@ -156,15 +156,16 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
     def forward(
         self, input: torch.Tensor, params: Optional[List[ParamItem]] = None, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Performs the forward pass of the policy augmentation.
+        """Apply the policy to ``input`` and cache the parameters used.
 
         Args:
-            input: The input tensor.
-            params: Optional parameters to use for the transformations.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input tensor.
+            params: Optional precomputed parameters. If omitted, parameters are
+                sampled on-the-fly.
+            extra_args: Optional overrides forwarded to child transforms.
 
         Returns:
-            The augmented input tensor.
+            Augmented tensor.
         """
         self.clear_state()
 

--- a/kornia/augmentation/auto/operations/base.py
+++ b/kornia/augmentation/auto/operations/base.py
@@ -129,27 +129,46 @@ class OperationBase(nn.Module):
             self.op._p_gen = Bernoulli(self.probability)
 
     def train(self, mode: bool = True) -> Self:
-        self._update_probability_gen(relaxation=mode)
+        """Sets the module in training mode.
 
+        Args:
+            mode: Whether to set training mode (True) or evaluation mode (False).
+
+        Returns:
+            The module itself.
+        """
+        self._update_probability_gen(relaxation=mode)
         return super().train(mode=mode)
 
     def eval(self) -> Self:
+        """Sets the module in evaluation mode.
+
+        Returns:
+            The module itself.
+        """
         return self.train(False)
 
     def forward_parameters(
         self, batch_shape: torch.Size, mag: Optional[torch.Tensor] = None
     ) -> Dict[str, torch.Tensor]:
+        """Generates the parameters for the forward pass.
+
+        Args:
+            batch_shape: The shape of the input batch.
+            mag: Optional magnitude tensor to override the default magnitude.
+
+        Returns:
+            A dictionary containing the generated parameters.
+        """
         if mag is None:
             mag = self.magnitude
-        # Need to setup the sampler again for each update.
-        # Otherwise, an error for updating the same graph twice will be thrown.
+            
         self._update_probability_gen(relaxation=True)
         params = self.op.forward_parameters(batch_shape)
 
         if mag is not None:
             if self._factor_name is None:
                 raise RuntimeError("No factor found in the params while `mag` is provided.")
-            # For single factor operations, this is equivalent to `same_on_batch=True`
             params[self._factor_name] = params[self._factor_name].zero_() + mag
 
         if self._factor_name is not None:
@@ -158,6 +177,15 @@ class OperationBase(nn.Module):
         return params
 
     def forward(self, input: torch.Tensor, params: Optional[Dict[str, torch.Tensor]] = None) -> torch.Tensor:
+        """Performs the forward pass of the operation.
+
+        Args:
+            input: The input tensor.
+            params: Optional parameters to use for the operation.
+
+        Returns:
+            The augmented input tensor.
+        """
         if params is None:
             params = self.forward_parameters(input.shape)
 
@@ -167,12 +195,22 @@ class OperationBase(nn.Module):
 
     @property
     def transform_matrix(self) -> Optional[torch.Tensor]:
+        """Returns the transformation matrix of the operation.
+
+        Returns:
+            The transformation matrix tensor or None.
+        """
         if hasattr(self.op, "transform_matrix"):
             return self.op.transform_matrix
         return None
 
     @property
     def magnitude(self) -> Optional[torch.Tensor]:
+        """Returns the magnitude of the operation.
+
+        Returns:
+            The clamped magnitude tensor or None.
+        """
         if self._magnitude is None:
             return None
         mag = self._magnitude
@@ -182,5 +220,10 @@ class OperationBase(nn.Module):
 
     @property
     def probability(self) -> torch.Tensor:
+        """Returns the probability of applying the operation.
+
+        Returns:
+            The clamped probability tensor.
+        """
         p = self._probability.clamp(*self.probability_range)
         return p

--- a/kornia/augmentation/auto/operations/base.py
+++ b/kornia/augmentation/auto/operations/base.py
@@ -129,36 +129,37 @@ class OperationBase(nn.Module):
             self.op._p_gen = Bernoulli(self.probability)
 
     def train(self, mode: bool = True) -> Self:
-        """Sets the module in training mode.
+        """Switch training mode and refresh probability samplers.
 
         Args:
-            mode: Whether to set training mode (True) or evaluation mode (False).
+            mode: ``True`` for training mode, ``False`` for evaluation mode.
 
         Returns:
-            The module itself.
+            This module.
         """
         self._update_probability_gen(relaxation=mode)
         return super().train(mode=mode)
 
     def eval(self) -> Self:
-        """Sets the module in evaluation mode.
+        """Switch to evaluation mode.
 
         Returns:
-            The module itself.
+            This module.
         """
         return self.train(False)
 
     def forward_parameters(
         self, batch_shape: torch.Size, mag: Optional[torch.Tensor] = None
     ) -> Dict[str, torch.Tensor]:
-        """Generates the parameters for the forward pass.
+        """Sample parameters for the wrapped augmentation op.
 
         Args:
-            batch_shape: The shape of the input batch.
-            mag: Optional magnitude tensor to override the default magnitude.
+            batch_shape: Input batch shape used for sampling.
+            mag: Optional magnitude override. When set, it replaces the sampled
+                factor before the magnitude mapping function is applied.
 
         Returns:
-            A dictionary containing the generated parameters.
+            Parameter dictionary consumed by :meth:`forward`.
         """
         if mag is None:
             mag = self.magnitude
@@ -177,14 +178,16 @@ class OperationBase(nn.Module):
         return params
 
     def forward(self, input: torch.Tensor, params: Optional[Dict[str, torch.Tensor]] = None) -> torch.Tensor:
-        """Performs the forward pass of the operation.
+        """Apply the operation with probabilistic gating.
 
         Args:
-            input: The input tensor.
-            params: Optional parameters to use for the operation.
+            input: Input tensor.
+            params: Optional precomputed parameters. If omitted, parameters are
+                sampled from ``input.shape``.
 
         Returns:
-            The augmented input tensor.
+            Tensor where each sample is either transformed or left unchanged
+            according to ``batch_prob``.
         """
         if params is None:
             params = self.forward_parameters(input.shape)
@@ -195,10 +198,10 @@ class OperationBase(nn.Module):
 
     @property
     def transform_matrix(self) -> Optional[torch.Tensor]:
-        """Returns the transformation matrix of the operation.
+        """Return the latest transform matrix from the wrapped op, if available.
 
         Returns:
-            The transformation matrix tensor or None.
+            Transform matrix tensor or ``None`` for non-geometric operations.
         """
         if hasattr(self.op, "transform_matrix"):
             return self.op.transform_matrix
@@ -206,10 +209,12 @@ class OperationBase(nn.Module):
 
     @property
     def magnitude(self) -> Optional[torch.Tensor]:
-        """Returns the magnitude of the operation.
+        """Return the learned magnitude value for the operation.
 
         Returns:
-            The clamped magnitude tensor or None.
+            Magnitude tensor, clamped to ``magnitude_range`` when defined; otherwise
+            the raw learnable value. Returns ``None`` when this operation has no
+            magnitude parameter.
         """
         if self._magnitude is None:
             return None
@@ -220,10 +225,10 @@ class OperationBase(nn.Module):
 
     @property
     def probability(self) -> torch.Tensor:
-        """Returns the probability of applying the operation.
+        """Return the operation probability after applying configured bounds.
 
         Returns:
-            The clamped probability tensor.
+            Probability tensor clamped to ``probability_range``.
         """
         p = self._probability.clamp(*self.probability_range)
         return p

--- a/kornia/augmentation/auto/operations/base.py
+++ b/kornia/augmentation/auto/operations/base.py
@@ -162,7 +162,7 @@ class OperationBase(nn.Module):
         """
         if mag is None:
             mag = self.magnitude
-            
+
         self._update_probability_gen(relaxation=True)
         params = self.op.forward_parameters(batch_shape)
 

--- a/kornia/augmentation/auto/operations/policy.py
+++ b/kornia/augmentation/auto/operations/policy.py
@@ -46,10 +46,19 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
         self._transform_matrices.append(module.transform_matrix)
 
     def clear_state(self) -> None:
+        """Clears the internal state of the policy, including the transform matrices."""
         self._reset_transform_matrix_state()
         return super().clear_state()
 
     def validate_operations(self, *operations: OperationBase) -> None:
+        """Validates that all provided operations are instances of OperationBase.
+
+        Args:
+            *operations: A variable number of operations to validate.
+
+        Raises:
+            ValueError: If any operation is not an instance of OperationBase.
+        """
         invalid_ops: List[OperationBase] = []
         for op in operations:
             if not isinstance(op, OperationBase):
@@ -104,6 +113,11 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
         return res_mat
 
     def is_intensity_only(self) -> bool:
+        """Checks if the policy contains only intensity-based transformations.
+
+        Returns:
+            True if there are no geometric augmentations, False otherwise.
+        """
         for module in self.children():
             module = cast(OperationBase, module)
             if isinstance(module.op, (K.GeometricAugmentationBase2D,)):
@@ -111,11 +125,27 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
         return True
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
+        """Retrieves the forward sequence of operations.
+
+        Args:
+            params: Optional list of parameters to retrieve specific children.
+
+        Returns:
+            An iterator yielding tuples of operation names and their corresponding modules.
+        """
         if params is not None:
             return super().get_children_by_params(params)
         return self.named_children()
 
     def forward_parameters(self, batch_shape: Size) -> List[ParamItem]:
+        """Generates the parameters for the forward pass based on the batch shape.
+
+        Args:
+            batch_shape: The shape of the input batch.
+
+        Returns:
+            A list of generated parameters for each operation in the policy.
+        """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
 
         params: List[ParamItem] = []
@@ -130,6 +160,16 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Transforms the input tensor using the provided parameters and updates the transform matrix.
+
+        Args:
+            input: The input tensor to transform.
+            params: The list of parameters for each operation.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed input tensor.
+        """
         for param in params:
             module = self.get_submodule(param.name)
             input = InputSequentialOps.transform(input, module=module, param=param, extra_args=extra_args)

--- a/kornia/augmentation/auto/operations/policy.py
+++ b/kornia/augmentation/auto/operations/policy.py
@@ -46,18 +46,18 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
         self._transform_matrices.append(module.transform_matrix)
 
     def clear_state(self) -> None:
-        """Clears the internal state of the policy, including the transform matrices."""
+        """Reset cached params and transformation-matrix state."""
         self._reset_transform_matrix_state()
         return super().clear_state()
 
     def validate_operations(self, *operations: OperationBase) -> None:
-        """Validates that all provided operations are instances of OperationBase.
+        """Ensure all provided modules are :class:`OperationBase` instances.
 
         Args:
-            *operations: A variable number of operations to validate.
+            *operations: Operations passed to :class:`PolicySequential`.
 
         Raises:
-            ValueError: If any operation is not an instance of OperationBase.
+            ValueError: Any provided operation is not a Kornia auto operation.
         """
         invalid_ops: List[OperationBase] = []
         for op in operations:
@@ -113,10 +113,10 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
         return res_mat
 
     def is_intensity_only(self) -> bool:
-        """Checks if the policy contains only intensity-based transformations.
+        """Check whether the policy contains only intensity transforms.
 
         Returns:
-            True if there are no geometric augmentations, False otherwise.
+            ``True`` when no geometric operation is present.
         """
         for module in self.children():
             module = cast(OperationBase, module)
@@ -125,26 +125,27 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
         return True
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
-        """Retrieves the forward sequence of operations.
+        """Return the operation sequence used for execution.
 
         Args:
-            params: Optional list of parameters to retrieve specific children.
+            params: Optional recorded parameters. When provided, only modules
+                referenced by those params are returned.
 
         Returns:
-            An iterator yielding tuples of operation names and their corresponding modules.
+            Iterator of ``(name, module)`` pairs.
         """
         if params is not None:
             return super().get_children_by_params(params)
         return self.named_children()
 
     def forward_parameters(self, batch_shape: Size) -> List[ParamItem]:
-        """Generates the parameters for the forward pass based on the batch shape.
+        """Generate parameter dictionaries for each operation in the policy.
 
         Args:
-            batch_shape: The shape of the input batch.
+            batch_shape: Input shape used to sample operation parameters.
 
         Returns:
-            A list of generated parameters for each operation in the policy.
+            List of :class:`ParamItem` objects in execution order.
         """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
 
@@ -160,15 +161,15 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Transforms the input tensor using the provided parameters and updates the transform matrix.
+        """Apply all operations using a prepared parameter list.
 
         Args:
-            input: The input tensor to transform.
-            params: The list of parameters for each operation.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input tensor.
+            params: Parameters for each operation in this policy.
+            extra_args: Optional overrides forwarded to child modules.
 
         Returns:
-            The transformed input tensor.
+            Transformed tensor.
         """
         for param in params:
             module = self.get_submodule(param.name)

--- a/kornia/augmentation/auto/rand_augment/rand_augment.py
+++ b/kornia/augmentation/auto/rand_augment/rand_augment.py
@@ -91,29 +91,29 @@ class RandAugment(PolicyAugmentBase):
         self.m = m
 
     def rand_selector(self, n: int) -> torch.Tensor:
-        """Randomly selects a specified number of augmentation indices.
+        """Randomly choose ``n`` policy indices without replacement.
 
         Args:
-            n: The number of unique indices to select.
+            n: Number of candidate policies to sample.
 
         Returns:
-            A tensor containing the randomly selected indices.
+            Tensor of indices into this module's children.
         """
         perm = torch.randperm(len(self._modules))
         idx = perm[:n]
         return idx
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
-        """Composes a sequential policy module from a single-operation subpolicy.
+        """Build a :class:`PolicySequential` for one RandAugment candidate op.
 
         Args:
-            subpolicy: A list containing exactly one operation configuration (name, low, high).
+            subpolicy: Single-entry policy as ``[(name, low, high)]``.
 
         Returns:
-            The composed sequential policy module.
+            Sequential wrapper around that operation.
 
         Raises:
-            RuntimeError: If the subpolicy does not contain exactly one operation.
+            RuntimeError: ``subpolicy`` contains more than one operation.
         """
         if len(subpolicy) != 1:
             raise RuntimeError(f"Each policy must have only one operation for RandAugment. Got {len(subpolicy)}.")
@@ -121,13 +121,14 @@ class RandAugment(PolicyAugmentBase):
         return PolicySequential(*[getattr(ops, name)(low, high)])
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
-        """Retrieves the sequence of augmentation modules to be applied.
+        """Return the policy modules to execute for this forward call.
 
         Args:
-            params: Optional parameters to fetch a specific sequence of modules.
+            params: Optional recorded parameters. When provided, the sequence is
+                reconstructed from them.
 
         Returns:
-            An iterator yielding tuples of operation names and their corresponding modules.
+            Iterator of ``(name, module)`` pairs.
         """
         if params is None:
             idx = self.rand_selector(self.n)
@@ -136,13 +137,14 @@ class RandAugment(PolicyAugmentBase):
         return self.get_children_by_params(params)
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
-        """Generates augmentation parameters for the forward pass.
+        """Sample parameters for the selected RandAugment operations.
 
         Args:
-            batch_shape: The shape of the input batch.
+            batch_shape: Input shape used for parameter sampling.
 
         Returns:
-            A list of parameters for each selected augmentation module.
+            Parameters for the sampled operations, including magnitude scaled from
+            the global ``m`` value.
         """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
         params: List[ParamItem] = []

--- a/kornia/augmentation/auto/rand_augment/rand_augment.py
+++ b/kornia/augmentation/auto/rand_augment/rand_augment.py
@@ -91,26 +91,59 @@ class RandAugment(PolicyAugmentBase):
         self.m = m
 
     def rand_selector(self, n: int) -> torch.Tensor:
+        """Randomly selects a specified number of augmentation indices.
+
+        Args:
+            n: The number of unique indices to select.
+
+        Returns:
+            A tensor containing the randomly selected indices.
+        """
         perm = torch.randperm(len(self._modules))
         idx = perm[:n]
         return idx
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
+        """Composes a sequential policy module from a single-operation subpolicy.
+
+        Args:
+            subpolicy: A list containing exactly one operation configuration (name, low, high).
+
+        Returns:
+            The composed sequential policy module.
+
+        Raises:
+            RuntimeError: If the subpolicy does not contain exactly one operation.
+        """
         if len(subpolicy) != 1:
             raise RuntimeError(f"Each policy must have only one operation for RandAugment. Got {len(subpolicy)}.")
         name, low, high = subpolicy[0]
         return PolicySequential(*[getattr(ops, name)(low, high)])
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
+        """Retrieves the sequence of augmentation modules to be applied.
+
+        Args:
+            params: Optional parameters to fetch a specific sequence of modules.
+
+        Returns:
+            An iterator yielding tuples of operation names and their corresponding modules.
+        """
         if params is None:
-            idx = self.rand_selector(
-                self.n,
-            )
+            idx = self.rand_selector(self.n)
             return self.get_children_by_indices(idx)
 
         return self.get_children_by_params(params)
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
+        """Generates augmentation parameters for the forward pass.
+
+        Args:
+            batch_shape: The shape of the input batch.
+
+        Returns:
+            A list of parameters for each selected augmentation module.
+        """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
         params: List[ParamItem] = []
         mod_param: Union[Dict[str, torch.Tensor], List[ParamItem]]

--- a/kornia/augmentation/auto/trivial_augment/trivial_augment.py
+++ b/kornia/augmentation/auto/trivial_augment/trivial_augment.py
@@ -79,16 +79,16 @@ class TrivialAugment(PolicyAugmentBase):
         self.rand_selector = Categorical(selection_weights)
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
-        """Composes a sequential policy module from a single-operation subpolicy.
+        """Build a :class:`PolicySequential` from one TrivialAugment candidate.
 
         Args:
-            subpolicy: A list containing exactly one operation configuration (name, low, high).
+            subpolicy: Single-entry policy as ``[(name, low, high)]``.
 
         Returns:
-            The composed sequential policy module.
+            Sequential wrapper around the selected operation.
 
         Raises:
-            RuntimeError: If the subpolicy does not contain exactly one operation.
+            RuntimeError: ``subpolicy`` contains more than one operation.
         """
         if len(subpolicy) != 1:
             raise RuntimeError(f"Each policy must have only one operation for TrivialAugment. Got {len(subpolicy)}.")
@@ -96,13 +96,14 @@ class TrivialAugment(PolicyAugmentBase):
         return PolicySequential(*[getattr(ops, name)(low, high)])
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
-        """Retrieves the sequence of augmentation modules to be applied.
+        """Return the operation sequence to execute.
 
         Args:
-            params: Optional parameters to fetch a specific sequence of modules.
+            params: Optional recorded parameters. When provided, the sequence is
+                reconstructed from them.
 
         Returns:
-            An iterator yielding tuples of operation names and their corresponding modules.
+            Iterator of ``(name, module)`` pairs.
         """
         if params is None:
             idx = self.rand_selector.sample((1,))

--- a/kornia/augmentation/auto/trivial_augment/trivial_augment.py
+++ b/kornia/augmentation/auto/trivial_augment/trivial_augment.py
@@ -79,12 +79,31 @@ class TrivialAugment(PolicyAugmentBase):
         self.rand_selector = Categorical(selection_weights)
 
     def compose_subpolicy_sequential(self, subpolicy: SUBPOLICY_CONFIG) -> PolicySequential:
+        """Composes a sequential policy module from a single-operation subpolicy.
+
+        Args:
+            subpolicy: A list containing exactly one operation configuration (name, low, high).
+
+        Returns:
+            The composed sequential policy module.
+
+        Raises:
+            RuntimeError: If the subpolicy does not contain exactly one operation.
+        """
         if len(subpolicy) != 1:
             raise RuntimeError(f"Each policy must have only one operation for TrivialAugment. Got {len(subpolicy)}.")
         name, low, high = subpolicy[0]
         return PolicySequential(*[getattr(ops, name)(low, high)])
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
+        """Retrieves the sequence of augmentation modules to be applied.
+
+        Args:
+            params: Optional parameters to fetch a specific sequence of modules.
+
+        Returns:
+            An iterator yielding tuples of operation names and their corresponding modules.
+        """
         if params is None:
             idx = self.rand_selector.sample((1,))
             return self.get_children_by_indices(idx)

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -285,7 +285,7 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         self.extra_args = extra_args or {DataKey.MASK: {"resample": Resample.NEAREST, "align_corners": None}}
 
     def clear_state(self) -> None:
-        """Clears the internal state of the augmentation sequence, including the transform matrix."""
+        """Reset cached params and transformation-matrix state."""
         self._reset_transform_matrix_state()
         return super().clear_state()
 

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -285,6 +285,7 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         self.extra_args = extra_args or {DataKey.MASK: {"resample": Resample.NEAREST, "align_corners": None}}
 
     def clear_state(self) -> None:
+        """Clears the internal state of the augmentation sequence, including the transform matrix."""
         self._reset_transform_matrix_state()
         return super().clear_state()
 

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -396,8 +396,8 @@ class ImageSequentialBase(SequentialBase):
         """Inverses the transformation applied to keypoints.
 
         Args:
-            input: The transformed keypoints to inverse. The underlying data conceptually 
-                represents a shape of (B, N, 2), where B is the batch size, N is the 
+            input: The transformed keypoints to inverse. The underlying data conceptually
+                represents a shape of (B, N, 2), where B is the batch size, N is the
                 number of keypoints, and 2 represents the (x, y) coordinates.
             params: The list of parameters used during the forward pass.
             extra_args: Optional dictionary of extra arguments.

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -396,12 +396,14 @@ class ImageSequentialBase(SequentialBase):
         """Inverses the transformation applied to keypoints.
 
         Args:
-            input: The transformed keypoints to inverse.
-            params: The parameters used during the forward pass.
+            input: The transformed keypoints to inverse. The underlying data conceptually 
+                represents a shape of (B, N, 2), where B is the batch size, N is the 
+                number of keypoints, and 2 represents the (x, y) coordinates.
+            params: The list of parameters used during the forward pass.
             extra_args: Optional dictionary of extra arguments.
 
         Returns:
-            The inversed keypoints.
+            The inversed keypoints, maintaining the same structure as the input.
         """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = KeypointSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -95,20 +95,52 @@ class BasicSequentialBase(nn.Sequential):
 
     # TODO: Implement this for all submodules.
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
+        """Generates the parameters for the forward pass.
+
+        Args:
+            batch_shape: The shape of the input batch.
+
+        Returns:
+            A list of generated parameters.
+        """
         raise NotImplementedError
 
     def get_children_by_indices(self, indices: torch.Tensor) -> Iterator[Tuple[str, nn.Module]]:
+        """Retrieves child modules by their indices.
+
+        Args:
+            indices: A tensor containing the indices of the modules to retrieve.
+
+        Yields:
+            An iterator of tuples containing the name and the module itself.
+        """
         modules = list(self.named_children())
         for idx in indices:
             yield modules[idx]
 
     def get_children_by_params(self, params: List[ParamItem]) -> Iterator[Tuple[str, nn.Module]]:
+        """Retrieves child modules based on the provided parameters.
+
+        Args:
+            params: A list of parameter items corresponding to the modules.
+
+        Yields:
+            An iterator of tuples containing the name and the module itself.
+        """
         modules = list(self.named_children())
         # TODO: Wrong params passed here when nested ImageSequential
         for param in params:
             yield modules[list(dict(self.named_children()).keys()).index(param.name)]
 
     def get_params_by_module(self, named_modules: Iterator[Tuple[str, nn.Module]]) -> Iterator[ParamItem]:
+        """Retrieves empty parameters for the provided named modules.
+
+        Args:
+            named_modules: An iterator of named modules.
+
+        Yields:
+            An iterator of initialized ParamItems with None values.
+        """
         # This will not take module._params
         for name, _ in named_modules:
             yield ParamItem(name, None)
@@ -141,6 +173,13 @@ class SequentialBase(BasicSequentialBase):
         return_transform: Optional[bool] = None,
         keepdim: Optional[bool] = None,
     ) -> None:
+        """Updates the attributes of the child modules in the sequence.
+
+        Args:
+            same_on_batch: Whether to apply the same transformation across the batch.
+            return_transform: Whether to return the transformation matrix.
+            keepdim: Whether to keep the output shape the same as input.
+        """
         for mod in self.children():
             # MixAugmentation does not have return transform
             if isinstance(mod, (_AugmentationBase, K.MixAugmentationBaseV2)):
@@ -153,6 +192,7 @@ class SequentialBase(BasicSequentialBase):
 
     @property
     def same_on_batch(self) -> Optional[bool]:
+        """Returns the same_on_batch state of the sequence."""
         return self._same_on_batch
 
     @same_on_batch.setter
@@ -162,6 +202,7 @@ class SequentialBase(BasicSequentialBase):
 
     @property
     def keepdim(self) -> Optional[bool]:
+        """Returns the keepdim state of the sequence."""
         return self._keepdim
 
     @keepdim.setter
@@ -212,6 +253,14 @@ class ImageSequentialBase(SequentialBase):
         raise NotImplementedError
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
+        """Generates parameters for each module in the sequence based on the batch shape.
+
+        Args:
+            batch_shape: The shape of the input batch.
+
+        Returns:
+            A list of generated parameters.
+        """
         raise NotImplementedError
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
@@ -221,6 +270,16 @@ class ImageSequentialBase(SequentialBase):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Transforms the input tensor using the sequence of operations.
+
+        Args:
+            input: The input tensor to transform.
+            params: A list of parameters for each operation.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed input tensor.
+        """
         for param in params:
             module = self.get_submodule(param.name)
             input = InputSequentialOps.transform(input, module=module, param=param, extra_args=extra_args)
@@ -229,6 +288,16 @@ class ImageSequentialBase(SequentialBase):
     def inverse_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Inverses the transformation applied to the input tensor.
+
+        Args:
+            input: The transformed tensor to inverse.
+            params: The parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed input tensor.
+        """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = InputSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
         return input
@@ -236,6 +305,16 @@ class ImageSequentialBase(SequentialBase):
     def transform_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Transforms the mask tensor using the sequence of operations.
+
+        Args:
+            input: The mask tensor to transform.
+            params: A list of parameters for each operation.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed mask tensor.
+        """
         for param in params:
             module = self.get_submodule(param.name)
             input = MaskSequentialOps.transform(input, module=module, param=param, extra_args=extra_args)
@@ -244,6 +323,16 @@ class ImageSequentialBase(SequentialBase):
     def inverse_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Inverses the transformation applied to the mask tensor.
+
+        Args:
+            input: The transformed mask tensor to inverse.
+            params: The parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed mask tensor.
+        """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = MaskSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
         return input
@@ -251,6 +340,16 @@ class ImageSequentialBase(SequentialBase):
     def transform_boxes(
         self, input: Boxes, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
+        """Transforms bounding boxes using the sequence of operations.
+
+        Args:
+            input: The bounding boxes to transform.
+            params: A list of parameters for each operation.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed bounding boxes.
+        """
         for param in params:
             module = self.get_submodule(param.name)
             input = BoxSequentialOps.transform(input, module=module, param=param, extra_args=extra_args)
@@ -259,6 +358,16 @@ class ImageSequentialBase(SequentialBase):
     def inverse_boxes(
         self, input: Boxes, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
+        """Inverses the transformation applied to bounding boxes.
+
+        Args:
+            input: The transformed bounding boxes to inverse.
+            params: The parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed bounding boxes.
+        """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = BoxSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
         return input
@@ -266,6 +375,16 @@ class ImageSequentialBase(SequentialBase):
     def transform_keypoints(
         self, input: Keypoints, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
+        """Transforms keypoints using the sequence of operations.
+
+        Args:
+            input: The keypoints to transform.
+            params: A list of parameters for each operation.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed keypoints.
+        """
         for param in params:
             module = self.get_submodule(param.name)
             input = KeypointSequentialOps.transform(input, module=module, param=param, extra_args=extra_args)
@@ -274,6 +393,16 @@ class ImageSequentialBase(SequentialBase):
     def inverse_keypoints(
         self, input: Keypoints, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
+        """Inverses the transformation applied to keypoints.
+
+        Args:
+            input: The transformed keypoints to inverse.
+            params: The parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed keypoints.
+        """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = KeypointSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
         return input
@@ -301,6 +430,16 @@ class ImageSequentialBase(SequentialBase):
     def forward(
         self, input: torch.Tensor, params: Optional[List[ParamItem]] = None, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Performs the forward pass of the sequential augmentation.
+
+        Args:
+            input: The input tensor.
+            params: Optional parameters to use for the transformations.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The augmented input tensor.
+        """
         self.clear_state()
 
         if params is None:

--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -95,37 +95,37 @@ class BasicSequentialBase(nn.Sequential):
 
     # TODO: Implement this for all submodules.
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
-        """Generates the parameters for the forward pass.
+        """Generate parameters for a forward pass.
 
         Args:
-            batch_shape: The shape of the input batch.
+            batch_shape: Input batch shape.
 
         Returns:
-            A list of generated parameters.
+            Per-module parameters in execution order.
         """
         raise NotImplementedError
 
     def get_children_by_indices(self, indices: torch.Tensor) -> Iterator[Tuple[str, nn.Module]]:
-        """Retrieves child modules by their indices.
+        """Yield child modules selected by index.
 
         Args:
-            indices: A tensor containing the indices of the modules to retrieve.
+            indices: Indices of children to fetch.
 
         Yields:
-            An iterator of tuples containing the name and the module itself.
+            ``(name, module)`` pairs matching ``indices`` order.
         """
         modules = list(self.named_children())
         for idx in indices:
             yield modules[idx]
 
     def get_children_by_params(self, params: List[ParamItem]) -> Iterator[Tuple[str, nn.Module]]:
-        """Retrieves child modules based on the provided parameters.
+        """Yield child modules referenced by a list of params.
 
         Args:
-            params: A list of parameter items corresponding to the modules.
+            params: Parameter items whose ``name`` fields identify the children.
 
         Yields:
-            An iterator of tuples containing the name and the module itself.
+            ``(name, module)`` pairs matching ``params`` order.
         """
         modules = list(self.named_children())
         # TODO: Wrong params passed here when nested ImageSequential
@@ -133,13 +133,13 @@ class BasicSequentialBase(nn.Sequential):
             yield modules[list(dict(self.named_children()).keys()).index(param.name)]
 
     def get_params_by_module(self, named_modules: Iterator[Tuple[str, nn.Module]]) -> Iterator[ParamItem]:
-        """Retrieves empty parameters for the provided named modules.
+        """Create placeholder params for a module iterator.
 
         Args:
-            named_modules: An iterator of named modules.
+            named_modules: Modules that will be executed.
 
         Yields:
-            An iterator of initialized ParamItems with None values.
+            :class:`ParamItem` entries with ``data=None``.
         """
         # This will not take module._params
         for name, _ in named_modules:
@@ -173,12 +173,12 @@ class SequentialBase(BasicSequentialBase):
         return_transform: Optional[bool] = None,
         keepdim: Optional[bool] = None,
     ) -> None:
-        """Updates the attributes of the child modules in the sequence.
+        """Propagate sequence-level flags to child augmentation modules.
 
         Args:
-            same_on_batch: Whether to apply the same transformation across the batch.
-            return_transform: Whether to return the transformation matrix.
-            keepdim: Whether to keep the output shape the same as input.
+            same_on_batch: Override for ``same_on_batch``.
+            return_transform: Reserved for compatibility with older interfaces.
+            keepdim: Override for ``keepdim``.
         """
         for mod in self.children():
             # MixAugmentation does not have return transform
@@ -192,7 +192,7 @@ class SequentialBase(BasicSequentialBase):
 
     @property
     def same_on_batch(self) -> Optional[bool]:
-        """Returns the same_on_batch state of the sequence."""
+        """Return the sequence-level ``same_on_batch`` setting."""
         return self._same_on_batch
 
     @same_on_batch.setter
@@ -202,7 +202,7 @@ class SequentialBase(BasicSequentialBase):
 
     @property
     def keepdim(self) -> Optional[bool]:
-        """Returns the keepdim state of the sequence."""
+        """Return the sequence-level ``keepdim`` setting."""
         return self._keepdim
 
     @keepdim.setter
@@ -253,13 +253,13 @@ class ImageSequentialBase(SequentialBase):
         raise NotImplementedError
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
-        """Generates parameters for each module in the sequence based on the batch shape.
+        """Generate parameters for child modules.
 
         Args:
-            batch_shape: The shape of the input batch.
+            batch_shape: Input batch shape.
 
         Returns:
-            A list of generated parameters.
+            Per-module parameter list.
         """
         raise NotImplementedError
 
@@ -270,15 +270,15 @@ class ImageSequentialBase(SequentialBase):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Transforms the input tensor using the sequence of operations.
+        """Apply the sequence to an input tensor.
 
         Args:
-            input: The input tensor to transform.
-            params: A list of parameters for each operation.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input tensor.
+            params: Parameters aligned with the execution sequence.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The transformed input tensor.
+            Transformed tensor.
         """
         for param in params:
             module = self.get_submodule(param.name)
@@ -288,15 +288,15 @@ class ImageSequentialBase(SequentialBase):
     def inverse_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Inverses the transformation applied to the input tensor.
+        """Apply inverse transforms for an input tensor.
 
         Args:
-            input: The transformed tensor to inverse.
-            params: The parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Tensor produced by :meth:`transform_inputs`.
+            params: Parameters used during forward execution.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The inversed input tensor.
+            Tensor mapped back through inverse operations.
         """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = InputSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
@@ -305,15 +305,15 @@ class ImageSequentialBase(SequentialBase):
     def transform_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Transforms the mask tensor using the sequence of operations.
+        """Apply the sequence to mask tensors.
 
         Args:
-            input: The mask tensor to transform.
-            params: A list of parameters for each operation.
-            extra_args: Optional dictionary of extra arguments.
+            input: Mask tensor.
+            params: Parameters aligned with the execution sequence.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The transformed mask tensor.
+            Transformed mask tensor.
         """
         for param in params:
             module = self.get_submodule(param.name)
@@ -323,15 +323,15 @@ class ImageSequentialBase(SequentialBase):
     def inverse_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Inverses the transformation applied to the mask tensor.
+        """Apply inverse transforms for mask tensors.
 
         Args:
-            input: The transformed mask tensor to inverse.
-            params: The parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Mask tensor produced by :meth:`transform_masks`.
+            params: Parameters used during forward execution.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The inversed mask tensor.
+            Inverse-transformed mask tensor.
         """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = MaskSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
@@ -340,15 +340,15 @@ class ImageSequentialBase(SequentialBase):
     def transform_boxes(
         self, input: Boxes, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
-        """Transforms bounding boxes using the sequence of operations.
+        """Apply the sequence to bounding boxes.
 
         Args:
-            input: The bounding boxes to transform.
-            params: A list of parameters for each operation.
-            extra_args: Optional dictionary of extra arguments.
+            input: Bounding boxes.
+            params: Parameters aligned with the execution sequence.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The transformed bounding boxes.
+            Transformed boxes.
         """
         for param in params:
             module = self.get_submodule(param.name)
@@ -358,15 +358,15 @@ class ImageSequentialBase(SequentialBase):
     def inverse_boxes(
         self, input: Boxes, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
-        """Inverses the transformation applied to bounding boxes.
+        """Apply inverse transforms for bounding boxes.
 
         Args:
-            input: The transformed bounding boxes to inverse.
-            params: The parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Boxes produced by :meth:`transform_boxes`.
+            params: Parameters used during forward execution.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The inversed bounding boxes.
+            Inverse-transformed boxes.
         """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = BoxSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
@@ -375,15 +375,15 @@ class ImageSequentialBase(SequentialBase):
     def transform_keypoints(
         self, input: Keypoints, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
-        """Transforms keypoints using the sequence of operations.
+        """Apply the sequence to keypoints.
 
         Args:
-            input: The keypoints to transform.
-            params: A list of parameters for each operation.
-            extra_args: Optional dictionary of extra arguments.
+            input: Keypoints.
+            params: Parameters aligned with the execution sequence.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The transformed keypoints.
+            Transformed keypoints.
         """
         for param in params:
             module = self.get_submodule(param.name)
@@ -393,17 +393,17 @@ class ImageSequentialBase(SequentialBase):
     def inverse_keypoints(
         self, input: Keypoints, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
-        """Inverses the transformation applied to keypoints.
+        """Apply inverse transforms for keypoints.
 
         Args:
-            input: The transformed keypoints to inverse. The underlying data conceptually
-                represents a shape of (B, N, 2), where B is the batch size, N is the
-                number of keypoints, and 2 represents the (x, y) coordinates.
-            params: The list of parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Keypoints produced by :meth:`transform_keypoints` (conceptually
+                ``(B, N, 2)`` coordinates, where the last dimension stores
+                ``(x, y)``.
+            params: Parameters used during forward execution.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The inversed keypoints, maintaining the same structure as the input.
+            Inverse-transformed keypoints.
         """
         for (_, module), param in zip_longest(list(self.get_forward_sequence(params))[::-1], params[::-1]):
             input = KeypointSequentialOps.inverse(input, module=module, param=param, extra_args=extra_args)
@@ -432,15 +432,16 @@ class ImageSequentialBase(SequentialBase):
     def forward(
         self, input: torch.Tensor, params: Optional[List[ParamItem]] = None, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Performs the forward pass of the sequential augmentation.
+        """Run the sequential augmentation pipeline.
 
         Args:
-            input: The input tensor.
-            params: Optional parameters to use for the transformations.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input tensor.
+            params: Optional precomputed parameters. If omitted, parameters are
+                sampled from ``input``.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The augmented input tensor.
+            Augmented tensor.
         """
         self.clear_state()
 

--- a/kornia/augmentation/container/dispatcher.py
+++ b/kornia/augmentation/container/dispatcher.py
@@ -60,13 +60,13 @@ class ManyToManyAugmentationDispather(nn.Module):
         return True
 
     def forward(self, *input: Union[List[Tensor], List[Tuple[Tensor]]]) -> Union[List[Tensor], List[Tuple[Tensor]]]:
-        """Dispatches each augmentation to its corresponding input in the sequence.
+        """Apply each augmentation to the matching input tuple.
 
         Args:
-            *input: A variable number of inputs, where each input corresponds to an augmentation sequence.
+            *input: One input bundle per configured augmentation.
 
         Returns:
-            A list containing the results of each augmentation applied to its respective input.
+            Outputs from each augmentation, preserving input order.
         """
         return [aug(*inp) for inp, aug in zip(input, self.augmentations)]
 
@@ -119,12 +119,12 @@ class ManyToOneAugmentationDispather(nn.Module):
         return True
 
     def forward(self, *input: Union[Tensor, Tuple[Tensor]]) -> Union[List[Tensor], List[Tuple[Tensor]]]:
-        """Applies all defined augmentations to the same single input.
+        """Apply all augmentations to the same input payload.
 
         Args:
-            *input: The shared input (e.g., image, mask) to be augmented by multiple sequences.
+            *input: Shared input payload passed to every augmentation.
 
         Returns:
-            A list containing the results of each individual augmentation sequence applied to the input.
+            One output per augmentation sequence.
         """
         return [aug(*input) for aug in self.augmentations]

--- a/kornia/augmentation/container/dispatcher.py
+++ b/kornia/augmentation/container/dispatcher.py
@@ -60,6 +60,14 @@ class ManyToManyAugmentationDispather(nn.Module):
         return True
 
     def forward(self, *input: Union[List[Tensor], List[Tuple[Tensor]]]) -> Union[List[Tensor], List[Tuple[Tensor]]]:
+        """Dispatches each augmentation to its corresponding input in the sequence.
+
+        Args:
+            *input: A variable number of inputs, where each input corresponds to an augmentation sequence.
+
+        Returns:
+            A list containing the results of each augmentation applied to its respective input.
+        """
         return [aug(*inp) for inp, aug in zip(input, self.augmentations)]
 
 
@@ -111,4 +119,12 @@ class ManyToOneAugmentationDispather(nn.Module):
         return True
 
     def forward(self, *input: Union[Tensor, Tuple[Tensor]]) -> Union[List[Tensor], List[Tuple[Tensor]]]:
+        """Applies all defined augmentations to the same single input.
+
+        Args:
+            *input: The shared input (e.g., image, mask) to be augmented by multiple sequences.
+
+        Returns:
+            A list containing the results of each individual augmentation sequence applied to the input.
+        """
         return [aug(*input) for aug in self.augmentations]

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -224,17 +224,18 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
         return [idx for idx, (_, child) in enumerate(named_modules) if isinstance(child, K.MixAugmentationBaseV2)]
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
-        """Retrieves the sequence of augmentation modules to be applied during the forward pass.
+        """Return the module sequence used for the current forward call.
 
         Args:
-            params: Optional list of parameters to retrieve specific children. If None, it uses
-                random application settings or returns all named children.
+            params: Optional recorded parameters. When provided, the sequence is
+                reconstructed from them.
 
         Returns:
-            An iterator yielding tuples of operation names and their corresponding modules.
+            Iterator of ``(name, module)`` pairs.
 
         Raises:
-            ValueError: If multiple mix augmentations are detected without enabling random_apply.
+            ValueError: More than one mix augmentation is present while
+                ``random_apply`` is disabled.
         """
         if params is None:
             # Mix augmentation can only be applied once per forward
@@ -254,13 +255,13 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
         return self.get_children_by_params(params)
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
-        """Generates the parameters for each augmentation in the sequence based on the batch shape.
+        """Generate parameters for all modules in the chosen sequence.
 
         Args:
-            batch_shape: The shape of the input batch.
+            batch_shape: Input batch shape.
 
         Returns:
-            A list of generated parameters (ParamItem) for each module in the forward sequence.
+            Parameter list aligned with the execution order.
         """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
 

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -227,7 +227,7 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
         """Retrieves the sequence of augmentation modules to be applied during the forward pass.
 
         Args:
-            params: Optional list of parameters to retrieve specific children. If None, it uses 
+            params: Optional list of parameters to retrieve specific children. If None, it uses
                 random application settings or returns all named children.
 
         Returns:

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -224,6 +224,18 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
         return [idx for idx, (_, child) in enumerate(named_modules) if isinstance(child, K.MixAugmentationBaseV2)]
 
     def get_forward_sequence(self, params: Optional[List[ParamItem]] = None) -> Iterator[Tuple[str, nn.Module]]:
+        """Retrieves the sequence of augmentation modules to be applied during the forward pass.
+
+        Args:
+            params: Optional list of parameters to retrieve specific children. If None, it uses 
+                random application settings or returns all named children.
+
+        Returns:
+            An iterator yielding tuples of operation names and their corresponding modules.
+
+        Raises:
+            ValueError: If multiple mix augmentations are detected without enabling random_apply.
+        """
         if params is None:
             # Mix augmentation can only be applied once per forward
             mix_indices = self.get_mix_augmentation_indices(self.named_children())
@@ -242,6 +254,14 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
         return self.get_children_by_params(params)
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
+        """Generates the parameters for each augmentation in the sequence based on the batch shape.
+
+        Args:
+            batch_shape: The shape of the input batch.
+
+        Returns:
+            A list of generated parameters (ParamItem) for each module in the forward sequence.
+        """
         named_modules: Iterator[Tuple[str, nn.Module]] = self.get_forward_sequence()
 
         params: List[ParamItem] = []

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -707,8 +707,8 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
         """Inverse a transformation with respect to the parameters.
 
         Args:
-            input: The input keypoints. The underlying data conceptually 
-                represents a shape of (B, N, 2), where B is the batch size, N is the 
+            input: The input keypoints. The underlying data conceptually
+                represents a shape of (B, N, 2), where B is the batch size, N is the
                 number of keypoints, and 2 represents the (x, y) coordinates.
             module: any torch nn.Module but only kornia augmentation modules will count
                 to apply transformations.

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -707,11 +707,16 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
         """Inverse a transformation with respect to the parameters.
 
         Args:
-            input: the input torch.Tensor.
+            input: The input keypoints. The underlying data conceptually 
+                represents a shape of (B, N, 2), where B is the batch size, N is the 
+                number of keypoints, and 2 represents the (x, y) coordinates.
             module: any torch nn.Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
             extra_args: Optional dictionary of extra arguments with specific options for different input types.
+
+        Returns:
+            The inversed keypoints, maintaining the same structure as the input.
         """
         if extra_args is None:
             extra_args = {}

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -44,16 +44,16 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
 
     @classmethod
     def get_instance_module_param(cls, param: ParamItem) -> Dict[str, torch.Tensor]:
-        """Retrieves parameters for a single augmentation instance.
+        """Extract per-module parameter dict from a :class:`ParamItem`.
 
         Args:
-            param: A ParamItem containing the parameters, expected to be a dictionary.
+            param: Parameter wrapper produced by sequential containers.
 
         Returns:
-            A dictionary containing the tensor parameters for the instance.
+            Dictionary of tensor parameters for one module call.
 
         Raises:
-            TypeError: If the param.data is not a dictionary.
+            TypeError: ``param.data`` is not a dictionary.
         """
         if isinstance(param, ParamItem) and isinstance(param.data, dict):
             _params = param.data
@@ -63,16 +63,16 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
 
     @classmethod
     def get_sequential_module_param(cls, param: ParamItem) -> List[ParamItem]:
-        """Retrieves parameters for a sequential module.
+        """Extract nested sequential parameters from a :class:`ParamItem`.
 
         Args:
-            param: A ParamItem containing the parameters, expected to be a list.
+            param: Parameter wrapper produced by sequential containers.
 
         Returns:
-            A list of ParamItems for the sequential operations.
+            List of :class:`ParamItem` values for nested modules.
 
         Raises:
-            TypeError: If the param.data is not a list.
+            TypeError: ``param.data`` is not a list.
         """
         if isinstance(param, ParamItem) and isinstance(param.data, list):
             _params = param.data
@@ -124,7 +124,7 @@ class AugmentationSequentialOps:
 
     @property
     def data_keys(self) -> Optional[List[DataKey]]:
-        """Returns the list of data keys configured for the sequential container."""
+        """Return currently configured data keys."""
         return self._data_keys
 
     @data_keys.setter
@@ -135,17 +135,17 @@ class AugmentationSequentialOps:
             self._data_keys = None
 
     def preproc_datakeys(self, data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None) -> List[DataKey]:
-        """Preprocesses the input data keys into standard DataKey enum values.
+        """Normalize user-provided data keys into :class:`DataKey` values.
 
         Args:
-            data_keys: An optional list of strings, ints, or DataKeys to process.
-                If None, falls back to the instance's configured data_keys.
+            data_keys: Optional keys passed by the caller. If omitted, this method
+                uses ``self.data_keys``.
 
         Returns:
-            A list of validated DataKey enum values.
+            Normalized list of data keys.
 
         Raises:
-            ValueError: If no data keys are provided or configured.
+            ValueError: Neither argument nor instance-level keys are available.
         """
         if data_keys is None:
             if isinstance(self.data_keys, list):
@@ -176,17 +176,18 @@ class AugmentationSequentialOps:
         extra_args: Dict[DataKey, Dict[str, Any]],
         data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None,
     ) -> Union[DataType, SequenceDataType]:
-        """Applies a transformation module to all configured inputs based on their data keys.
+        """Apply one module to all inputs according to their data keys.
 
         Args:
-            *arg: The inputs to transform (e.g., images, masks, boxes).
-            module: The augmentation module to apply.
-            param: The parameter item containing generation data for the module.
-            extra_args: A dictionary mapping data keys to extra arguments for the transformation.
-            data_keys: Optional list of data keys to override the default configuration.
+            *arg: Inputs to transform (image, mask, boxes, keypoints, ...).
+            module: Module to execute.
+            param: Parameters associated with ``module``.
+            extra_args: Optional runtime overrides keyed by :class:`DataKey`.
+            data_keys: Optional key override for this call.
 
         Returns:
-            The transformed inputs. Returns a single item if only one input is provided, otherwise a list.
+            Transformed output(s). A single value is returned for one input,
+            otherwise a list is returned.
         """
         _data_keys = self.preproc_datakeys(data_keys)
 
@@ -222,17 +223,18 @@ class AugmentationSequentialOps:
         extra_args: Dict[DataKey, Dict[str, Any]],
         data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None,
     ) -> Union[DataType, SequenceDataType]:
-        """Applies an inverse transformation module to all configured inputs based on their data keys.
+        """Apply inverse transformation dispatch for one module step.
 
         Args:
-            *arg: The augmented inputs to inverse.
-            module: The augmentation module used in the forward pass.
-            param: The parameter item containing generation data used in the forward pass.
-            extra_args: A dictionary mapping data keys to extra arguments for the inversion.
-            data_keys: Optional list of data keys to override the default configuration.
+            *arg: Inputs to invert.
+            module: Module used in the forward pass.
+            param: Parameters captured for ``module`` during forward.
+            extra_args: Optional runtime overrides keyed by :class:`DataKey`.
+            data_keys: Optional key override for this call.
 
         Returns:
-            The inversed inputs. Returns a single item if only one input is provided, otherwise a list.
+            Inverse-transformed output(s). A single value is returned for one
+            input, otherwise a list is returned.
         """
         _data_keys = self.preproc_datakeys(data_keys)
         outputs = []
@@ -279,19 +281,19 @@ class InputSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def transform(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies a transformation to an input image tensor within a sequential container.
+        """Apply one module step to an image tensor.
 
         Args:
-            input: The input image tensor.
-            module: The module performing the transformation.
-            param: The parameters associated with the module.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input image tensor.
+            module: Module to execute.
+            param: Parameters for ``module``.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The transformed image tensor.
+            Transformed tensor.
 
         Raises:
-            AssertionError: If a non-augmentation module receives non-empty parameters.
+            AssertionError: A non-augmentation module receives non-empty params.
         """
         if extra_args is None:
             extra_args = {}
@@ -311,19 +313,19 @@ class InputSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def inverse(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies an inverse transformation to an augmented image tensor within a sequential container.
+        """Apply one inverse module step to an image tensor.
 
         Args:
-            input: The augmented image tensor to inverse.
-            module: The module performing the inverse transformation.
-            param: The parameters associated with the module used in the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Tensor to invert.
+            module: Module used in the forward path.
+            param: Forward parameters for ``module``.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The inversed image tensor.
+            Inverse-transformed tensor.
 
         Raises:
-            NotImplementedError: If the module is a 3D geometric augmentation.
+            NotImplementedError: Inverse for 3D geometric ops is not supported.
         """
         if extra_args is None:
             extra_args = {}
@@ -349,19 +351,19 @@ class ClassSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def transform(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies a transformation to class labels within a sequential container.
+        """Apply class-label handling for one module step.
 
         Args:
-            input: The input class label tensor.
-            module: The module performing the transformation.
-            param: The parameters associated with the module.
-            extra_args: Optional dictionary of extra arguments.
+            input: Class-label tensor.
+            module: Module to execute.
+            param: Parameters for ``module``.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The transformed class label tensor.
+            Class labels after transformation handling.
 
         Raises:
-            NotImplementedError: If the module is a mix augmentation attempting to change class labels.
+            NotImplementedError: Label-changing mix ops are not supported yet.
         """
         if isinstance(module, K.MixAugmentationBaseV2):
             raise NotImplementedError(
@@ -373,20 +375,19 @@ class ClassSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def inverse(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies an inverse transformation to class labels within a sequential container.
+        """Return class labels unchanged during inverse dispatch.
 
         Note:
-            Class labels typically do not undergo geometric or intensity inversions, so this method
-            currently acts as an identity function.
+            Class labels do not have a geometric inverse in this pipeline.
 
         Args:
-            input: The input class label tensor.
-            module: The module performing the transformation.
-            param: The parameters associated with the module.
-            extra_args: Optional dictionary of extra arguments.
+            input: Class-label tensor.
+            module: Module used in forward (unused).
+            param: Forward parameters (unused).
+            extra_args: Optional runtime overrides (unused).
 
         Returns:
-            The original class label tensor.
+            Unmodified class labels.
         """
         return input
 
@@ -707,16 +708,15 @@ class KeypointSequentialOps(SequentialOpsInterface[Keypoints]):
         """Inverse a transformation with respect to the parameters.
 
         Args:
-            input: The input keypoints. The underlying data conceptually
-                represents a shape of (B, N, 2), where B is the batch size, N is the
-                number of keypoints, and 2 represents the (x, y) coordinates.
+            input: Input keypoints. Coordinates are conceptually stored as
+                ``(B, N, 2)``, where the last dimension stores ``(x, y)``.
             module: any torch nn.Module but only kornia augmentation modules will count
                 to apply transformations.
             param: the corresponding parameters to the module.
             extra_args: Optional dictionary of extra arguments with specific options for different input types.
 
         Returns:
-            The inversed keypoints, maintaining the same structure as the input.
+            Keypoints after inverse transformation.
         """
         if extra_args is None:
             extra_args = {}

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -138,7 +138,7 @@ class AugmentationSequentialOps:
         """Preprocesses the input data keys into standard DataKey enum values.
 
         Args:
-            data_keys: An optional list of strings, ints, or DataKeys to process. 
+            data_keys: An optional list of strings, ints, or DataKeys to process.
                 If None, falls back to the instance's configured data_keys.
 
         Returns:
@@ -289,7 +289,7 @@ class InputSequentialOps(SequentialOpsInterface[torch.Tensor]):
 
         Returns:
             The transformed image tensor.
-            
+
         Raises:
             AssertionError: If a non-augmentation module receives non-empty parameters.
         """
@@ -359,7 +359,7 @@ class ClassSequentialOps(SequentialOpsInterface[torch.Tensor]):
 
         Returns:
             The transformed class label tensor.
-            
+
         Raises:
             NotImplementedError: If the module is a mix augmentation attempting to change class labels.
         """
@@ -374,9 +374,9 @@ class ClassSequentialOps(SequentialOpsInterface[torch.Tensor]):
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
         """Applies an inverse transformation to class labels within a sequential container.
-        
+
         Note:
-            Class labels typically do not undergo geometric or intensity inversions, so this method 
+            Class labels typically do not undergo geometric or intensity inversions, so this method
             currently acts as an identity function.
 
         Args:

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -44,6 +44,17 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
 
     @classmethod
     def get_instance_module_param(cls, param: ParamItem) -> Dict[str, torch.Tensor]:
+        """Retrieves parameters for a single augmentation instance.
+
+        Args:
+            param: A ParamItem containing the parameters, expected to be a dictionary.
+
+        Returns:
+            A dictionary containing the tensor parameters for the instance.
+
+        Raises:
+            TypeError: If the param.data is not a dictionary.
+        """
         if isinstance(param, ParamItem) and isinstance(param.data, dict):
             _params = param.data
         else:
@@ -52,6 +63,17 @@ class SequentialOpsInterface(Generic[T], metaclass=ABCMeta):
 
     @classmethod
     def get_sequential_module_param(cls, param: ParamItem) -> List[ParamItem]:
+        """Retrieves parameters for a sequential module.
+
+        Args:
+            param: A ParamItem containing the parameters, expected to be a list.
+
+        Returns:
+            A list of ParamItems for the sequential operations.
+
+        Raises:
+            TypeError: If the param.data is not a list.
+        """
         if isinstance(param, ParamItem) and isinstance(param.data, list):
             _params = param.data
         else:
@@ -102,6 +124,7 @@ class AugmentationSequentialOps:
 
     @property
     def data_keys(self) -> Optional[List[DataKey]]:
+        """Returns the list of data keys configured for the sequential container."""
         return self._data_keys
 
     @data_keys.setter
@@ -112,6 +135,18 @@ class AugmentationSequentialOps:
             self._data_keys = None
 
     def preproc_datakeys(self, data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None) -> List[DataKey]:
+        """Preprocesses the input data keys into standard DataKey enum values.
+
+        Args:
+            data_keys: An optional list of strings, ints, or DataKeys to process. 
+                If None, falls back to the instance's configured data_keys.
+
+        Returns:
+            A list of validated DataKey enum values.
+
+        Raises:
+            ValueError: If no data keys are provided or configured.
+        """
         if data_keys is None:
             if isinstance(self.data_keys, list):
                 return self.data_keys
@@ -141,6 +176,18 @@ class AugmentationSequentialOps:
         extra_args: Dict[DataKey, Dict[str, Any]],
         data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None,
     ) -> Union[DataType, SequenceDataType]:
+        """Applies a transformation module to all configured inputs based on their data keys.
+
+        Args:
+            *arg: The inputs to transform (e.g., images, masks, boxes).
+            module: The augmentation module to apply.
+            param: The parameter item containing generation data for the module.
+            extra_args: A dictionary mapping data keys to extra arguments for the transformation.
+            data_keys: Optional list of data keys to override the default configuration.
+
+        Returns:
+            The transformed inputs. Returns a single item if only one input is provided, otherwise a list.
+        """
         _data_keys = self.preproc_datakeys(data_keys)
 
         if isinstance(module, K.RandomTransplantation):
@@ -175,6 +222,18 @@ class AugmentationSequentialOps:
         extra_args: Dict[DataKey, Dict[str, Any]],
         data_keys: Optional[Union[List[str], List[int], List[DataKey]]] = None,
     ) -> Union[DataType, SequenceDataType]:
+        """Applies an inverse transformation module to all configured inputs based on their data keys.
+
+        Args:
+            *arg: The augmented inputs to inverse.
+            module: The augmentation module used in the forward pass.
+            param: The parameter item containing generation data used in the forward pass.
+            extra_args: A dictionary mapping data keys to extra arguments for the inversion.
+            data_keys: Optional list of data keys to override the default configuration.
+
+        Returns:
+            The inversed inputs. Returns a single item if only one input is provided, otherwise a list.
+        """
         _data_keys = self.preproc_datakeys(data_keys)
         outputs = []
         for inp, dcate in zip(arg, _data_keys):
@@ -220,6 +279,20 @@ class InputSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def transform(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies a transformation to an input image tensor within a sequential container.
+
+        Args:
+            input: The input image tensor.
+            module: The module performing the transformation.
+            param: The parameters associated with the module.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed image tensor.
+            
+        Raises:
+            AssertionError: If a non-augmentation module receives non-empty parameters.
+        """
         if extra_args is None:
             extra_args = {}
         if isinstance(module, (_AugmentationBase, K.MixAugmentationBaseV2)):
@@ -238,6 +311,20 @@ class InputSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def inverse(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies an inverse transformation to an augmented image tensor within a sequential container.
+
+        Args:
+            input: The augmented image tensor to inverse.
+            module: The module performing the inverse transformation.
+            param: The parameters associated with the module used in the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed image tensor.
+
+        Raises:
+            NotImplementedError: If the module is a 3D geometric augmentation.
+        """
         if extra_args is None:
             extra_args = {}
         if isinstance(module, K.GeometricAugmentationBase2D):
@@ -262,6 +349,20 @@ class ClassSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def transform(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies a transformation to class labels within a sequential container.
+
+        Args:
+            input: The input class label tensor.
+            module: The module performing the transformation.
+            param: The parameters associated with the module.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed class label tensor.
+            
+        Raises:
+            NotImplementedError: If the module is a mix augmentation attempting to change class labels.
+        """
         if isinstance(module, K.MixAugmentationBaseV2):
             raise NotImplementedError(
                 "The support for class labels for mix augmentations that change the class label is not yet supported."
@@ -272,6 +373,21 @@ class ClassSequentialOps(SequentialOpsInterface[torch.Tensor]):
     def inverse(
         cls, input: torch.Tensor, module: nn.Module, param: ParamItem, extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies an inverse transformation to class labels within a sequential container.
+        
+        Note:
+            Class labels typically do not undergo geometric or intensity inversions, so this method 
+            currently acts as an identity function.
+
+        Args:
+            input: The input class label tensor.
+            module: The module performing the transformation.
+            param: The parameters associated with the module.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The original class label tensor.
+        """
         return input
 
 

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -516,8 +516,8 @@ class PatchSequential(ImageSequential):
         """Applies the inverse transformations to the augmented keypoints.
 
         Args:
-            input: The augmented keypoints to inverse. The underlying data conceptually 
-                represents a shape of (B, N, 2), where B is the batch size, N is the 
+            input: The augmented keypoints to inverse. The underlying data conceptually
+                represents a shape of (B, N, 2), where B is the batch size, N is the
                 number of keypoints, and 2 represents the (x, y) coordinates.
             params: The list of patch parameters used during the forward pass.
             extra_args: Optional dictionary of extra arguments.

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -516,12 +516,14 @@ class PatchSequential(ImageSequential):
         """Applies the inverse transformations to the augmented keypoints.
 
         Args:
-            input: The augmented keypoints to inverse.
+            input: The augmented keypoints to inverse. The underlying data conceptually 
+                represents a shape of (B, N, 2), where B is the batch size, N is the 
+                number of keypoints, and 2 represents the (x, y) coordinates.
             params: The list of patch parameters used during the forward pass.
             extra_args: Optional dictionary of extra arguments.
 
         Returns:
-            The inversed keypoints.
+            The inversed keypoints, maintaining the same structure as the input.
 
         Raises:
             NotImplementedError: If the sequence contains geometric transformations.

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -172,18 +172,18 @@ class PatchSequential(ImageSequential):
     def compute_padding(
         self, input: torch.Tensor, padding: str, grid_size: Optional[Tuple[int, int]] = None
     ) -> Tuple[int, int, int, int]:
-        """Computes the padding required for the input tensor based on the grid size and padding mode.
+        """Compute spatial padding needed before patch extraction.
 
         Args:
-            input: The input image tensor.
-            padding: The padding mode, either "same" or "valid".
-            grid_size: The size of the patch grid. Defaults to the instance's grid_size.
+            input: Input image tensor.
+            padding: Padding mode, either ``"same"`` or ``"valid"``.
+            grid_size: Optional grid override. Uses ``self.grid_size`` when omitted.
 
         Returns:
-            A tuple of four integers representing the padding (left, right, top, bottom).
+            Padding tuple ``(left, right, top, bottom)``.
 
         Raises:
-            NotImplementedError: If the padding mode is not "valid" or "same".
+            NotImplementedError: ``padding`` is neither ``"same"`` nor ``"valid"``.
         """
         if grid_size is None:
             grid_size = self.grid_size
@@ -273,13 +273,14 @@ class PatchSequential(ImageSequential):
         return restored_tensor
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[PatchParamItem]:  # type: ignore[override]
-        """Generates the parameters for each patch augmentation in the sequence.
+        """Generate patch-level parameters for a forward pass.
 
         Args:
-            batch_shape: The shape of the input batch.
+            batch_shape: Shape of the extracted patch batch.
 
         Returns:
-            A list of generated parameters specifically structured for patch-wise application.
+            List of :class:`PatchParamItem` entries, including patch indices and
+            operation params.
         """
         out_param: List[PatchParamItem] = []
         if not self.patchwise_apply:
@@ -343,14 +344,14 @@ class PatchSequential(ImageSequential):
                         yield ParamItem(s[0], None), i
 
     def forward_by_params(self, input: torch.Tensor, params: List[PatchParamItem]) -> torch.Tensor:
-        """Applies transformations to specific patches based on the provided parameters.
+        """Apply module parameters to selected patch indices.
 
         Args:
-            input: The tensor of extracted patches.
-            params: A list of PatchParamItem containing the indices and transformation parameters.
+            input: Tensor of extracted patches.
+            params: Patch operation payloads with ``indices`` and per-module params.
 
         Returns:
-            The augmented tensor of patches.
+            Augmented patch tensor.
         """
         in_shape = input.shape
         input = input.reshape(-1, *in_shape[-3:])
@@ -367,15 +368,15 @@ class PatchSequential(ImageSequential):
     def transform_inputs(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the patch-wise augmentation transformations to the input tensor.
+        """Apply patch-wise augmentation to an input tensor.
 
         Args:
-            input: The input image tensor to transform.
-            params: The list of patch parameters for the operations.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input image tensor.
+            params: Patch-level parameters from :meth:`forward_parameters`.
+            extra_args: Optional runtime overrides (unused in this implementation).
 
         Returns:
-            The transformed image tensor.
+            Augmented image tensor after extract-transform-restore.
         """
         pad = self.compute_padding(input, self.padding)
         input = self.extract_patches(input, self.grid_size, pad)
@@ -387,18 +388,18 @@ class PatchSequential(ImageSequential):
     def inverse_inputs(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the inverse transformations to the augmented input tensor.
+        """Inverse the patch pipeline when supported.
 
         Args:
-            input: The augmented image tensor to inverse.
-            params: The list of patch parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Augmented image tensor.
+            params: Parameters used during forward.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The inversed image tensor.
+            Original tensor for intensity-only pipelines.
 
         Raises:
-            NotImplementedError: If the sequence contains geometric transformations.
+            NotImplementedError: Geometric patch pipelines cannot be inverted.
         """
         if self.is_intensity_only():
             return input
@@ -408,18 +409,18 @@ class PatchSequential(ImageSequential):
     def transform_masks(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the patch-wise augmentation transformations to the mask tensor.
+        """Transform masks for intensity-only patch pipelines.
 
         Args:
-            input: The input mask tensor to transform.
-            params: The list of patch parameters for the operations.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input mask tensor.
+            params: Parameters used during forward.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The transformed mask tensor.
+            Unchanged mask tensor when the pipeline is intensity-only.
 
         Raises:
-            NotImplementedError: If the sequence contains geometric transformations.
+            NotImplementedError: Geometric patch pipelines are unsupported for masks.
         """
         if self.is_intensity_only():
             return input
@@ -429,18 +430,18 @@ class PatchSequential(ImageSequential):
     def inverse_masks(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the inverse transformations to the augmented mask tensor.
+        """Inverse mask transforms for supported patch pipelines.
 
         Args:
-            input: The augmented mask tensor to inverse.
-            params: The list of patch parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Augmented mask tensor.
+            params: Parameters used during forward.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The inversed mask tensor.
+            Original mask tensor for intensity-only pipelines.
 
         Raises:
-            NotImplementedError: If the sequence contains geometric transformations.
+            NotImplementedError: Geometric patch pipelines cannot be inverted.
         """
         if self.is_intensity_only():
             return input
@@ -450,18 +451,18 @@ class PatchSequential(ImageSequential):
     def transform_boxes(  # type: ignore[override]
         self, input: Boxes, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
-        """Applies the patch-wise augmentation transformations to the bounding boxes.
+        """Transform boxes for intensity-only patch pipelines.
 
         Args:
-            input: The bounding boxes to transform.
-            params: The list of patch parameters for the operations.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input boxes.
+            params: Parameters used during forward.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The transformed bounding boxes.
+            Unchanged boxes when the pipeline is intensity-only.
 
         Raises:
-            NotImplementedError: If the sequence contains geometric transformations.
+            NotImplementedError: Geometric patch pipelines are unsupported for boxes.
         """
         if self.is_intensity_only():
             return input
@@ -471,18 +472,18 @@ class PatchSequential(ImageSequential):
     def inverse_boxes(  # type: ignore[override]
         self, input: Boxes, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
-        """Applies the inverse transformations to the augmented bounding boxes.
+        """Inverse box transforms for supported patch pipelines.
 
         Args:
-            input: The augmented bounding boxes to inverse.
-            params: The list of patch parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Augmented boxes.
+            params: Parameters used during forward.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The inversed bounding boxes.
+            Original boxes for intensity-only pipelines.
 
         Raises:
-            NotImplementedError: If the sequence contains geometric transformations.
+            NotImplementedError: Geometric patch pipelines cannot be inverted.
         """
         if self.is_intensity_only():
             return input
@@ -492,18 +493,18 @@ class PatchSequential(ImageSequential):
     def transform_keypoints(  # type: ignore[override]
         self, input: Keypoints, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
-        """Applies the patch-wise augmentation transformations to the keypoints.
+        """Transform keypoints for intensity-only patch pipelines.
 
         Args:
-            input: The keypoints to transform.
-            params: The list of patch parameters for the operations.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input keypoints.
+            params: Parameters used during forward.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The transformed keypoints.
+            Unchanged keypoints when the pipeline is intensity-only.
 
         Raises:
-            NotImplementedError: If the sequence contains geometric transformations.
+            NotImplementedError: Geometric patch pipelines are unsupported for keypoints.
         """
         if self.is_intensity_only():
             return input
@@ -513,20 +514,19 @@ class PatchSequential(ImageSequential):
     def inverse_keypoints(  # type: ignore[override]
         self, input: Keypoints, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
-        """Applies the inverse transformations to the augmented keypoints.
+        """Inverse keypoint transforms for supported patch pipelines.
 
         Args:
-            input: The augmented keypoints to inverse. The underlying data conceptually
-                represents a shape of (B, N, 2), where B is the batch size, N is the
-                number of keypoints, and 2 represents the (x, y) coordinates.
-            params: The list of patch parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Augmented keypoints (conceptually ``(B, N, 2)`` coordinates,
+                where the last dimension stores ``(x, y)``).
+            params: Parameters used during forward.
+            extra_args: Optional runtime overrides.
 
         Returns:
-            The inversed keypoints, maintaining the same structure as the input.
+            Original keypoints for intensity-only pipelines.
 
         Raises:
-            NotImplementedError: If the sequence contains geometric transformations.
+            NotImplementedError: Geometric patch pipelines cannot be inverted.
         """
         if self.is_intensity_only():
             return input

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -172,6 +172,19 @@ class PatchSequential(ImageSequential):
     def compute_padding(
         self, input: torch.Tensor, padding: str, grid_size: Optional[Tuple[int, int]] = None
     ) -> Tuple[int, int, int, int]:
+        """Computes the padding required for the input tensor based on the grid size and padding mode.
+
+        Args:
+            input: The input image tensor.
+            padding: The padding mode, either "same" or "valid".
+            grid_size: The size of the patch grid. Defaults to the instance's grid_size.
+
+        Returns:
+            A tuple of four integers representing the padding (left, right, top, bottom).
+
+        Raises:
+            NotImplementedError: If the padding mode is not "valid" or "same".
+        """
         if grid_size is None:
             grid_size = self.grid_size
         if padding == "valid":
@@ -260,6 +273,14 @@ class PatchSequential(ImageSequential):
         return restored_tensor
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[PatchParamItem]:  # type: ignore[override]
+        """Generates the parameters for each patch augmentation in the sequence.
+
+        Args:
+            batch_shape: The shape of the input batch.
+
+        Returns:
+            A list of generated parameters specifically structured for patch-wise application.
+        """
         out_param: List[PatchParamItem] = []
         if not self.patchwise_apply:
             params = self.generate_parameters(torch.Size([1, batch_shape[0] * batch_shape[1], *batch_shape[2:]]))
@@ -322,6 +343,15 @@ class PatchSequential(ImageSequential):
                         yield ParamItem(s[0], None), i
 
     def forward_by_params(self, input: torch.Tensor, params: List[PatchParamItem]) -> torch.Tensor:
+        """Applies transformations to specific patches based on the provided parameters.
+
+        Args:
+            input: The tensor of extracted patches.
+            params: A list of PatchParamItem containing the indices and transformation parameters.
+
+        Returns:
+            The augmented tensor of patches.
+        """
         in_shape = input.shape
         input = input.reshape(-1, *in_shape[-3:])
 
@@ -337,6 +367,16 @@ class PatchSequential(ImageSequential):
     def transform_inputs(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the patch-wise augmentation transformations to the input tensor.
+
+        Args:
+            input: The input image tensor to transform.
+            params: The list of patch parameters for the operations.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed image tensor.
+        """
         pad = self.compute_padding(input, self.padding)
         input = self.extract_patches(input, self.grid_size, pad)
         input = self.forward_by_params(input, params)
@@ -347,6 +387,19 @@ class PatchSequential(ImageSequential):
     def inverse_inputs(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the inverse transformations to the augmented input tensor.
+
+        Args:
+            input: The augmented image tensor to inverse.
+            params: The list of patch parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed image tensor.
+
+        Raises:
+            NotImplementedError: If the sequence contains geometric transformations.
+        """
         if self.is_intensity_only():
             return input
 
@@ -355,6 +408,19 @@ class PatchSequential(ImageSequential):
     def transform_masks(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the patch-wise augmentation transformations to the mask tensor.
+
+        Args:
+            input: The input mask tensor to transform.
+            params: The list of patch parameters for the operations.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed mask tensor.
+
+        Raises:
+            NotImplementedError: If the sequence contains geometric transformations.
+        """
         if self.is_intensity_only():
             return input
 
@@ -363,6 +429,19 @@ class PatchSequential(ImageSequential):
     def inverse_masks(  # type: ignore[override]
         self, input: torch.Tensor, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the inverse transformations to the augmented mask tensor.
+
+        Args:
+            input: The augmented mask tensor to inverse.
+            params: The list of patch parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed mask tensor.
+
+        Raises:
+            NotImplementedError: If the sequence contains geometric transformations.
+        """
         if self.is_intensity_only():
             return input
 
@@ -371,6 +450,19 @@ class PatchSequential(ImageSequential):
     def transform_boxes(  # type: ignore[override]
         self, input: Boxes, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
+        """Applies the patch-wise augmentation transformations to the bounding boxes.
+
+        Args:
+            input: The bounding boxes to transform.
+            params: The list of patch parameters for the operations.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed bounding boxes.
+
+        Raises:
+            NotImplementedError: If the sequence contains geometric transformations.
+        """
         if self.is_intensity_only():
             return input
 
@@ -379,6 +471,19 @@ class PatchSequential(ImageSequential):
     def inverse_boxes(  # type: ignore[override]
         self, input: Boxes, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Boxes:
+        """Applies the inverse transformations to the augmented bounding boxes.
+
+        Args:
+            input: The augmented bounding boxes to inverse.
+            params: The list of patch parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed bounding boxes.
+
+        Raises:
+            NotImplementedError: If the sequence contains geometric transformations.
+        """
         if self.is_intensity_only():
             return input
 
@@ -387,6 +492,19 @@ class PatchSequential(ImageSequential):
     def transform_keypoints(  # type: ignore[override]
         self, input: Keypoints, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
+        """Applies the patch-wise augmentation transformations to the keypoints.
+
+        Args:
+            input: The keypoints to transform.
+            params: The list of patch parameters for the operations.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed keypoints.
+
+        Raises:
+            NotImplementedError: If the sequence contains geometric transformations.
+        """
         if self.is_intensity_only():
             return input
 
@@ -395,6 +513,19 @@ class PatchSequential(ImageSequential):
     def inverse_keypoints(  # type: ignore[override]
         self, input: Keypoints, params: List[PatchParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> Keypoints:
+        """Applies the inverse transformations to the augmented keypoints.
+
+        Args:
+            input: The augmented keypoints to inverse.
+            params: The list of patch parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed keypoints.
+
+        Raises:
+            NotImplementedError: If the sequence contains geometric transformations.
+        """
         if self.is_intensity_only():
             return input
 

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -192,6 +192,14 @@ class VideoSequential(ImageSequential):
         return input
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
+        """Generates parameters for the video augmentation sequence based on the batch shape.
+
+        Args:
+            batch_shape: The shape of the input video batch (typically 5D).
+
+        Returns:
+            A list of generated parameters (ParamItem) for each module in the sequence.
+        """
         frame_num = batch_shape[self._temporal_channel]
         named_modules = self.get_forward_sequence()
         # Got param generation shape to (B, C, H, W). Ignoring T.
@@ -244,6 +252,16 @@ class VideoSequential(ImageSequential):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the augmentation transformations to the video input tensor.
+
+        Args:
+            input: The input video tensor to transform.
+            params: The list of parameters for each operation in the sequence.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed video tensor.
+        """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)
 
@@ -255,6 +273,16 @@ class VideoSequential(ImageSequential):
     def inverse_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the inverse transformations to the video input tensor.
+
+        Args:
+            input: The augmented video tensor to inverse.
+            params: The list of parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed video tensor.
+        """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)
 
@@ -266,6 +294,16 @@ class VideoSequential(ImageSequential):
     def transform_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the augmentation transformations to the video mask tensor.
+
+        Args:
+            input: The video mask tensor to transform.
+            params: The list of parameters for each operation.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The transformed video mask tensor.
+        """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)
 
@@ -277,6 +315,16 @@ class VideoSequential(ImageSequential):
     def inverse_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
+        """Applies the inverse transformations to the video mask tensor.
+
+        Args:
+            input: The transformed video mask tensor to inverse.
+            params: The list of parameters used during the forward pass.
+            extra_args: Optional dictionary of extra arguments.
+
+        Returns:
+            The inversed video mask tensor.
+        """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)
 

--- a/kornia/augmentation/container/video.py
+++ b/kornia/augmentation/container/video.py
@@ -192,13 +192,14 @@ class VideoSequential(ImageSequential):
         return input
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
-        """Generates parameters for the video augmentation sequence based on the batch shape.
+        """Generate per-module parameters for video inputs.
 
         Args:
-            batch_shape: The shape of the input video batch (typically 5D).
+            batch_shape: Video batch shape, typically 5D.
 
         Returns:
-            A list of generated parameters (ParamItem) for each module in the sequence.
+            Parameter list aligned with execution order, with values broadcast
+            across frames depending on ``same_on_frame`` and module settings.
         """
         frame_num = batch_shape[self._temporal_channel]
         named_modules = self.get_forward_sequence()
@@ -252,15 +253,15 @@ class VideoSequential(ImageSequential):
     def transform_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the augmentation transformations to the video input tensor.
+        """Apply sequence transforms to video tensors.
 
         Args:
-            input: The input video tensor to transform.
-            params: The list of parameters for each operation in the sequence.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input video tensor.
+            params: Parameters aligned with the execution sequence.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The transformed video tensor.
+            Transformed video tensor in the original video layout.
         """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)
@@ -273,15 +274,15 @@ class VideoSequential(ImageSequential):
     def inverse_inputs(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the inverse transformations to the video input tensor.
+        """Apply inverse sequence transforms to video tensors.
 
         Args:
-            input: The augmented video tensor to inverse.
-            params: The list of parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Augmented video tensor.
+            params: Parameters used during forward execution.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The inversed video tensor.
+            Inverse-transformed video tensor in the original layout.
         """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)
@@ -294,15 +295,15 @@ class VideoSequential(ImageSequential):
     def transform_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the augmentation transformations to the video mask tensor.
+        """Apply sequence transforms to video mask tensors.
 
         Args:
-            input: The video mask tensor to transform.
-            params: The list of parameters for each operation.
-            extra_args: Optional dictionary of extra arguments.
+            input: Input video mask tensor.
+            params: Parameters aligned with the execution sequence.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The transformed video mask tensor.
+            Transformed mask tensor in the original video layout.
         """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)
@@ -315,15 +316,15 @@ class VideoSequential(ImageSequential):
     def inverse_masks(
         self, input: torch.Tensor, params: List[ParamItem], extra_args: Optional[Dict[str, Any]] = None
     ) -> torch.Tensor:
-        """Applies the inverse transformations to the video mask tensor.
+        """Apply inverse sequence transforms to video masks.
 
         Args:
-            input: The transformed video mask tensor to inverse.
-            params: The list of parameters used during the forward pass.
-            extra_args: Optional dictionary of extra arguments.
+            input: Augmented video mask tensor.
+            params: Parameters used during forward execution.
+            extra_args: Optional per-input-type overrides.
 
         Returns:
-            The inversed video mask tensor.
+            Inverse-transformed mask tensor in the original layout.
         """
         frame_num: int = input.size(self._temporal_channel)
         input = self._input_shape_convert_in(input, frame_num)

--- a/kornia/augmentation/presets/ada.py
+++ b/kornia/augmentation/presets/ada.py
@@ -169,6 +169,16 @@ class AdaptiveDiscriminatorAugmentation(AugmentationSequential):
         ratio: Union[torch.Tensor, Tuple[float, float]],
         value: float,
     ) -> Tuple[Union[_AugmentationBase, ImageSequential], ...]:
+        """Returns the default set of augmentation transformations for ADA.
+
+        Args:
+            scale: Range for the relative area of the erased region used in RandomErasing.
+            ratio: Aspect ratio range for the erased region used in RandomErasing.
+            value: Fill value for the erased region used in RandomErasing.
+
+        Returns:
+            A tuple containing the standard set of augmentation modules (flips, rotations, erasing, etc.).
+        """
         # if changed in the future, please change the expected transforms list in test_presets.py
         return (
             RandomHorizontalFlip(p=1),

--- a/kornia/augmentation/presets/ada.py
+++ b/kornia/augmentation/presets/ada.py
@@ -169,15 +169,15 @@ class AdaptiveDiscriminatorAugmentation(AugmentationSequential):
         ratio: Union[torch.Tensor, Tuple[float, float]],
         value: float,
     ) -> Tuple[Union[_AugmentationBase, ImageSequential], ...]:
-        """Returns the default set of augmentation transformations for ADA.
+        """Return the default augmentation stack used by ADA.
 
         Args:
-            scale: Range for the relative area of the erased region used in RandomErasing.
-            ratio: Aspect ratio range for the erased region used in RandomErasing.
-            value: Fill value for the erased region used in RandomErasing.
+            scale: Erase-area range passed to :class:`RandomErasing`.
+            ratio: Erase-aspect-ratio range passed to :class:`RandomErasing`.
+            value: Fill value used by :class:`RandomErasing`.
 
         Returns:
-            A tuple containing the standard set of augmentation modules (flips, rotations, erasing, etc.).
+            Tuple of augmentation modules applied inside ADA.
         """
         # if changed in the future, please change the expected transforms list in test_presets.py
         return (

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -67,14 +67,44 @@ class RandomGeneratorBase(nn.Module, metaclass=_PostInitInjectionMetaClass):
 
     # TODO: refine the logic with module.to()
     def to(self, *args: Any, **kwargs: Any) -> "RandomGeneratorBase":
+        """Moves and/or casts the parameters and buffers of the random generator.
+
+        Args:
+            *args: Arguments passed to torch._C._nn._parse_to.
+            **kwargs: Keyword arguments passed to torch._C._nn._parse_to.
+
+        Returns:
+            The module itself with the updated device and dtype.
+        """
         device, dtype, _, _ = torch._C._nn._parse_to(*args, **kwargs)
         self.set_rng_device_and_dtype(device=device, dtype=dtype)
         return self
 
     def make_samplers(self, device: torch.device, dtype: torch.dtype) -> None:
+        """Initializes the random distributions on the specified device and dtype.
+
+        Args:
+            device: The target device for the samplers.
+            dtype: The target data type for the samplers.
+
+        Raises:
+            NotImplementedError: If not implemented in the child class.
+        """
         raise NotImplementedError
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, torch.Tensor]:
+        """Generates the random parameters for the augmentation.
+
+        Args:
+            batch_shape: The shape of the batch to generate parameters for.
+            same_on_batch: Whether to generate the same parameters for the entire batch.
+
+        Returns:
+            A dictionary containing the generated parameter tensors.
+
+        Raises:
+            NotImplementedError: If not implemented in the child class.
+        """
         raise NotImplementedError
 
 
@@ -109,18 +139,42 @@ class DistributionWithMapper(Distribution):
         self.map_fn = map_fn
 
     def rsample(self, sample_shape: Tuple[int, ...]) -> torch.Tensor:  # type: ignore[override]
+        """Generates a reparameterized sample from the distribution and applies the map function.
+
+        Args:
+            sample_shape: The shape of the sample to draw.
+
+        Returns:
+            The drawn sample tensor, optionally modified by the map function.
+        """
         out = self.dist.rsample(torch.Size(sample_shape))
         if self.map_fn is not None:
             out = self.map_fn(out)
         return out
 
     def sample(self, sample_shape: Tuple[int, ...]) -> torch.Tensor:  # type: ignore[override]
+        """Generates a sample from the distribution and applies the map function.
+
+        Args:
+            sample_shape: The shape of the sample to draw.
+
+        Returns:
+            The drawn sample tensor, optionally modified by the map function.
+        """
         out = self.dist.sample(torch.Size(sample_shape))
         if self.map_fn is not None:
             out = self.map_fn(out)
         return out
 
     def sample_n(self, n: int) -> torch.Tensor:
+        """Generates `n` samples from the distribution and applies the map function.
+
+        Args:
+            n: The number of samples to draw.
+
+        Returns:
+            A tensor containing the `n` drawn samples, optionally modified by the map function.
+        """
         out = self.dist.sample_n(n)
         if self.map_fn is not None:
             out = self.map_fn(out)

--- a/kornia/augmentation/random_generator/base.py
+++ b/kornia/augmentation/random_generator/base.py
@@ -67,43 +67,44 @@ class RandomGeneratorBase(nn.Module, metaclass=_PostInitInjectionMetaClass):
 
     # TODO: refine the logic with module.to()
     def to(self, *args: Any, **kwargs: Any) -> "RandomGeneratorBase":
-        """Moves and/or casts the parameters and buffers of the random generator.
+        """Update sampler device and dtype using ``torch.nn.Module.to`` semantics.
 
         Args:
-            *args: Arguments passed to torch._C._nn._parse_to.
-            **kwargs: Keyword arguments passed to torch._C._nn._parse_to.
+            *args: Positional arguments accepted by ``Module.to``.
+            **kwargs: Keyword arguments accepted by ``Module.to``.
 
         Returns:
-            The module itself with the updated device and dtype.
+            This generator instance.
         """
         device, dtype, _, _ = torch._C._nn._parse_to(*args, **kwargs)
         self.set_rng_device_and_dtype(device=device, dtype=dtype)
         return self
 
     def make_samplers(self, device: torch.device, dtype: torch.dtype) -> None:
-        """Initializes the random distributions on the specified device and dtype.
+        """Create distribution samplers for the given device and dtype.
 
         Args:
-            device: The target device for the samplers.
-            dtype: The target data type for the samplers.
+            device: Target device.
+            dtype: Target floating-point dtype.
 
         Raises:
-            NotImplementedError: If not implemented in the child class.
+            NotImplementedError: Subclass did not implement sampler creation.
         """
         raise NotImplementedError
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, torch.Tensor]:
-        """Generates the random parameters for the augmentation.
+        """Sample random augmentation parameters.
 
         Args:
-            batch_shape: The shape of the batch to generate parameters for.
-            same_on_batch: Whether to generate the same parameters for the entire batch.
+            batch_shape: Target batch shape.
+            same_on_batch: If ``True``, use one sample and broadcast it across the
+                batch dimension.
 
         Returns:
-            A dictionary containing the generated parameter tensors.
+            Dictionary of tensors consumed by augmentation modules.
 
         Raises:
-            NotImplementedError: If not implemented in the child class.
+            NotImplementedError: Subclass did not implement parameter sampling.
         """
         raise NotImplementedError
 
@@ -139,13 +140,13 @@ class DistributionWithMapper(Distribution):
         self.map_fn = map_fn
 
     def rsample(self, sample_shape: Tuple[int, ...]) -> torch.Tensor:  # type: ignore[override]
-        """Generates a reparameterized sample from the distribution and applies the map function.
+        """Draw a reparameterized sample and apply ``map_fn`` when provided.
 
         Args:
-            sample_shape: The shape of the sample to draw.
+            sample_shape: Desired sample shape.
 
         Returns:
-            The drawn sample tensor, optionally modified by the map function.
+            Sample tensor after optional mapping.
         """
         out = self.dist.rsample(torch.Size(sample_shape))
         if self.map_fn is not None:
@@ -153,13 +154,13 @@ class DistributionWithMapper(Distribution):
         return out
 
     def sample(self, sample_shape: Tuple[int, ...]) -> torch.Tensor:  # type: ignore[override]
-        """Generates a sample from the distribution and applies the map function.
+        """Draw a sample and apply ``map_fn`` when provided.
 
         Args:
-            sample_shape: The shape of the sample to draw.
+            sample_shape: Desired sample shape.
 
         Returns:
-            The drawn sample tensor, optionally modified by the map function.
+            Sample tensor after optional mapping.
         """
         out = self.dist.sample(torch.Size(sample_shape))
         if self.map_fn is not None:
@@ -167,13 +168,13 @@ class DistributionWithMapper(Distribution):
         return out
 
     def sample_n(self, n: int) -> torch.Tensor:
-        """Generates `n` samples from the distribution and applies the map function.
+        """Draw ``n`` samples and apply ``map_fn`` when provided.
 
         Args:
-            n: The number of samples to draw.
+            n: Number of samples.
 
         Returns:
-            A tensor containing the `n` drawn samples, optionally modified by the map function.
+            Sample tensor after optional mapping.
         """
         out = self.dist.sample_n(n)
         if self.map_fn is not None:


### PR DESCRIPTION
# Description

**Fixes/Relates to:** Follow-up to PR #3648 / Issue #3083 as discussed with @shijianjian and @Meggison.

*(Note to maintainers: As discussed in PR #3648, I am splitting the docstring fixes by module to keep reviews clean. This PR covers the entire `kornia/augmentation/` folder. Let me know if you need me to open a new specific issue for this, otherwise, the bot might complain about the assignment!)*

## Changes Made
- [x] Added missing public method docstrings (resolving Ruff `D102` errors) across the `kornia/augmentation/` module.
- [x] Files updated include `auto/`, `container/`, `random_generator/`, and `presets/` to enforce standard `Args` and `Returns` documentation.

## How Was This Tested?
- [x] **Manual Verification:** Checked against the `missing_docstrings.txt` log to ensure all flagged `D102` errors in the targeted files were resolved.

## AI Usage Disclosure
- [x] AI-assisted: I used AI for boilerplate/refactoring but have manually reviewed and tested every line.# Description

**Fixes/Relates to:** Follow-up to PR #3648 / Issue #3083 as discussed with @shijianjian and @Meggison.

*(Note to maintainers: As discussed in PR #3648, I am splitting the docstring fixes by module to keep reviews clean. This PR covers the entire `kornia/augmentation/` folder. Let me know if you need me to open a new specific issue for this, otherwise, the bot might complain about the assignment!)*

## Changes Made
- [x] Added missing public method docstrings (resolving Ruff `D102` errors) across the `kornia/augmentation/` module.
- [x] Files updated include `auto/`, `container/`, `random_generator/`, and `presets/` to enforce standard `Args` and `Returns` documentation.

## How Was This Tested?
- [x] **Manual Verification:** Checked against the `missing_docstrings.txt` log to ensure all flagged `D102` errors in the targeted files were resolved.

## AI Usage Disclosure
- [x] AI-assisted: I used AI for boilerplate/refactoring but have manually reviewed and tested every line.