### PR TITLE
fix(filters): handle empty batch (B=0) in median_blur

### DIFF
--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -57,6 +57,7 @@ def median_blur(input: torch.Tensor, kernel_size: tuple[int, int] | int) -> torc
     KORNIA_CHECK_IS_TENSOR(input)
     KORNIA_CHECK_SHAPE(input, ["B", "C", "H", "W"])
 
+    ky, kx = _unpack_2d_ks(kernel_size)
     padding = _compute_zero_padding(kernel_size)
 
     # prepare kernel
@@ -65,7 +66,7 @@ def median_blur(input: torch.Tensor, kernel_size: tuple[int, int] | int) -> torc
 
     # map the local window to single vector
     features: torch.Tensor = F.conv2d(input.reshape(b * c, 1, h, w), kernel, padding=padding, stride=1)
-    features = features.view(b, c, -1, h, w)  # BxCx(K_h * K_w)xHxW
+    features = features.view(b, c, ky * kx, h, w)  # BxCx(K_h * K_w)xHxW
 
     # compute the median along the feature axis
     return features.median(dim=2)[0]

--- a/tests/filters/test_median.py
+++ b/tests/filters/test_median.py
@@ -29,7 +29,7 @@ class TestMedianBlur(BaseTester):
         actual = median_blur(inp, 3)
         assert isinstance(actual, torch.Tensor)
 
-    @pytest.mark.parametrize("batch_size", [1, 2])
+    @pytest.mark.parametrize("batch_size", [0, 1, 2])
     @pytest.mark.parametrize("kernel_size", [3, (5, 7)])
     def test_cardinality(self, batch_size, kernel_size, device, dtype):
         inp = torch.zeros(batch_size, 3, 4, 4, device=device, dtype=dtype)


### PR DESCRIPTION
## 📝 Description

Fixes #3580

`median_blur` crashed on a zero-sized batch. The local-window features are
reshaped with an inferred `-1` dimension:

```python
features = features.view(b, c, -1, h, w)
```

When `B = 0` the tensor has 0 elements, so PyTorch cannot resolve `-1`
unambiguously and raises:

> RuntimeError: cannot reshape tensor of 0 elements into shape [0, 1, -1, 64, 64]
> because the unspecified dimension size -1 can be any value and is ambiguous

Sibling filters (`gaussian_blur2d`, `box_blur`, `bilateral_blur`, ...) already
handle `B = 0` correctly, so this aligns `median_blur` with the rest of the
module and with PyTorch's convention that ops accept 0-batch tensors.

**Fixes/Relates to:** #3580

---

## 🛠️ Changes Made
- [x] `kornia/filters/median.py`: replace the inferred `-1` reshape dimension with the explicit kernel-element count `ky * kx` (from the already-imported `_unpack_2d_ks`), which is well defined regardless of batch size.
- [x] `tests/filters/test_median.py`: extend `test_cardinality` with `batch_size=0`.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** `test_cardinality` now parametrizes `batch_size=0` over kernel sizes `3` and `(5, 7)`.
- [x] **Manual Verification:** confirmed `median_blur(torch.empty(0, 1, 64, 64), (3, 3))` now returns shape `(0, 1, 64, 64)`, and that the exact `RuntimeError` reproduces on `main` without the fix.
- [x] **Performance/Edge Cases:** output shape and values are unchanged for all non-empty inputs; only the previously-crashing `B = 0` path is fixed.

```
$ pytest tests/filters/test_median.py -q --dtype=float32,float64
25 passed, 43 warnings in 0.28s

$ pytest tests/filters/test_median.py::TestMedianBlur::test_cardinality -v --dtype=float32
tests/filters/test_median.py::TestMedianBlur::test_cardinality[cpu-float32-3-0] PASSED
tests/filters/test_median.py::TestMedianBlur::test_cardinality[cpu-float32-3-1] PASSED
tests/filters/test_median.py::TestMedianBlur::test_cardinality[cpu-float32-3-2] PASSED
tests/filters/test_median.py::TestMedianBlur::test_cardinality[cpu-float32-kernel_size1-0] PASSED
tests/filters/test_median.py::TestMedianBlur::test_cardinality[cpu-float32-kernel_size1-1] PASSED
tests/filters/test_median.py::TestMedianBlur::test_cardinality[cpu-float32-kernel_size1-2] PASSED
6 passed in 0.22s
```

`ruff check` and `ruff format --check` pass on both changed files.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ x] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.

---

## 💭 Additional Context
Reference: this follows PyTorch `view`/`reshape` semantics — an inferred `-1`
dimension is undefined when the tensor has 0 elements, whereas a fixed
`ky * kx` is not. The kernel-element count equals the number of values the
median is taken over per pixel, matching the existing `# BxCx(K_h * K_w)xHxW`
annotation.
