### PR TITLE
docs(sensors): add detailed missing public docstrings

### DIFF
--- a/kornia/sensors/camera/distortion_model.py
+++ b/kornia/sensors/camera/distortion_model.py
@@ -89,9 +89,42 @@ class BrownConradyTransform:
     """
 
     def distort(self, params: torch.Tensor, points: Vector2) -> Vector2:
+        """Apply Brown-Conrady lens distortion to ideal normalized points.
+
+        Args:
+            params: Distortion parameter tensor, typically containing radial
+                coefficients such as ``k1``, ``k2``, ``k3`` and tangential
+                coefficients such as ``p1`` and ``p2``.
+            points: Ideal two-dimensional normalized points before lens
+                distortion. Leading dimensions may represent a batch.
+
+        Returns:
+            Distorted two-dimensional points in the same coordinate convention.
+
+        Raises:
+            NotImplementedError: The Brown-Conrady transform interface is
+                declared here, but the concrete computation is not implemented.
+        """
         raise NotImplementedError
 
     def undistort(self, params: torch.Tensor, points: Vector2) -> Vector2:
+        """Remove Brown-Conrady lens distortion from observed points.
+
+        Args:
+            params: Distortion parameter tensor matching the coefficients used
+                by :meth:`distort`.
+            points: Distorted two-dimensional points, usually measured in the
+                normalized image plane.
+
+        Returns:
+            Undistorted two-dimensional points that approximate the ideal
+            pinhole projection.
+
+        Raises:
+            NotImplementedError: The Brown-Conrady inverse transform interface
+                is declared here, but the concrete computation is not
+                implemented.
+        """
         raise NotImplementedError
 
 
@@ -103,7 +136,36 @@ class KannalaBrandtK3Transform:
     """
 
     def distort(self, params: torch.Tensor, points: Vector2) -> Vector2:
+        """Apply Kannala-Brandt K3 fisheye distortion to normalized points.
+
+        Args:
+            params: Fisheye distortion coefficients for the K3 polynomial model.
+            points: Ideal two-dimensional normalized points before fisheye
+                distortion is applied.
+
+        Returns:
+            Distorted two-dimensional points following the K3 fisheye model.
+
+        Raises:
+            NotImplementedError: The K3 distortion interface is declared here,
+                but the concrete computation is not implemented.
+        """
         raise NotImplementedError
 
     def undistort(self, params: torch.Tensor, points: Vector2) -> Vector2:
+        """Remove Kannala-Brandt K3 fisheye distortion from observed points.
+
+        Args:
+            params: Fisheye distortion coefficients matching the K3 model used
+                for distortion.
+            points: Distorted two-dimensional fisheye points.
+
+        Returns:
+            Undistorted normalized points that approximate ideal pinhole
+            coordinates.
+
+        Raises:
+            NotImplementedError: The K3 inverse distortion interface is
+                declared here, but the concrete computation is not implemented.
+        """
         raise NotImplementedError

--- a/kornia/sensors/camera/projection_model.py
+++ b/kornia/sensors/camera/projection_model.py
@@ -85,7 +85,42 @@ class OrthographicProjection:
     """
 
     def project(self, points: Vector3) -> Vector2:
+        """Project 3D camera-frame points with an orthographic camera model.
+
+        Orthographic projection keeps the horizontal and vertical coordinates
+        unchanged and discards depth. Unlike perspective projection, objects do
+        not shrink as their ``z`` value increases.
+
+        Args:
+            points: Three-dimensional point container with coordinates
+                ``x``, ``y``, and ``z``. Leading dimensions may represent a
+                batch of points.
+
+        Returns:
+            Two-dimensional point container containing the projected ``x`` and
+            ``y`` coordinates.
+
+        Raises:
+            NotImplementedError: This projection model is declared as an
+                interface placeholder and is not implemented yet.
+        """
         raise NotImplementedError
 
     def unproject(self, points: Vector2, depth: torch.Tensor) -> Vector3:
+        """Lift orthographic image-plane points back into 3D using depth.
+
+        Args:
+            points: Two-dimensional point container with image-plane
+                coordinates ``x`` and ``y``.
+            depth: Tensor containing the target ``z`` coordinate for each
+                unprojected point.
+
+        Returns:
+            Three-dimensional point container with ``x`` and ``y`` copied from
+            ``points`` and ``z`` supplied by ``depth``.
+
+        Raises:
+            NotImplementedError: This projection model is declared as an
+                interface placeholder and is not implemented yet.
+        """
         raise NotImplementedError


### PR DESCRIPTION
## Description

Fixes/Relates to: Follow-up to PR https://github.com/kornia/kornia/pull/3648 / Issue https://github.com/kornia/kornia/issues/3083 as discussed with @edgarriba 


Adds detailed missing public docstrings for camera sensor projection and distortion model interfaces.

The docstrings explain projection, unprojection, distortion, and undistortion behavior, including the role of 2D and 3D vector containers, depth, lens distortion parameters, and currently unimplemented interface methods.

## Changes Made

- Added public method docstrings for orthographic projection methods.
- Added public method docstrings for Brown-Conrady distortion interface methods.
- Added public method docstrings for Kannala-Brandt K3 fisheye distortion interface methods.
- Kept runtime behavior unchanged.

## Files Changed

- `kornia/sensors/camera/distortion_model.py`
- `kornia/sensors/camera/projection_model.py`

## How Was This Tested?

- `pydocstyle --select=D101,D102,D103 kornia/sensors`
- `git diff --check -- kornia/sensors`
- `python3 -m py_compile kornia/sensors/camera/*.py`