### PR TITLE
docs(metrics): add detailed missing public docstrings

### DIFF
--- a/kornia/metrics/average_meter.py
+++ b/kornia/metrics/average_meter.py
@@ -41,12 +41,20 @@ class AverageMeter:
         self.reset()
 
     def reset(self) -> None:
+        """Reset the current value, accumulated sum, count, and average."""
         self.val = 0
         self._avg = 0
         self.sum = 0
         self.count = 0
 
     def update(self, val: Union[float, bool, torch.Tensor], n: int = 1) -> None:
+        """Add a new value to the running average.
+
+        Args:
+            val: New scalar value or scalar tensor to accumulate.
+            n: Weight for ``val``. This is usually the batch size represented
+                by the value.
+        """
         self.val = val
         self.sum += val * n
         self.count += n
@@ -54,6 +62,7 @@ class AverageMeter:
 
     @property
     def avg(self) -> float:
+        """Return the accumulated average as a Python float."""
         if isinstance(self._avg, torch.Tensor):
             return float(self._avg.item())
         return self._avg

--- a/kornia/metrics/endpoint_error.py
+++ b/kornia/metrics/endpoint_error.py
@@ -107,6 +107,17 @@ class AEPE(nn.Module):
         self.reduction: str = reduction
 
     def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Compute average endpoint error between vector fields.
+
+        Args:
+            input: Predicted vector field with shape :math:`(B, H, W, 2)`.
+            target: Target vector field with the same shape as ``input``.
+
+        Returns:
+            Endpoint-error tensor reduced according to ``self.reduction``.
+            The endpoint error is the Euclidean distance between predicted and
+            target vectors at each spatial location.
+        """
         return aepe(input, target, self.reduction)
 
 

--- a/kornia/metrics/ssim.py
+++ b/kornia/metrics/ssim.py
@@ -185,4 +185,14 @@ class SSIM(nn.Module):
         self.padding = padding
 
     def forward(self, img1: torch.Tensor, img2: torch.Tensor) -> torch.Tensor:
+        """Compute a 2D SSIM map between two image batches.
+
+        Args:
+            img1: First image tensor with shape :math:`(B, C, H, W)`.
+            img2: Second image tensor with the same shape as ``img1``.
+
+        Returns:
+            Tensor with shape :math:`(B, C, H, W)` containing local structural
+            similarity values for each channel and spatial location.
+        """
         return ssim(img1, img2, self.window_size, self.max_val, self.eps, self.padding)

--- a/kornia/metrics/ssim3d.py
+++ b/kornia/metrics/ssim3d.py
@@ -186,4 +186,14 @@ class SSIM3D(nn.Module):
         self.padding = padding
 
     def forward(self, img1: torch.Tensor, img2: torch.Tensor) -> torch.Tensor:
+        """Compute a 3D SSIM map between two volume batches.
+
+        Args:
+            img1: First volume tensor with shape :math:`(B, C, D, H, W)`.
+            img2: Second volume tensor with the same shape as ``img1``.
+
+        Returns:
+            Tensor with shape :math:`(B, C, D, H, W)` containing local
+            structural similarity values across depth, height, and width.
+        """
         return ssim3d(img1, img2, self.window_size, self.max_val, self.eps, self.padding)


### PR DESCRIPTION
## Description

Fixes/Relates to: Follow-up to PR https://github.com/kornia/kornia/pull/3648 / Issue https://github.com/kornia/kornia/issues/3083 as discussed with @edgarriba.

Adds detailed missing public docstrings for the metrics module.

The docstrings describe how metric wrappers receive prediction and target tensors, explain common tensor symbols such as `B`, `C`, `H`, `W`, and `D`, and clarify what each returned metric value represents.

## Changes Made

- Added public method docstrings for average-meter state handling.
- Added detailed forward docstrings for SSIM, SSIM3D, and endpoint error metric wrappers.
- Clarified image, volume, and flow tensor layouts.
- Kept runtime behavior unchanged.

## Files Changed

- `kornia/metrics/average_meter.py`
- `kornia/metrics/endpoint_error.py`
- `kornia/metrics/ssim.py`
- `kornia/metrics/ssim3d.py`

## How Was This Tested?

- `pydocstyle --select=D101,D102,D103 kornia/metrics`
- `git diff --check -- kornia/metrics`