### PR TITLE
Fix BgrToRgba calling wrong conversion function

### DIFF
--- a/kornia/color/rgb.py
+++ b/kornia/color/rgb.py
@@ -478,7 +478,7 @@ class BgrToRgba(nn.Module):
         self.alpha_val = alpha_val
 
     def forward(self, image: torch.Tensor) -> torch.Tensor:
-        return rgb_to_rgba(image, self.alpha_val)
+        return bgr_to_rgba(image, self.alpha_val)
 
 
 class RgbaToRgb(nn.Module):

--- a/tests/color/test_rgb.py
+++ b/tests/color/test_rgb.py
@@ -262,14 +262,14 @@ class TestRgbToRgba(BaseTester):
 
     def test_module(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
-        img = torch.rand(B, C, H, W, device=device, dtype=dtype)
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
         ops = kornia.color.RgbToRgba(1.0).to(device, dtype)
         fcn = kornia.color.rgb_to_rgba
         self.assert_close(ops(img), fcn(img, 1.0))
 
     def test_module_bgr(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
-        img = torch.rand(B, C, H, W, device=device, dtype=dtype)
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
         ops = kornia.color.BgrToRgba(1.0).to(device, dtype)
         fcn = kornia.color.bgr_to_rgba
         self.assert_close(ops(img), fcn(img, 1.0))
@@ -287,6 +287,22 @@ class TestRgbToRgba(BaseTester):
         ops = kornia.color.RgbaToBgr().to(device, dtype)
         fcn = kornia.color.rgba_to_bgr
         self.assert_close(ops(img), fcn(img))
+
+    def test_numerical_bgr(self, device, dtype):
+        # input: B=1, G=0.5, R=0 (BGR)
+        data = torch.tensor([[[1.0]], [[0.5]], [[0.0]]], device=device, dtype=dtype)  # 3x1x1
+        # expected: R=0, G=0.5, B=1, A=1.0 (RGBA)
+        expected = torch.tensor([[[0.0]], [[0.5]], [[1.0]], [[1.0]]], device=device, dtype=dtype)
+        self.assert_close(kornia.color.bgr_to_rgba(data, 1.0), expected)
+
+    def test_numerical_rgba_bgr(self, device, dtype):
+        # input: R=0.2, G=0.4, B=0.6, A=1.0 (RGBA)
+        data = torch.tensor([[[0.2]], [[0.4]], [[0.6]], [[1.0]]], device=device, dtype=dtype)  # 4x1x1
+        # expected: B=0.6, G=0.4, R=0.2 (BGR)
+        # Note: rgba_to_bgr uses rgba_to_rgb internally which does alpha compositing.
+        # With A=1.0, it should just be the RGB channels.
+        expected = torch.tensor([[[0.6]], [[0.4]], [[0.2]]], device=device, dtype=dtype)
+        self.assert_close(kornia.color.rgba_to_bgr(data), expected)
 
 
 class TestLinearRgb(BaseTester):

--- a/tests/color/test_rgb.py
+++ b/tests/color/test_rgb.py
@@ -262,14 +262,14 @@ class TestRgbToRgba(BaseTester):
 
     def test_module(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
-        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        img = torch.rand(B, C, H, W, device=device, dtype=dtype)
         ops = kornia.color.RgbToRgba(1.0).to(device, dtype)
         fcn = kornia.color.rgb_to_rgba
         self.assert_close(ops(img), fcn(img, 1.0))
 
     def test_module_bgr(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4
-        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        img = torch.rand(B, C, H, W, device=device, dtype=dtype)
         ops = kornia.color.BgrToRgba(1.0).to(device, dtype)
         fcn = kornia.color.bgr_to_rgba
         self.assert_close(ops(img), fcn(img, 1.0))


### PR DESCRIPTION
Fixes #3670.

## Description
The BgrToRgba module was incorrectly calling rgb_to_rgba instead of bgr_to_rgba. Also updated the test case to use torch.rand instead of torch.ones so that channel swaps are actually tested properly.

## AI Usage Disclosure
- [ ] No AI used.
- [ ] - [x] AI-assisted: I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] - [ ] AI-generated: (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).