### PR TITLE
docs: add missing docstrings to planar_tracker (D101, D102, D103)

### DIFF
--- a/kornia/tracking/planar_tracker.py
+++ b/kornia/tracking/planar_tracker.py
@@ -69,14 +69,36 @@ class HomographyTracker(nn.Module):
 
     @property
     def device(self) -> torch.device:
+        """Return the device used by the current target image tensor.
+
+        Returns:
+            The ``torch.device`` where ``self.target`` is allocated.
+        """
         return self.target.device
 
     @property
     def dtype(self) -> torch.dtype:
+        """Return the data type used by the current target image tensor.
+
+        Returns:
+            The ``torch.dtype`` of ``self.target``.
+        """
         return self.target.dtype
 
     @torch.no_grad()
     def set_target(self, target: torch.Tensor) -> None:
+        """Register a new target image and refresh cached matcher features.
+
+        Args:
+            target: Reference target image tensor used for subsequent matching.
+
+        Returns:
+            None.
+
+        The method clears previously cached features and precomputes new
+        feature representations when the configured matchers expose an
+        ``extract_features`` method.
+        """
         self.target = target
         self.target_initial_representation = {}
         self.target_fast_representation = {}
@@ -88,16 +110,38 @@ class HomographyTracker(nn.Module):
             self.target_fast_representation = self.fast_matcher.extract_features(target)
 
     def reset_tracking(self) -> None:
+        """Reset temporal tracking state from previously processed frames.
+
+        Returns:
+            None.
+        """
         self.previous_homography = None
 
     def no_match(self) -> Tuple[torch.Tensor, bool]:
+        """Return a failed-match response and clear current match statistics.
+
+        Returns:
+            A tuple ``(H, is_valid)`` where ``H`` is an empty ``3 x 3`` tensor
+            on the tracker device and dtype, and ``is_valid`` is ``False``.
+        """
         self.inliers_num = 0
         self.keypoints0_num = 0
         self.keypoints1_num = 0
         return torch.empty(3, 3, device=self.device, dtype=self.dtype), False
 
     def match_initial(self, x: torch.Tensor) -> Tuple[torch.Tensor, bool]:
-        """Match the frame `x` with initial_matcher and verified with ransac."""
+        """Estimate a homography from the initial target frame to frame ``x``.
+
+        Args:
+            x: Current frame tensor to match against the stored target image.
+
+        Returns:
+            A tuple ``(H, is_valid)`` where ``H`` is the estimated homography
+            matrix and ``is_valid`` indicates whether enough inliers were found.
+
+        The method updates keypoint counters, inlier statistics, and stores the
+        estimated homography as ``previous_homography`` on success.
+        """
         input_dict: Dict[str, torch.Tensor] = {"image0": self.target, "image1": x}
 
         for k, v in self.target_initial_representation.items():
@@ -123,9 +167,17 @@ class HomographyTracker(nn.Module):
         return H, True
 
     def track_next_frame(self, x: torch.Tensor) -> Tuple[torch.Tensor, bool]:
-        """Prewarp the frame `x` according to the previous frame homography.
+        """Track the target in frame ``x`` using the previous homography prior.
 
-        Matched with fast_matcher verified with ransac.
+        Args:
+            x: Current frame tensor to align with the target image.
+
+        Returns:
+            A tuple ``(H, is_valid)`` where ``H`` is the updated homography and
+            ``is_valid`` indicates whether tracking remained reliable.
+
+        The frame is first prewarped by the inverse of the previous homography,
+        then matched with ``fast_matcher`` and verified using RANSAC.
         """
         if self.previous_homography is not None:  # mypy, shut up
             Hwarp = self.previous_homography.clone()[None]
@@ -162,6 +214,15 @@ class HomographyTracker(nn.Module):
         return H, True
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, bool]:
+        """Run one tracking step on frame ``x``.
+
+        Args:
+            x: Current frame tensor.
+
+        Returns:
+            A tuple ``(H, is_valid)`` from ``track_next_frame`` when previous
+            state exists, otherwise from ``match_initial``.
+        """
         if self.previous_homography is not None:
             return self.track_next_frame(x)
         return self.match_initial(x)


### PR DESCRIPTION
## Description

**Fixes/Relates to:** Relates to #3083 as discussed with @edgarriba, @shijianjian, and @Meggison.



---

## Changes Made
- [x] Added missing structural docstrings (D101, D102, D103) to `kornia/tracking/planar_tracker.py`
- [x] Ignored stylistic rules (like D400) as requested by maintainers in the issue thread.

---

## How Was This Tested?
- [ ] **Unit Tests:** N/A (Docstring updates only)
- [x] **Manual Verification:** Ran the linter locally to ensure the target file passes cleanly without warnings. Executed: `ruff check kornia/tracking/planar_tracker.py --select D101,D102,D103`
- [ ] **Performance/Edge Cases:** N/A

---

## AI Usage Disclosure
*Check one of the following:*
- [ ] **No AI used.**
- [x] **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.

---

## Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.

---

## Additional Context
Note to maintainers: This PR is a direct, clean replacement for PR #3648. My local WSL environment corrupted the GPG commit history on that older branch, which was blocking the auto-merge. I am opening this fresh PR with the exact same approved code to ensure clean, verified signatures!