### PR TITLE
Release 0.8.3

### DIFF
--- a/kornia/__init__.py
+++ b/kornia/__init__.py
@@ -245,4 +245,4 @@ def one_hot(*args: Any, **kwargs: Any) -> Any:
 
 
 # Version variable
-__version__ = "0.8.2"
+__version__ = "0.8.3"


### PR DESCRIPTION
## Summary

Kornia v0.8.3 is a patch release rolling up ~175 commits since v0.8.2. Highlights:
new feature detectors and descriptors (XFeat, ALIKED), VisualPrompter batched
inference, half-precision (float16/bfloat16) support and test infrastructure,
performance improvements to core geometry ops (depth_to_normals ~3x, transform
points, denormalize_points_with_intrinsics ~2x), MPS device fixes, ONNX export
fixes, and broad documentation/docstring coverage. Several deprecated utilities
in kornia.utils begin emitting DeprecationWarning targeting future removal.

### Features

- add missing docstrings to color module (#3712) (9ffbca8b)
- feat: enable batched inference and add tests for VisualPrompter (#3671) (bbb581f3)
- Add XFeat, add new weights to  (#3654) (67e6c128)
- Add missing docstrings to kornia/color/sepia.py (#3628) (45c0b8e3)
- Add small sr test suite (#3557) (5af8116c)
- Add unit tests and improve RGB↔YUV conversion accuracy (#3539) (dd1568eb)
- feat: add AdaptiveQuadInterp3d and scale-space detector speedups (#3623) (398665c7)
- feat: add ALIKED local feature detector and descriptor (#3617) (42e4f78c)
- feat: add iterative_quad_interp3d with Cramer's rule  (#3616) (1940cf59)
- feat(image): add KORNIA_CHECK_IMAGE_LAYOUT for layout validation (#3549) (af4419f6)
- feat(geometry): implement closed-form solve_quartic (#3536) (4b3f2168)
- Enable grouping for GitHub Actions in Dependabot (#3506) (0a6d9104)
- Add GitHub Actions updates to Dependabot config (#3497) (4c5a843d)
- Add SmolVLM2 model scaffold (#3475) (74d33541)
- feat: add rectangular and gaussian kernels for mutual information loss (#3478) (8856d821)
- feat(contrib):  add 3D volume support to distance_transform (#3470) (e8164508)
- feat: add initial skeleton for paligemma mode (#3477) (a38cf3d0)
- feat(sam3): Implement Phase 2 architecture (PromptEncoder + MaskDecoder) (#3433) (e912db63)
- Add gradcheck for RandomVerticalFlip (#3476) (b0900e48)
- feat: Add KimiVL Vision-Language Model implementation (#3448) (ee23688c)
- New features: Mutual information losses and normalized mutual information losses. (#3398) (feb79cf0)
- add more instructions and development protocol (#3438) (39824895)
- Implement Siglip2 in kornia.models (#3412) (5c04bfc8)
- implement ai policy for contributors (#3435) (240c0786)
- implement custom errors (#3430) (e68ac757)
- Add GitHub Copilot repository instructions (#3425) (d416945e)
- Add tests for augmentation parameter validation utilities (#3417) (85226997)
- Add parametrized_test decorator and framework files (3a98a57d)
- feat: automate simple test cases with parametrized_tester decorator (#3367) (40023827)
- feat: support padding_mode="fill" and fill_value in RandomAffine (#3391) (c809fbda)

### Bug Fixes

- fix(tests): verify gradients through distCoeff and K in distort_point… (#3685) (430ecc4c)
- fix(geometry): harmonise dtypes in transform_points bmm (#3707) (1a3af2a3)
- fix: propagate device and dtype in get_shear_matrix2d and get_shear_matrix3d (#3652) (631a0824)
- Fix BgrToRgba calling wrong conversion function (#3677) (d5bb50c3)
- fix xfeat dynamo (#3659) (6f03716d)
- fix(onnx): fix io_name_conversion bug and update variadic type hints (#3644) (35f78164)
- fix: skip MPS-unsupported tests and fix MPS-specific runtime errors (#3649) (85017908)
- fix: correct logic bugs in augmentation and crop validation (#3605) (5fa12081)
- Fix typo in index.rst (out → our) (#3633) (f9535c91)
- fix: resolve two CI failures in coverage workflow (#3639) (bf56558a)
- fix doctest warnings (#3632) (37ac9674)
- fix: fix doctest failures for ALIKED and fft_conv (#3630) (4c9c0b62)
- Fix/rgba png loading (#3608) (90193306)
- fix: use StrEnum instead of string and enum (#3573) (d66489b2)
- fix(siglip2): clamp logit_scale to avoid overflow (#3480) (f4ee06ce)
- fix: correct Thin Plate Spline warp normalization for grid_sample (#3468) (33307959)
- Fix RandomThinPlateSpline same_on_batch behaviour and add unit tests (#3465) (f99683df)
- fix(augmentation): resolve device mismatch in RandomGaussianIllumination (#3457) (db0447bb)
- Fix AugmentationSequential crash with mix-only augmentations (#3424) (745c6f11)
- Fix doctest failures and build-docs task (#3456) (bc7b3e3d)
- fix: preserve align_corners from extra_args in inverse_masks (fixes #3400) (#3450) (e71e50cb)
- fix doctests in ci (#3402) (dff89bd0)
- fix(filters): validate positive sigma values in gaussian_blur2d (#3397) (d5e46fc4)
- Fix smoke_inputs in morphology tests to include both tensor and kernel arguments (04412649)
- fix: resolve broadcasting error in affine transform for multi-channel masks (#3388) (8f4561cb)
- fix(docs): replace deprecated torch.range with torch.arange (#3381) (de52fdf1)
- fix(core): enable weights_only=False for TensorWrapper serialization (04b0723b)
- Fix Bug #2876: normalize_min_max now supports 3D tensors (C, H, W) (#3352) (eae117b7)
- Fix homography between unit square and scaled version (#3335) (8ca3e6b7)

### Performance

- perf(geometry): speed up depth_to_normals (~3×) and denormalize_points_with_intrinsics (~2×) (#3656) (78496b7b)
- perf: vectorize xyz conversions (5.6x speedup) with safety checks (#3482) (f6339e01)
- optimize(color): use addcmul for rgb_to_grayscale speedup (#3474) (bf0f8a18)
- Perf: optimized unsharp by using lerp (#3418) (d4347d3f)
- Optimize render_gaussian2d (~18x speedup) and fix PDF variance bug (#3366) (2b6d466b)

### Documentation

- Docs/contrib docstrings  (#3715) (860747eb)
- Docs/core docstrings (#3716) (f0c65537)
- docs: add missing docstrings to planar_tracker (D101, D102, D103) (#3709) (97ac7069)
- docs: add missing docstrings to augmentation module (#3666) (c6c108f7)
- docs: refine shapes and clarify logits in DiceLoss docstrings (39b4d797)
- docs: add structural docstrings to kornia.losses.dice (9f370b09)
- docs: fix canonical URL by setting html_baseurl to /en/latest/ (#3587) (#3589) (245f578e)
- docs: add CLAUDE.md with dev environment and architecture guide (bcd6a380)
- docs: fix output shape comment in RawToRgb example (#3563) (e4bea595)
- docs: add interactive image equalization demo reference (#3509) (efc676a4)
- docs: add missing docstrings for public classes (D101) (#3447) (32aec762)
- Docs: add module docstrings(D100) for sample and draw utilities (#3390) (15c8327e)
- docs: add missing package docstrings (D104) (d76c2a5f)
- Docs: fix remaining D401 docstring violations (#3385) (c78f19ca)
- Docs: fix D401 imperative mood in adalam utils (#3384) (466040aa)
- Docs: fix docstring imperative mood (D401) (2acccd1e)
- docs: Fix RST formatting errors in augmentation.container (#3373) (e68c3f0e)
- docs: remove deprecated slack link (188ff49d)
- docs: update community invite link (78eddb1c)
- Docs: clarified difference between ImageSequential and AugmentationSequential (#3369) (bd372946)

### Tests

- tests: improve branch coverage and remove dead test stubs (#3651) (7bbae17a)
- test : add missing exception and dynamo tests for FaceDetector (#3520) (af0be4f9)
- test(image): migrate image to BaseTester (#3504) (6770ba57)
- tests(tracking): migrate tracking to BaseTester (#3505) (56bfd3de)
- tests(geometry): migrate geometry module to use BaseTester. (#3469) (a0d32de8)
- tests(integration): migrate integration to BaseTester (#3431) (55d96653)
- tests(image): migrate test_image to BaseTester (#3407) (29f82617)

### CI

- ci: allow tutorials to fail to unblock merges (#3591) (16401e11)
- ci: add path filters to skip CI on docs/non-code changes (#3445) (c90e3d73)

### Refactor

- remove too-many-positional-arguments ignore from ty config (#3543) (c161d432)
- refactor(color): vectorize yuv with device-aware dispatch and safety … (#3514) (d27a9b7e)
- Remove deprecated `reviewers` from Dependabot config (#3493) (7049f295)
- remove unused testing code (#3429) (b2705aec)
- Refactor kornia.models across repo (#3426) (0b78c772)
- remove old testing code (#3423) (ece63605)
- refactor(tests): Add parametrization to smoke, shape, and gradcheck tests (#3419) (c627572d)
- refactor(tests/losses): Add @pytest.mark.grad() decorator and dtype parameter to test_gradcheck methods (#3414) (791c978b)
- remove grad_estimator, nerf and x modules (#3401) (4d6ca7b6)
- Refactor morphology tests using @parametrized_test decorator (c2cd3b4e)
- Refactor: Move NeRF helper utilities to kornia.geometry.camera.utils (#3365) (30eec367)

### Dependencies

- build(deps): bump urllib3 from 2.6.3 to 2.7.0 (#3719) (33cf66d7)
- :arrow_up: bump actions/github-script in the github-actions group (#3711) (d398fcf7)
- build(deps): bump pytest from 9.0.2 to 9.0.3 (#3701) (3e49effe)
- build(deps): bump pillow from 12.1.1 to 12.2.0 (#3700) (d7265430)
- build(deps-dev): update transformers requirement from <5.2 to <5.6 (#3695) (f3f62726)
- build(deps): bump cryptography from 46.0.5 to 46.0.7 (#3699) (7d699f1b)
- :arrow_up: bump the github-actions group with 4 updates (#3691) (7352ca30)
- build(deps): bump transformers from 4.56.2 to 5.0.0rc3 (#3697) (9c4c4d49)
- build(deps): bump onnx from 1.20.0 to 1.21.0 (#3692) (07d48160)
- build(deps): bump pillow from 12.0.0 to 12.1.1 (#3569) (0f8d1972)
- build(deps): bump filelock from 3.20.1 to 3.20.3 (#3570) (1d0fd0a4)
- build(deps): bump cryptography from 46.0.3 to 46.0.5 (#3571) (b63296a8)
- build(deps-dev): update transformers requirement from <4.58 to <5.2 (#3561) (5179c951)
- build(deps): bump protobuf from 6.33.2 to 6.33.5 (#3546) (d64263cd)
- build(deps): bump urllib3 from 2.6.2 to 2.6.3 (#3545) (6b36b772)
- build(deps): bump virtualenv from 20.35.4 to 20.36.1 (#3544) (bb2d17e6)
- :arrow_up: Bump prefix-dev/setup-pixi in the github-actions group (#3542) (fdeb5037)
- :arrow_up: Bump the github-actions group with 4 updates (#3507) (8fa47b25)
- :arrow_up: bump actions/github-script from 7 to 8 (#3499) (c27ca0d4)
- :arrow_up: bump actions/cache from 4 to 5 (#3500) (258638e2)
- :arrow_up: bump actions/download-artifact from 4 to 7 (#3501) (d8498548)
- :arrow_up: bump codecov/codecov-action from 3.1.6 to 5.5.2 (#3502) (775ca146)
- :arrow_up: bump actions/upload-artifact from 4 to 6 (#3503) (efc6820d)
- build(deps-dev): update transformers requirement from <4.57 to <4.58 (#3495) (79bcdf2e)

### Release

- release: 0.8.3 (8cd8dd33)

### Other

- More fixes for triangulate and docs (#3661) (915b6b47)
- More speed opts (#3660) (90209959)
-  Half-precision (float16 / bfloat16) support and test infrastructure  (#3647) (97f5ae11)
- Fixes #3595 - avoid unnecessary copy when converting ORT outputs to torch tensors (#3598) (d0e829ea)
- Issue: LightGlue crashes when adaptive width pruning removes all keypoints (#3564). (#3565) (9e6db647)
- (feature): Added Open-CV style thresholding operations to the `enhance/threshold` module (#3515) (e49a1438)
-  Fix Resize ONNX export compatibility                           Make … (#3463) (fe1a7d9b)
- Housekeeping: more tests, warnings cleanup, tf32 issues fixed/explained (#3645) (e14d0235)
- Fox doctest1 (#3631) (a8a1c498)
- adopt ruff rule D400 (#3613) (ad972a56)
- corrects lint command for pixi (#3615) (cc6c9020)
- Update _utils.py (#3547) (5eb50af6)
- Writing fft_conv  (#3592) (776e3768)
- [pre-commit.ci] pre-commit suggestions (#3519) (a0d263b4)
- Adds support for multiple bounding box formats (xywh and cxcywh) to the mean_iou_bbox function, addressing the limitation mentioned in issue #3529. (#3537) (7a2e8230)
- small sr implementation fix (#3551) (b7410c0d)
- removed output.clone() in _transform_output_shape() (#3510) (010296d0)
- optimized Xu kernel (#3486) (bf7faeef)
- [pre-commit.ci] pre-commit suggestions (#3485) (bf8cc199)
- Update PR validation workflow (#3498) (1ba73167)
- Migrate codespell config to pyproject.toml (#3492) (dbcfe2e2)
- implemented gemma decoder and connect vision tower (#3483) (b69a60cb)
- Link in docs AND on RTD? (#3467) (b6a25ee5)
- link to github in docs (#3466) (2eb0176e)
- show link to code source in to docs (#3462) (58cc4dee)
- fixed some docstring mismatches, but msotly wrong torch.where -> where (#3461) (320b7e92)
- CPU only for tutorials and fix ty (#3460) (e44014e8)
- clean version of fast ransac (#3458) (e9e93584)
- added-naflex-feature as an independent module (#3451) (c775c33f)
- Qwen2.5-VL Vision Encoder (Native PyTorch) (#3409) (2496e792)
- deprecate utils module across library (#3449) (94882c52)
- Feat/sam3 phase1 architecture (#3411) (d9649023)
- stablish Torch core (#3432) (9e521cac)
- update contribution guidelines and readme (#3422) (0c429a8d)
- Update stale policy to match kornia-rs (#3420) (a63e3e5e)
- optimized DCT and IDCT computation (#3415) (a93d29fb)
- [pre-commit.ci] auto fixes from pre-commit.com hooks (c2044a29)
- integrate pixi and infra refactor (#3396) (339f20ed)
- Hf token fix (#3393) (dba027e1)
- [pre-commit.ci] pre-commit suggestions (#3392) (e841e67f)
- [pre-commit.ci] auto fixes from pre-commit.com hooks (33d79b9d)
- wip: partial fix for D104 docstring lint (b872c7ef)
- [pre-commit.ci] pre-commit suggestions (#3360) (035bea7e)
- Fixed the broken LICENSE links in README.md and README_zh-CN.md (#3372) (f72e6984)
- GPU support for `create_meshgrid` inside `depth_to_3d` function (#3362) (d66cb7b8)
- Update affwarp.py correcting class Affine documentation (#3361) (c7b1d1ef)
- [pre-commit.ci] pre-commit suggestions (#3358) (76a2a28b)
