### PR TITLE
docs(onnx): add detailed missing public docstrings

### DIFF
--- a/kornia/onnx/download.py
+++ b/kornia/onnx/download.py
@@ -60,6 +60,27 @@ class CachedDownloader:
 
     @classmethod
     def download_to_cache(cls, url: str, name: str, download: bool = True, **kwargs: Any) -> str:
+        """Resolve a remote file into Kornia's local cache and download it when needed.
+
+        Args:
+            url: HTTP or HTTPS URL of the file to cache.
+            name: Logical model or operator name used to construct the cache
+                path. Directory components in ``name`` are preserved under the
+                cache directory.
+            download: If ``True``, download the file when it is not already
+                present in the cache. If ``False``, require the cached file to
+                exist.
+            kwargs: Optional cache parameters. Supported keys include
+                ``cache_dir`` for overriding the default cache root and
+                ``suffix`` for appending a filename suffix when needed.
+
+        Returns:
+            Local filesystem path to the cached file.
+
+        Raises:
+            ValueError: If ``url`` is not an HTTP or HTTPS URL, or if download is
+                disabled and the file is missing.
+        """
         if url.startswith(("http:", "https:")):
             cache_dir = kwargs.get("cache_dir", None)
             suffix = kwargs.get("suffix", None)

--- a/kornia/onnx/module.py
+++ b/kornia/onnx/module.py
@@ -63,12 +63,43 @@ class ONNXModule(ONNXMixin, ONNXRuntimeMixin):
     def create_session(
         self, providers: list[str] | None = None, session_options: Any | None = None
     ) -> ort.InferenceSession:  # type: ignore
+        """Create an ONNX Runtime session for the wrapped model graph.
+
+        Args:
+            providers: Optional ordered list of ONNX Runtime execution providers,
+                such as ``"CUDAExecutionProvider"`` followed by
+                ``"CPUExecutionProvider"``. The first available provider is used
+                according to ONNX Runtime's provider selection rules.
+            session_options: Optional ONNX Runtime session options controlling
+                graph optimization, threading, logging, and other runtime
+                execution settings.
+
+        Returns:
+            ONNX Runtime inference session bound to ``self.op``, the wrapped
+            ONNX model graph.
+        """
         return super()._create_session(self.op, providers, session_options)
 
     def export(self, file_path: str, **kwargs: Any) -> None:
+        """Serialize the wrapped ONNX model graph to disk.
+
+        Args:
+            file_path: Destination path for the exported ``.onnx`` file.
+            kwargs: Additional keyword arguments forwarded to the underlying
+                ONNX export helper.
+        """
         return super()._export(self.op, file_path, **kwargs)
 
     def add_metadata(self, additional_metadata: Optional[list[tuple[str, str]]] = None) -> onnx.ModelProto:  # type:ignore
+        """Attach metadata entries to the wrapped ONNX model graph.
+
+        Args:
+            additional_metadata: Optional list of ``(key, value)`` string pairs
+                to store in the ONNX model metadata properties.
+
+        Returns:
+            The wrapped ONNX model graph after metadata has been added.
+        """
         return super()._add_metadata(self.op, additional_metadata)
 
 

--- a/kornia/onnx/sequential.py
+++ b/kornia/onnx/sequential.py
@@ -101,15 +101,53 @@ class ONNXSequential(ONNXMixin, ONNXRuntimeMixin):
         return op_list
 
     def combine(self, io_maps: list[tuple[str, str]] | None = None) -> onnx.ModelProto:  # type: ignore
+        """Combine the stored ONNX operators into one executable graph.
+
+        Args:
+            io_maps: Optional list of ``(source_output, target_input)`` name
+                pairs describing how adjacent graphs should be connected. When
+                omitted, the helper assumes the default single input/output
+                names used by the ONNX composition utility.
+
+        Returns:
+            Combined ONNX model graph containing all operators in
+            ``self.operators`` connected in sequence.
+        """
         return super()._combine(*self.operators, io_maps=io_maps)
 
     def create_session(
         self, providers: list[str] | None = None, session_options: Any | None = None
     ) -> ort.InferenceSession:  # type: ignore
+        """Create an ONNX Runtime session for the combined graph.
+
+        Args:
+            providers: Optional ordered list of execution providers used by ONNX
+                Runtime, for example GPU first and CPU as fallback.
+            session_options: Optional ONNX Runtime session options controlling
+                optimization, threading, and runtime behavior.
+
+        Returns:
+            ONNX Runtime inference session for ``self._combined_op``.
+        """
         return super()._create_session(self._combined_op, providers, session_options)
 
     def export(self, file_path: str, **kwargs: Any) -> None:
+        """Serialize the combined ONNX graph to an ``.onnx`` file.
+
+        Args:
+            file_path: Destination path where the composed ONNX graph is saved.
+            kwargs: Additional keyword arguments forwarded to the export helper.
+        """
         return super()._export(self._combined_op, file_path, **kwargs)
 
     def add_metadata(self, additional_metadata: Optional[list[tuple[str, str]]] = None) -> onnx.ModelProto:  # type:ignore
+        """Attach metadata entries to the combined ONNX graph.
+
+        Args:
+            additional_metadata: Optional list of ``(key, value)`` pairs to add
+                to the ONNX model metadata properties.
+
+        Returns:
+            Combined ONNX model graph after metadata has been attached.
+        """
         return super()._add_metadata(self._combined_op, additional_metadata)


### PR DESCRIPTION
## Description

Fixes/Relates to: Follow-up to PR https://github.com/kornia/kornia/pull/3648 / Issue https://github.com/kornia/kornia/issues/3083 as discussed with @edgarriba 

Adds detailed missing public docstrings for the `kornia.onnx` module.

The docstrings explain ONNX Runtime session creation, graph export, metadata attachment, graph composition, and cached downloads. They clarify how execution providers, session options, cache paths, and metadata pairs are used.

## Changes Made

- Added public method docstrings for `ONNXModule`.
- Added public method docstrings for `ONNXSequential`.
- Added a public method docstring for cached ONNX downloads.
- Kept runtime behavior unchanged.

## Files Changed

- `kornia/onnx/download.py`
- `kornia/onnx/module.py`
- `kornia/onnx/sequential.py`

## How Was This Tested?

- `pydocstyle --select=D101,D102,D103 kornia/onnx`
- `git diff --check -- kornia/onnx`
- `python3 -m py_compile kornia/onnx/*.py`