### PR TITLE
feat(augmentation): add crop_if_exceeds parameter to PadTo

### DIFF
--- a/kornia/augmentation/_2d/geometric/pad.py
+++ b/kornia/augmentation/_2d/geometric/pad.py
@@ -34,6 +34,9 @@ class PadTo(GeometricAugmentationBase2D):
         pad_mode: the type of padding to perform on the image (valid values
             are those accepted by torch.nn.functional.pad)
         pad_value: fill value for 'constant' padding applied to the image
+        crop_if_exceeds: if True, crops the input when it exceeds the target size
+            (original behavior). If False, dimensions that exceed the target size
+            are left unchanged.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
 
@@ -64,10 +67,15 @@ class PadTo(GeometricAugmentationBase2D):
     """
 
     def __init__(
-        self, size: Tuple[int, int], pad_mode: str = "constant", pad_value: float = 0, keepdim: bool = False
+        self,
+        size: Tuple[int, int],
+        pad_mode: str = "constant",
+        pad_value: float = 0,
+        crop_if_exceeds: bool = True,
+        keepdim: bool = False,
     ) -> None:
         super().__init__(p=1.0, same_on_batch=True, p_batch=1.0, keepdim=keepdim)
-        self.flags = {"size": size, "pad_mode": pad_mode, "pad_value": pad_value}
+        self.flags = {"size": size, "pad_mode": pad_mode, "pad_value": pad_value, "crop_if_exceeds": crop_if_exceeds}
 
     # TODO: It is incorrect to return identity
     # TODO: Having a resampled version with ``warp_affine``
@@ -80,6 +88,9 @@ class PadTo(GeometricAugmentationBase2D):
         _, _, height, width = input.shape
         height_pad: int = flags["size"][0] - height
         width_pad: int = flags["size"][1] - width
+        if not flags["crop_if_exceeds"]:
+            height_pad = max(height_pad, 0)
+            width_pad = max(width_pad, 0)
         return torch.nn.functional.pad(
             input, [0, width_pad, 0, height_pad], mode=flags["pad_mode"], value=flags["pad_value"]
         )

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -4607,6 +4607,27 @@ class TestPadTo(BaseTester):
         assert out.shape == (1, 1, 4, 5)
         self.assert_close(aug.inverse(out), img)
 
+    def test_crop_if_exceeds_true(self, device, dtype):
+        # Default behavior: crops when input exceeds target size
+        img = torch.rand(1, 1, 6, 8, device=device, dtype=dtype)
+        aug = PadTo(size=(4, 5), crop_if_exceeds=True)
+        out = aug(img)
+        assert out.shape == (1, 1, 4, 5)
+
+    def test_crop_if_exceeds_false(self, device, dtype):
+        # When crop_if_exceeds=False, dimensions that exceed target are unchanged
+        img = torch.rand(1, 1, 6, 8, device=device, dtype=dtype)
+        aug = PadTo(size=(4, 5), crop_if_exceeds=False)
+        out = aug(img)
+        assert out.shape == (1, 1, 6, 8)
+
+    def test_crop_if_exceeds_false_mixed(self, device, dtype):
+        # One dimension needs padding, the other exceeds
+        img = torch.rand(1, 1, 2, 8, device=device, dtype=dtype)
+        aug = PadTo(size=(4, 5), crop_if_exceeds=False)
+        out = aug(img)
+        assert out.shape == (1, 1, 4, 8)
+
 
 class TestResize:
     def test_smoke(self, device, dtype):


### PR DESCRIPTION
Add a `crop_if_exceeds` parameter to `PadTo` that controls whether inputs larger than the target size are cropped. When set to False, dimensions that exceed the target size are left unchanged, and only smaller dimensions are padded.

This addresses the confusing behavior where PadTo silently crops images that exceed the target size, which is unexpected given the class name implies padding only.

- Default: crop_if_exceeds=True (preserves backward compatibility)
- When False: only pads, never crops
- Added tests for crop_if_exceeds in both True/False modes

Ref: #3518

## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request) for details.

**Fixes/Relates to:** # (issue number)

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [ ] Item 1
- [ ] Item 2

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** (List new/updated tests)
- [ ] **Manual Verification:** (Describe the steps you took)
- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [ ] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [ ] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
