### PR TITLE
Docs/enhance module docstrings

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -1103,6 +1103,14 @@ class AdjustSaturation(nn.Module):
         self.saturation_factor: Union[float, torch.Tensor] = saturation_factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Adjust RGB saturation using the module's configured factor.
+
+        Args:
+            input: Input RGB tensor, typically shaped :math:`(*, 3, H, W)`.
+
+        Returns:
+            Saturation-adjusted tensor with the same shape as ``input``.
+        """
         return adjust_saturation(input, self.saturation_factor)
 
 
@@ -1154,6 +1162,17 @@ class AdjustSaturationWithGraySubtraction(nn.Module):
         self.saturation_factor: Union[float, torch.Tensor] = saturation_factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Adjust saturation using gray-subtraction interpolation behavior.
+
+        This forwards to :func:`adjust_saturation_with_gray_subtraction`,
+        which follows PIL-like saturation behavior.
+
+        Args:
+            input: Input image tensor, typically shaped :math:`(*, 3, H, W)`.
+
+        Returns:
+            Saturation-adjusted tensor with the same shape as ``input``.
+        """
         return adjust_saturation_with_gray_subtraction(input, self.saturation_factor)
 
 
@@ -1205,6 +1224,15 @@ class AdjustHue(nn.Module):
         self.hue_factor: Union[float, torch.Tensor] = hue_factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Shift image hue by the module's configured hue factor.
+
+        Args:
+            input: Input RGB tensor in the expected image range, usually shaped
+                :math:`(*, 3, H, W)`.
+
+        Returns:
+            Hue-adjusted tensor with the same shape as ``input``.
+        """
         return adjust_hue(input, self.hue_factor)
 
 
@@ -1244,6 +1272,15 @@ class AdjustGamma(nn.Module):
         self.gain: Union[float, torch.Tensor] = gain
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Apply gamma correction using this module's ``gamma`` and ``gain``.
+
+        Args:
+            input: Input tensor to correct, commonly image-shaped
+                :math:`(*, C, H, W)`.
+
+        Returns:
+            Gamma-corrected tensor with the same shape as ``input``.
+        """
         return adjust_gamma(input, self.gamma, self.gain)
 
 
@@ -1282,6 +1319,14 @@ class AdjustContrast(nn.Module):
         self.contrast_factor: Union[float, torch.Tensor] = contrast_factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Adjust contrast using the configured contrast factor.
+
+        Args:
+            input: Input tensor to adjust, typically shaped :math:`(*, C, H, W)`.
+
+        Returns:
+            Contrast-adjusted tensor with the same shape as ``input``.
+        """
         return adjust_contrast(input, self.contrast_factor)
 
 
@@ -1321,6 +1366,17 @@ class AdjustContrastWithMeanSubtraction(nn.Module):
         self.contrast_factor: Union[float, torch.Tensor] = contrast_factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Adjust contrast with mean-subtraction based interpolation.
+
+        This forwards to :func:`adjust_contrast_with_mean_subtraction`, which
+        applies PIL-like contrast behavior.
+
+        Args:
+            input: Input tensor to adjust, typically shaped :math:`(*, C, H, W)`.
+
+        Returns:
+            Contrast-adjusted tensor with the same shape as ``input``.
+        """
         return adjust_contrast_with_mean_subtraction(input, self.contrast_factor)
 
 
@@ -1358,6 +1414,14 @@ class AdjustBrightness(nn.Module):
         self.brightness_factor: Union[float, torch.Tensor] = brightness_factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Adjust image brightness using the configured brightness factor.
+
+        Args:
+            input: Input tensor to adjust, commonly shaped :math:`(*, C, H, W)`.
+
+        Returns:
+            Brightness-adjusted tensor with the same shape as ``input``.
+        """
         return adjust_brightness(input, self.brightness_factor)
 
 
@@ -1391,6 +1455,15 @@ class AdjustSigmoid(nn.Module):
         self.inv: bool = inv
 
     def forward(self, image: torch.Tensor) -> torch.Tensor:
+        """Apply sigmoid-based intensity remapping to the input image.
+
+        Args:
+            image: Input image tensor to remap, typically shaped
+                :math:`(*, C, H, W)` or :math:`(*, H, W)`.
+
+        Returns:
+            Tensor with sigmoid correction applied, preserving input shape.
+        """
         return adjust_sigmoid(image, cutoff=self.cutoff, gain=self.gain, inv=self.inv)
 
 
@@ -1423,6 +1496,15 @@ class AdjustLog(nn.Module):
         self.clip_output: bool = clip_output
 
     def forward(self, image: torch.Tensor) -> torch.Tensor:
+        """Apply logarithmic or inverse-logarithmic intensity correction.
+
+        Args:
+            image: Input image tensor to transform, typically shaped
+                :math:`(*, C, H, W)` or :math:`(*, H, W)`.
+
+        Returns:
+            Log-corrected tensor with the same shape as ``image``.
+        """
         return adjust_log(image, gain=self.gain, inv=self.inv, clip_output=self.clip_output)
 
 
@@ -1460,6 +1542,14 @@ class AdjustBrightnessAccumulative(nn.Module):
         self.brightness_factor: Union[float, torch.Tensor] = brightness_factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Adjust brightness with accumulative (PIL-like) behavior.
+
+        Args:
+            input: Input tensor to adjust, commonly shaped :math:`(*, C, H, W)`.
+
+        Returns:
+            Brightness-adjusted tensor with the same shape as ``input``.
+        """
         return adjust_brightness_accumulative(input, self.brightness_factor)
 
 
@@ -1496,4 +1586,13 @@ class Invert(nn.Module):
             self.max_val = max_val
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Invert values using the module's configured maximum reference.
+
+        Args:
+            input: Tensor to invert. Any shape is accepted as long as it is
+                broadcast-compatible with ``self.max_val``.
+
+        Returns:
+            Inverted tensor with the same shape as ``input``.
+        """
         return invert(input, self.max_val)

--- a/kornia/enhance/core.py
+++ b/kornia/enhance/core.py
@@ -121,4 +121,18 @@ class AddWeighted(nn.Module):
         self.gamma = gamma
 
     def forward(self, src1: torch.Tensor, src2: torch.Tensor) -> torch.Tensor:
+        """Compute a weighted sum of two tensors with a scalar bias term.
+
+        This method is a module wrapper around :func:`add_weighted`, using the
+        ``alpha``, ``beta``, and ``gamma`` values defined at initialization.
+
+        Args:
+            src1: First input tensor.
+            src2: Second input tensor. It must have the same shape as ``src1``.
+
+        Returns:
+            A tensor with the same shape as the inputs, computed as
+            ``src1 * alpha + src2 * beta + gamma`` with broadcasting applied
+            where supported by :func:`add_weighted`.
+        """
         return add_weighted(src1, self.alpha, src2, self.beta, self.gamma)

--- a/kornia/enhance/integral.py
+++ b/kornia/enhance/integral.py
@@ -117,6 +117,17 @@ class IntegralTensor(nn.Module):
         self.dim = dim
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Compute cumulative sums of the input tensor along configured axes.
+
+        Args:
+            input: Tensor to integrate. The operation supports arbitrary rank,
+                and dimensions are accumulated according to ``self.dim``.
+
+        Returns:
+            A tensor with the same shape as ``input`` containing cumulative
+            sums. If ``self.dim`` is ``None``, integration is applied to the
+            last dimension by :func:`integral_tensor`.
+        """
         return integral_tensor(input, self.dim)
 
 
@@ -148,4 +159,15 @@ class IntegralImage(nn.Module):
     """
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Compute a 2D integral image by summing over height and width.
+
+        Args:
+            input: Tensor whose last two dimensions represent spatial axes,
+                typically shaped :math:`(*, H, W)`.
+
+        Returns:
+            A tensor of the same shape as ``input`` where each location stores
+            the cumulative sum over the top-left rectangle ending at that
+            location.
+        """
         return integral_image(input)

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -745,6 +745,24 @@ class JPEGCodecDifferentiable(nn.Module):
         image_rgb: torch.Tensor,
         jpeg_quality: torch.Tensor,
     ) -> torch.Tensor:
+        """Apply differentiable JPEG compression and decompression.
+
+        The method runs an RGB image through the internal JPEG codec pipeline
+        using the module's quantization tables, then reconstructs an RGB tensor.
+        Quantization tables are moved to the input device and dtype before
+        encoding/decoding.
+
+        Args:
+            image_rgb: Input RGB tensor with shape :math:`(*, 3, H, W)`.
+            jpeg_quality: JPEG quality factor tensor. It can be scalar or
+                batched, and must be broadcast-compatible with the leading
+                dimensions of ``image_rgb`` as required by
+                :func:`jpeg_codec_differentiable`.
+
+        Returns:
+            Reconstructed RGB tensor after differentiable JPEG processing, with
+            the same shape as ``image_rgb``.
+        """
         device = image_rgb.device
         dtype = image_rgb.dtype
         # Move quantization tables to the same device and dtype as input

--- a/kornia/enhance/normalize.py
+++ b/kornia/enhance/normalize.py
@@ -81,6 +81,20 @@ class Normalize(nn.Module):
         self.std = std
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Normalize an input tensor channel-wise with this module's statistics.
+
+        This method is a thin wrapper over :func:`normalize`, reusing the
+        ``mean`` and ``std`` values stored in the module constructor.
+
+        Args:
+            input: Tensor to normalize, typically with shape :math:`(*, C, ...)`,
+                where ``*`` represents optional leading dimensions (for example
+                batch) and ``C`` is the channel dimension.
+
+        Returns:
+            A tensor with the same shape as ``input`` whose channel values are
+            normalized by ``(x - mean) / std``.
+        """
         return normalize(input, self.mean, self.std)
 
     def __repr__(self) -> str:
@@ -194,6 +208,19 @@ class Denormalize(nn.Module):
         self.std = std
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Restore scale/offset from a tensor normalized by mean and std.
+
+        This method delegates to :func:`denormalize` using this module's stored
+        ``mean`` and ``std`` parameters.
+
+        Args:
+            input: Tensor to denormalize, commonly shaped :math:`(*, C, ...)`
+                with channel dimension ``C``.
+
+        Returns:
+            A tensor with the same shape as ``input`` where each channel is
+            transformed by ``x * std + mean``.
+        """
         return denormalize(input, self.mean, self.std)
 
     def __repr__(self) -> str:

--- a/kornia/enhance/rescale.py
+++ b/kornia/enhance/rescale.py
@@ -39,4 +39,16 @@ class Rescale(nn.Module):
             self.factor = factor
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Multiply the input tensor by the configured scaling factor.
+
+        Args:
+            input: Tensor to be rescaled. In image workflows this is commonly
+                shaped as :math:`(*, C, H, W)`, where ``*`` denotes optional
+                leading dimensions (for example batch), ``C`` is channel count,
+                and ``H``/``W`` are spatial dimensions.
+
+        Returns:
+            A tensor with the same shape as ``input``, where each element is
+            multiplied by ``self.factor``.
+        """
         return input * self.factor

--- a/kornia/enhance/threshold.py
+++ b/kornia/enhance/threshold.py
@@ -134,4 +134,19 @@ class Threshold(Module):
         self.type = int(type)
 
     def forward(self, input: Tensor) -> Tensor:
+        """Apply thresholding with this module's configured parameters.
+
+        This method delegates to :func:`threshold` and reuses the threshold
+        value, maximum replacement value, and thresholding mode stored on the
+        module instance.
+
+        Args:
+            input: Input tensor to threshold. Typical image inputs are shaped
+                :math:`(*, C, H, W)`, but any tensor shape supported by
+                :func:`threshold` is accepted.
+
+        Returns:
+            A tensor with the same shape as ``input`` where values are remapped
+            according to ``self.type`` using ``self.thresh`` and ``self.maxval``.
+        """
         return threshold(input, self.thresh, self.maxval, self.type)


### PR DESCRIPTION
## Description


Fixes/Relates to: Follow-up to PR https://github.com/kornia/kornia/pull/3648 / Issue https://github.com/kornia/kornia/issues/3083 as discussed with @edgarriba.

This PR adds detailed, behavior-accurate docstrings for missing public methods in the `kornia/enhance` module, focused on `D102` coverage (missing public method docstrings).

Scope is documentation-only:
- No logic changes
- No API behavior changes
- No tensor math/functionality changes

Updated files:
- `kornia/enhance/rescale.py`
- `kornia/enhance/normalize.py`
- `kornia/enhance/integral.py`
- `kornia/enhance/jpeg.py`
- `kornia/enhance/threshold.py`
- `kornia/enhance/core.py`
- `kornia/enhance/adjust.py`

---

## Changes Made

- Added detailed docstrings to previously undocumented public methods (`forward` and related public methods flagged by lint).
- Documented:
  - expected input tensor semantics and common shapes
  - what each wrapper/module forwards to internally
  - return tensor behavior and shape consistency
- Kept wording aligned with actual implementation (no speculative behavior added).

---

## How Was This Tested?

- [x] **Manual verification:** reviewed each added docstring against method body to ensure behavioral accuracy.
- [x] **Lint validation:** `pydocstyle --select=D101,D102,D103` on touched `kornia/enhance/*` files passes.
- [x] **No code-path changes:** this PR only adds docstrings.

---

## AI Usage Disclosure
- [ ] **No AI used.**
- [x] **AI-assisted:** I used AI for enhancing docstrings after manually written, then manually reviewed and validated content against implementation.
