### PR TITLE
docs(image): add detailed missing public docstrings

### DIFF
--- a/kornia/image/utils.py
+++ b/kornia/image/utils.py
@@ -238,6 +238,19 @@ class ImageToTensor(nn.Module):
         self.keepdim = keepdim
 
     def forward(self, x: Any) -> torch.Tensor:
+        """Convert a NumPy-style image object into a PyTorch image tensor.
+
+        Args:
+            x: Input image array accepted by :func:`image_to_tensor`. Common
+                layouts are ``(H, W)``, ``(H, W, C)``, or ``(B, H, W, C)``,
+                where :math:`B` is batch size, :math:`H` is height,
+                :math:`W` is width, and :math:`C` is channel count.
+
+        Returns:
+            Tensor returned by :func:`image_to_tensor`. When ``self.keepdim`` is
+            ``False``, a batch dimension is added so image data follows
+            PyTorch's channel-first convention.
+        """
         return image_to_tensor(x, keepdim=self.keepdim)
 
 


### PR DESCRIPTION
## Description

Fixes/Relates to: Follow-up to PR https://github.com/kornia/kornia/pull/3648 / Issue https://github.com/kornia/kornia/issues/3083 as discussed with @edgarriba.

Adds a detailed missing public method docstring for the image module.

The new docstring explains the expected image tensor layout, including the meaning of `B`, `H`, `W`, and `C`, and clarifies how the module converts input images into PyTorch's channel-first tensor format.

## Changes Made

- Added detailed public docstring coverage for `ImageToTensor.forward`.
- Clarified input and output tensor shapes for beginner readers.
- Kept the implementation unchanged.

## Files Changed

- `kornia/image/utils.py`

## How Was This Tested?

- `pydocstyle --select=D101,D102,D103 kornia/image`
- `git diff --check -- kornia/image`