### PR TITLE
Add representation profiling under input changes

### DIFF
--- a/kornia/profiler/__init__.py
+++ b/kornia/profiler/__init__.py
@@ -1,0 +1,16 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/kornia/profiler/api.py
+++ b/kornia/profiler/api.py
@@ -1,0 +1,98 @@
+import json
+
+from kornia.profiler.model_profiler import ModelProfiler
+from kornia.profiler.augment import AugmentationPipeline
+
+
+# -------------------- CONFIG LOADER --------------------
+
+def _load_config(config):
+    """
+    Supports:
+    - dict (direct use)
+    - str (path to JSON file)
+    """
+    if config is None:
+        return {}
+
+    if isinstance(config, str):
+        with open(config, "r") as f:
+            return json.load(f)
+
+    return config
+
+
+# -------------------- CORE GENERIC API --------------------
+
+def model_profile_under_input_changes(
+    model,
+    input_a,
+    input_b,
+    config=None,
+    output=None,
+):
+    """
+    Generic representation comparison between two inputs
+    """
+
+    config = _load_config(config)
+
+    layers = config.get("layers", None)
+    processing = config.get("processing", "flatten")
+    metrics = config.get("metrics", ["cosine", "linear"])
+
+    with ModelProfiler(model, layers=layers, processing=processing) as p:
+
+        p(x=input_a, group="group_a", tag="input_a")
+        p(x=input_b, group="group_b", tag="input_b")
+
+        p.compute(
+            metrics=metrics,
+            groups=["group_a", "group_b"]
+        )
+
+        if output:
+            p.save_as_report(output)
+
+        return p
+
+
+# -------------------- AUGMENTATION WRAPPER --------------------
+
+def model_profile_under_augmentation(
+    model,
+    config,
+    output=None,
+):
+    """
+    Wrapper over generic API for augmentation-based evaluation
+    """
+
+    config = _load_config(config)
+
+    layers = config.get("layers", None)
+    augment_config = config.get("augmentations", None)
+    mode = config.get("mode", "individual")
+    processing = config.get("processing", "flatten")
+    metrics = config.get("metrics", ["cosine", "linear"])
+
+    input_a = config["input"]
+
+    augmenter = AugmentationPipeline(augment_config, mode=mode)
+    aug_outputs = augmenter(input_a)
+
+    with ModelProfiler(model, layers=layers, processing=processing) as p:
+
+        for aug_name, input_b in aug_outputs.items():
+            p(x=input_a, group="group_a", tag="original")
+            p(x=input_b, group="group_b", tag=aug_name)
+
+        p.compute(
+            metrics=metrics,
+            groups=["group_a", "group_b"]
+        )
+
+        if output:
+            p.save_as_report(output)
+
+        return p

--- a/kornia/profiler/api.py
+++ b/kornia/profiler/api.py
@@ -24,7 +24,17 @@ from kornia.profiler.model_profiler import ModelProfiler
 
 
 def _load_config(config):
-    """Load config from dict or JSON file."""
+    r"""Load configuration from a dictionary or a JSON file.
+
+    If the input is ``None``, an empty dictionary is returned. If the input
+    is a string, it is interpreted as a file path to a JSON configuration file.
+
+    Args:
+        config: Configuration provided either as a dictionary or a path to a JSON file.
+
+    Returns:
+        Dictionary containing configuration parameters.
+    """
     if config is None:
         return {}
 
@@ -45,7 +55,25 @@ def model_profile_under_input_changes(
     config=None,
     output=None,
 ):
-    """Generic representation comparison between two inputs."""
+    r"""Profile model representations under two different inputs.
+
+    This function compares intermediate representations of a model when
+    evaluated on two inputs. The comparison is performed layer-wise using
+    the specified metrics.
+
+    Args:
+        model: PyTorch model to be profiled.
+        input_a: First input tensor.
+        input_b: Second input tensor.
+        config: Optional configuration (dict or JSON path) specifying:
+            - ``layers``: Layers to capture.
+            - ``processing``: Feature processing method (e.g., ``"flatten"``).
+            - ``metrics``: List of similarity metrics.
+        output: Optional file path to save the profiling report.
+
+    Returns:
+        ModelProfiler instance containing computed results.
+    """
     config = _load_config(config)
 
     layers = config.get("layers", None)
@@ -72,7 +100,26 @@ def model_profile_under_augmentation(
     config,
     output=None,
 ):
-    """Wrapper over generic API for augmentation-based evaluation."""
+    r"""Profile model representations under input augmentations.
+
+    This function applies a set of augmentations to an input and compares
+    the resulting representations against the original input using the
+    specified similarity metrics.
+
+    Args:
+        model: PyTorch model to be profiled.
+        config: Configuration (dict or JSON path) containing:
+            - ``input``: Base input tensor.
+            - ``layers``: Layers to capture.
+            - ``augmentations``: Augmentation configuration.
+            - ``mode``: Augmentation mode (e.g., ``"individual"``).
+            - ``processing``: Feature processing method.
+            - ``metrics``: List of similarity metrics.
+        output: Optional file path to save the profiling report.
+
+    Returns:
+        ModelProfiler instance containing computed results.
+    """
     config = _load_config(config)
 
     layers = config.get("layers", None)

--- a/kornia/profiler/api.py
+++ b/kornia/profiler/api.py
@@ -1,28 +1,42 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import json
 
-from kornia.profiler.model_profiler import ModelProfiler
 from kornia.profiler.augment import AugmentationPipeline
-
+from kornia.profiler.model_profiler import ModelProfiler
 
 # -------------------- CONFIG LOADER --------------------
 
+
 def _load_config(config):
-    """
-    Supports:
-    - dict (direct use)
-    - str (path to JSON file)
-    """
+    """Load config from dict or JSON file."""
     if config is None:
         return {}
 
     if isinstance(config, str):
-        with open(config, "r") as f:
+        with open(config) as f:
             return json.load(f)
 
     return config
 
 
 # -------------------- CORE GENERIC API --------------------
+
 
 def model_profile_under_input_changes(
     model,
@@ -31,10 +45,7 @@ def model_profile_under_input_changes(
     config=None,
     output=None,
 ):
-    """
-    Generic representation comparison between two inputs
-    """
-
+    """Generic representation comparison between two inputs."""
     config = _load_config(config)
 
     layers = config.get("layers", None)
@@ -42,14 +53,10 @@ def model_profile_under_input_changes(
     metrics = config.get("metrics", ["cosine", "linear"])
 
     with ModelProfiler(model, layers=layers, processing=processing) as p:
-
         p(x=input_a, group="group_a", tag="input_a")
         p(x=input_b, group="group_b", tag="input_b")
 
-        p.compute(
-            metrics=metrics,
-            groups=["group_a", "group_b"]
-        )
+        p.compute(metrics=metrics, groups=["group_a", "group_b"])
 
         if output:
             p.save_as_report(output)
@@ -59,15 +66,13 @@ def model_profile_under_input_changes(
 
 # -------------------- AUGMENTATION WRAPPER --------------------
 
+
 def model_profile_under_augmentation(
     model,
     config,
     output=None,
 ):
-    """
-    Wrapper over generic API for augmentation-based evaluation
-    """
-
+    """Wrapper over generic API for augmentation-based evaluation."""
     config = _load_config(config)
 
     layers = config.get("layers", None)
@@ -82,15 +87,11 @@ def model_profile_under_augmentation(
     aug_outputs = augmenter(input_a)
 
     with ModelProfiler(model, layers=layers, processing=processing) as p:
-
         for aug_name, input_b in aug_outputs.items():
             p(x=input_a, group="group_a", tag="original")
             p(x=input_b, group="group_b", tag=aug_name)
 
-        p.compute(
-            metrics=metrics,
-            groups=["group_a", "group_b"]
-        )
+        p.compute(metrics=metrics, groups=["group_a", "group_b"])
 
         if output:
             p.save_as_report(output)

--- a/kornia/profiler/augment.py
+++ b/kornia/profiler/augment.py
@@ -19,23 +19,76 @@ import torch
 
 import kornia.augmentation as K
 
-AUGMENTATION_REGISTRY = {
-    "rotation": lambda cfg: K.RandomRotation(degrees=cfg.get("degrees", 15.0), p=1.0),
-    "blur": lambda cfg: K.RandomGaussianBlur(
+
+def _build_rotation(cfg):
+    r"""Build a RandomRotation augmentation module.
+
+    Args:
+        cfg: Configuration dictionary containing augmentation parameters.
+
+    Returns:
+        Initialized ``RandomRotation`` module.
+    """
+    return K.RandomRotation(degrees=cfg.get("degrees", 15.0), p=1.0)
+
+
+def _build_blur(cfg):
+    r"""Build a RandomGaussianBlur augmentation module.
+
+    Args:
+        cfg: Configuration dictionary containing augmentation parameters.
+
+    Returns:
+        Initialized ``RandomGaussianBlur`` module.
+    """
+    return K.RandomGaussianBlur(
         kernel_size=cfg.get("kernel_size", (3, 3)),
         sigma=cfg.get("sigma", (0.1, 2.0)),
         p=1.0,
-    ),
-    "brightness": lambda cfg: K.RandomBrightness(
+    )
+
+
+def _build_brightness(cfg):
+    r"""Build a RandomBrightness augmentation module.
+
+    Args:
+        cfg: Configuration dictionary containing augmentation parameters.
+
+    Returns:
+        Initialized ``RandomBrightness`` module.
+    """
+    return K.RandomBrightness(
         brightness=cfg.get("brightness", (0.8, 1.2)),
         p=1.0,
-    ),
+    )
+
+
+AUGMENTATION_REGISTRY = {
+    "rotation": _build_rotation,
+    "blur": _build_blur,
+    "brightness": _build_brightness,
 }
 
 
 class AugmentationPipeline:
     def __init__(self, augmentations_config=None, mode="sequential"):
-        """Initialize augmentation pipeline."""
+        r"""Initialize an augmentation pipeline.
+
+        The pipeline can operate either by applying all augmentations
+        sequentially or by applying each augmentation independently.
+
+        Args:
+            augmentations_config: List of augmentation configurations, where each
+                configuration is a dictionary with keys:
+                - ``"name"``: Name of the augmentation.
+                - ``"params"``: Optional parameters for the augmentation.
+            mode: Execution mode of the pipeline:
+                - ``"sequential"``: Apply all augmentations in sequence.
+                - ``"individual"``: Apply each augmentation independently.
+
+        Raises:
+            ValueError: If an unknown augmentation name is provided.
+        """
         self.mode = mode
         self.augmentations = []
 
@@ -61,6 +114,22 @@ class AugmentationPipeline:
             self.pipeline = torch.nn.Sequential(*modules)
 
     def __call__(self, x):
+        r"""Apply augmentations to the input tensor.
+
+        Depending on the selected mode, either applies all augmentations
+        sequentially or applies each augmentation independently.
+
+        Args:
+            x: Input tensor to be augmented.
+
+        Returns:
+            Dictionary mapping augmentation names to augmented outputs:
+            - In ``"sequential"`` mode, a single entry with the combined name.
+            - In ``"individual"`` mode, one entry per augmentation.
+
+        Raises:
+            ValueError: If an unknown mode is specified.
+        """
         if self.mode == "sequential":
             combined_name = "+".join([name for name, _ in self.augmentations])
             return {combined_name: self.pipeline(x)}

--- a/kornia/profiler/augment.py
+++ b/kornia/profiler/augment.py
@@ -1,11 +1,26 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import torch
+
 import kornia.augmentation as K
 
-
 AUGMENTATION_REGISTRY = {
-    "rotation": lambda cfg: K.RandomRotation(
-        degrees=cfg.get("degrees", 15.0), p=1.0
-    ),
+    "rotation": lambda cfg: K.RandomRotation(degrees=cfg.get("degrees", 15.0), p=1.0),
     "blur": lambda cfg: K.RandomGaussianBlur(
         kernel_size=cfg.get("kernel_size", (3, 3)),
         sigma=cfg.get("sigma", (0.1, 2.0)),
@@ -20,12 +35,7 @@ AUGMENTATION_REGISTRY = {
 
 class AugmentationPipeline:
     def __init__(self, augmentations_config=None, mode="sequential"):
-        """
-        augmentations_config: list of dicts
-        mode:
-            "sequential" → apply all augmentations in sequence
-            "individual" → apply each augmentation separately
-        """
+        """Initialize augmentation pipeline."""
         self.mode = mode
         self.augmentations = []
 

--- a/kornia/profiler/augment.py
+++ b/kornia/profiler/augment.py
@@ -1,0 +1,65 @@
+import torch
+import kornia.augmentation as K
+
+
+AUGMENTATION_REGISTRY = {
+    "rotation": lambda cfg: K.RandomRotation(
+        degrees=cfg.get("degrees", 15.0), p=1.0
+    ),
+    "blur": lambda cfg: K.RandomGaussianBlur(
+        kernel_size=cfg.get("kernel_size", (3, 3)),
+        sigma=cfg.get("sigma", (0.1, 2.0)),
+        p=1.0,
+    ),
+    "brightness": lambda cfg: K.RandomBrightness(
+        brightness=cfg.get("brightness", (0.8, 1.2)),
+        p=1.0,
+    ),
+}
+
+
+class AugmentationPipeline:
+    def __init__(self, augmentations_config=None, mode="sequential"):
+        """
+        augmentations_config: list of dicts
+        mode:
+            "sequential" → apply all augmentations in sequence
+            "individual" → apply each augmentation separately
+        """
+        self.mode = mode
+        self.augmentations = []
+
+        if augmentations_config is None:
+            augmentations_config = [
+                {"name": "rotation", "params": {}},
+                {"name": "blur", "params": {}},
+                {"name": "brightness", "params": {}},
+            ]
+
+        for aug in augmentations_config:
+            name = aug["name"]
+            params = aug.get("params", {})
+
+            if name not in AUGMENTATION_REGISTRY:
+                raise ValueError(f"Unknown augmentation: {name}")
+
+            module = AUGMENTATION_REGISTRY[name](params)
+            self.augmentations.append((name, module))
+
+        if self.mode == "sequential":
+            modules = [module for _, module in self.augmentations]
+            self.pipeline = torch.nn.Sequential(*modules)
+
+    def __call__(self, x):
+        if self.mode == "sequential":
+            combined_name = "+".join([name for name, _ in self.augmentations])
+            return {combined_name: self.pipeline(x)}
+
+        elif self.mode == "individual":
+            outputs = {}
+            for name, aug in self.augmentations:
+                outputs[name] = aug(x)
+            return outputs
+
+        else:
+            raise ValueError(f"Unknown mode: {self.mode}")

--- a/kornia/profiler/feature_extractor.py
+++ b/kornia/profiler/feature_extractor.py
@@ -24,7 +24,25 @@ from torch import nn
 
 class FeatureExtractor:
     def __init__(self, model: nn.Module, layers: Optional[List[str]] = None, processing: str = "none"):
-        """Initialize feature extractor for selected layers."""
+        r"""Initialize a feature extractor for selected model layers.
+
+        This utility registers forward hooks on specified layers of a model
+        and captures their outputs during the forward pass. Optionally, the
+        extracted features can be post-processed.
+
+        Args:
+            model: PyTorch model from which features will be extracted.
+            layers: List of layer names to hook. If ``None``, all layers
+                (except the root module) are selected.
+            processing: Feature processing method. Supported options:
+                - ``"none"``: No processing.
+                - ``"flatten"``: Flatten features to shape :math:`(B, D)`.
+                - ``"gap"``: Apply global average pooling for 4D tensors,
+                  otherwise fallback to flatten.
+
+        Raises:
+            ValueError: If an unknown processing mode is provided.
+        """
         self.model = model
         self.layers = layers
         self.processing = processing
@@ -35,9 +53,25 @@ class FeatureExtractor:
         self._register_hooks()
 
     def _get_layer_dict(self):
+        r"""Retrieve a dictionary mapping layer names to modules.
+
+        Returns:
+            Dictionary where keys are layer names and values are modules.
+        """
         return dict(self.model.named_modules())
 
     def _process(self, x):
+        r"""Process extracted features according to the selected mode.
+
+        Args:
+            x: Feature tensor output from a hooked layer.
+
+        Returns:
+            Processed feature tensor.
+
+        Raises:
+            ValueError: If an unknown processing mode is specified.
+        """
         if self.processing == "none":
             return x
 
@@ -56,6 +90,15 @@ class FeatureExtractor:
             raise ValueError(f"Unknown processing: {self.processing}")
 
     def _hook_fn(self, name):
+        r"""Create a forward hook function for a given layer.
+
+        Args:
+            name: Name of the layer being hooked.
+
+        Returns:
+            A forward hook function that stores processed outputs.
+        """
+
         def hook(module, input, output):
             if isinstance(output, torch.Tensor):
                 self.features[name] = self._process(output.detach())
@@ -63,6 +106,13 @@ class FeatureExtractor:
         return hook
 
     def _register_hooks(self):
+        r"""Register forward hooks on the selected layers.
+
+        Automatically selects all layers if none are provided.
+
+        Raises:
+            ValueError: If a specified layer name is not found in the model.
+        """
         layer_dict = self._get_layer_dict()
 
         # Auto-select all layers if None
@@ -81,15 +131,24 @@ class FeatureExtractor:
             self.handles.append(handle)
 
     def clear(self):
+        r"""Clear stored features from previous forward passes."""
         self.features = {}
 
     def remove_hooks(self):
+        r"""Remove all registered forward hooks from the model."""
         for handle in self.handles:
             handle.remove()
         self.handles = []
 
     def __call__(self, **inputs):
-        """Run model forward pass and collect features."""
+        r"""Run a forward pass and collect features from hooked layers.
+
+        Args:
+            **inputs: Keyword arguments passed to the model's forward method.
+
+        Returns:
+            Dictionary mapping layer names to extracted feature tensors.
+        """
         self.clear()
 
         with torch.no_grad():

--- a/kornia/profiler/feature_extractor.py
+++ b/kornia/profiler/feature_extractor.py
@@ -1,19 +1,30 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import List, Optional
+
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
+from torch import nn
 
 
 class FeatureExtractor:
-    def __init__(self, model: nn.Module, layers: list = None, processing: str = "none"):
-        """
-        model: PyTorch model
-        layers: list of layer names (strings) to hook
-                if None → hooks all layers
-        processing:
-            "none"    → raw features
-            "flatten" → flatten to (B, -1)
-            "gap"     → global average pooling (if applicable)
-        """
+    def __init__(self, model: nn.Module, layers: Optional[List[str]] = None, processing: str = "none"):
+        """Initialize feature extractor for selected layers."""
         self.model = model
         self.layers = layers
         self.processing = processing
@@ -48,6 +59,7 @@ class FeatureExtractor:
         def hook(module, input, output):
             if isinstance(output, torch.Tensor):
                 self.features[name] = self._process(output.detach())
+
         return hook
 
     def _register_hooks(self):
@@ -56,7 +68,8 @@ class FeatureExtractor:
         # Auto-select all layers if None
         if self.layers is None:
             self.layers = [
-                name for name in layer_dict.keys()
+                name
+                for name in layer_dict.keys()
                 if name != ""  # skip root module
             ]
 
@@ -64,9 +77,7 @@ class FeatureExtractor:
             if name not in layer_dict:
                 raise ValueError(f"Layer {name} not found in model")
 
-            handle = layer_dict[name].register_forward_hook(
-                self._hook_fn(name)
-            )
+            handle = layer_dict[name].register_forward_hook(self._hook_fn(name))
             self.handles.append(handle)
 
     def clear(self):
@@ -78,12 +89,7 @@ class FeatureExtractor:
         self.handles = []
 
     def __call__(self, **inputs):
-        """
-        Supports:
-            model(x=...)
-            model(input=...)
-            model(**kwargs)
-        """
+        """Run model forward pass and collect features."""
         self.clear()
 
         with torch.no_grad():

--- a/kornia/profiler/feature_extractor.py
+++ b/kornia/profiler/feature_extractor.py
@@ -1,0 +1,92 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class FeatureExtractor:
+    def __init__(self, model: nn.Module, layers: list = None, processing: str = "none"):
+        """
+        model: PyTorch model
+        layers: list of layer names (strings) to hook
+                if None → hooks all layers
+        processing:
+            "none"    → raw features
+            "flatten" → flatten to (B, -1)
+            "gap"     → global average pooling (if applicable)
+        """
+        self.model = model
+        self.layers = layers
+        self.processing = processing
+
+        self.features = {}
+        self.handles = []
+
+        self._register_hooks()
+
+    def _get_layer_dict(self):
+        return dict(self.model.named_modules())
+
+    def _process(self, x):
+        if self.processing == "none":
+            return x
+
+        elif self.processing == "flatten":
+            return x.reshape(x.size(0), -1)
+
+        elif self.processing == "gap":
+            # apply GAP only if feature map is 4D
+            if x.dim() == 4:
+                return F.adaptive_avg_pool2d(x, (1, 1)).reshape(x.size(0), -1)
+            else:
+                # fallback to flatten for non-CNN layers
+                return x.reshape(x.size(0), -1)
+
+        else:
+            raise ValueError(f"Unknown processing: {self.processing}")
+
+    def _hook_fn(self, name):
+        def hook(module, input, output):
+            if isinstance(output, torch.Tensor):
+                self.features[name] = self._process(output.detach())
+        return hook
+
+    def _register_hooks(self):
+        layer_dict = self._get_layer_dict()
+
+        # Auto-select all layers if None
+        if self.layers is None:
+            self.layers = [
+                name for name in layer_dict.keys()
+                if name != ""  # skip root module
+            ]
+
+        for name in self.layers:
+            if name not in layer_dict:
+                raise ValueError(f"Layer {name} not found in model")
+
+            handle = layer_dict[name].register_forward_hook(
+                self._hook_fn(name)
+            )
+            self.handles.append(handle)
+
+    def clear(self):
+        self.features = {}
+
+    def remove_hooks(self):
+        for handle in self.handles:
+            handle.remove()
+        self.handles = []
+
+    def __call__(self, **inputs):
+        """
+        Supports:
+            model(x=...)
+            model(input=...)
+            model(**kwargs)
+        """
+        self.clear()
+
+        with torch.no_grad():
+            _ = self.model(**inputs)
+
+        return self.features

--- a/kornia/profiler/metrics/__init__.py
+++ b/kornia/profiler/metrics/__init__.py
@@ -1,0 +1,16 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/kornia/profiler/metrics/cosine.py
+++ b/kornia/profiler/metrics/cosine.py
@@ -1,10 +1,25 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import torch.nn.functional as F
 
 
 def cosine_similarity(f1, f2):
-    """
-    Layer-wise cosine similarity between feature dictionaries
-    """
+    """Layer-wise cosine similarity between feature dictionaries."""
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 

--- a/kornia/profiler/metrics/cosine.py
+++ b/kornia/profiler/metrics/cosine.py
@@ -15,18 +15,35 @@
 # limitations under the License.
 #
 
+from typing import Dict
+
+import torch
 import torch.nn.functional as F
 
 
-def cosine_similarity(f1, f2):
-    """Layer-wise cosine similarity between feature dictionaries."""
+def cosine_similarity(
+    f1: Dict[str, torch.Tensor],
+    f2: Dict[str, torch.Tensor],
+) -> Dict[str, float]:
+    """Compute layer-wise cosine similarity between feature dictionaries.
+
+    Each dictionary maps layer names to feature tensors. The features are
+    flattened and cosine similarity is computed independently for each layer.
+
+    Args:
+        f1: Dictionary mapping layer names to tensors of shape (B, ...).
+        f2: Dictionary mapping layer names to tensors of shape (B, ...).
+
+    Returns:
+        Dictionary mapping layer names to mean cosine similarity across batch.
+    """
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 
     results = {}
 
-    for layer in f1:
-        x = f1[layer].reshape(f1[layer].size(0), -1)
+    for layer, x in f1.items():
+        x = x.reshape(x.size(0), -1)
         y = f2[layer].reshape(f2[layer].size(0), -1)
 
         sim = F.cosine_similarity(x, y, dim=1).mean().item()

--- a/kornia/profiler/metrics/cosine.py
+++ b/kornia/profiler/metrics/cosine.py
@@ -1,0 +1,20 @@
+import torch.nn.functional as F
+
+
+def cosine_similarity(f1, f2):
+    """
+    Layer-wise cosine similarity between feature dictionaries
+    """
+    if f1.keys() != f2.keys():
+        raise ValueError("Feature dictionaries must have same layers")
+
+    results = {}
+
+    for layer in f1:
+        x = f1[layer].reshape(f1[layer].size(0), -1)
+        y = f2[layer].reshape(f2[layer].size(0), -1)
+
+        sim = F.cosine_similarity(x, y, dim=1).mean().item()
+        results[layer] = sim
+
+    return results

--- a/kornia/profiler/metrics/gram.py
+++ b/kornia/profiler/metrics/gram.py
@@ -1,8 +1,26 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import torch
 import torch.nn.functional as F
 
 
 def gram_matrix(fmap):
+    """Compute Gram matrix for feature map."""
     B, C, H, W = fmap.shape
     fmap = fmap.reshape(B, C, -1)
     G = torch.bmm(fmap, fmap.transpose(1, 2))
@@ -10,9 +28,7 @@ def gram_matrix(fmap):
 
 
 def gram_similarity(f1, f2):
-    """
-    Gram-based similarity (only for 4D feature maps)
-    """
+    """Gram-based similarity (only for 4D feature maps)."""
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 
@@ -29,11 +45,7 @@ def gram_similarity(f1, f2):
         G1 = gram_matrix(x)
         G2 = gram_matrix(y)
 
-        sim = F.cosine_similarity(
-            G1.reshape(G1.size(0), -1),
-            G2.reshape(G2.size(0), -1),
-            dim=1
-        ).mean().item()
+        sim = F.cosine_similarity(G1.reshape(G1.size(0), -1), G2.reshape(G2.size(0), -1), dim=1).mean().item()
 
         results[layer] = sim
 

--- a/kornia/profiler/metrics/gram.py
+++ b/kornia/profiler/metrics/gram.py
@@ -1,0 +1,40 @@
+import torch
+import torch.nn.functional as F
+
+
+def gram_matrix(fmap):
+    B, C, H, W = fmap.shape
+    fmap = fmap.reshape(B, C, -1)
+    G = torch.bmm(fmap, fmap.transpose(1, 2))
+    return G / (C * H * W)
+
+
+def gram_similarity(f1, f2):
+    """
+    Gram-based similarity (only for 4D feature maps)
+    """
+    if f1.keys() != f2.keys():
+        raise ValueError("Feature dictionaries must have same layers")
+
+    results = {}
+
+    for layer in f1:
+        x = f1[layer]
+        y = f2[layer]
+
+        if x.dim() != 4 or y.dim() != 4:
+            results[layer] = None
+            continue
+
+        G1 = gram_matrix(x)
+        G2 = gram_matrix(y)
+
+        sim = F.cosine_similarity(
+            G1.reshape(G1.size(0), -1),
+            G2.reshape(G2.size(0), -1),
+            dim=1
+        ).mean().item()
+
+        results[layer] = sim
+
+    return results

--- a/kornia/profiler/metrics/gram.py
+++ b/kornia/profiler/metrics/gram.py
@@ -15,27 +15,65 @@
 # limitations under the License.
 #
 
+from typing import Dict, Optional
+
 import torch
 import torch.nn.functional as F
+from torch import Tensor
 
 
-def gram_matrix(fmap):
-    """Compute Gram matrix for feature map."""
+def gram_matrix(fmap: Tensor) -> Tensor:
+    r"""Compute the Gram matrix for a feature map.
+
+    The Gram matrix captures correlations between feature channels and is
+    commonly used in style-based similarity metrics.
+
+    Args:
+        fmap: Input feature map of shape :math:`(B, C, H, W)`.
+
+    Returns:
+        Gram matrix of shape :math:`(B, C, C)`.
+
+    Raises:
+        ValueError: If the input tensor is not 4-dimensional.
+    """
+    if fmap.dim() != 4:
+        raise ValueError(f"Expected 4D tensor (B, C, H, W), got {fmap.shape}")
+
     B, C, H, W = fmap.shape
     fmap = fmap.reshape(B, C, -1)
     G = torch.bmm(fmap, fmap.transpose(1, 2))
     return G / (C * H * W)
 
 
-def gram_similarity(f1, f2):
-    """Gram-based similarity (only for 4D feature maps)."""
+def gram_similarity(
+    f1: Dict[str, Tensor],
+    f2: Dict[str, Tensor],
+) -> Dict[str, Optional[float]]:
+    r"""Compute Gram-based similarity between two feature dictionaries.
+
+    For each matching layer, computes the cosine similarity between the
+    flattened Gram matrices of the corresponding feature maps.
+
+    Only 4D feature maps are considered. Non-4D entries will return ``None``.
+
+    Args:
+        f1: Dictionary mapping layer names to feature tensors.
+        f2: Dictionary mapping layer names to feature tensors.
+
+    Returns:
+        Dictionary mapping layer names to similarity scores (float). If a layer
+        does not contain valid 4D tensors, the value is ``None``.
+
+    Raises:
+        ValueError: If the dictionaries do not have identical keys.
+    """
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 
-    results = {}
+    results: Dict[str, Optional[float]] = {}
 
-    for layer in f1:
-        x = f1[layer]
+    for layer, x in f1.items():
         y = f2[layer]
 
         if x.dim() != 4 or y.dim() != 4:
@@ -45,8 +83,10 @@ def gram_similarity(f1, f2):
         G1 = gram_matrix(x)
         G2 = gram_matrix(y)
 
-        sim = F.cosine_similarity(G1.reshape(G1.size(0), -1), G2.reshape(G2.size(0), -1), dim=1).mean().item()
+        G1_flat = G1.reshape(G1.size(0), -1)
+        G2_flat = G2.reshape(G2.size(0), -1)
 
+        sim = F.cosine_similarity(G1_flat, G2_flat, dim=1).mean().item()
         results[layer] = sim
 
-    return results
+        return results

--- a/kornia/profiler/metrics/l2.py
+++ b/kornia/profiler/metrics/l2.py
@@ -1,10 +1,25 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import torch
 
 
 def l2_normalized(f1, f2):
-    """
-    Normalized L2 distance per layer
-    """
+    """Normalized L2 distance per layer."""
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 

--- a/kornia/profiler/metrics/l2.py
+++ b/kornia/profiler/metrics/l2.py
@@ -1,0 +1,22 @@
+import torch
+
+
+def l2_normalized(f1, f2):
+    """
+    Normalized L2 distance per layer
+    """
+    if f1.keys() != f2.keys():
+        raise ValueError("Feature dictionaries must have same layers")
+
+    results = {}
+
+    for layer in f1:
+        x = f1[layer].reshape(f1[layer].size(0), -1)
+        y = f2[layer].reshape(f2[layer].size(0), -1)
+
+        l2 = torch.norm(x - y, p=2, dim=1).mean()
+        norm = torch.norm(x, p=2, dim=1).mean()
+
+        results[layer] = (l2 / (norm + 1e-8)).item()
+
+    return results

--- a/kornia/profiler/metrics/l2.py
+++ b/kornia/profiler/metrics/l2.py
@@ -15,23 +15,46 @@
 # limitations under the License.
 #
 
+from typing import Dict
+
 import torch
+from torch import Tensor
 
 
-def l2_normalized(f1, f2):
-    """Normalized L2 distance per layer."""
+def l2_normalized(
+    f1: Dict[str, Tensor],
+    f2: Dict[str, Tensor],
+) -> Dict[str, float]:
+    r"""Compute normalized L2 distance between feature dictionaries.
+
+    For each matching layer, computes the L2 distance between flattened
+    feature tensors and normalizes it by the L2 norm of the reference tensor.
+
+    The normalization is performed per sample and then averaged across the batch.
+
+    Args:
+        f1: Dictionary mapping layer names to feature tensors.
+        f2: Dictionary mapping layer names to feature tensors.
+
+    Returns:
+        Dictionary mapping layer names to normalized L2 distance (float).
+
+    Raises:
+        ValueError: If the dictionaries do not have identical keys.
+    """
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 
-    results = {}
+    results: Dict[str, float] = {}
 
-    for layer in f1:
-        x = f1[layer].reshape(f1[layer].size(0), -1)
+    for layer, x in f1.items():
+        x = x.reshape(x.size(0), -1)
         y = f2[layer].reshape(f2[layer].size(0), -1)
 
-        l2 = torch.norm(x - y, p=2, dim=1).mean()
-        norm = torch.norm(x, p=2, dim=1).mean()
+        l2 = torch.norm(x - y, p=2, dim=1)
+        norm = torch.norm(x, p=2, dim=1)
 
-        results[layer] = (l2 / (norm + 1e-8)).item()
+        normalized = l2 / (norm + 1e-8)
+        results[layer] = normalized.mean().item()
 
     return results

--- a/kornia/profiler/metrics/linear.py
+++ b/kornia/profiler/metrics/linear.py
@@ -19,7 +19,19 @@ import torch.nn.functional as F
 
 
 def linear_cka(x, y):
-    """Compute linear CKA similarity."""
+    r"""Compute linear CKA similarity between two tensors.
+
+    The inputs are first centered along the feature dimension and then
+    L2-normalized. The similarity is computed as the mean cosine similarity
+    between corresponding samples.
+
+    Args:
+        x: Input tensor of shape :math:`(B, D)`.
+        y: Input tensor of shape :math:`(B, D)`.
+
+    Returns:
+        Scalar similarity score (float), averaged over the batch.
+    """
     x = x - x.mean(dim=1, keepdim=True)
     y = y - y.mean(dim=1, keepdim=True)
 
@@ -30,7 +42,21 @@ def linear_cka(x, y):
 
 
 def linear_similarity(f1, f2):
-    """Applies CKA layer-wise."""
+    r"""Apply linear CKA similarity layer-wise between feature dictionaries.
+
+    For each matching layer, feature tensors are flattened into 2D tensors
+    of shape :math:`(B, D)` and compared using ``linear_cka``.
+
+    Args:
+        f1: Dictionary mapping layer names to feature tensors.
+        f2: Dictionary mapping layer names to feature tensors.
+
+    Returns:
+        Dictionary mapping each layer name to its similarity score (float).
+
+    Raises:
+        ValueError: If the input dictionaries do not have identical keys.
+    """
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 

--- a/kornia/profiler/metrics/linear.py
+++ b/kornia/profiler/metrics/linear.py
@@ -1,0 +1,29 @@
+import torch.nn.functional as F
+
+
+def linear_cka(x, y):
+    x = x - x.mean(dim=1, keepdim=True)
+    y = y - y.mean(dim=1, keepdim=True)
+
+    x = F.normalize(x, dim=1)
+    y = F.normalize(y, dim=1)
+
+    return (x * y).sum(dim=1).mean().item()
+
+
+def linear_similarity(f1, f2):
+    """
+    Applies CKA layer-wise
+    """
+    if f1.keys() != f2.keys():
+        raise ValueError("Feature dictionaries must have same layers")
+
+    results = {}
+
+    for layer in f1:
+        x = f1[layer].reshape(f1[layer].size(0), -1)
+        y = f2[layer].reshape(f2[layer].size(0), -1)
+
+        results[layer] = linear_cka(x, y)
+
+    return results

--- a/kornia/profiler/metrics/linear.py
+++ b/kornia/profiler/metrics/linear.py
@@ -1,7 +1,25 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import torch.nn.functional as F
 
 
 def linear_cka(x, y):
+    """Compute linear CKA similarity."""
     x = x - x.mean(dim=1, keepdim=True)
     y = y - y.mean(dim=1, keepdim=True)
 
@@ -12,9 +30,7 @@ def linear_cka(x, y):
 
 
 def linear_similarity(f1, f2):
-    """
-    Applies CKA layer-wise
-    """
+    """Applies CKA layer-wise."""
     if f1.keys() != f2.keys():
         raise ValueError("Feature dictionaries must have same layers")
 

--- a/kornia/profiler/model_profiler.py
+++ b/kornia/profiler/model_profiler.py
@@ -42,6 +42,18 @@ METRIC_REGISTRY = {
 
 class ModelProfiler:
     def __init__(self, model, layers=None, processing="flatten"):
+        r"""Initialize the model profiler.
+
+        This class captures intermediate representations from selected layers
+        of a model and computes similarity metrics between different input groups.
+
+        Args:
+            model: PyTorch model to be profiled.
+            layers: List of layer names to extract features from. If ``None``,
+                all layers are used.
+            processing: Feature processing method applied to extracted outputs.
+                Common options include ``"flatten"`` and ``"none"``.
+        """
         self.model = model
         self.model.eval()
 
@@ -56,20 +68,49 @@ class ModelProfiler:
         self.extractor = None
 
     def __enter__(self):
+        r"""Enter context manager and initialize feature extraction hooks.
+
+        Returns:
+            The current ``ModelProfiler`` instance.
+        """
         self.extractor = FeatureExtractor(self.model, self.layers, processing=self.processing)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        r"""Exit context manager and remove registered hooks."""
         if hasattr(self.extractor, "remove_hooks"):
             self.extractor.remove_hooks()
 
     def __call__(self, group="default", tag=None, **inputs):
+        r"""Run a forward pass and store extracted features.
+
+        Features are grouped and optionally tagged for later comparison.
+
+        Args:
+            group: Name of the group to which the input belongs.
+            tag: Optional identifier for the input (e.g., augmentation name).
+            **inputs: Keyword arguments passed to the model's forward method.
+        """
         with torch.no_grad():
             features = self.extractor(**inputs)
 
         self.storage[group].append({"features": features, "tag": tag})
 
     def compute(self, metrics, groups):
+        r"""Compute similarity metrics between two groups of inputs.
+
+        The comparison is performed pairwise between corresponding entries
+        in the specified groups.
+
+        Args:
+            metrics: List of metric names to compute.
+            groups: List of exactly two group names to compare.
+
+        Raises:
+            ValueError: If the number of groups is not two or if an unknown
+                metric is specified.
+            RuntimeError: If one of the groups has no stored data.
+        """
         if len(groups) != 2:
             raise ValueError("Currently supports pairwise group comparison")
         g1, g2 = groups
@@ -119,12 +160,24 @@ class ModelProfiler:
         self._df = pandas.DataFrame(results)
 
     def print(self):
+        r"""Print the computed results as a DataFrame."""
         if self._df is not None:
             print(self._df)
         else:
             print("No results computed yet.")
 
     def save_as_report(self, path):
+        r"""Save computed results to a file.
+
+        Supported formats include CSV and JSON.
+
+        Args:
+            path: File path where the report will be saved.
+
+        Raises:
+            RuntimeError: If results have not been computed.
+            ValueError: If the file format is unsupported.
+        """
         if self._df is None:
             raise RuntimeError("Run compute() before saving report.")
 
@@ -137,4 +190,10 @@ class ModelProfiler:
 
     @property
     def df(self):
+        r"""Return the results as a pandas DataFrame.
+
+        Returns:
+            DataFrame containing computed similarity metrics, or ``None``
+            if results have not been computed yet.
+        """
         return self._df

--- a/kornia/profiler/model_profiler.py
+++ b/kornia/profiler/model_profiler.py
@@ -1,0 +1,129 @@
+import torch
+import warnings
+from collections import defaultdict
+
+from feature_extractor import FeatureExtractor
+
+# Lazy pandas import (Kornia style)
+from kornia.core.external import LazyLoader
+pandas = LazyLoader("pandas")
+
+# Metric registry
+from kornia.profiler.metrics.cosine import cosine_similarity
+from kornia.profiler.metrics.linear import linear_similarity
+from kornia.profiler.metrics.gram import gram_similarity
+from kornia.profiler.metrics.l2 import l2_normalized
+
+METRIC_REGISTRY = {
+    "cosine": cosine_similarity,
+    "linear": linear_similarity,
+    "gram": gram_similarity,
+    "l2": l2_normalized,
+}
+
+
+class ModelProfiler:
+    def __init__(self, model, layers=None, processing="flatten"):
+        self.model = model
+        self.model.eval()
+
+        self.layers = layers
+        self.processing = processing
+
+        self.storage = defaultdict(list)
+
+        self.results = None
+        self._df = None
+
+        self.extractor = None
+
+    def __enter__(self):
+        self.extractor = FeatureExtractor(
+            self.model,
+            self.layers,
+            processing=self.processing
+        )
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if hasattr(self.extractor, "remove_hooks"):
+            self.extractor.remove_hooks()
+
+    def __call__(self, group="default", tag=None, **inputs):
+        with torch.no_grad():
+            features = self.extractor(**inputs)
+
+        self.storage[group].append({
+            "features": features,
+            "tag": tag
+        })
+
+    def compute(self, metrics, groups):
+        assert len(groups) == 2, "Currently supports pairwise group comparison"
+
+        g1, g2 = groups
+        feats1 = self.storage[g1]
+        feats2 = self.storage[g2]
+
+        if len(feats1) == 0 or len(feats2) == 0:
+            raise RuntimeError("One of the groups has no data.")
+
+        if len(feats1) != len(feats2):
+            warnings.warn("Unequal group sizes, truncating to minimum length.")
+
+        min_len = min(len(feats1), len(feats2))
+
+        results = []
+
+        for i in range(min_len):
+            f1_entry = feats1[i]
+            f2_entry = feats2[i]
+
+            f1 = f1_entry["features"]
+            f2 = f2_entry["features"]
+
+            tag = f2_entry.get("tag", None) or f1_entry.get("tag", None)
+
+            row = {}
+
+            if tag is not None:
+                row["tag"] = tag
+
+            for metric_name in metrics:
+                if metric_name not in METRIC_REGISTRY:
+                    raise ValueError(f"Unknown metric: {metric_name}")
+
+                metric_fn = METRIC_REGISTRY[metric_name]
+                metric_output = metric_fn(f1, f2)
+
+                for layer, val in metric_output.items():
+                    if val is None:
+                        continue
+                    key = f"{metric_name}_{layer}"
+                    row[key] = val
+
+            results.append(row)
+
+        self.results = results
+        self._df = pandas.DataFrame(results)
+
+    def print(self):
+        if self._df is not None:
+            print(self._df)
+        else:
+            print("No results computed yet.")
+
+    def save_as_report(self, path):
+        if self._df is None:
+            raise RuntimeError("Run compute() before saving report.")
+
+        if path.endswith(".csv"):
+            self._df.to_csv(path, index=False)
+        elif path.endswith(".json"):
+            self._df.to_json(path, orient="records", indent=2)
+        else:
+            raise ValueError("Unsupported format. Use .csv or .json")
+
+    @property
+    def df(self):
+        return self._df

--- a/kornia/profiler/model_profiler.py
+++ b/kornia/profiler/model_profiler.py
@@ -1,18 +1,36 @@
-import torch
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import warnings
 from collections import defaultdict
 
+import torch
 from feature_extractor import FeatureExtractor
 
 # Lazy pandas import (Kornia style)
 from kornia.core.external import LazyLoader
-pandas = LazyLoader("pandas")
 
 # Metric registry
 from kornia.profiler.metrics.cosine import cosine_similarity
-from kornia.profiler.metrics.linear import linear_similarity
 from kornia.profiler.metrics.gram import gram_similarity
 from kornia.profiler.metrics.l2 import l2_normalized
+from kornia.profiler.metrics.linear import linear_similarity
+
+pandas = LazyLoader("pandas")
 
 METRIC_REGISTRY = {
     "cosine": cosine_similarity,
@@ -38,11 +56,7 @@ class ModelProfiler:
         self.extractor = None
 
     def __enter__(self):
-        self.extractor = FeatureExtractor(
-            self.model,
-            self.layers,
-            processing=self.processing
-        )
+        self.extractor = FeatureExtractor(self.model, self.layers, processing=self.processing)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -53,14 +67,11 @@ class ModelProfiler:
         with torch.no_grad():
             features = self.extractor(**inputs)
 
-        self.storage[group].append({
-            "features": features,
-            "tag": tag
-        })
+        self.storage[group].append({"features": features, "tag": tag})
 
     def compute(self, metrics, groups):
-        assert len(groups) == 2, "Currently supports pairwise group comparison"
-
+        if len(groups) != 2:
+            raise ValueError("Currently supports pairwise group comparison")
         g1, g2 = groups
         feats1 = self.storage[g1]
         feats2 = self.storage[g2]
@@ -69,7 +80,7 @@ class ModelProfiler:
             raise RuntimeError("One of the groups has no data.")
 
         if len(feats1) != len(feats2):
-            warnings.warn("Unequal group sizes, truncating to minimum length.")
+            warnings.warn("Unequal group sizes, truncating to minimum length.", stacklevel=2)
 
         min_len = min(len(feats1), len(feats2))
 


### PR DESCRIPTION


## 📝 Description

Fixes #3626

---

## 🛠️ Changes Made
- Added `kornia.profiler` module for representation-level analysis
- Implemented `ModelProfiler` with context-manager API for layer-wise feature extraction
- Added generic API `model_profile_under_input_changes` for comparing representations across inputs
- Added config-driven augmentation wrapper built on top of the core API
- Implemented modular metrics:
  - cosine similarity
  - linear CKA
  - normalized L2
  - gram similarity

---

## 🧪 How Was This Tested?

- [ ] **Unit Tests:** Not added (can be added based on maintainer feedback)
- [x] **Manual Verification:** 
  - Verified feature extraction across multiple layers
  - Tested input pairing and group-based comparison
  - Validated metric outputs across different inputs and augmentations
- [x] **Performance/Edge Cases:**
  - Handles mismatched group sizes (with safe truncation)
  - Supports non-4D tensors (Gram metric safely skipped)
  - Works with arbitrary models and input structures

---

## 🕵️ AI Usage Disclosure

- [x] 🟡 **AI-assisted:** I used AI for minor formatting and refinement.

---

## 🚦 Checklist

- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a self-review of my code
- [x] My code follows the existing style guidelines of this project
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my feature works
- [ ] UI changes

---

## 💭 Additional Context

This implementation follows the design direction discussed in the issue:
- Core functionality is framed as representation comparison under input changes
- Augmentations are implemented as a thin wrapper on top of the generic API
- Metrics are modularized (one per file)

Higher-level composite metrics (e.g., sensitivity/stability scoring) were intentionally excluded to keep the core minimal and composable. These can be layered on top if needed.