### PR TITLE
fix: propagate NaN from w-component in quaternion_to_axis_angle

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -658,6 +658,10 @@ def quaternion_to_axis_angle(quaternion: torch.Tensor) -> torch.Tensor:
     k_neg: torch.Tensor = 2.0 * torch.ones_like(sin_theta)
     k: torch.Tensor = torch.where(sin_squared_theta > 0.0, k_pos, k_neg)
 
+    # Propagate NaN from w-component: when cos_theta is NaN, the angle is
+    # undefined and the output must be NaN rather than silently returning zero.
+    k = torch.where(torch.isnan(cos_theta), cos_theta, k)
+
     axis_angle: torch.Tensor = torch.zeros_like(quaternion)[..., :3]
     axis_angle[..., 0] += q1 * k
     axis_angle[..., 1] += q2 * k

--- a/tests/integration/test_conversions.py
+++ b/tests/integration/test_conversions.py
@@ -94,6 +94,17 @@ class TestQuaternionToAngleAxisToQuaternion(BaseTester):
         quaternion_hat = kornia.geometry.conversions.axis_angle_to_quaternion(axis_angle)
         self.assert_close(quaternion_hat, quaternion, atol=atol, rtol=rtol)
 
+    def test_nan_w_propagation(self, device, dtype, atol, rtol):
+        # gh-3629: NaN in w-component should propagate to output
+        quaternion = torch.tensor([float("nan"), 0.0, 0.0, 0.0], device=device, dtype=dtype)
+        axis_angle = kornia.geometry.conversions.quaternion_to_axis_angle(quaternion)
+        assert axis_angle.isnan().all()
+
+    def test_nan_w_nonzero_xyz_propagation(self, device, dtype, atol, rtol):
+        quaternion = torch.tensor([float("nan"), 1.0, 0.0, 0.0], device=device, dtype=dtype)
+        axis_angle = kornia.geometry.conversions.quaternion_to_axis_angle(quaternion)
+        assert axis_angle.isnan().all()
+
 
 class TestQuaternionToRotationMatrixToAngleAxis(BaseTester):
     @pytest.mark.parametrize("axis", (0, 1, 2))


### PR DESCRIPTION
## Summary

Fixes #3629

`quaternion_to_axis_angle` returns `[0, 0, 0]` when the w-component is NaN and the xyz components are zero (or near-zero). NaN in xyz correctly propagates, but NaN in w is silently dropped.

## Root cause

When `sin_squared_theta` (from xyz) is 0, the function takes the small-angle branch (`k = 2.0`) regardless of whether `cos_theta` (w) is valid. The NaN in w never reaches the output.

## Fix

After computing `k`, add a single line that forces NaN propagation from `cos_theta`:

```python
k = torch.where(torch.isnan(cos_theta), cos_theta, k)
```

This has no effect on valid inputs since `cos_theta` is only NaN when the input is invalid.

## Test plan

- Added `test_nan_w_propagation`: verifies NaN w with zero xyz produces all-NaN output
- Added `test_nan_w_nonzero_xyz_propagation`: verifies NaN w with nonzero xyz also propagates
- Verified existing tests (identity, rotation, small_angle, roundtrip) still pass