### PR TITLE
Optimize OnnxLightGlue DLPack output conversion by removing redundant device transfer

### DIFF
--- a/kornia/feature/lightglue_onnx/lightglue.py
+++ b/kornia/feature/lightglue_onnx/lightglue.py
@@ -189,8 +189,8 @@ class OnnxLightGlue:
         # The fallback path uses NumPy, which incurs a device-to-host copy and is slower.
         if hasattr(matches, "to_dlpack"):
             outputs = {
-                "matches": dlpack.from_dlpack(matches.to_dlpack()).to(self.device),
-                "scores": dlpack.from_dlpack(mscores.to_dlpack()).to(self.device),
+                "matches": dlpack.from_dlpack(matches.to_dlpack()),
+                "scores": dlpack.from_dlpack(mscores.to_dlpack()),
             }
         else:
             outputs = {

--- a/tests/feature/test_lightglue_onnx.py
+++ b/tests/feature/test_lightglue_onnx.py
@@ -65,6 +65,8 @@ class TestOnnxLightGlue:
 
         assert "matches" in outputs
         assert "scores" in outputs
+        assert outputs["matches"].device.type == model.device.type
+        assert outputs["scores"].device.type == model.device.type
 
     def test_normalize_keypoints(self):
         kpts = torch.randint(0, 100, (1, 5, 2))


### PR DESCRIPTION
## 📝 Description

This PR removes redundant .to(self.device) calls from the DLPack output conversion path in OnnxLightGlue.

When ONNX Runtime outputs are retrieved through IOBinding and converted using DLPack, device placement is already preserved by the DLPack interoperability mechanism. The additional .to(self.device) operation is therefore unnecessary in this code path.

The NumPy fallback path remains unchanged since tensors created through torch.from_numpy() are CPU-resident and still require an explicit device transfer when running on CUDA.

Fixes #3749


## 🛠️ Changes Made
- [x] Removed redundant .to(self.device) calls from the DLPack conversion path.
- [x] I have added tests that prove my fix is effective or that my feature works.


---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** (List new/updated tests)
  Verified that outputs returned through the DLPack path are placed on the expected device.
  Verified that the NumPy fallback path continues to return tensors on the requested device.
- [x] **Manual Verification:** (Describe the steps you took)
    Executed OnnxLightGlue inference and confirmed output tensor devices match the execution provider device.
- [x] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?):
  Confirmed behavior remains unchanged for both CPU and CUDA execution providers.
  No API or output format changes.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [x] 🟢 **No AI used.**
---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.

