### PR TITLE
Post-0.8.3 cleanup: workflow permissions, numpy dep, gitignore

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'release'
+    permissions:
+      contents: write  # Required to attach assets to the GitHub Release
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ weights/
 .uv_cache/
 
 .python-version
+
+# Benchmark profiling outputs
+benchmarks/profile/
+
+# Editor / agent metadata
+.omc/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Image Processing",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["kornia_rs>=0.1.9", "packaging", "torch>=2.0.0"]
+dependencies = ["kornia_rs>=0.1.9", "numpy>=1.21", "packaging", "torch>=2.0.0"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
Three follow-up fixes identified during the v0.8.3 release. None are release-blocking; all are simple targeted changes.

## Changes

### 1. `ci(release): grant contents: write to upload-release job`
The `upload-release` job in `.github/workflows/pypi-release.yml` uses [`AButler/upload-release-assets`](https://github.com/AButler/upload-release-assets) to attach the built sdist + wheel to the GitHub Release page. The workflow-level `permissions: contents: read` blocks this — during the v0.8.3 release the job failed with `Resource not accessible by integration`. PyPI was unaffected (`publish-pypi` succeeded), but the `dist/*` files were not attached to https://github.com/kornia/kornia/releases/tag/v0.8.3.

Fix: add a job-level `permissions: contents: write` block, matching the per-job narrow-scoping pattern `publish-pypi` already uses (`permissions: id-token: write`).

### 2. `build(deps): declare numpy as explicit runtime dependency`
`kornia.io.write_image` → `kornia.image.utils.tensor_to_image` calls `tensor.numpy()` at runtime, requiring numpy to be importable. numpy was previously a hidden transitive dep — universal in practice (every PyTorch user has it), but not declared in `pyproject.toml`. A minimal venv with only kornia and its declared deps (`kornia_rs`, `packaging`, `torch`) fails at `write_image` time with `RuntimeError: Numpy is not available`.

Discovered during the v0.8.3 post-release smoke test in an isolated `uv venv` defaulting to Python 3.14t, which doesn't auto-install numpy as a transitive of any declared dep.

Floor `>=1.21` matches the oldest numpy supported by `torch>=2.0.0`.

### 3. `chore: ignore benchmarks/profile and .omc artifacts`
- `benchmarks/profile/` — local profiling trace outputs from running benchmark scripts.
- `.omc/` — oh-my-claudecode agent tooling metadata. Optional/personal; included here for convenience since it's harmless for non-Claude users.

## Test plan
- [ ] Local `pixi run lint` clean
- [ ] CI green on PR
- [ ] Workflow permission change will be validated on the *next* release (v0.8.4+) — cannot retroactively backfill `v0.8.3` Release assets via CI, but they remain available on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)