### PR TITLE
fix(geometry): harmonise dtypes in transform_points bmm

### DIFF
--- a/kornia/geometry/linalg.py
+++ b/kornia/geometry/linalg.py
@@ -218,15 +218,19 @@ def transform_points(trans_01: torch.Tensor, points_1: torch.Tensor) -> torch.Te
     trans_01 = torch.repeat_interleave(trans_01, repeats=int(points_1.shape[0] // trans_01.shape[0]), dim=0)
     # to homogeneous
     points_1_h = convert_points_to_homogeneous(points_1)  # BxNxD+1
+    # `torch.bmm` requires both operands to share a scalar type. Callers may pass coordinate
+    # tensors in a different dtype than the transform matrix (e.g. fp32 bbox + fp16 image), so
+    # harmonise at the bmm site and restore the caller's coordinate dtype on return.
+    points_dtype = points_1_h.dtype
     # transform coordinates
-    points_0_h = torch.bmm(points_1_h, trans_01.permute(0, 2, 1))
+    points_0_h = torch.bmm(points_1_h.to(trans_01.dtype), trans_01.permute(0, 2, 1))
     # to euclidean
     points_0 = convert_points_from_homogeneous(points_0_h)  # BxNxD
     # reshape to the input shape
     shape_inp[-2] = points_0.shape[-2]
     shape_inp[-1] = points_0.shape[-1]
     points_0 = points_0.reshape(shape_inp)
-    return points_0
+    return points_0.to(points_dtype)
 
 
 def point_line_distance(point: torch.Tensor, line: torch.Tensor, eps: float = 1e-9) -> torch.Tensor:

--- a/tests/augmentation/container/test_augmentation_sequential.py
+++ b/tests/augmentation/container/test_augmentation_sequential.py
@@ -107,6 +107,24 @@ class TestAugmentationSequential:
         out = aug_list(input)
         assert out.shape == input.shape
 
+    @pytest.mark.parametrize("image_dtype", [torch.float16, torch.float32, torch.float64, torch.bfloat16])
+    def test_mixed_image_bbox_dtypes(self, device, image_dtype):
+        # Regression test for https://github.com/kornia/kornia/issues/3705 and #3706:
+        # bbox stays in fp32 while the image uses a half/double compute dtype.
+        torch.manual_seed(0)
+        img = torch.rand(2, 3, 32, 32, device=device, dtype=image_dtype)
+        bb = torch.tensor(
+            [[[[4.0, 4.0], [12.0, 4.0], [12.0, 12.0], [4.0, 12.0]]]] * 2,
+            device=device,
+            dtype=torch.float32,
+        )
+        aug = K.AugmentationSequential(K.RandomAffine(degrees=10, p=1.0), data_keys=["image", "bbox"])
+        out_img, out_bb = aug(img, bb)
+        assert out_img.dtype == image_dtype
+        assert out_bb.dtype == torch.float32
+        assert out_img.shape == img.shape
+        assert out_bb.shape == bb.shape
+
     def test_random_flips(self, device, dtype):
         inp = torch.randn(1, 3, 510, 1020, device=device, dtype=dtype)
         bbox = torch.tensor([[[355, 10], [660, 10], [660, 250], [355, 250]]], device=device, dtype=dtype)

--- a/tests/geometry/test_linalg.py
+++ b/tests/geometry/test_linalg.py
@@ -67,6 +67,16 @@ class TestTransformPoints(BaseTester):
         expected = op(transform, points)
         self.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
 
+    @pytest.mark.parametrize("trans_dtype", [torch.float16, torch.float32, torch.float64])
+    @pytest.mark.parametrize("points_dtype", [torch.float16, torch.float32, torch.float64])
+    def test_mixed_dtypes(self, device, trans_dtype, points_dtype):
+        # Regression test for https://github.com/kornia/kornia/issues/3705
+        points_src = torch.rand(2, 3, 2, device=device, dtype=points_dtype)
+        trans = kornia.core.ops.eye_like(3, points_src).to(trans_dtype)
+        out = kgl.transform_points(trans, points_src)
+        assert out.dtype == points_dtype
+        self.assert_close(out.to(torch.float32), points_src.to(torch.float32), atol=1e-2, rtol=1e-2)
+
 
 class TestComposeTransforms(BaseTester):
     def test_smoke(self, device, dtype):


### PR DESCRIPTION
Here's the filled-out PR body — paste this into the upstream PR:

---

`torch.bmm` requires both operands to share a scalar type, but `transform_points` builds the homogeneous point tensor in the caller's original dtype while the transform matrix often comes from a different dtype (e.g. an fp32 bbox against an fp16/fp64 image from mixed-precision training). Coerce the points to `trans_01.dtype` at the bmm site and restore the caller's coordinate dtype on return so mixed-dtype `data_keys` no longer crash inside `AugmentationSequential`.

Fixes #3705

Note: #3706 (`torch.bfloat16` rejected by `AugmentationBase2D`) is already resolved in main (via #3647); added an `AugmentationSequential` mixed-dtype regression test that also exercises the bf16 path.

## 📝 Description

Inside `transform_points` (`kornia/geometry/linalg.py`), `torch.bmm(points_1_h, trans_01.permute(0, 2, 1))` raises

```
RuntimeError: expected scalar type Float but found Half    # (fp16 image, fp32 bbox)
RuntimeError: expected scalar type Float but found Double  # (fp64 image, fp32 bbox)
```

whenever the points tensor and the transform matrix use different float dtypes. This combination is routine in mixed-precision training: the image is cast to the compute dtype by the DataLoader / autocast path, while bboxes and keypoints stay in fp32 because pixel coordinates gain nothing from fp16. Same-dtype-throughout works; only mixed-dtype multi-key inputs crash.

The fix promotes the points tensor to the transform matrix's dtype just before `bmm`, then restores the caller's coordinate dtype on return, so `AugmentationSequential(..., data_keys=["image", "bbox"])` works end-to-end for any `(image_dtype, points_dtype)` pair without changing coordinate-tensor dtypes observed by the caller.

**Fixes/Relates to:** #3705 (also covered by the added test: #3706, already resolved on main via #3647)

---

## 🛠️ Changes Made
- [x] `kornia/geometry/linalg.py`: in `transform_points`, cast `points_1_h` to `trans_01.dtype` at the `bmm` site and return the result cast back to the caller's coordinate dtype (3 lines of logic + 3 lines of comment explaining the constraint).
- [x] `tests/geometry/test_linalg.py`: added `TestTransformPoints::test_mixed_dtypes` (9 combinations across fp16/fp32/fp64 for points × transform dtypes; asserts output dtype matches the points dtype).
- [x] `tests/augmentation/container/test_augmentation_sequential.py`: added `TestAugmentationSequential::test_mixed_image_bbox_dtypes` (4 image dtypes × fp32 bbox through `AugmentationSequential(RandomAffine, data_keys=["image", "bbox"])`).

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:**
  - New: `tests/geometry/test_linalg.py::TestTransformPoints::test_mixed_dtypes`
  - New: `tests/augmentation/container/test_augmentation_sequential.py::TestAugmentationSequential::test_mixed_image_bbox_dtypes`
- [x] **Manual Verification:** reproduced the original crash from the issue (fp16/fp64 image + fp32 bbox), then ran it against the patched branch — all four image dtypes (fp16, fp32, fp64, bf16) now pass, and same-dtype paths are unchanged.
  ```
  $ pixi run test tests/geometry/test_linalg.py --dtype=float32,float64
  46 passed
  $ pixi run test tests/geometry/test_homography.py --dtype=float32
  passed
  $ pixi run test tests/augmentation/container/test_augmentation_sequential.py --dtype=float32
  passed (incl. new mixed-dtype test)
  $ ruff check / ruff format --check on changed files
  clean
  ```
- [x] **Performance/Edge Cases:** when `points_1.dtype == trans_01.dtype`, the two `.to(...)` calls are no-ops (PyTorch short-circuits `.to(same_dtype)` and returns `self`), so the hot same-dtype path incurs no copy. The `points_dtype = points_1_h.dtype` capture preserves the caller's dtype through `convert_points_from_homogeneous` and the final reshape so coordinate tensors don't silently widen.

---

## 🕵️ AI Usage Disclosure
- [x] 🔴 **AI-generated:** patch authored with Claude Code. The change is localised (3 logical lines in `transform_points`) and the reasoning above explains why casting at the `bmm` site is the correct repair: `torch.bmm` is dtype-strict, the natural "winner" between the two dtypes is the transform matrix (derived from the augmentation's compute path), and preserving the caller's coordinate dtype on return avoids surprising downstream consumers whose bboxes/keypoints live in fp32.

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context

- Impacts any `data_keys` beyond `image` that carry coordinate tensors (`bbox`, `keypoints`, `mask` when polygonal) — all travel through `transform_points`. Confirmed on `bbox`; others share the same path.
- Alternative considered: harmonising at the geometric-aug entry point rather than inside `linalg.transform_points`. Rejected because the constraint is purely a `torch.bmm` scalar-type requirement — fixing it at the call site is narrower, covers every caller (not just `AugmentationSequential`), and doesn't impose dtype coupling on augmentation-level APIs.
