### PR TITLE
feat(augmentation): add keyword-only crop_if_exceeds parameter to PadTo

### DIFF
--- a/kornia/augmentation/_2d/geometric/pad.py
+++ b/kornia/augmentation/_2d/geometric/pad.py
@@ -36,6 +36,9 @@ class PadTo(GeometricAugmentationBase2D):
         pad_value: fill value for 'constant' padding applied to the image
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
+        crop_if_exceeds: if True (default), inputs larger than ``size`` will be cropped
+            to fit. If False, dimensions that already exceed ``size`` are left unchanged
+            and only smaller dimensions are padded.
 
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
@@ -43,6 +46,10 @@ class PadTo(GeometricAugmentationBase2D):
 
     .. note::
         This function internally uses :func:`torch.nn.functional.pad`.
+
+    .. note::
+        When ``crop_if_exceeds=True`` (the default), inputs larger than ``size`` will be
+        cropped. Set ``crop_if_exceeds=False`` if you want padding-only behavior.
 
     Examples:
         >>> import torch
@@ -64,10 +71,16 @@ class PadTo(GeometricAugmentationBase2D):
     """
 
     def __init__(
-        self, size: Tuple[int, int], pad_mode: str = "constant", pad_value: float = 0, keepdim: bool = False
+        self,
+        size: Tuple[int, int],
+        pad_mode: str = "constant",
+        pad_value: float = 0,
+        keepdim: bool = False,
+        *,
+        crop_if_exceeds: bool = True,
     ) -> None:
         super().__init__(p=1.0, same_on_batch=True, p_batch=1.0, keepdim=keepdim)
-        self.flags = {"size": size, "pad_mode": pad_mode, "pad_value": pad_value}
+        self.flags = {"size": size, "pad_mode": pad_mode, "pad_value": pad_value, "crop_if_exceeds": crop_if_exceeds}
 
     # TODO: It is incorrect to return identity
     # TODO: Having a resampled version with ``warp_affine``
@@ -80,6 +93,11 @@ class PadTo(GeometricAugmentationBase2D):
         _, _, height, width = input.shape
         height_pad: int = flags["size"][0] - height
         width_pad: int = flags["size"][1] - width
+
+        if not flags["crop_if_exceeds"]:
+            height_pad = max(height_pad, 0)
+            width_pad = max(width_pad, 0)
+
         return torch.nn.functional.pad(
             input, [0, width_pad, 0, height_pad], mode=flags["pad_mode"], value=flags["pad_value"]
         )

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5326,3 +5326,45 @@ class TestRandomThinPlateSpline(CommonTests):
             return aug(x, params=fixed_params)
 
         self.gradcheck(forward_with_fixed_params, (input_tensor,))
+
+
+class TestPadTo:
+    def test_pad_smaller_input(self, device, dtype):
+        input = torch.zeros(1, 1, 3, 3, device=device, dtype=dtype)
+        pad = PadTo((5, 5), pad_value=1.0)
+        output = pad(input)
+        assert output.shape == (1, 1, 5, 5)
+        assert (output[..., :3, :3] == 0).all()
+        assert (output[..., 3:, :] == 1).all()
+        assert (output[..., :3, 3:] == 1).all()
+
+    def test_crop_if_exceeds_true(self, device, dtype):
+        input = torch.ones(1, 1, 10, 10, device=device, dtype=dtype)
+        pad = PadTo((5, 5), crop_if_exceeds=True)
+        output = pad(input)
+        assert output.shape == (1, 1, 5, 5)
+
+    def test_crop_if_exceeds_false(self, device, dtype):
+        input = torch.ones(1, 1, 10, 10, device=device, dtype=dtype)
+        pad = PadTo((5, 5), crop_if_exceeds=False)
+        output = pad(input)
+        assert output.shape == (1, 1, 10, 10)
+
+    def test_crop_if_exceeds_false_mixed(self, device, dtype):
+        input = torch.ones(1, 1, 10, 3, device=device, dtype=dtype)
+        pad = PadTo((5, 5), pad_value=0.0, crop_if_exceeds=False)
+        output = pad(input)
+        assert output.shape == (1, 1, 10, 5)
+        assert (output[..., :10, :3] == 1).all()
+        assert (output[..., :10, 3:] == 0).all()
+
+    def test_inverse(self, device, dtype):
+        input = torch.zeros(1, 1, 3, 3, device=device, dtype=dtype)
+        pad = PadTo((5, 5))
+        output = pad(input)
+        recovered = pad.inverse(output)
+        assert recovered.shape == input.shape
+
+    def test_keyword_only(self):
+        with pytest.raises(TypeError):
+            PadTo((5, 5), "constant", 0, False, True)


### PR DESCRIPTION
Add crop_if_exceeds as a keyword-only parameter to PadTo that controls whether inputs larger than the target size are cropped.

- crop_if_exceeds=True (default): preserves existing behavior
- crop_if_exceeds=False: padding-only, larger dims left unchanged
- Uses bare * to enforce keyword-only usage (no positional arg breakage)
- Adds TestPadTo with 6 test cases

Closes #3518

## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request) for details.

**Fixes/Relates to:** # (issue number)

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [ ] Item 1
- [ ] Item 2

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** (List new/updated tests)
- [ ] **Manual Verification:** (Describe the steps you took)
- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [ ] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [ ] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
