### PR TITLE
docs(filters): detailed public method docstrings

### DIFF
--- a/kornia/filters/bilateral.py
+++ b/kornia/filters/bilateral.py
@@ -240,6 +240,27 @@ class BilateralBlur(_BilateralBlur):
     """
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Smooth an image while keeping strong intensity edges visible.
+
+        Bilateral filtering combines two weights for every pixel in the local
+        window: a spatial weight based on distance in the image plane and a
+        range weight based on color or intensity similarity. Nearby pixels with
+        similar values contribute strongly, while pixels across an edge are
+        suppressed even if they are spatially close.
+
+        Args:
+            input: Input image tensor with shape :math:`(B, C, H, W)`,
+                where :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the image height, and :math:`W` is the
+                image width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the
+            edge-preserving smoothed image. The output keeps the same layout,
+            dtype, and device as ``input`` while reducing small local
+            variations according to the configured kernel size and sigma
+            values.
+        """
         return bilateral_blur(
             input, self.kernel_size, self.sigma_color, self.sigma_space, self.border_type, self.color_distance_type
         )
@@ -283,6 +304,29 @@ class JointBilateralBlur(_BilateralBlur):
     """
 
     def forward(self, input: torch.Tensor, guidance: torch.Tensor) -> torch.Tensor:
+        """Smooth an input image using edges measured from a guidance image.
+
+        Joint bilateral filtering is useful when the image being smoothed and
+        the image that should define the edges are different tensors. The
+        spatial kernel is applied around each location of ``input``, but the
+        range similarity term is computed from ``guidance``. This lets a clean
+        or higher-quality reference image preserve boundaries in another
+        signal, such as a depth map, mask, or noisy feature image.
+
+        Args:
+            input: Tensor to smooth with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of input
+                channels, :math:`H` is the height, and :math:`W` is the width.
+            guidance: Tensor used to compute range weights. Its batch and
+                spatial dimensions must be compatible with ``input``; its
+                channel count may differ when the guidance signal uses a
+                different representation.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the filtered
+            ``input`` values. Edges present in ``guidance`` reduce mixing
+            across boundaries, while smooth regions are averaged more strongly.
+        """
         return joint_bilateral_blur(
             input,
             guidance,

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -142,6 +142,26 @@ class BoxBlur(nn.Module):
         )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Average each pixel with its local neighborhood.
+
+        The box blur uses a rectangular averaging kernel where every location
+        inside the window has the same weight. It is a simple low-pass filter:
+        high-frequency details are reduced, while broader image structures are
+        preserved. Depending on the module configuration, the kernel is applied
+        either as a full two-dimensional filter or as two separable one-
+        dimensional passes.
+
+        Args:
+            input: Image or feature tensor with shape :math:`(B, C, H, W)`,
+                where :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the locally
+            averaged result. The output keeps the same batch, channel, and
+            spatial layout as ``input``; border pixels are handled according to
+            the configured border mode.
+        """
         KORNIA_CHECK_IS_TENSOR(input)
         if self.separable:
             return filter2d_separable(input, self.kernel_x, self.kernel_y, self.border_type)

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -75,6 +75,24 @@ class BlurPool2D(nn.Module):
         self.kernel = get_pascal_kernel_2d(kernel_size, norm=True)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Downsample a feature map after applying an anti-aliasing blur.
+
+        Blur pooling first smooths the input with a normalized Pascal kernel
+        and then samples it with the configured stride. The blur step reduces
+        aliasing artifacts that can appear when high-frequency image or feature
+        content is subsampled directly.
+
+        Args:
+            input: Feature map tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the input height, and :math:`W` is the
+                input width.
+
+        Returns:
+            Downsampled tensor with shape :math:`(B, C, H_{out}, W_{out})`.
+            :math:`H_{out}` and :math:`W_{out}` are determined by the kernel
+            size, padding used inside the helper, and ``self.stride``.
+        """
         self.kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
         return _blur_pool_by_kernel2d(input, self.kernel.repeat((input.shape[1], 1, 1, 1)), self.stride)
 
@@ -125,6 +143,23 @@ class MaxBlurPool2D(nn.Module):
         self.kernel = get_pascal_kernel_2d(kernel_size, norm=True)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Apply max pooling and then anti-aliased blur downsampling.
+
+        This layer keeps the local peak response with max pooling before
+        applying the blur-pool downsampling step. It is useful in convolutional
+        networks where pooling should remain less sensitive to small spatial
+        shifts while still reducing the feature resolution.
+
+        Args:
+            input: Feature map tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the channel count,
+                :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H_{out}, W_{out})` after max
+            pooling and blur pooling. The spatial output sizes depend on the
+            configured max-pool size, stride, blur kernel, and ``ceil_mode``.
+        """
         self.kernel = torch.as_tensor(self.kernel, device=input.device, dtype=input.dtype)
         return _max_blur_pool_by_kernel2d(
             input, self.kernel.repeat((input.size(1), 1, 1, 1)), self.stride, self.max_pool_size, self.ceil_mode
@@ -152,6 +187,28 @@ class EdgeAwareBlurPool2D(nn.Module):
         self.edge_dilation_kernel_size = edge_dilation_kernel_size
 
     def forward(self, input: torch.Tensor, epsilon: float = 1e-6) -> torch.Tensor:
+        """Downsample while adapting the blur near image or feature edges.
+
+        Edge-aware blur pooling estimates where strong local changes occur and
+        uses that information to avoid over-smoothing across boundaries before
+        reducing the spatial resolution. The operation is designed for feature
+        maps where edges should remain sharp after downsampling.
+
+        Args:
+            input: Feature map tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the input height, and :math:`W` is the
+                input width.
+            epsilon: Small positive value used to keep edge-aware divisions
+                numerically stable when local normalization terms are close to
+                zero.
+
+        Returns:
+            Edge-aware downsampled tensor with shape
+            :math:`(B, C, H_{out}, W_{out})`. The output preserves channel
+            order while reducing the spatial dimensions according to the
+            configured pooling parameters.
+        """
         return edge_aware_blur_pool2d(
             input, self.kernel_size, self.edge_threshold, self.edge_dilation_kernel_size, epsilon
         )

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -237,6 +237,28 @@ class Canny(nn.Module):
         )
 
     def forward(self, input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Detect image edges with the Canny pipeline.
+
+        The Canny detector smooths the image, estimates spatial gradients,
+        performs non-maximum suppression, and thresholds candidate edges using
+        the configured low and high thresholds. When hysteresis is enabled,
+        weak edge pixels are kept only when they are connected to strong edge
+        pixels.
+
+        Args:
+            input: Image tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the image height, and :math:`W` is the
+                image width. Multi-channel inputs are handled by the underlying
+                functional implementation.
+
+        Returns:
+            Tuple ``(magnitude, edges)``. ``magnitude`` contains the gradient
+            magnitude response for each pixel, and ``edges`` contains the final
+            thresholded edge map. Both tensors follow the layout returned by
+            :func:`canny` and keep the same batch and spatial dimensions as the
+            input.
+        """
         return canny(
             input, self.low_threshold, self.high_threshold, self.kernel_size, self.sigma, self.hysteresis, self.eps
         )

--- a/kornia/filters/dexined.py
+++ b/kornia/filters/dexined.py
@@ -73,6 +73,24 @@ class CoFusion(nn.Module):
         self.norm_layer2 = nn.GroupNorm(4, 64)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Fuse side-output edge maps into a single edge response.
+
+        The input contains edge predictions from several depths of the DexiNed
+        network concatenated along the channel dimension. This block predicts
+        attention weights from those stacked responses and uses them to combine
+        the side outputs into one refined edge map.
+
+        Args:
+            x: Concatenated side-output tensor with shape
+                :math:`(B, C_{side}, H, W)`, where :math:`B` is the batch size,
+                :math:`C_{side}` is the number of stacked side-output channels,
+                :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, 1, H, W)` containing the fused edge
+            response. Larger values indicate locations that the network
+            considers more likely to be image boundaries.
+        """
         # fusecat = torch.cat(x, dim=1)
         attn = self.relu(self.norm_layer1(self.conv1(x)))
         attn = self.relu(self.norm_layer2(self.conv2(attn)))
@@ -138,6 +156,24 @@ class UpConvBlock(nn.Module):
         self.features = nn.Sequential(*layers)
 
     def make_deconv_layers(self, in_features: int, up_scale: int) -> nn.ModuleList:
+        """Build the transposed-convolution stages used by an upsampling branch.
+
+        Each stage reduces or preserves the feature-channel count and increases
+        the spatial resolution by a factor of two. The final stage emits a
+        single-channel side-output edge map, while intermediate stages use the
+        block's constant feature width.
+
+        Args:
+            in_features: Number of channels in the input feature map entering
+                the first upsampling stage.
+            up_scale: Number of progressive upsampling stages to create. A
+                value of ``0`` means no transposed-convolution stages are added.
+
+        Returns:
+            ``nn.ModuleList`` containing the convolution, activation, and
+            transposed-convolution layers that are later wrapped by
+            ``nn.Sequential`` in ``self.features``.
+        """
         layers = nn.ModuleList([])
         all_pads = [0, 0, 1, 3, 7]
         for i in range(up_scale):
@@ -151,9 +187,45 @@ class UpConvBlock(nn.Module):
         return layers
 
     def compute_out_features(self, idx: int, up_scale: int) -> int:
+        """Return the channel count produced by one upsampling stage.
+
+        DexiNed side branches keep a fixed number of channels in intermediate
+        upsampling stages and collapse to a single edge channel at the end.
+        This helper centralizes that rule while ``make_deconv_layers`` builds
+        the branch.
+
+        Args:
+            idx: Zero-based stage index. ``0`` is the first stage and
+                ``up_scale - 1`` is the final stage.
+            up_scale: Total number of upsampling stages in the branch.
+
+        Returns:
+            ``1`` for the final stage, because the side output is an edge map,
+            otherwise ``self.constant_features`` for intermediate feature maps.
+        """
         return 1 if idx == up_scale - 1 else self.constant_features
 
     def forward(self, x: torch.Tensor, out_shape: list[int]) -> torch.Tensor:
+        """Convert a backbone feature map into an aligned side-output edge map.
+
+        The stored upsampling layers progressively increase the resolution of
+        ``x``. A final bilinear interpolation aligns the branch output exactly
+        to ``out_shape`` so that side outputs from different backbone depths can
+        be concatenated later.
+
+        Args:
+            x: Feature tensor with shape :math:`(B, C, H_{in}, W_{in})`, where
+                :math:`B` is the batch size, :math:`C` is the number of input
+                feature channels, and :math:`H_{in}`, :math:`W_{in}` are the
+                current feature-map height and width.
+            out_shape: Target spatial size ``[H, W]`` used for the final
+                interpolation, where :math:`H` is the desired height and
+                :math:`W` is the desired width.
+
+        Returns:
+            Side-output tensor resized to ``out_shape``, typically with shape
+            :math:`(B, 1, H, W)` for an edge prediction branch.
+        """
         out = self.features(x)
         out = F.interpolate(out, out_shape, mode="bilinear")
         return out
@@ -176,6 +248,23 @@ class SingleConvBlock(nn.Module):
         self.bn = nn.BatchNorm2d(out_features)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Project feature channels with a pointwise convolution.
+
+        A ``1x1`` convolution mixes information across channels without
+        changing the spatial resolution. When ``use_bn`` was enabled during
+        construction, batch normalization is applied after the projection.
+
+        Args:
+            x: Feature map tensor with shape :math:`(B, C_{in}, H, W)`, where
+                :math:`B` is the batch size, :math:`C_{in}` is the number of
+                input channels, :math:`H` is the height, and :math:`W` is the
+                width.
+
+        Returns:
+            Tensor with shape :math:`(B, C_{out}, H, W)`, where
+            :math:`C_{out}` is the ``out_features`` value configured for this
+            block.
+        """
         x = self.conv(x)
         if self.use_bn:
             x = self.bn(x)
@@ -264,12 +353,42 @@ class DexiNed(nn.Module):
             self.apply(weight_init)
 
     def load_from_file(self, path_file: str) -> None:
+        """Load pretrained DexiNed weights and switch the module to eval mode.
+
+        The checkpoint is loaded on CPU through ``torch.hub`` and then applied
+        with strict key matching. After loading, ``eval()`` is called so layers
+        such as batch normalization use inference behavior.
+
+        Args:
+            path_file: URL or local checkpoint identifier accepted by
+                :func:`torch.hub.load_state_dict_from_url`.
+        """
         # use torch.hub to load pretrained model
         pretrained_dict = torch.hub.load_state_dict_from_url(path_file, map_location=torch.device("cpu"))
         self.load_state_dict(pretrained_dict, strict=True)
         self.eval()
 
     def get_features(self, x: torch.Tensor) -> list[torch.Tensor]:
+        """Compute the DexiNed side-output edge maps before final fusion.
+
+        The image is processed through the stacked backbone blocks. Each block
+        produces a feature map at a different semantic depth and spatial scale;
+        the corresponding side branch upsamples it back to the original image
+        resolution. The returned list is later concatenated and fused by
+        ``CoFusion``.
+
+        Args:
+            x: Input image tensor with shape :math:`(B, 3, H, W)`, where
+                :math:`B` is the batch size, ``3`` is the RGB channel count,
+                :math:`H` is the image height, and :math:`W` is the image
+                width.
+
+        Returns:
+            List of six tensors, each aligned to the input spatial size. Every
+            tensor represents a side-output edge prediction with batch
+            dimension :math:`B` and spatial dimensions :math:`H` and
+            :math:`W`.
+        """
         # Block 1
         block_1 = self.block_1(x)
         block_1_side = self.side_1(block_1)
@@ -316,6 +435,23 @@ class DexiNed(nn.Module):
         return results
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Predict a fused edge map from an RGB image batch.
+
+        The forward pass collects six multi-scale side outputs, concatenates
+        them along the channel dimension, and applies the fusion block to
+        produce the final edge response. This keeps both low-level edge detail
+        and deeper semantic boundary information in the prediction.
+
+        Args:
+            x: Input image tensor with shape :math:`(B, 3, H, W)`, where
+                :math:`B` is the batch size, ``3`` is the RGB channel count,
+                :math:`H` is the image height, and :math:`W` is the image
+                width.
+
+        Returns:
+            Tensor with shape :math:`(B, 1, H, W)` containing the fused edge
+            probability-style response for each image in the batch.
+        """
         features = self.get_features(x)
 
         # torch.cat multiscale outputs

--- a/kornia/filters/dissolving.py
+++ b/kornia/filters/dissolving.py
@@ -273,4 +273,26 @@ class StableDiffusionDissolving(ImageModule):
         self.model = _DissolvingWraper_HF(self._sdm_model, num_ddim_steps=1000, is_sdxl=is_sdxl)
 
     def forward(self, input: torch.Tensor, step_number: int) -> torch.Tensor:
+        """Apply one Stable Diffusion dissolving step to an image tensor.
+
+        The wrapped diffusion model progressively removes or weakens image
+        content according to the requested diffusion timestep. Lower and higher
+        ``step_number`` values correspond to different points on the internal
+        denoising schedule configured by the wrapper.
+
+        Args:
+            input: Image tensor passed to the wrapped dissolving model. The
+                expected shape follows the model wrapper, typically
+                :math:`(B, C, H, W)`, where :math:`B` is the batch size,
+                :math:`C` is the channel count, :math:`H` is the image height,
+                and :math:`W` is the image width.
+            step_number: Integer diffusion timestep used by the dissolving
+                process. It selects how far along the configured DDIM schedule
+                the image is processed.
+
+        Returns:
+            Tensor produced by the diffusion model at ``step_number``. The
+            tensor follows the wrapper's image layout and represents the
+            dissolved version of ``input``.
+        """
         return self.model.dissolve(input, step_number)

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -169,6 +169,24 @@ class GaussianBlur2d(nn.Module):
         )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Blur an image with a Gaussian low-pass filter.
+
+        Gaussian blur computes a weighted local average where pixels near the
+        center of the kernel have larger weights than pixels farther away. The
+        configured standard deviation, ``sigma``, controls how quickly those
+        weights decay with distance, and the kernel size controls the support
+        of the approximation.
+
+        Args:
+            input: Image or feature tensor with shape :math:`(B, C, H, W)`,
+                where :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the smoothed
+            result. The output keeps the same channel layout as ``input`` while
+            reducing high-frequency noise and fine texture.
+        """
         return gaussian_blur2d(input, self.kernel_size, self.sigma, self.border_type, self.separable)
 
 

--- a/kornia/filters/guided.py
+++ b/kornia/filters/guided.py
@@ -228,4 +228,26 @@ class GuidedBlur(nn.Module):
         )
 
     def forward(self, guidance: torch.Tensor, input: torch.Tensor) -> torch.Tensor:
+        """Filter an input tensor with local linear guidance.
+
+        Guided filtering assumes that, inside each local window, the output can
+        be represented as a linear transform of the ``guidance`` image. This
+        makes the filter useful for edge-aware smoothing: flat regions are
+        averaged, while strong structures in the guidance tensor are preserved
+        in the filtered result.
+
+        Args:
+            guidance: Guidance tensor with shape :math:`(B, C_g, H, W)`, where
+                :math:`B` is the batch size, :math:`C_g` is the number of
+                guidance channels, :math:`H` is the height, and :math:`W` is
+                the width.
+            input: Tensor to filter with shape :math:`(B, C_i, H, W)`, where
+                :math:`C_i` is the number of channels in the signal being
+                smoothed. Its batch and spatial dimensions must be compatible
+                with ``guidance``.
+
+        Returns:
+            Tensor with shape :math:`(B, C_i, H, W)` containing the
+            edge-aware filtered version of ``input``.
+        """
         return guided_blur(guidance, input, self.kernel_size, self.eps, self.border_type, self.subsample)

--- a/kornia/filters/in_range.py
+++ b/kornia/filters/in_range.py
@@ -189,4 +189,22 @@ class InRange(nn.Module):
         self.return_mask = return_mask
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Select values that fall inside the configured inclusive range.
+
+        The stored ``lower`` and ``upper`` bounds are compared against
+        ``input`` channel-wise. Depending on ``self.return_mask``, the module
+        either returns the binary in-range mask itself or uses that mask to keep
+        only values that satisfy the bounds.
+
+        Args:
+            input: Tensor to test against the configured bounds. For images the
+                usual shape is :math:`(B, C, H, W)`, where :math:`B` is the
+                batch size, :math:`C` is the number of channels, :math:`H` is
+                the height, and :math:`W` is the width.
+
+        Returns:
+            If ``self.return_mask`` is ``True``, a mask indicating which
+            entries lie within the inclusive range. Otherwise, a tensor with
+            values outside the range removed according to :func:`in_range`.
+        """
         return in_range(input, self.lower, self.upper, self.return_mask)

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -106,4 +106,21 @@ class Laplacian(nn.Module):
         )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Compute the second-order Laplacian response of an image tensor.
+
+        The Laplacian filter measures rapid local intensity changes by
+        combining second derivatives along the spatial axes. It is commonly
+        used for edge detection, focus measures, and highlighting fine image
+        detail.
+
+        Args:
+            input: Image tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the Laplacian
+            response for each batch item and channel. Positive and negative
+            values represent opposite directions of local curvature.
+        """
         return laplacian(input, self.kernel_size, self.border_type, self.normalized)

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -98,4 +98,21 @@ class MedianBlur(nn.Module):
         self.kernel_size = kernel_size
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Replace each pixel with the median value in its local window.
+
+        Median filtering is a non-linear smoothing operation. Instead of
+        averaging neighboring values, it sorts the values inside the kernel
+        window and chooses the middle value. This makes it effective for
+        reducing impulse-like noise while preserving sharper boundaries than a
+        simple mean filter.
+
+        Args:
+            input: Image or feature tensor with shape :math:`(B, C, H, W)`,
+                where :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the median-
+            filtered result for each channel independently.
+        """
         return median_blur(input, self.kernel_size)

--- a/kornia/filters/motion.py
+++ b/kornia/filters/motion.py
@@ -75,6 +75,23 @@ class MotionBlur(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Blur an image along a configured two-dimensional motion direction.
+
+        The motion-blur kernel simulates linear camera or object movement in
+        the image plane. ``self.angle`` controls the direction of the blur, and
+        ``self.direction`` controls whether the kernel is centered, forward-
+        biased, or backward-biased along that line.
+
+        Args:
+            x: Image tensor with shape :math:`(B, C, H, W)`, where :math:`B`
+                is the batch size, :math:`C` is the number of channels,
+                :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the directional
+            blur response. The output uses the same batch, channel, and spatial
+            layout as ``x``.
+        """
         return motion_blur(x, self.kernel_size, self.angle, self.direction, self.border_type)
 
 
@@ -140,6 +157,22 @@ class MotionBlur3D(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Blur a volume along a configured three-dimensional motion direction.
+
+        This module extends motion blur from images to volumetric tensors. The
+        configured kernel is applied through depth, height, and width so that
+        movement can be modeled in three spatial dimensions.
+
+        Args:
+            x: Volume tensor with shape :math:`(B, C, D, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the channel count,
+                :math:`D` is the depth, :math:`H` is the height, and
+                :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, D, H, W)` containing the blurred
+            volume. The output keeps the same dimensional order as ``x``.
+        """
         return motion_blur3d(x, self.kernel_size, self.angle, self.direction, self.border_type)
 
 

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -207,6 +207,25 @@ class SpatialGradient(nn.Module):
         return f"{self.__class__.__name__}(order={self.order}, normalized={self.normalized}, mode={self.mode})"
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Compute horizontal and vertical spatial derivatives.
+
+        The module applies Sobel or difference kernels, depending on
+        ``self.mode``, to estimate image gradients along the width and height
+        axes. First-order derivatives describe local slope; second-order
+        derivatives describe how that slope changes.
+
+        Args:
+            input: Image tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Gradient tensor from :func:`spatial_gradient`. For first-order
+            derivatives the shape is typically :math:`(B, C, 2, H, W)`, where
+            the derivative axis of size ``2`` stores the response along
+            :math:`x` (width) and :math:`y` (height). Higher orders may expose
+            additional derivative components according to the functional API.
+        """
         return spatial_gradient(input, self.mode, self.order, self.normalized)
 
 
@@ -245,6 +264,24 @@ class SpatialGradient3d(nn.Module):
         return f"{self.__class__.__name__}(order={self.order}, mode={self.mode})"
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Compute spatial derivatives through depth, height, and width.
+
+        This is the volumetric counterpart of :class:`SpatialGradient`. It
+        estimates changes along the three spatial axes of a five-dimensional
+        tensor, which is useful for 3D images, videos represented as volumes,
+        or feature maps with an explicit depth dimension.
+
+        Args:
+            input: Volume tensor with shape :math:`(B, C, D, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the channel count,
+                :math:`D` is the depth, :math:`H` is the height, and
+                :math:`W` is the width.
+
+        Returns:
+            Derivative tensor from :func:`spatial_gradient3d`. The output keeps
+            the input batch and channel dimensions and includes a derivative
+            axis for the spatial directions requested by ``self.order``.
+        """
         return spatial_gradient3d(input, self.mode, self.order)
 
 
@@ -277,4 +314,22 @@ class Sobel(nn.Module):
         return f"{self.__class__.__name__}(normalized={self.normalized})"
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Compute the Sobel gradient magnitude for every image channel.
+
+        Sobel filtering estimates horizontal and vertical derivatives and then
+        combines them into a magnitude response. Large values indicate strong
+        local intensity changes, which often correspond to edges or texture
+        boundaries.
+
+        Args:
+            input: Image tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the height, and :math:`W` is the width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the gradient
+            magnitude for each channel. The ``self.eps`` value is used by the
+            underlying function to keep magnitude computation numerically
+            stable near zero.
+        """
         return sobel(input, self.normalized, self.eps)

--- a/kornia/filters/unsharp.py
+++ b/kornia/filters/unsharp.py
@@ -96,4 +96,22 @@ class UnsharpMask(nn.Module):
         self.border_type = border_type
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Sharpen an image by adding back high-frequency detail.
+
+        Unsharp masking first builds a blurred version of the image and then
+        uses the difference between the original and blurred images as a detail
+        signal. Adding that detail back emphasizes edges and fine texture while
+        keeping the tensor layout unchanged.
+
+        Args:
+            input: Image tensor with shape :math:`(B, C, H, W)`, where
+                :math:`B` is the batch size, :math:`C` is the number of
+                channels, :math:`H` is the image height, and :math:`W` is the
+                image width.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing the sharpened
+            image. The amount and spatial scale of sharpening are controlled by
+            the configured Gaussian kernel size, sigma, and border handling.
+        """
         return unsharp_mask(input, self.kernel_size, self.sigma, self.border_type)


### PR DESCRIPTION
## Description

Fixes/Relates to: Follow-up to PR https://github.com/kornia/kornia/pull/3648 / Issue https://github.com/kornia/kornia/issues/3083 as discussed with @edgarriba.

(Note to maintainers: As discussed in PR https://github.com/kornia/kornia/pull/3648, I am splitting the docstring fixes by module to keep reviews clean. This PR covers the entire kornia/filters/ folder. Let me know if you need me to open a new specific issue for this, otherwise, the bot might complain about the assignment!)

Adds detailed docstrings for missing public methods in the `kornia.filters` module.

The new documentation focuses on explaining what each filtering wrapper does, what tensor shapes are expected, and how parameters such as kernel sizes, sigma values, border handling, thresholds, and channel dimensions are interpreted. The goal is to make these APIs easier to understand for both new users and contributors reading the module for the first time.


## Changes Made

- Added missing public method docstrings reported by `pydocstyle` for `D101`, `D102`, and `D103`.
- Documented input and output tensor shapes using readable notation.
- Clarified common abbreviations such as `B` for batch size, `C` for channels, `H` for height, and `W` for width where relevant.
- Kept the change documentation-only with no implementation or behavior changes.

## How Was This Tested?

- Ran `pydocstyle --select=D101,D102,D103 kornia/filters`.
- Verified the filters module reports no remaining missing public docstrings for the selected checks.