### PR TITLE
fix: propagate NaN from w-component in quaternion_to_axis_angle

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -649,6 +649,9 @@ def quaternion_to_axis_angle(quaternion: torch.Tensor) -> torch.Tensor:
 
     sin_squared_theta: torch.Tensor = q1 * q1 + q2 * q2 + q3 * q3
 
+    # Propagate NaN from w-component: if cos_theta is NaN but xyz are zero,
+    # sin_squared_theta is zero and NaN would be silently swallowed.
+    sin_squared_theta = sin_squared_theta + cos_theta * 0.0
     sin_theta: torch.Tensor = torch.sqrt(sin_squared_theta)
     two_theta: torch.Tensor = 2.0 * torch.where(
         cos_theta < 0.0, torch.atan2(-sin_theta, -cos_theta), torch.atan2(sin_theta, cos_theta)

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -649,9 +649,6 @@ def quaternion_to_axis_angle(quaternion: torch.Tensor) -> torch.Tensor:
 
     sin_squared_theta: torch.Tensor = q1 * q1 + q2 * q2 + q3 * q3
 
-    # Propagate NaN from w-component: if cos_theta is NaN but xyz are zero,
-    # sin_squared_theta is zero and NaN would be silently swallowed.
-    sin_squared_theta = sin_squared_theta + cos_theta * 0.0
     sin_theta: torch.Tensor = torch.sqrt(sin_squared_theta)
     two_theta: torch.Tensor = 2.0 * torch.where(
         cos_theta < 0.0, torch.atan2(-sin_theta, -cos_theta), torch.atan2(sin_theta, cos_theta)
@@ -665,6 +662,9 @@ def quaternion_to_axis_angle(quaternion: torch.Tensor) -> torch.Tensor:
     axis_angle[..., 0] += q1 * k
     axis_angle[..., 1] += q2 * k
     axis_angle[..., 2] += q3 * k
+    # Propagate NaN from w-component: if cos_theta is NaN but xyz are zero,
+    # NaN would be silently swallowed through the where/atan2 path above.
+    axis_angle = axis_angle + cos_theta.unsqueeze(-1) * 0.0
     return axis_angle
 
 

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -188,6 +188,12 @@ class TestQuaternionToAngleAxis(BaseTester):
         axis_angle = kornia.geometry.conversions.quaternion_to_axis_angle(quaternion)
         self.assert_close(axis_angle, expected, atol=atol, rtol=rtol)
 
+    def test_nan_w_component_propagates(self, device, dtype):
+        """NaN in the w-component should propagate to the output, not be silently swallowed."""
+        quaternion = torch.tensor((float("nan"), 0.0, 0.0, 0.0), device=device, dtype=dtype)
+        axis_angle = kornia.geometry.conversions.quaternion_to_axis_angle(quaternion)
+        assert torch.isnan(axis_angle).any(), "NaN in w-component should propagate to axis_angle output"
+
     def test_gradcheck(self, device):
         dtype = torch.float64
         eps = torch.finfo(dtype).eps


### PR DESCRIPTION
## Description

Fixes #3629

When the w-component of a quaternion is NaN but xyz components are zero,  silently returns  instead of propagating NaN. This happens because  becomes 0 (since xyz are all zero), and the  at line 659 picks  (which is ), producing a zero output.

### Root cause
 is zero when xyz are zero, regardless of whether w is NaN. The NaN from w-component gets swallowed by the  condition.

### Fix
Added  which preserves all existing values (since  when cos_theta is NaN, and  otherwise).

### Test
Added  to verify NaN propagation.