### PR TITLE
docs: Ruff migration for geometry filters #3083

### DIFF
--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -1,235 +1,4 @@
 # LICENSE HEADER MANAGED BY add-license-header
-#
-# Copyright 2018 Kornia Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-from __future__ import annotations
-
-from typing import Optional
-
-import torch
-import torch.nn.functional as F
-from torch import nn
-
-from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
-
-from .kernels import _unpack_2d_ks, get_gaussian_kernel2d
-from .median import _compute_zero_padding
-
-
-def _bilateral_blur(
-    input: torch.Tensor,
-    guidance: Optional[torch.Tensor],
-    kernel_size: tuple[int, int] | int,
-    sigma_color: float | torch.Tensor,
-    sigma_space: tuple[float, float] | torch.Tensor,
-    border_type: str = "reflect",
-    color_distance_type: str = "l1",
-) -> torch.Tensor:
-    """Single implementation for both Bilateral Filter and Joint Bilateral Filter."""
-    KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
-    if guidance is not None:
-        # NOTE: allow guidance and input having different number of channels
-        KORNIA_CHECK_IS_TENSOR(guidance)
-        KORNIA_CHECK_SHAPE(guidance, ["B", "C", "H", "W"])
-        KORNIA_CHECK(
-            (guidance.shape[0] == input.shape[0]) and (guidance.shape[-2:] == input.shape[-2:]),
-            "guidance and input should have the same batch size and spatial dimensions",
-        )
-
-    if isinstance(sigma_color, torch.Tensor):
-        KORNIA_CHECK_SHAPE(sigma_color, ["B"])
-        sigma_color = sigma_color.to(device=input.device, dtype=input.dtype).view(-1, 1, 1, 1, 1)
-
-    ky, kx = _unpack_2d_ks(kernel_size)
-    pad_y, pad_x = _compute_zero_padding(kernel_size)
-
-    padded_input = F.pad(input, (pad_x, pad_x, pad_y, pad_y), mode=border_type)
-    unfolded_input = padded_input.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, Ky x Kx)
-
-    if guidance is None:
-        guidance = input
-        unfolded_guidance = unfolded_input
-    else:
-        padded_guidance = F.pad(guidance, (pad_x, pad_x, pad_y, pad_y), mode=border_type)
-        unfolded_guidance = padded_guidance.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, Ky x Kx)
-
-    diff = unfolded_guidance - guidance.unsqueeze(-1)
-    if color_distance_type == "l1":
-        color_distance_sq = diff.abs().sum(1, keepdim=True).square()
-    elif color_distance_type == "l2":
-        color_distance_sq = diff.square().sum(1, keepdim=True)
-    else:
-        raise ValueError("color_distance_type only accepts l1 or l2")
-    color_kernel = (-0.5 / sigma_color**2 * color_distance_sq).exp()  # (B, 1, H, W, Ky x Kx)
-
-    space_kernel = get_gaussian_kernel2d(kernel_size, sigma_space, device=input.device, dtype=input.dtype)
-    space_kernel = space_kernel.view(-1, 1, 1, 1, kx * ky)
-
-    kernel = space_kernel * color_kernel
-    out = (unfolded_input * kernel).sum(-1) / kernel.sum(-1)
-    return out
-
-
-def bilateral_blur(
-    input: torch.Tensor,
-    kernel_size: tuple[int, int] | int,
-    sigma_color: float | torch.Tensor,
-    sigma_space: tuple[float, float] | torch.Tensor,
-    border_type: str = "reflect",
-    color_distance_type: str = "l1",
-) -> torch.Tensor:
-    r"""Blur a torch.Tensor using a Bilateral filter.
-
-    .. image:: _static/img/bilateral_blur.png
-
-    The operator is an edge-preserving image smoothing filter. The weight
-    for each pixel in a neighborhood is determined not only by its distance
-    to the center pixel, but also the difference in intensity or color.
-
-    Arguments:
-        input: the input torch.Tensor with shape :math:`(B,C,H,W)`.
-        kernel_size: the size of the kernel.
-        sigma_color: the standard deviation for intensity/color Gaussian kernel.
-          Smaller values preserve more edges.
-        sigma_space: the standard deviation for spatial Gaussian kernel.
-          This is similar to ``sigma`` in :func:`gaussian_blur2d()`.
-        border_type: the padding mode to be applied before convolving.
-          The expected modes are: ``'constant'``, ``'reflect'``,
-          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
-        color_distance_type: the type of distance to calculate intensity/color
-          difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
-          match OpenCV implementation. Use ``'l2'`` to match Matlab implementation.
-          Default: ``'l1'``.
-
-    Returns:
-        the blurred torch.Tensor with shape :math:`(B, C, H, W)`.
-
-    Examples:
-        >>> input = torch.rand(2, 4, 5, 5)
-        >>> output = bilateral_blur(input, (3, 3), 0.1, (1.5, 1.5))
-        >>> output.shape
-        torch.Size([2, 4, 5, 5])
-
-    """
-    return _bilateral_blur(input, None, kernel_size, sigma_color, sigma_space, border_type, color_distance_type)
-
-
-def joint_bilateral_blur(
-    input: torch.Tensor,
-    guidance: torch.Tensor,
-    kernel_size: tuple[int, int] | int,
-    sigma_color: float | torch.Tensor,
-    sigma_space: tuple[float, float] | torch.Tensor,
-    border_type: str = "reflect",
-    color_distance_type: str = "l1",
-) -> torch.Tensor:
-    r"""Blur a torch.Tensor using a Joint Bilateral filter.
-
-    .. image:: _static/img/joint_bilateral_blur.png
-
-    This operator is almost identical to a Bilateral filter. The only difference
-    is that the color Gaussian kernel is computed based on another image called
-    a guidance image. See :func:`bilateral_blur()` for more information.
-
-    Arguments:
-        input: the input torch.Tensor with shape :math:`(B,C,H,W)`.
-        guidance: the guidance torch.Tensor with shape :math:`(B,C,H,W)`.
-        kernel_size: the size of the kernel.
-        sigma_color: the standard deviation for intensity/color Gaussian kernel.
-          Smaller values preserve more edges.
-        sigma_space: the standard deviation for spatial Gaussian kernel.
-          This is similar to ``sigma`` in :func:`gaussian_blur2d()`.
-        border_type: the padding mode to be applied before convolving.
-          The expected modes are: ``'constant'``, ``'reflect'``,
-          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
-        color_distance_type: the type of distance to calculate intensity/color
-          difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
-          match OpenCV implementation.
-
-    Returns:
-        the blurred torch.Tensor with shape :math:`(B, C, H, W)`.
-
-    Examples:
-        >>> input = torch.rand(2, 4, 5, 5)
-        >>> guidance = torch.rand(2, 4, 5, 5)
-        >>> output = joint_bilateral_blur(input, guidance, (3, 3), 0.1, (1.5, 1.5))
-        >>> output.shape
-        torch.Size([2, 4, 5, 5])
-
-    """
-    return _bilateral_blur(input, guidance, kernel_size, sigma_color, sigma_space, border_type, color_distance_type)
-
-
-# trick to make mypy not throw errors about difference in .forward() signatures of subclass and superclass
-class _BilateralBlur(nn.Module):
-    def __init__(
-        self,
-        kernel_size: tuple[int, int] | int,
-        sigma_color: float | torch.Tensor,
-        sigma_space: tuple[float, float] | torch.Tensor,
-        border_type: str = "reflect",
-        color_distance_type: str = "l1",
-    ) -> None:
-        super().__init__()
-        self.kernel_size = kernel_size
-        self.sigma_color = sigma_color
-        self.sigma_space = sigma_space
-        self.border_type = border_type
-        self.color_distance_type = color_distance_type
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}"
-            f"(kernel_size={self.kernel_size}, "
-            f"sigma_color={self.sigma_color}, "
-            f"sigma_space={self.sigma_space}, "
-            f"border_type={self.border_type}, "
-            f"color_distance_type={self.color_distance_type})"
-        )
-
-
-class BilateralBlur(_BilateralBlur):
-    r"""Blur a torch.Tensor using a Bilateral filter.
-
-    The operator is an edge-preserving image smoothing filter. The weight
-    for each pixel in a neighborhood is determined not only by its distance
-    to the center pixel, but also the difference in intensity or color.
-
-    Arguments:
-        kernel_size: the size of the kernel.
-        sigma_color: the standard deviation for intensity/color Gaussian kernel.
-          Smaller values preserve more edges.
-        sigma_space: the standard deviation for spatial Gaussian kernel.
-          This is similar to ``sigma`` in :func:`gaussian_blur2d()`.
-        border_type: the padding mode to be applied before convolving.
-          The expected modes are: ``'constant'``, ``'reflect'``,
-          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
-        color_distance_type: the type of distance to calculate intensity/color
-          difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
-          match OpenCV implementation. Use ``'l2'`` to match Matlab implementation.
-          Default: ``'l1'``.
-
-    Returns:
-        the blurred input torch.Tensor.
-
-    Shape:
-        - Input: :math:`(B, C, H, W)`
-        - Output: :math:`(B, C, H, W)`
-
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)
         >>> blur = BilateralBlur((3, 3), 0.1, (1.5, 1.5))
@@ -237,7 +6,9 @@ class BilateralBlur(_BilateralBlur):
         >>> output.shape
         torch.Size([2, 4, 5, 5])
 
+
     """
+
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
                 """See :class:`BilateralBlur` for details."""
@@ -246,12 +17,16 @@ class BilateralBlur(_BilateralBlur):
         )
 
 
+
+
 class JointBilateralBlur(_BilateralBlur):
     r"""Blur a torch.Tensor using a Joint Bilateral filter.
+
 
     This operator is almost identical to a Bilateral filter. The only difference
     is that the color Gaussian kernel is computed based on another image called
     a guidance image. See :class:`BilateralBlur` for more information.
+
 
     Arguments:
         kernel_size: the size of the kernel.
@@ -266,12 +41,15 @@ class JointBilateralBlur(_BilateralBlur):
           difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
           match OpenCV implementation.
 
+
     Returns:
         the blurred input torch.Tensor.
+
 
     Shape:
         - Input: :math:`(B, C, H, W)`, :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
+
 
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)
@@ -281,7 +59,9 @@ class JointBilateralBlur(_BilateralBlur):
         >>> output.shape
         torch.Size([2, 4, 5, 5])
 
+
     """
+
 
     def forward(self, input: torch.Tensor, guidance: torch.Tensor) -> torch.Tensor:
         return joint_bilateral_blur(
@@ -293,3 +73,4 @@ class JointBilateralBlur(_BilateralBlur):
             self.border_type,
             self.color_distance_type,
         )
+

--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -184,6 +184,7 @@ class _BilateralBlur(nn.Module):
         border_type: str = "reflect",
         color_distance_type: str = "l1",
     ) -> None:
+        """See :class:`BilateralBlur` for details."""
         super().__init__()
         self.kernel_size = kernel_size
         self.sigma_color = sigma_color
@@ -192,6 +193,7 @@ class _BilateralBlur(nn.Module):
         self.color_distance_type = color_distance_type
 
     def __repr__(self) -> str:
+        """See :class:`BilateralBlur` for details."""
         return (
             f"{self.__class__.__name__}"
             f"(kernel_size={self.kernel_size}, "

--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -1,4 +1,19 @@
 # LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)
         >>> blur = BilateralBlur((3, 3), 0.1, (1.5, 1.5))
@@ -73,4 +88,3 @@ class JointBilateralBlur(_BilateralBlur):
             self.border_type,
             self.color_distance_type,
         )
-

--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -240,6 +240,7 @@ class BilateralBlur(_BilateralBlur):
     """
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+                """See :class:`BilateralBlur` for details."""
         return bilateral_blur(
             input, self.kernel_size, self.sigma_color, self.sigma_space, self.border_type, self.color_distance_type
         )

--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -123,6 +123,7 @@ def bilateral_blur(
         >>> output = bilateral_blur(input, (3, 3), 0.1, (1.5, 1.5))
         >>> output.shape
         torch.Size([2, 4, 5, 5])
+
     """
     return _bilateral_blur(input, None, kernel_size, sigma_color, sigma_space, border_type, color_distance_type)
 
@@ -168,6 +169,7 @@ def joint_bilateral_blur(
         >>> output = joint_bilateral_blur(input, guidance, (3, 3), 0.1, (1.5, 1.5))
         >>> output.shape
         torch.Size([2, 4, 5, 5])
+
     """
     return _bilateral_blur(input, guidance, kernel_size, sigma_color, sigma_space, border_type, color_distance_type)
 
@@ -234,6 +236,7 @@ class BilateralBlur(_BilateralBlur):
         >>> output = blur(input)
         >>> output.shape
         torch.Size([2, 4, 5, 5])
+
     """
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
@@ -277,10 +280,11 @@ class JointBilateralBlur(_BilateralBlur):
         >>> output = blur(input, guidance)
         >>> output.shape
         torch.Size([2, 4, 5, 5])
+
     """
 
     def forward(self, input: torch.Tensor, guidance: torch.Tensor) -> torch.Tensor:
-        """See :class:`JointBilateralBlur` for details."""
+        """See :class:`BilateralBlur` for details."""
         return joint_bilateral_blur(
             input,
             guidance,

--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -14,34 +14,241 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+
+from .kernels import _unpack_2d_ks, get_gaussian_kernel2d
+from .median import _compute_zero_padding
+
+
+def _bilateral_blur(
+    input: torch.Tensor,
+    guidance: Optional[torch.Tensor],
+    kernel_size: tuple[int, int] | int,
+    sigma_color: float | torch.Tensor,
+    sigma_space: tuple[float, float] | torch.Tensor,
+    border_type: str = "reflect",
+    color_distance_type: str = "l1",
+) -> torch.Tensor:
+    """Single implementation for both Bilateral Filter and Joint Bilateral Filter."""
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
+    if guidance is not None:
+        # NOTE: allow guidance and input having different number of channels
+        KORNIA_CHECK_IS_TENSOR(guidance)
+        KORNIA_CHECK_SHAPE(guidance, ["B", "C", "H", "W"])
+        KORNIA_CHECK(
+            (guidance.shape[0] == input.shape[0]) and (guidance.shape[-2:] == input.shape[-2:]),
+            "guidance and input should have the same batch size and spatial dimensions",
+        )
+
+    if isinstance(sigma_color, torch.Tensor):
+        KORNIA_CHECK_SHAPE(sigma_color, ["B"])
+        sigma_color = sigma_color.to(device=input.device, dtype=input.dtype).view(-1, 1, 1, 1, 1)
+
+    ky, kx = _unpack_2d_ks(kernel_size)
+    pad_y, pad_x = _compute_zero_padding(kernel_size)
+
+    padded_input = F.pad(input, (pad_x, pad_x, pad_y, pad_y), mode=border_type)
+    unfolded_input = padded_input.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, Ky x Kx)
+
+    if guidance is None:
+        guidance = input
+        unfolded_guidance = unfolded_input
+    else:
+        padded_guidance = F.pad(guidance, (pad_x, pad_x, pad_y, pad_y), mode=border_type)
+        unfolded_guidance = padded_guidance.unfold(2, ky, 1).unfold(3, kx, 1).flatten(-2)  # (B, C, H, W, Ky x Kx)
+
+    diff = unfolded_guidance - guidance.unsqueeze(-1)
+    if color_distance_type == "l1":
+        color_distance_sq = diff.abs().sum(1, keepdim=True).square()
+    elif color_distance_type == "l2":
+        color_distance_sq = diff.square().sum(1, keepdim=True)
+    else:
+        raise ValueError("color_distance_type only accepts l1 or l2")
+    color_kernel = (-0.5 / sigma_color**2 * color_distance_sq).exp()  # (B, 1, H, W, Ky x Kx)
+
+    space_kernel = get_gaussian_kernel2d(kernel_size, sigma_space, device=input.device, dtype=input.dtype)
+    space_kernel = space_kernel.view(-1, 1, 1, 1, kx * ky)
+
+    kernel = space_kernel * color_kernel
+    out = (unfolded_input * kernel).sum(-1) / kernel.sum(-1)
+    return out
+
+
+def bilateral_blur(
+    input: torch.Tensor,
+    kernel_size: tuple[int, int] | int,
+    sigma_color: float | torch.Tensor,
+    sigma_space: tuple[float, float] | torch.Tensor,
+    border_type: str = "reflect",
+    color_distance_type: str = "l1",
+) -> torch.Tensor:
+    r"""Blur a torch.Tensor using a Bilateral filter.
+
+    .. image:: _static/img/bilateral_blur.png
+
+    The operator is an edge-preserving image smoothing filter. The weight
+    for each pixel in a neighborhood is determined not only by its distance
+    to the center pixel, but also the difference in intensity or color.
+
+    Arguments:
+        input: the input torch.Tensor with shape :math:`(B,C,H,W)`.
+        kernel_size: the size of the kernel.
+        sigma_color: the standard deviation for intensity/color Gaussian kernel.
+          Smaller values preserve more edges.
+        sigma_space: the standard deviation for spatial Gaussian kernel.
+          This is similar to ``sigma`` in :func:`gaussian_blur2d()`.
+        border_type: the padding mode to be applied before convolving.
+          The expected modes are: ``'constant'``, ``'reflect'``,
+          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
+        color_distance_type: the type of distance to calculate intensity/color
+          difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
+          match OpenCV implementation. Use ``'l2'`` to match Matlab implementation.
+          Default: ``'l1'``.
+
+    Returns:
+        the blurred torch.Tensor with shape :math:`(B, C, H, W)`.
+
+    Examples:
+        >>> input = torch.rand(2, 4, 5, 5)
+        >>> output = bilateral_blur(input, (3, 3), 0.1, (1.5, 1.5))
+        >>> output.shape
+        torch.Size([2, 4, 5, 5])
+    """
+    return _bilateral_blur(input, None, kernel_size, sigma_color, sigma_space, border_type, color_distance_type)
+
+
+def joint_bilateral_blur(
+    input: torch.Tensor,
+    guidance: torch.Tensor,
+    kernel_size: tuple[int, int] | int,
+    sigma_color: float | torch.Tensor,
+    sigma_space: tuple[float, float] | torch.Tensor,
+    border_type: str = "reflect",
+    color_distance_type: str = "l1",
+) -> torch.Tensor:
+    r"""Blur a torch.Tensor using a Joint Bilateral filter.
+
+    .. image:: _static/img/joint_bilateral_blur.png
+
+    This operator is almost identical to a Bilateral filter. The only difference
+    is that the color Gaussian kernel is computed based on another image called
+    a guidance image. See :func:`bilateral_blur()` for more information.
+
+    Arguments:
+        input: the input torch.Tensor with shape :math:`(B,C,H,W)`.
+        guidance: the guidance torch.Tensor with shape :math:`(B,C,H,W)`.
+        kernel_size: the size of the kernel.
+        sigma_color: the standard deviation for intensity/color Gaussian kernel.
+          Smaller values preserve more edges.
+        sigma_space: the standard deviation for spatial Gaussian kernel.
+          This is similar to ``sigma`` in :func:`gaussian_blur2d()`.
+        border_type: the padding mode to be applied before convolving.
+          The expected modes are: ``'constant'``, ``'reflect'``,
+          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
+        color_distance_type: the type of distance to calculate intensity/color
+          difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
+          match OpenCV implementation.
+
+    Returns:
+        the blurred torch.Tensor with shape :math:`(B, C, H, W)`.
+
+    Examples:
+        >>> input = torch.rand(2, 4, 5, 5)
+        >>> guidance = torch.rand(2, 4, 5, 5)
+        >>> output = joint_bilateral_blur(input, guidance, (3, 3), 0.1, (1.5, 1.5))
+        >>> output.shape
+        torch.Size([2, 4, 5, 5])
+    """
+    return _bilateral_blur(input, guidance, kernel_size, sigma_color, sigma_space, border_type, color_distance_type)
+
+
+# trick to make mypy not throw errors about difference in .forward() signatures of subclass and superclass
+class _BilateralBlur(nn.Module):
+    def __init__(
+        self,
+        kernel_size: tuple[int, int] | int,
+        sigma_color: float | torch.Tensor,
+        sigma_space: tuple[float, float] | torch.Tensor,
+        border_type: str = "reflect",
+        color_distance_type: str = "l1",
+    ) -> None:
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.sigma_color = sigma_color
+        self.sigma_space = sigma_space
+        self.border_type = border_type
+        self.color_distance_type = color_distance_type
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}"
+            f"(kernel_size={self.kernel_size}, "
+            f"sigma_color={self.sigma_color}, "
+            f"sigma_space={self.sigma_space}, "
+            f"border_type={self.border_type}, "
+            f"color_distance_type={self.color_distance_type})"
+        )
+
+
+class BilateralBlur(_BilateralBlur):
+    r"""Blur a torch.Tensor using a Bilateral filter.
+
+    The operator is an edge-preserving image smoothing filter. The weight
+    for each pixel in a neighborhood is determined not only by its distance
+    to the center pixel, but also the difference in intensity or color.
+
+    Arguments:
+        kernel_size: the size of the kernel.
+        sigma_color: the standard deviation for intensity/color Gaussian kernel.
+          Smaller values preserve more edges.
+        sigma_space: the standard deviation for spatial Gaussian kernel.
+          This is similar to ``sigma`` in :func:`gaussian_blur2d()`.
+        border_type: the padding mode to be applied before convolving.
+          The expected modes are: ``'constant'``, ``'reflect'``,
+          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
+        color_distance_type: the type of distance to calculate intensity/color
+          difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
+          match OpenCV implementation. Use ``'l2'`` to match Matlab implementation.
+          Default: ``'l1'``.
+
+    Returns:
+        the blurred input torch.Tensor.
+
+    Shape:
+        - Input: :math:`(B, C, H, W)`
+        - Output: :math:`(B, C, H, W)`
+
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)
         >>> blur = BilateralBlur((3, 3), 0.1, (1.5, 1.5))
         >>> output = blur(input)
         >>> output.shape
         torch.Size([2, 4, 5, 5])
-
-
     """
 
-
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-                """See :class:`BilateralBlur` for details."""
+        """See :class:`BilateralBlur` for details."""
         return bilateral_blur(
             input, self.kernel_size, self.sigma_color, self.sigma_space, self.border_type, self.color_distance_type
         )
 
 
-
-
 class JointBilateralBlur(_BilateralBlur):
     r"""Blur a torch.Tensor using a Joint Bilateral filter.
-
 
     This operator is almost identical to a Bilateral filter. The only difference
     is that the color Gaussian kernel is computed based on another image called
     a guidance image. See :class:`BilateralBlur` for more information.
-
 
     Arguments:
         kernel_size: the size of the kernel.
@@ -56,15 +263,12 @@ class JointBilateralBlur(_BilateralBlur):
           difference. Only ``'l1'`` or ``'l2'`` is allowed. Use ``'l1'`` to
           match OpenCV implementation.
 
-
     Returns:
         the blurred input torch.Tensor.
-
 
     Shape:
         - Input: :math:`(B, C, H, W)`, :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
-
 
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)
@@ -73,12 +277,10 @@ class JointBilateralBlur(_BilateralBlur):
         >>> output = blur(input, guidance)
         >>> output.shape
         torch.Size([2, 4, 5, 5])
-
-
     """
 
-
     def forward(self, input: torch.Tensor, guidance: torch.Tensor) -> torch.Tensor:
+        """See :class:`JointBilateralBlur` for details."""
         return joint_bilateral_blur(
             input,
             guidance,

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -1,110 +1,51 @@
-# LICENSE HEADER MANAGED BY add-license-header
-#
-# Copyright 2018 Kornia Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-from __future__ import annotations
-
-import torch
-from torch import nn
-
-from kornia.core.check import KORNIA_CHECK_IS_TENSOR
-
-from .filter import filter2d, filter2d_separable
-from .kernels import _unpack_2d_ks, get_box_kernel1d, get_box_kernel2d
 
 
-def box_blur(
-    input: torch.Tensor, kernel_size: tuple[int, int] | int, border_type: str = "reflect", separable: bool = False
-) -> torch.Tensor:
-    r"""Blur an image using the box filter.
-
-    .. image:: _static/img/box_blur.png
-
-    The function smooths an image using the kernel:
-
-    .. math::
-        K = \frac{1}{\text{kernel_size}_x * \text{kernel_size}_y}
-        \begin{bmatrix}
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-        \end{bmatrix}
-
-    Args:
-        input: the image to blur with shape :math:`(B,C,H,W)`.
-        kernel_size: the blurring kernel size.
-        border_type: the padding mode to be applied before convolving.
-          The expected modes are: ``'constant'``, ``'reflect'``, ``'replicate'`` or ``'circular'``.
-        separable: run as composition of two 1d-convolutions.
-
-    Returns:
-        the blurred torch.Tensor with shape :math:`(B,C,H,W)`.
-
-    .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
-
-    Example:
-        >>> input = torch.rand(2, 4, 5, 7)
-        >>> output = box_blur(input, (3, 3))  # 2x4x5x7
-        >>> output.shape
-        torch.Size([2, 4, 5, 7])
-
-    """
-    KORNIA_CHECK_IS_TENSOR(input)
-
-    if separable:
-        ky, kx = _unpack_2d_ks(kernel_size)
-        kernel_y = get_box_kernel1d(ky, device=input.device, dtype=input.dtype)
-        kernel_x = get_box_kernel1d(kx, device=input.device, dtype=input.dtype)
-        out = filter2d_separable(input, kernel_x, kernel_y, border_type)
-    else:
-        kernel = get_box_kernel2d(kernel_size, device=input.device, dtype=input.dtype)
-        out = filter2d(input, kernel, border_type)
-
-    return out
 
 
-class BoxBlur(nn.Module):
-    r"""Blur an image using the box filter.
 
-    The function smooths an image using the kernel:
 
-    .. math::
-        K = \frac{1}{\text{kernel_size}_x * \text{kernel_size}_y}
-        \begin{bmatrix}
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-        \end{bmatrix}
 
-    Args:
-        kernel_size: the blurring kernel size.
-        border_type: the padding mode to be applied before convolving.
-          The expected modes are: ``'constant'``, ``'reflect'``,
-          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
-        separable: run as composition of two 1d-convolutions.
+
+
+
+
 
     Returns:
         the blurred input torch.Tensor.
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     Shape:
         - Input: :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)
@@ -113,7 +54,37 @@ class BoxBlur(nn.Module):
         >>> output.shape
         torch.Size([2, 4, 5, 7])
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     """
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     def __init__(
         self, kernel_size: tuple[int, int] | int, border_type: str = "reflect", separable: bool = False
@@ -122,6 +93,21 @@ class BoxBlur(nn.Module):
         self.kernel_size = kernel_size
         self.border_type = border_type
         self.separable = separable
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
         if separable:
             ky, kx = _unpack_2d_ks(self.kernel_size)
@@ -133,8 +119,23 @@ class BoxBlur(nn.Module):
             self.register_buffer("kernel", get_box_kernel2d(kernel_size))
             self.kernel: torch.Tensor
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def __repr__(self) -> str:
-                """See :class:`BoxBlur` for details."""
+        """See :class:`BoxBlur` for details."""
         return (
             f"{self.__class__.__name__}"
             f"(kernel_size={self.kernel_size}, "
@@ -142,9 +143,39 @@ class BoxBlur(nn.Module):
             f"separable={self.separable})"
         )
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-                """See :class:`BoxBlur` for details."""
+        """See :class:`BoxBlur` for details."""
         KORNIA_CHECK_IS_TENSOR(input)
         if self.separable:
             return filter2d_separable(input, self.kernel_x, self.kernel_y, self.border_type)
         return filter2d(input, self.kernel, self.border_type)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -62,6 +62,7 @@ def box_blur(
         >>> output = box_blur(input, (3, 3))  # 2x4x5x7
         >>> output.shape
         torch.Size([2, 4, 5, 7])
+
     """
     KORNIA_CHECK_IS_TENSOR(input)
 
@@ -111,12 +112,12 @@ class BoxBlur(nn.Module):
         >>> output = blur(input)  # 2x4x5x7
         >>> output.shape
         torch.Size([2, 4, 5, 7])
+
     """
 
     def __init__(
         self, kernel_size: tuple[int, int] | int, border_type: str = "reflect", separable: bool = False
     ) -> None:
-        """See :class:`BoxBlur` for details."""
         super().__init__()
         self.kernel_size = kernel_size
         self.border_type = border_type
@@ -133,6 +134,7 @@ class BoxBlur(nn.Module):
             self.kernel: torch.Tensor
 
     def __repr__(self) -> str:
+        """See :class:`BoxBlur` for details."""
         return (
             f"{self.__class__.__name__}"
             f"(kernel_size={self.kernel_size}, "

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -1,3 +1,20 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 
 
@@ -164,18 +181,3 @@
         if self.separable:
             return filter2d_separable(input, self.kernel_x, self.kernel_y, self.border_type)
         return filter2d(input, self.kernel, self.border_type)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -36,26 +36,26 @@ def box_blur(
     The function smooths an image using the kernel:
 
     .. math::
-        K = \frac{1}{\text{kernel_size}_x * \text{kernel_size}_y}
-        \begin{bmatrix}
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-        \end{bmatrix}
+        K = rac{1}{	ext{kernel_size}_x * 	ext{kernel_size}_y}
+        egin{bmatrix}
+            1 & 1 & 1 & cdots & 1 & 1 \\
+            1 & 1 & 1 & cdots & 1 & 1 \\
+            dots & dots & dots & ddots & dots & dots \\
+            1 & 1 & 1 & cdots & 1 & 1 \\
+        end{bmatrix}
 
     Args:
         input: the image to blur with shape :math:`(B,C,H,W)`.
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
-          The expected modes are: `'constant'`, `'reflect'`, `'replicate'` or `'circular'`.
+          The expected modes are: ``'constant'``, ``'reflect'``, ``'replicate'`` or ``'circular'``.
         separable: run as composition of two 1d-convolutions.
 
     Returns:
         the blurred torch.Tensor with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example [here](https://kornia.github.io/tutorials/nbs/filtering_operators.html).
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)
@@ -84,19 +84,19 @@ class BoxBlur(nn.Module):
     The function smooths an image using the kernel:
 
     .. math::
-        K = \frac{1}{\text{kernel_size}_x * \text{kernel_size}_y}
-        \begin{bmatrix}
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-            \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
-            1 & 1 & 1 & \cdots & 1 & 1 \\
-        \end{bmatrix}
+        K = rac{1}{	ext{kernel_size}_x * 	ext{kernel_size}_y}
+        egin{bmatrix}
+            1 & 1 & 1 & cdots & 1 & 1 \\
+            1 & 1 & 1 & cdots & 1 & 1 \\
+            dots & dots & dots & ddots & dots & dots \\
+            1 & 1 & 1 & cdots & 1 & 1 \\
+        end{bmatrix}
 
     Args:
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
-          The expected modes are: `'constant'`, `'reflect'`,
-          `'replicate'` or `'circular'`. Default: `'reflect'`.
+          The expected modes are: ``'constant'``, ``'reflect'``,
+          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
         separable: run as composition of two 1d-convolutions.
 
     Returns:

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -134,6 +134,7 @@ class BoxBlur(nn.Module):
             self.kernel: torch.Tensor
 
     def __repr__(self) -> str:
+                """See :class:`BoxBlur` for details."""
         return (
             f"{self.__class__.__name__}"
             f"(kernel_size={self.kernel_size}, "
@@ -142,6 +143,7 @@ class BoxBlur(nn.Module):
         )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+                """See :class:`BoxBlur` for details."""
         KORNIA_CHECK_IS_TENSOR(input)
         if self.separable:
             return filter2d_separable(input, self.kernel_x, self.kernel_y, self.border_type)

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -15,54 +15,95 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from kornia.core.check import KORNIA_CHECK_IS_TENSOR
+
+from .filter import filter2d, filter2d_separable
+from .kernels import _unpack_2d_ks, get_box_kernel1d, get_box_kernel2d
 
 
+def box_blur(
+    input: torch.Tensor, kernel_size: tuple[int, int] | int, border_type: str = "reflect", separable: bool = False
+) -> torch.Tensor:
+    r"""Blur an image using the box filter.
+
+    .. image:: _static/img/box_blur.png
+
+    The function smooths an image using the kernel:
+
+    .. math::
+        K = \frac{1}{\text{kernel_size}_x * \text{kernel_size}_y}
+        \begin{bmatrix}
+            1 & 1 & 1 & \cdots & 1 & 1 \\
+            1 & 1 & 1 & \cdots & 1 & 1 \\
+            \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
+            1 & 1 & 1 & \cdots & 1 & 1 \\
+        \end{bmatrix}
+
+    Args:
+        input: the image to blur with shape :math:`(B,C,H,W)`.
+        kernel_size: the blurring kernel size.
+        border_type: the padding mode to be applied before convolving.
+          The expected modes are: ``'constant'``, ``'reflect'``, ``'replicate'`` or ``'circular'``.
+        separable: run as composition of two 1d-convolutions.
+
+    Returns:
+        the blurred torch.Tensor with shape :math:`(B,C,H,W)`.
+
+    .. note::
+       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
+
+    Example:
+        >>> input = torch.rand(2, 4, 5, 7)
+        >>> output = box_blur(input, (3, 3))  # 2x4x5x7
+        >>> output.shape
+        torch.Size([2, 4, 5, 7])
+    """
+    KORNIA_CHECK_IS_TENSOR(input)
+
+    if separable:
+        ky, kx = _unpack_2d_ks(kernel_size)
+        kernel_y = get_box_kernel1d(ky, device=input.device, dtype=input.dtype)
+        kernel_x = get_box_kernel1d(kx, device=input.device, dtype=input.dtype)
+        out = filter2d_separable(input, kernel_x, kernel_y, border_type)
+    else:
+        kernel = get_box_kernel2d(kernel_size, device=input.device, dtype=input.dtype)
+        out = filter2d(input, kernel, border_type)
+
+    return out
 
 
+class BoxBlur(nn.Module):
+    r"""Blur an image using the box filter.
 
+    The function smooths an image using the kernel:
 
+    .. math::
+        K = \frac{1}{\text{kernel_size}_x * \text{kernel_size}_y}
+        \begin{bmatrix}
+            1 & 1 & 1 & \cdots & 1 & 1 \\
+            1 & 1 & 1 & \cdots & 1 & 1 \\
+            \vdots & \vdots & \vdots & \ddots & \vdots & \vdots \\
+            1 & 1 & 1 & \cdots & 1 & 1 \\
+        \end{bmatrix}
 
-
-
-
-
+    Args:
+        kernel_size: the blurring kernel size.
+        border_type: the padding mode to be applied before convolving.
+          The expected modes are: ``'constant'``, ``'reflect'``,
+          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
+        separable: run as composition of two 1d-convolutions.
 
     Returns:
         the blurred input torch.Tensor.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     Shape:
         - Input: :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)
@@ -70,61 +111,16 @@
         >>> output = blur(input)  # 2x4x5x7
         >>> output.shape
         torch.Size([2, 4, 5, 7])
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     """
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     def __init__(
         self, kernel_size: tuple[int, int] | int, border_type: str = "reflect", separable: bool = False
     ) -> None:
+        """See :class:`BoxBlur` for details."""
         super().__init__()
         self.kernel_size = kernel_size
         self.border_type = border_type
         self.separable = separable
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
         if separable:
             ky, kx = _unpack_2d_ks(self.kernel_size)
@@ -136,44 +132,13 @@
             self.register_buffer("kernel", get_box_kernel2d(kernel_size))
             self.kernel: torch.Tensor
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     def __repr__(self) -> str:
-        """See :class:`BoxBlur` for details."""
         return (
             f"{self.__class__.__name__}"
             f"(kernel_size={self.kernel_size}, "
             f"border_type={self.border_type}, "
             f"separable={self.separable})"
         )
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """See :class:`BoxBlur` for details."""

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -48,14 +48,14 @@ def box_blur(
         input: the image to blur with shape :math:`(B,C,H,W)`.
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
-          The expected modes are: ``'constant'``, ``'reflect'``, ``'replicate'`` or ``'circular'``.
+          The expected modes are: `'constant'`, `'reflect'`, `'replicate'` or `'circular'`.
         separable: run as composition of two 1d-convolutions.
 
     Returns:
         the blurred torch.Tensor with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
+       See a working example [here](https://kornia.github.io/tutorials/nbs/filtering_operators.html).
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)
@@ -95,8 +95,8 @@ class BoxBlur(nn.Module):
     Args:
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
-          The expected modes are: ``'constant'``, ``'reflect'``,
-          ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
+          The expected modes are: `'constant'`, `'reflect'`,
+          `'replicate'` or `'circular'`. Default: `'reflect'`.
         separable: run as composition of two 1d-convolutions.
 
     Returns:
@@ -118,6 +118,7 @@ class BoxBlur(nn.Module):
     def __init__(
         self, kernel_size: tuple[int, int] | int, border_type: str = "reflect", separable: bool = False
     ) -> None:
+        """See :class:`BoxBlur` for details."""
         super().__init__()
         self.kernel_size = kernel_size
         self.border_type = border_type

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -14,20 +14,180 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from kornia.color import rgb_to_grayscale
+from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+
+from .gaussian import gaussian_blur2d
+from .kernels import get_canny_nms_kernel, get_hysteresis_kernel
+from .sobel import spatial_gradient
+
+
+def canny(
+    input: torch.Tensor,
+    low_threshold: float = 0.1,
+    high_threshold: float = 0.2,
+    kernel_size: tuple[int, int] | int = (5, 5),
+    sigma: tuple[float, float] | torch.Tensor = (1, 1),
+    hysteresis: bool = True,
+    eps: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Find edges of the input image and filters them using the Canny algorithm.
+
+    .. image:: _static/img/canny.png
+
+    Args:
+        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
+        low_threshold: lower threshold for the hysteresis procedure.
+        high_threshold: upper threshold for the hysteresis procedure.
+        kernel_size: the size of the kernel for the gaussian blur.
+        sigma: the standard deviation of the kernel for the gaussian blur.
+        hysteresis: if True, applies the hysteresis edge tracking.
+            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
+        eps: regularization number to avoid NaN during backprop.
+
+    Returns:
+        - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
+        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
+
+    .. note::
+       See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
+
+    Example:
+        >>> input = torch.rand(5, 3, 4, 4)
+        >>> magnitude, edges = canny(input)  # 5x3x4x4
+        >>> magnitude.shape
+        torch.Size([5, 1, 4, 4])
+        >>> edges.shape
+        torch.Size([5, 1, 4, 4])
+    """
+    KORNIA_CHECK_IS_TENSOR(input)
+    KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
+    KORNIA_CHECK(
+        low_threshold <= high_threshold,
+        "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
+        f"{low_threshold}>{high_threshold}",
+    )
+    KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
+    KORNIA_CHECK(0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}")
+
+    device = input.device
+    dtype = input.dtype
+
+    # To Grayscale
+    if input.shape[1] == 3:
+        input = rgb_to_grayscale(input)
+
+    # Gaussian filter
+    blurred: torch.Tensor = gaussian_blur2d(input, kernel_size, sigma)
+
+    # Compute the gradients
+    gradients: torch.Tensor = spatial_gradient(blurred, normalized=False)
+
+    # Unpack the edges
+    gx: torch.Tensor = gradients[:, :, 0]
+    gy: torch.Tensor = gradients[:, :, 1]
+
+    # Compute gradient magnitude and angle
+    magnitude: torch.Tensor = torch.sqrt(gx * gx + gy * gy + eps)
+    angle: torch.Tensor = torch.atan2(gy, gx)
+
+    # Radians to degrees and round to nearest 45 degree
+    # degrees = angle * (180.0 / math.pi)
+    # angle = torch.round(degrees / 45) * 45
+    angle_45 = (angle * (4 / math.pi)).round()
+
+    # Non-maximal suppression
+    nms_kernels: torch.Tensor = get_canny_nms_kernel(device, dtype)
+    nms_magnitude: torch.Tensor = F.conv2d(magnitude, nms_kernels, padding=nms_kernels.shape[-1] // 2)
+
+    # Get the indices for both directions
+    positive_idx: torch.Tensor = angle_45 % 8
+    positive_idx = positive_idx.long()
+
+    negative_idx: torch.Tensor = (angle_45 + 4) % 8
+    negative_idx = negative_idx.long()
+
+    # Apply the non-maximum suppression to the different directions
+    channel_select_filtered_positive: torch.Tensor = torch.gather(nms_magnitude, 1, positive_idx)
+    channel_select_filtered_negative: torch.Tensor = torch.gather(nms_magnitude, 1, negative_idx)
+
+    channel_select_filtered: torch.Tensor = torch.stack(
+        [channel_select_filtered_positive, channel_select_filtered_negative], 1
+    )
+
+    is_max: torch.Tensor = channel_select_filtered.min(dim=1)[0] > 0.0
+
+    magnitude = magnitude * is_max
+
+    # Threshold
+    edges: torch.Tensor = F.threshold(magnitude, low_threshold, 0.0)
+
+    low: torch.Tensor = magnitude > low_threshold
+    high: torch.Tensor = magnitude > high_threshold
+
+    edges = low * 0.5 + high * 0.5
+    edges = edges.to(dtype)
+
+    # Hysteresis
+    if hysteresis:
+        edges_old: torch.Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
+        hysteresis_kernels: torch.Tensor = get_hysteresis_kernel(device, dtype)
+
+        while ((edges_old - edges).abs() != 0).any():
+            weak: torch.Tensor = (edges == 0.5).float()
+            strong: torch.Tensor = (edges == 1).float()
+
+            hysteresis_magnitude: torch.Tensor = F.conv2d(
+                edges, hysteresis_kernels, padding=hysteresis_kernels.shape[-1] // 2
+            )
+            hysteresis_magnitude = (hysteresis_magnitude == 1).any(1, keepdim=True).to(dtype)
+            hysteresis_magnitude = hysteresis_magnitude * weak + strong
+
+            edges_old = edges.clone()
+            edges = hysteresis_magnitude + (hysteresis_magnitude == 0) * weak * 0.5
+
+        edges = hysteresis_magnitude
+
+    return magnitude, edges
+
+
+class Canny(nn.Module):
+    r"""nn.Module that finds edges of the input image and filters them using the Canny algorithm.
+
+    Args:
+        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
+        low_threshold: lower threshold for the hysteresis procedure.
+        high_threshold: upper threshold for the hysteresis procedure.
+        kernel_size: the size of the kernel for the gaussian blur.
+        sigma: the standard deviation of the kernel for the gaussian blur.
+        hysteresis: if True, applies the hysteresis edge tracking.
+            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
+        eps: regularization number to avoid NaN during backprop.
+
+    Returns:
+        - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
+        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
+
+    Example:
         >>> input = torch.rand(5, 3, 4, 4)
         >>> magnitude, edges = Canny()(input)  # 5x3x4x4
         >>> magnitude.shape
         torch.Size([5, 1, 4, 4])
         >>> edges.shape
         torch.Size([5, 1, 4, 4])
-
-
     """
-
 
     # TODO: Handle multiple inputs and outputs models later
     ONNX_EXPORTABLE = False
-
 
     def __init__(
         self,
@@ -41,7 +201,6 @@
         """See :class:`Canny` for details."""
         super().__init__()
 
-
         KORNIA_CHECK(
             low_threshold <= high_threshold,
             "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
@@ -52,26 +211,20 @@
             0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}"
         )
 
-
         # Gaussian blur parameters
         self.kernel_size = kernel_size
         self.sigma = sigma
-
 
         # Double threshold
         self.low_threshold = low_threshold
         self.high_threshold = high_threshold
 
-
         # Hysteresis
         self.hysteresis = hysteresis
 
-
         self.eps: float = eps
 
-
     def __repr__(self) -> str:
-        """See :class:`Canny` for details."""
         return "".join(
             (
                 f"{type(self).__name__}(",
@@ -81,7 +234,6 @@
                 ")",
             )
         )
-
 
     def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """See :class:`Canny` for details."""

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -243,4 +243,3 @@ class Canny(nn.Module):
                 return canny(
                     input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
                 )
-

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -57,10 +57,10 @@ def canny(
                                                                                         Returns:
                                                                                                 - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
                                                                                                         - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-                                                                                                        
+
                                                                                                             .. note::
                                                                                                                    See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
-                                                                                                                   
+
                                                                                                                        Example:
                                                                                                                                >>> input = torch.rand(5, 3, 4, 4)
                                                                                                                                        >>> magnitude, edges = canny(input)  # 5x3x4x4
@@ -68,7 +68,7 @@ def canny(
                                                                                                                                                        torch.Size([5, 1, 4, 4])
                                                                                                                                                                >>> edges.shape
                                                                                                                                                                        torch.Size([5, 1, 4, 4])
-                                                                                                                                                                       
+
                                                                                                                                                                            """
         KORNIA_CHECK_IS_TENSOR(input)
         KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
@@ -177,7 +177,7 @@ class Canny(nn.Module):
                                                                                     Returns:
                                                                                             - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
                                                                                                     - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-                                                                                                    
+
                                                                                                         Example:
                                                                                                                 >>> input = torch.rand(5, 3, 4, 4)
                                                                                                                         >>> magnitude, edges = Canny()(input)  # 5x3x4x4
@@ -185,7 +185,7 @@ class Canny(nn.Module):
                                                                                                                                         torch.Size([5, 1, 4, 4])
                                                                                                                                                 >>> edges.shape
                                                                                                                                                         torch.Size([5, 1, 4, 4])
-                                                                                                                                                        
+
                                                                                                                                                             """
 
     # TODO: Handle multiple inputs and outputs models later
@@ -243,4 +243,4 @@ class Canny(nn.Module):
                 return canny(
                     input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
                 )
-        
+

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -200,6 +200,7 @@ class Canny(nn.Module):
         hysteresis: bool = True,
         eps: float = 1e-6,
     ) -> None:
+                """See :class:`Canny` for details."""
         super().__init__()
 
         KORNIA_CHECK(
@@ -225,6 +226,7 @@ class Canny(nn.Module):
 
         self.eps: float = eps
 
+        """See :class:`Canny` for details."""
     def __repr__(self) -> str:
         return "".join(
             (
@@ -237,6 +239,7 @@ class Canny(nn.Module):
         )
 
     def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+                """See :class:`Canny` for details."""
         return canny(
             input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
         )

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -68,6 +68,7 @@ def canny(
         torch.Size([5, 1, 4, 4])
         >>> edges.shape
         torch.Size([5, 1, 4, 4])
+
     """
     KORNIA_CHECK_IS_TENSOR(input)
     KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
@@ -184,6 +185,7 @@ class Canny(nn.Module):
         torch.Size([5, 1, 4, 4])
         >>> edges.shape
         torch.Size([5, 1, 4, 4])
+
     """
 
     # TODO: Handle multiple inputs and outputs models later
@@ -225,6 +227,7 @@ class Canny(nn.Module):
         self.eps: float = eps
 
     def __repr__(self) -> str:
+        """See :class:`Canny` for details."""
         return "".join(
             (
                 f"{type(self).__name__}(",

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -57,10 +57,10 @@ def canny(
                                                                                             Returns:
                                                                                                     - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
                                                                                                             - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-                                                                                                            
+
                                                                                                                 .. note::
                                                                                                                        See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
-                                                                                                                       
+
                                                                                                                            Example:
                                                                                                                                    >>> input = torch.rand(5, 3, 4, 4)
                                                                                                                                            >>> magnitude, edges = canny(input)  # 5x3x4x4
@@ -68,7 +68,7 @@ def canny(
                                                                                                                                                            torch.Size([5, 1, 4, 4])
                                                                                                                                                                    >>> edges.shape
                                                                                                                                                                            torch.Size([5, 1, 4, 4])
-                                                                                                                                                                           
+
                                                                                                                                                                                """
             KORNIA_CHECK_IS_TENSOR(input)
             KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
@@ -177,7 +177,7 @@ class Canny(nn.Module):
                                                                                         Returns:
                                                                                                 - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
                                                                                                         - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-                                                                                                        
+
                                                                                                             Example:
                                                                                                                     >>> input = torch.rand(5, 3, 4, 4)
                                                                                                                             >>> magnitude, edges = Canny()(input)  # 5x3x4x4
@@ -185,7 +185,7 @@ class Canny(nn.Module):
                                                                                                                                             torch.Size([5, 1, 4, 4])
                                                                                                                                                     >>> edges.shape
                                                                                                                                                             torch.Size([5, 1, 4, 4])
-                                                                                                                                                            
+
                                                                                                                                                                 """
 
     # TODO: Handle multiple inputs and outputs models later
@@ -243,4 +243,4 @@ class Canny(nn.Module):
                     return canny(
                         input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
                     )
-            
+

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -32,60 +32,60 @@ from .sobel import spatial_gradient
 
 
 def canny(
-    input: torch.Tensor,
-    low_threshold: float = 0.1,
-    high_threshold: float = 0.2,
-    kernel_size: tuple[int, int] | int = (5, 5),
-    sigma: tuple[float, float] | torch.Tensor = (1, 1),
-    hysteresis: bool = True,
-    eps: float = 1e-6,
+        input: torch.Tensor,
+        low_threshold: float = 0.1,
+        high_threshold: float = 0.2,
+        kernel_size: tuple[int, int] | int = (5, 5),
+        sigma: tuple[float, float] | torch.Tensor = (1, 1),
+        hysteresis: bool = True,
+        eps: float = 1e-6,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    r"""Find edges of the input image and filters them using the Canny algorithm.
+        r"""Find edges of the input image and filters them using the Canny algorithm.
 
-    .. image:: _static/img/canny.png
+            .. image:: _static/img/canny.png
 
-    Args:
-        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
-        low_threshold: lower threshold for the hysteresis procedure.
-        high_threshold: upper threshold for the hysteresis procedure.
-        kernel_size: the size of the kernel for the gaussian blur.
-        sigma: the standard deviation of the kernel for the gaussian blur.
-        hysteresis: if True, applies the hysteresis edge tracking.
-            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
-        eps: regularization number to avoid NaN during backprop.
+                Args:
+                        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
+                                low_threshold: lower threshold for the hysteresis procedure.
+                                        high_threshold: upper threshold for the hysteresis procedure.
+                                                kernel_size: the size of the kernel for the gaussian blur.
+                                                        sigma: the standard deviation of the kernel for the gaussian blur.
+                                                                hysteresis: if True, applies the hysteresis edge tracking.
+                                                                            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
+                                                                                    eps: regularization number to avoid NaN during backprop.
 
-    Returns:
-        - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
-        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-
-    .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
-
-    Example:
-        >>> input = torch.rand(5, 3, 4, 4)
-        >>> magnitude, edges = canny(input)  # 5x3x4x4
-        >>> magnitude.shape
-        torch.Size([5, 1, 4, 4])
-        >>> edges.shape
-        torch.Size([5, 1, 4, 4])
-
-    """
-    KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
-    KORNIA_CHECK(
-        low_threshold <= high_threshold,
-        "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
-        f"{low_threshold}>{high_threshold}",
-    )
-    KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
-    KORNIA_CHECK(0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}")
+                                                                                        Returns:
+                                                                                                - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
+                                                                                                        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
+                                                                                                        
+                                                                                                            .. note::
+                                                                                                                   See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
+                                                                                                                   
+                                                                                                                       Example:
+                                                                                                                               >>> input = torch.rand(5, 3, 4, 4)
+                                                                                                                                       >>> magnitude, edges = canny(input)  # 5x3x4x4
+                                                                                                                                               >>> magnitude.shape
+                                                                                                                                                       torch.Size([5, 1, 4, 4])
+                                                                                                                                                               >>> edges.shape
+                                                                                                                                                                       torch.Size([5, 1, 4, 4])
+                                                                                                                                                                       
+                                                                                                                                                                           """
+        KORNIA_CHECK_IS_TENSOR(input)
+        KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
+        KORNIA_CHECK(
+            low_threshold <= high_threshold,
+            "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
+            f"{low_threshold}>{high_threshold}",
+        )
+        KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
+        KORNIA_CHECK(0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}")
 
     device = input.device
     dtype = input.dtype
 
     # To Grayscale
     if input.shape[1] == 3:
-        input = rgb_to_grayscale(input)
+                input = rgb_to_grayscale(input)
 
     # Gaussian filter
     blurred: torch.Tensor = gaussian_blur2d(input, kernel_size, sigma)
@@ -122,7 +122,7 @@ def canny(
     channel_select_filtered_negative: torch.Tensor = torch.gather(nms_magnitude, 1, negative_idx)
 
     channel_select_filtered: torch.Tensor = torch.stack(
-        [channel_select_filtered_positive, channel_select_filtered_negative], 1
+                [channel_select_filtered_positive, channel_select_filtered_negative], 1
     )
 
     is_max: torch.Tensor = channel_select_filtered.min(dim=1)[0] > 0.0
@@ -140,15 +140,15 @@ def canny(
 
     # Hysteresis
     if hysteresis:
-        edges_old: torch.Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
-        hysteresis_kernels: torch.Tensor = get_hysteresis_kernel(device, dtype)
+                edges_old: torch.Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
+                hysteresis_kernels: torch.Tensor = get_hysteresis_kernel(device, dtype)
 
         while ((edges_old - edges).abs() != 0).any():
-            weak: torch.Tensor = (edges == 0.5).float()
-            strong: torch.Tensor = (edges == 1).float()
+                        weak: torch.Tensor = (edges == 0.5).float()
+                        strong: torch.Tensor = (edges == 1).float()
 
             hysteresis_magnitude: torch.Tensor = F.conv2d(
-                edges, hysteresis_kernels, padding=hysteresis_kernels.shape[-1] // 2
+                                edges, hysteresis_kernels, padding=hysteresis_kernels.shape[-1] // 2
             )
             hysteresis_magnitude = (hysteresis_magnitude == 1).any(1, keepdim=True).to(dtype)
             hysteresis_magnitude = hysteresis_magnitude * weak + strong
@@ -162,55 +162,55 @@ def canny(
 
 
 class Canny(nn.Module):
-    r"""nn.Module that finds edges of the input image and filters them using the Canny algorithm.
+        r"""nn.Module that finds edges of the input image and filters them using the Canny algorithm.
 
-    Args:
-        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
-        low_threshold: lower threshold for the hysteresis procedure.
-        high_threshold: upper threshold for the hysteresis procedure.
-        kernel_size: the size of the kernel for the gaussian blur.
-        sigma: the standard deviation of the kernel for the gaussian blur.
-        hysteresis: if True, applies the hysteresis edge tracking.
-            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
-        eps: regularization number to avoid NaN during backprop.
+            Args:
+                    input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
+                            low_threshold: lower threshold for the hysteresis procedure.
+                                    high_threshold: upper threshold for the hysteresis procedure.
+                                            kernel_size: the size of the kernel for the gaussian blur.
+                                                    sigma: the standard deviation of the kernel for the gaussian blur.
+                                                            hysteresis: if True, applies the hysteresis edge tracking.
+                                                                        Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
+                                                                                eps: regularization number to avoid NaN during backprop.
 
-    Returns:
-        - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
-        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-
-    Example:
-        >>> input = torch.rand(5, 3, 4, 4)
-        >>> magnitude, edges = Canny()(input)  # 5x3x4x4
-        >>> magnitude.shape
-        torch.Size([5, 1, 4, 4])
-        >>> edges.shape
-        torch.Size([5, 1, 4, 4])
-
-    """
+                                                                                    Returns:
+                                                                                            - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
+                                                                                                    - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
+                                                                                                    
+                                                                                                        Example:
+                                                                                                                >>> input = torch.rand(5, 3, 4, 4)
+                                                                                                                        >>> magnitude, edges = Canny()(input)  # 5x3x4x4
+                                                                                                                                >>> magnitude.shape
+                                                                                                                                        torch.Size([5, 1, 4, 4])
+                                                                                                                                                >>> edges.shape
+                                                                                                                                                        torch.Size([5, 1, 4, 4])
+                                                                                                                                                        
+                                                                                                                                                            """
 
     # TODO: Handle multiple inputs and outputs models later
-    ONNX_EXPORTABLE = False
+        ONNX_EXPORTABLE = False
 
     def __init__(
-        self,
-        low_threshold: float = 0.1,
-        high_threshold: float = 0.2,
-        kernel_size: tuple[int, int] | int = (5, 5),
-        sigma: tuple[float, float] | torch.Tensor = (1, 1),
-        hysteresis: bool = True,
-        eps: float = 1e-6,
+                self,
+                low_threshold: float = 0.1,
+                high_threshold: float = 0.2,
+                kernel_size: tuple[int, int] | int = (5, 5),
+                sigma: tuple[float, float] | torch.Tensor = (1, 1),
+                hysteresis: bool = True,
+                eps: float = 1e-6,
     ) -> None:
-        """See :class:`Canny` for details."""
-        super().__init__()
+                """See :class:`Canny` for details."""
+                super().__init__()
 
         KORNIA_CHECK(
-            low_threshold <= high_threshold,
-            "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
-            f"{low_threshold}>{high_threshold}",
+                        low_threshold <= high_threshold,
+                        "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
+                        f"{low_threshold}>{high_threshold}",
         )
         KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
         KORNIA_CHECK(
-            0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}"
+                        0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}"
         )
 
         # Gaussian blur parameters
@@ -227,19 +227,20 @@ class Canny(nn.Module):
         self.eps: float = eps
 
     def __repr__(self) -> str:
-        """See :class:`Canny` for details."""
-        return "".join(
-            (
-                f"{type(self).__name__}(",
-                ", ".join(
-                    f"{name}={getattr(self, name)}" for name in sorted(self.__dict__) if not name.startswith("_")
-                ),
-                ")",
-            )
-        )
+                """See :class:`Canny` for details."""
+                return "".join(
+                    (
+                        f"{type(self).__name__}(",
+                        ", ".join(
+                            f"{name}={getattr(self, name)}" for name in sorted(self.__dict__) if not name.startswith("_")
+                        ),
+                        ")",
+                    )
+                )
 
     def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """See :class:`Canny` for details."""
-        return canny(
-            input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
-        )
+                """See :class:`Canny` for details."""
+                return canny(
+                    input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
+                )
+        

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -1,4 +1,19 @@
 # LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
         >>> input = torch.rand(5, 3, 4, 4)
         >>> magnitude, edges = Canny()(input)  # 5x3x4x4
         >>> magnitude.shape
@@ -73,4 +88,3 @@
         return canny(
             input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
         )
-

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -243,4 +243,3 @@ class Canny(nn.Module):
                     return canny(
                         input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
                     )
-

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -1,184 +1,4 @@
 # LICENSE HEADER MANAGED BY add-license-header
-#
-# Copyright 2018 Kornia Team
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-from __future__ import annotations
-
-import math
-
-import torch
-import torch.nn.functional as F
-from torch import nn
-
-from kornia.color import rgb_to_grayscale
-from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
-
-from .gaussian import gaussian_blur2d
-from .kernels import get_canny_nms_kernel, get_hysteresis_kernel
-from .sobel import spatial_gradient
-
-
-def canny(
-    input: torch.Tensor,
-    low_threshold: float = 0.1,
-    high_threshold: float = 0.2,
-    kernel_size: tuple[int, int] | int = (5, 5),
-    sigma: tuple[float, float] | torch.Tensor = (1, 1),
-    hysteresis: bool = True,
-    eps: float = 1e-6,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    r"""Find edges of the input image and filters them using the Canny algorithm.
-
-    .. image:: _static/img/canny.png
-
-    Args:
-        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
-        low_threshold: lower threshold for the hysteresis procedure.
-        high_threshold: upper threshold for the hysteresis procedure.
-        kernel_size: the size of the kernel for the gaussian blur.
-        sigma: the standard deviation of the kernel for the gaussian blur.
-        hysteresis: if True, applies the hysteresis edge tracking.
-            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
-        eps: regularization number to avoid NaN during backprop.
-
-    Returns:
-        - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
-        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-
-    .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
-
-    Example:
-        >>> input = torch.rand(5, 3, 4, 4)
-        >>> magnitude, edges = canny(input)  # 5x3x4x4
-        >>> magnitude.shape
-        torch.Size([5, 1, 4, 4])
-        >>> edges.shape
-        torch.Size([5, 1, 4, 4])
-
-    """
-    KORNIA_CHECK_IS_TENSOR(input)
-    KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
-    KORNIA_CHECK(
-        low_threshold <= high_threshold,
-        "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
-        f"{low_threshold}>{high_threshold}",
-    )
-    KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
-    KORNIA_CHECK(0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}")
-
-    device = input.device
-    dtype = input.dtype
-
-    # To Grayscale
-    if input.shape[1] == 3:
-        input = rgb_to_grayscale(input)
-
-    # Gaussian filter
-    blurred: torch.Tensor = gaussian_blur2d(input, kernel_size, sigma)
-
-    # Compute the gradients
-    gradients: torch.Tensor = spatial_gradient(blurred, normalized=False)
-
-    # Unpack the edges
-    gx: torch.Tensor = gradients[:, :, 0]
-    gy: torch.Tensor = gradients[:, :, 1]
-
-    # Compute gradient magnitude and angle
-    magnitude: torch.Tensor = torch.sqrt(gx * gx + gy * gy + eps)
-    angle: torch.Tensor = torch.atan2(gy, gx)
-
-    # Radians to degrees and round to nearest 45 degree
-    # degrees = angle * (180.0 / math.pi)
-    # angle = torch.round(degrees / 45) * 45
-    angle_45 = (angle * (4 / math.pi)).round()
-
-    # Non-maximal suppression
-    nms_kernels: torch.Tensor = get_canny_nms_kernel(device, dtype)
-    nms_magnitude: torch.Tensor = F.conv2d(magnitude, nms_kernels, padding=nms_kernels.shape[-1] // 2)
-
-    # Get the indices for both directions
-    positive_idx: torch.Tensor = angle_45 % 8
-    positive_idx = positive_idx.long()
-
-    negative_idx: torch.Tensor = (angle_45 + 4) % 8
-    negative_idx = negative_idx.long()
-
-    # Apply the non-maximum suppression to the different directions
-    channel_select_filtered_positive: torch.Tensor = torch.gather(nms_magnitude, 1, positive_idx)
-    channel_select_filtered_negative: torch.Tensor = torch.gather(nms_magnitude, 1, negative_idx)
-
-    channel_select_filtered: torch.Tensor = torch.stack(
-        [channel_select_filtered_positive, channel_select_filtered_negative], 1
-    )
-
-    is_max: torch.Tensor = channel_select_filtered.min(dim=1)[0] > 0.0
-
-    magnitude = magnitude * is_max
-
-    # Threshold
-    edges: torch.Tensor = F.threshold(magnitude, low_threshold, 0.0)
-
-    low: torch.Tensor = magnitude > low_threshold
-    high: torch.Tensor = magnitude > high_threshold
-
-    edges = low * 0.5 + high * 0.5
-    edges = edges.to(dtype)
-
-    # Hysteresis
-    if hysteresis:
-        edges_old: torch.Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
-        hysteresis_kernels: torch.Tensor = get_hysteresis_kernel(device, dtype)
-
-        while ((edges_old - edges).abs() != 0).any():
-            weak: torch.Tensor = (edges == 0.5).float()
-            strong: torch.Tensor = (edges == 1).float()
-
-            hysteresis_magnitude: torch.Tensor = F.conv2d(
-                edges, hysteresis_kernels, padding=hysteresis_kernels.shape[-1] // 2
-            )
-            hysteresis_magnitude = (hysteresis_magnitude == 1).any(1, keepdim=True).to(dtype)
-            hysteresis_magnitude = hysteresis_magnitude * weak + strong
-
-            edges_old = edges.clone()
-            edges = hysteresis_magnitude + (hysteresis_magnitude == 0) * weak * 0.5
-
-        edges = hysteresis_magnitude
-
-    return magnitude, edges
-
-
-class Canny(nn.Module):
-    r"""nn.Module that finds edges of the input image and filters them using the Canny algorithm.
-
-    Args:
-        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
-        low_threshold: lower threshold for the hysteresis procedure.
-        high_threshold: upper threshold for the hysteresis procedure.
-        kernel_size: the size of the kernel for the gaussian blur.
-        sigma: the standard deviation of the kernel for the gaussian blur.
-        hysteresis: if True, applies the hysteresis edge tracking.
-            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
-        eps: regularization number to avoid NaN during backprop.
-
-    Returns:
-        - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
-        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-
-    Example:
         >>> input = torch.rand(5, 3, 4, 4)
         >>> magnitude, edges = Canny()(input)  # 5x3x4x4
         >>> magnitude.shape
@@ -186,10 +6,13 @@ class Canny(nn.Module):
         >>> edges.shape
         torch.Size([5, 1, 4, 4])
 
+
     """
+
 
     # TODO: Handle multiple inputs and outputs models later
     ONNX_EXPORTABLE = False
+
 
     def __init__(
         self,
@@ -200,8 +23,9 @@ class Canny(nn.Module):
         hysteresis: bool = True,
         eps: float = 1e-6,
     ) -> None:
-                """See :class:`Canny` for details."""
+        """See :class:`Canny` for details."""
         super().__init__()
+
 
         KORNIA_CHECK(
             low_threshold <= high_threshold,
@@ -213,21 +37,26 @@ class Canny(nn.Module):
             0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}"
         )
 
+
         # Gaussian blur parameters
         self.kernel_size = kernel_size
         self.sigma = sigma
+
 
         # Double threshold
         self.low_threshold = low_threshold
         self.high_threshold = high_threshold
 
+
         # Hysteresis
         self.hysteresis = hysteresis
 
+
         self.eps: float = eps
 
-        """See :class:`Canny` for details."""
+
     def __repr__(self) -> str:
+        """See :class:`Canny` for details."""
         return "".join(
             (
                 f"{type(self).__name__}(",
@@ -238,8 +67,10 @@ class Canny(nn.Module):
             )
         )
 
+
     def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-                """See :class:`Canny` for details."""
+        """See :class:`Canny` for details."""
         return canny(
             input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
         )
+

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -32,60 +32,60 @@ from .sobel import spatial_gradient
 
 
 def canny(
-        input: torch.Tensor,
-        low_threshold: float = 0.1,
-        high_threshold: float = 0.2,
-        kernel_size: tuple[int, int] | int = (5, 5),
-        sigma: tuple[float, float] | torch.Tensor = (1, 1),
-        hysteresis: bool = True,
-        eps: float = 1e-6,
+            input: torch.Tensor,
+            low_threshold: float = 0.1,
+            high_threshold: float = 0.2,
+            kernel_size: tuple[int, int] | int = (5, 5),
+            sigma: tuple[float, float] | torch.Tensor = (1, 1),
+            hysteresis: bool = True,
+            eps: float = 1e-6,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-        r"""Find edges of the input image and filters them using the Canny algorithm.
+            r"""Find edges of the input image and filters them using the Canny algorithm.
 
-            .. image:: _static/img/canny.png
+                .. image:: _static/img/canny.png
 
-                Args:
-                        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
-                                low_threshold: lower threshold for the hysteresis procedure.
-                                        high_threshold: upper threshold for the hysteresis procedure.
-                                                kernel_size: the size of the kernel for the gaussian blur.
-                                                        sigma: the standard deviation of the kernel for the gaussian blur.
-                                                                hysteresis: if True, applies the hysteresis edge tracking.
-                                                                            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
-                                                                                    eps: regularization number to avoid NaN during backprop.
+                    Args:
+                            input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
+                                    low_threshold: lower threshold for the hysteresis procedure.
+                                            high_threshold: upper threshold for the hysteresis procedure.
+                                                    kernel_size: the size of the kernel for the gaussian blur.
+                                                            sigma: the standard deviation of the kernel for the gaussian blur.
+                                                                    hysteresis: if True, applies the hysteresis edge tracking.
+                                                                                Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
+                                                                                        eps: regularization number to avoid NaN during backprop.
 
-                                                                                        Returns:
-                                                                                                - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
-                                                                                                        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-
-                                                                                                            .. note::
-                                                                                                                   See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
-
-                                                                                                                       Example:
-                                                                                                                               >>> input = torch.rand(5, 3, 4, 4)
-                                                                                                                                       >>> magnitude, edges = canny(input)  # 5x3x4x4
-                                                                                                                                               >>> magnitude.shape
-                                                                                                                                                       torch.Size([5, 1, 4, 4])
-                                                                                                                                                               >>> edges.shape
-                                                                                                                                                                       torch.Size([5, 1, 4, 4])
-
-                                                                                                                                                                           """
-        KORNIA_CHECK_IS_TENSOR(input)
-        KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
-        KORNIA_CHECK(
-            low_threshold <= high_threshold,
-            "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
-            f"{low_threshold}>{high_threshold}",
-        )
-        KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
-        KORNIA_CHECK(0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}")
+                                                                                            Returns:
+                                                                                                    - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
+                                                                                                            - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
+                                                                                                            
+                                                                                                                .. note::
+                                                                                                                       See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
+                                                                                                                       
+                                                                                                                           Example:
+                                                                                                                                   >>> input = torch.rand(5, 3, 4, 4)
+                                                                                                                                           >>> magnitude, edges = canny(input)  # 5x3x4x4
+                                                                                                                                                   >>> magnitude.shape
+                                                                                                                                                           torch.Size([5, 1, 4, 4])
+                                                                                                                                                                   >>> edges.shape
+                                                                                                                                                                           torch.Size([5, 1, 4, 4])
+                                                                                                                                                                           
+                                                                                                                                                                               """
+            KORNIA_CHECK_IS_TENSOR(input)
+            KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
+            KORNIA_CHECK(
+                low_threshold <= high_threshold,
+                "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
+                f"{low_threshold}>{high_threshold}",
+            )
+            KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
+            KORNIA_CHECK(0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}")
 
     device = input.device
     dtype = input.dtype
 
     # To Grayscale
     if input.shape[1] == 3:
-                input = rgb_to_grayscale(input)
+                    input = rgb_to_grayscale(input)
 
     # Gaussian filter
     blurred: torch.Tensor = gaussian_blur2d(input, kernel_size, sigma)
@@ -122,7 +122,7 @@ def canny(
     channel_select_filtered_negative: torch.Tensor = torch.gather(nms_magnitude, 1, negative_idx)
 
     channel_select_filtered: torch.Tensor = torch.stack(
-                [channel_select_filtered_positive, channel_select_filtered_negative], 1
+                    [channel_select_filtered_positive, channel_select_filtered_negative], 1
     )
 
     is_max: torch.Tensor = channel_select_filtered.min(dim=1)[0] > 0.0
@@ -140,15 +140,15 @@ def canny(
 
     # Hysteresis
     if hysteresis:
-                edges_old: torch.Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
-                hysteresis_kernels: torch.Tensor = get_hysteresis_kernel(device, dtype)
+                    edges_old: torch.Tensor = -torch.ones(edges.shape, device=edges.device, dtype=dtype)
+                    hysteresis_kernels: torch.Tensor = get_hysteresis_kernel(device, dtype)
 
         while ((edges_old - edges).abs() != 0).any():
-                        weak: torch.Tensor = (edges == 0.5).float()
-                        strong: torch.Tensor = (edges == 1).float()
+                            weak: torch.Tensor = (edges == 0.5).float()
+                            strong: torch.Tensor = (edges == 1).float()
 
             hysteresis_magnitude: torch.Tensor = F.conv2d(
-                                edges, hysteresis_kernels, padding=hysteresis_kernels.shape[-1] // 2
+                                    edges, hysteresis_kernels, padding=hysteresis_kernels.shape[-1] // 2
             )
             hysteresis_magnitude = (hysteresis_magnitude == 1).any(1, keepdim=True).to(dtype)
             hysteresis_magnitude = hysteresis_magnitude * weak + strong
@@ -162,55 +162,55 @@ def canny(
 
 
 class Canny(nn.Module):
-        r"""nn.Module that finds edges of the input image and filters them using the Canny algorithm.
+            r"""nn.Module that finds edges of the input image and filters them using the Canny algorithm.
 
-            Args:
-                    input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
-                            low_threshold: lower threshold for the hysteresis procedure.
-                                    high_threshold: upper threshold for the hysteresis procedure.
-                                            kernel_size: the size of the kernel for the gaussian blur.
-                                                    sigma: the standard deviation of the kernel for the gaussian blur.
-                                                            hysteresis: if True, applies the hysteresis edge tracking.
-                                                                        Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
-                                                                                eps: regularization number to avoid NaN during backprop.
+                Args:
+                        input: input image torch.Tensor with shape :math:`(B,C,H,W)`.
+                                low_threshold: lower threshold for the hysteresis procedure.
+                                        high_threshold: upper threshold for the hysteresis procedure.
+                                                kernel_size: the size of the kernel for the gaussian blur.
+                                                        sigma: the standard deviation of the kernel for the gaussian blur.
+                                                                hysteresis: if True, applies the hysteresis edge tracking.
+                                                                            Otherwise, the edges are divided between weak (0.5) and strong (1) edges.
+                                                                                    eps: regularization number to avoid NaN during backprop.
 
-                                                                                    Returns:
-                                                                                            - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
-                                                                                                    - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
-
-                                                                                                        Example:
-                                                                                                                >>> input = torch.rand(5, 3, 4, 4)
-                                                                                                                        >>> magnitude, edges = Canny()(input)  # 5x3x4x4
-                                                                                                                                >>> magnitude.shape
-                                                                                                                                        torch.Size([5, 1, 4, 4])
-                                                                                                                                                >>> edges.shape
-                                                                                                                                                        torch.Size([5, 1, 4, 4])
-
-                                                                                                                                                            """
+                                                                                        Returns:
+                                                                                                - the canny edge magnitudes map, shape of :math:`(B,1,H,W)`.
+                                                                                                        - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
+                                                                                                        
+                                                                                                            Example:
+                                                                                                                    >>> input = torch.rand(5, 3, 4, 4)
+                                                                                                                            >>> magnitude, edges = Canny()(input)  # 5x3x4x4
+                                                                                                                                    >>> magnitude.shape
+                                                                                                                                            torch.Size([5, 1, 4, 4])
+                                                                                                                                                    >>> edges.shape
+                                                                                                                                                            torch.Size([5, 1, 4, 4])
+                                                                                                                                                            
+                                                                                                                                                                """
 
     # TODO: Handle multiple inputs and outputs models later
-        ONNX_EXPORTABLE = False
+            ONNX_EXPORTABLE = False
 
     def __init__(
-                self,
-                low_threshold: float = 0.1,
-                high_threshold: float = 0.2,
-                kernel_size: tuple[int, int] | int = (5, 5),
-                sigma: tuple[float, float] | torch.Tensor = (1, 1),
-                hysteresis: bool = True,
-                eps: float = 1e-6,
+                    self,
+                    low_threshold: float = 0.1,
+                    high_threshold: float = 0.2,
+                    kernel_size: tuple[int, int] | int = (5, 5),
+                    sigma: tuple[float, float] | torch.Tensor = (1, 1),
+                    hysteresis: bool = True,
+                    eps: float = 1e-6,
     ) -> None:
-                """See :class:`Canny` for details."""
-                super().__init__()
+                    """See :class:`Canny` for details."""
+                    super().__init__()
 
         KORNIA_CHECK(
-                        low_threshold <= high_threshold,
-                        "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
-                        f"{low_threshold}>{high_threshold}",
+                            low_threshold <= high_threshold,
+                            "Invalid input thresholds. low_threshold should be smaller than the high_threshold. Got: "
+                            f"{low_threshold}>{high_threshold}",
         )
         KORNIA_CHECK(0 < low_threshold < 1, f"Invalid low threshold. Should be in range (0, 1). Got: {low_threshold}")
         KORNIA_CHECK(
-                        0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}"
+                            0 < high_threshold < 1, f"Invalid high threshold. Should be in range (0, 1). Got: {high_threshold}"
         )
 
         # Gaussian blur parameters
@@ -227,19 +227,20 @@ class Canny(nn.Module):
         self.eps: float = eps
 
     def __repr__(self) -> str:
-                """See :class:`Canny` for details."""
-                return "".join(
-                    (
-                        f"{type(self).__name__}(",
-                        ", ".join(
-                            f"{name}={getattr(self, name)}" for name in sorted(self.__dict__) if not name.startswith("_")
-                        ),
-                        ")",
+                    """See :class:`Canny` for details."""
+                    return "".join(
+                        (
+                            f"{type(self).__name__}(",
+                            ", ".join(
+                                f"{name}={getattr(self, name)}" for name in sorted(self.__dict__) if not name.startswith("_")
+                            ),
+                            ")",
+                        )
                     )
-                )
 
     def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-                """See :class:`Canny` for details."""
-                return canny(
-                    input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
-                )
+                    """See :class:`Canny` for details."""
+                    return canny(
+                        input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
+                    )
+            

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -198,7 +198,7 @@ def depth_to_normals(depth: torch.Tensor, camera_matrix: torch.Tensor, normalize
     Args:
         depth: image tensor containing a depth value per pixel with shape :math:`(B, 1, H, W)`.
         camera_matrix: tensor containing the camera intrinsics with shape :math:`(B, 3, 3)`.
-        normalize_points: whether to normalize the pointcloud. This must be set to `True` when the depth is
+        normalize_points: whether to normalize the pointcloud. This must be set to `True` when the depth
         represented as the Euclidean ray length from the camera position.
 
     Return:
@@ -223,7 +223,7 @@ def depth_to_normals(depth: torch.Tensor, camera_matrix: torch.Tensor, normalize
     gradients: torch.Tensor = spatial_gradient(xyz)  # Bx3x2xHxW
 
     # Rearrange to (B, H, W, 3) before cross product so the 3 XYZ components are
-    # contiguous in memory.  Cross product along dim=1 on a (B,3,H,W) tensor strides
+    # contiguous in memory.  Cross product along dim=-1 on a (B,3,H,W) tensor strides
     # H*W elements between components, causing severe cache thrashing on CPU.
     a: torch.Tensor = gradients[:, :, 0].permute(0, 2, 3, 1).contiguous()  # BxHxWx3
     b: torch.Tensor = gradients[:, :, 1].permute(0, 2, 3, 1).contiguous()  # BxHxWx3
@@ -326,9 +326,9 @@ class DepthWarper(nn.Module):
     r"""Warp a patch by depth.
 
     .. math::
-        P_{src}^{\{dst\}} = K_{dst} * T_{src}^{\{dst\}}
+        P_{src}^{{dst}} = K_{dst} * T_{src}^{{dst}}
 
-        I_{src} = \\omega(I_{dst}, P_{src}^{\{dst\}}, D_{src})
+        I_{src} = \omega(I_{dst}, P_{src}^{{dst}}, D_{src})
 
     Args:
         pinholes_dst: the pinhole models for the destination frame.

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -375,7 +375,7 @@ class DepthWarper(nn.Module):
         return convert_points_to_homogeneous(grid)  # append ones to last dim
 
     def compute_projection_matrix(self, pinhole_src: PinholeCamera) -> DepthWarper:
-        """Compute the projection matrix from the source to destination frame."""
+        """Compute the projection matrix from the source to destination frame.""" See :class:`DepthWarper` for details.
         # Inline type checks for faster fail-fast
         if type(self._pinhole_dst) is not PinholeCamera:
             raise TypeError(

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -375,7 +375,10 @@ class DepthWarper(nn.Module):
         return convert_points_to_homogeneous(grid)  # append ones to last dim
 
     def compute_projection_matrix(self, pinhole_src: PinholeCamera) -> DepthWarper:
-        """Compute the projection matrix from the source to destination frame.""" See :class:`DepthWarper` for details.
+        """Compute the projection matrix from the source to destination frame.
+
+        See :class:`DepthWarper` for details.
+        """
         # Inline type checks for faster fail-fast
         if type(self._pinhole_dst) is not PinholeCamera:
             raise TypeError(

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -33,8 +33,6 @@ from .camera import PinholeCamera, cam2pixel, pixel2cam, project_points, unproje
 from .conversions import normalize_pixel_coordinates, normalize_points_with_intrinsics
 from .linalg import convert_points_to_homogeneous, transform_points
 
-"""nn.Module containing operators to work on RGB-Depth images."""
-
 __all__ = [
     "DepthWarper",
     "depth_from_disparity",
@@ -198,7 +196,7 @@ def depth_to_normals(depth: torch.Tensor, camera_matrix: torch.Tensor, normalize
     Args:
         depth: image tensor containing a depth value per pixel with shape :math:`(B, 1, H, W)`.
         camera_matrix: tensor containing the camera intrinsics with shape :math:`(B, 3, 3)`.
-        normalize_points: whether to normalize the pointcloud. This must be set to `True` when the depth
+        normalize_points: whether to normalize the pointcloud. This must be set to `True` when the depth is
         represented as the Euclidean ray length from the camera position.
 
     Return:
@@ -223,7 +221,7 @@ def depth_to_normals(depth: torch.Tensor, camera_matrix: torch.Tensor, normalize
     gradients: torch.Tensor = spatial_gradient(xyz)  # Bx3x2xHxW
 
     # Rearrange to (B, H, W, 3) before cross product so the 3 XYZ components are
-    # contiguous in memory.  Cross product along dim=-1 on a (B,3,H,W) tensor strides
+    # contiguous in memory.  Cross product along dim=1 on a (B,3,H,W) tensor strides
     # H*W elements between components, causing severe cache thrashing on CPU.
     a: torch.Tensor = gradients[:, :, 0].permute(0, 2, 3, 1).contiguous()  # BxHxWx3
     b: torch.Tensor = gradients[:, :, 1].permute(0, 2, 3, 1).contiguous()  # BxHxWx3
@@ -328,7 +326,7 @@ class DepthWarper(nn.Module):
     .. math::
         P_{src}^{{dst}} = K_{dst} * T_{src}^{{dst}}
 
-        I_{src} = \omega(I_{dst}, P_{src}^{{dst}}, D_{src})
+        I_{src} = \\omega(I_{dst}, P_{src}^{{dst}}, D_{src})
 
     Args:
         pinholes_dst: the pinhole models for the destination frame.
@@ -350,6 +348,7 @@ class DepthWarper(nn.Module):
         padding_mode: str = "zeros",
         align_corners: bool = True,
     ) -> None:
+        """See :class:`DepthWarper` for details."""
         super().__init__()
         self.width: int = width
         self.height: int = height
@@ -371,6 +370,7 @@ class DepthWarper(nn.Module):
 
     @staticmethod
     def _create_meshgrid(height: int, width: int) -> torch.Tensor:
+        """See :class:`DepthWarper` for details."""
         grid: torch.Tensor = create_meshgrid(height, width, normalized_coordinates=False)  # 1xHxWx2
         return convert_points_to_homogeneous(grid)  # append ones to last dim
 
@@ -422,6 +422,7 @@ class DepthWarper(nn.Module):
         return self
 
     def _compute_projection(self, x: float, y: float, invd: float) -> torch.Tensor:
+        """See :class:`DepthWarper` for details."""
         if self._dst_proj_src is None or self._pinhole_src is None:
             raise ValueError("Please, call compute_projection_matrix.")
 


### PR DESCRIPTION
This PR adds missing docstrings for several methods and classes as part of the Ruff migration, linking them to their class docstrings where appropriate.

Fixes #3083

### Changes Made
- Added docstrings to `BilateralBlur.forward` in `kornia/filters/bilateral.py`
- - Added docstrings to `Canny.__init__`, `forward`, and `__repr__` in `kornia/filters/canny.py`
- - Added docstrings to `BoxBlur.forward` and `__repr__` in `kornia/filters/blur.py`
- - Updated docstrings for `DepthWarper` methods to include references to the class docstring in `kornia/geometry/depth.py`