### PR TITLE
fix(geometry): remove import-time torch.jit.script decorators

### DIFF
--- a/kornia/geometry/epipolar/_metrics.py
+++ b/kornia/geometry/epipolar/_metrics.py
@@ -17,7 +17,6 @@
 
 """Module including useful metrics for Structure from Motion."""
 
-import torch
 from torch import Tensor, ones_like
 
 from kornia.core.check import KORNIA_CHECK_IS_TENSOR
@@ -135,7 +134,6 @@ def _sampson_epipolar_distance_matmul_impl_(
     return (out + eps).sqrt()
 
 
-@torch.jit.script
 def sampson_epipolar_distance(
     pts1: Tensor,
     pts2: Tensor,

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -79,7 +79,6 @@ def run_5point(points1: torch.Tensor, points2: torch.Tensor, weights: Optional[t
     return E
 
 
-@torch.jit.script
 def _multiply_deg_one_poly(a: torch.Tensor, b: torch.Tensor, T_deg1: torch.Tensor) -> torch.Tensor:
     # a, b: (..., 4)
     product_basis = a.unsqueeze(2) * b.unsqueeze(1)  # (..., 4, 4)
@@ -87,7 +86,6 @@ def _multiply_deg_one_poly(a: torch.Tensor, b: torch.Tensor, T_deg1: torch.Tenso
     return product_vector @ T_deg1  # (..., 10)
 
 
-@torch.jit.script
 def _multiply_deg_two_one_poly(a: torch.Tensor, b: torch.Tensor, T_deg2: torch.Tensor) -> torch.Tensor:
     # a: (..., 10), b: (..., 4)
     product_basis = a.unsqueeze(2) * b.unsqueeze(1)  # (..., 10, 4)
@@ -95,7 +93,6 @@ def _multiply_deg_two_one_poly(a: torch.Tensor, b: torch.Tensor, T_deg2: torch.T
     return product_vector @ T_deg2  # (..., 20)
 
 
-@torch.jit.script
 def _determinant_to_polynomial_jit(
     A: torch.Tensor,
     multiplication_indices: torch.Tensor,
@@ -116,7 +113,6 @@ def _determinant_to_polynomial_jit(
     return cs
 
 
-@torch.jit.script
 def _solve_2x2_tikhonov_safe(A: torch.Tensor, b: torch.Tensor, eps: float = 1e-12) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Solve (A)x=b for A (...,2,2), b (...,2,1) using Tikhonov regularization.
 
@@ -196,7 +192,6 @@ def _fun_select(mat: torch.Tensor, i: int, j: int, ratio: int = 3) -> torch.Tens
     return mat[:, ratio * j + i]
 
 
-@torch.jit.script
 def _null_to_Nister_solution_script(
     X: torch.Tensor,
     batch_size: int,

--- a/kornia/geometry/epipolar/fundamental.py
+++ b/kornia/geometry/epipolar/fundamental.py
@@ -148,13 +148,11 @@ def _normalize_F(F: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
 
 # Reference: Adapted from the 'run_7point' function in opencv
 # https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/fundam.cpp
-@torch.jit.script
 def _isclose0(x: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
     # torch.isclose(x, 0) but TorchScript/GPU-friendly (no scalar tensor creation)
     return x.abs() <= eps
 
 
-@torch.jit.script
 def run_7point(points1: torch.Tensor, points2: torch.Tensor) -> torch.Tensor:
     r"""Compute the fundamental matrix using the 7-point algorithm.
 
@@ -256,7 +254,6 @@ def run_7point(points1: torch.Tensor, points2: torch.Tensor) -> torch.Tensor:
     return normalize_transformation(fmatrix)
 
 
-@torch.jit.script
 def run_8point(
     points1: torch.Tensor,
     points2: torch.Tensor,

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,51 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_import_without_jit_script_deprecation():
+    """Importing kornia must not eagerly call ``torch.jit.script``.
+
+    ``torch.jit.script`` is deprecated (and unsupported on Python 3.14+). Decorating
+    functions with ``@torch.jit.script`` runs the deprecated path at import time, which
+    makes ``python -W error -c "import kornia"`` fail. This guards against reintroducing
+    an import-time scripting call. See https://github.com/kornia/kornia/issues/3727.
+
+    A fresh interpreter is used so the result is independent of kornia already being
+    imported by the test session. Only the ``torch.jit.script`` deprecation is promoted
+    to an error to avoid coupling the test to unrelated third-party warnings.
+    """
+    script = textwrap.dedent(
+        """
+        import warnings
+
+        warnings.filterwarnings("error", message=r".*torch\\.jit\\.script.*")
+        warnings.filterwarnings("error", category=DeprecationWarning, module=r"kornia.*")
+        warnings.filterwarnings("error", category=FutureWarning, module=r"kornia.*")
+
+        import kornia  # noqa: F401
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"importing kornia raised a deprecation warning:\n{result.stderr}"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,53 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_import_without_jit_script_deprecation():
+    """Importing kornia must not eagerly call ``torch.jit.script``.
+
+    ``torch.jit.script`` is deprecated (and unsupported on Python 3.14+). Decorating
+    functions with ``@torch.jit.script`` runs the deprecated path at import time, which
+    makes ``python -W error -c "import kornia"`` fail. This guards against reintroducing
+    an import-time scripting call. See https://github.com/kornia/kornia/issues/3727.
+
+    A fresh interpreter is used so the result is independent of kornia already being
+    imported by the test session. Only the ``torch.jit.script`` deprecation is promoted
+    to an error to avoid coupling the test to unrelated third-party warnings.
+    """
+    script = textwrap.dedent(
+        """
+        import warnings
+
+        warnings.filterwarnings("error", message=r".*torch\\.jit\\.script.*")
+        warnings.filterwarnings("error", category=DeprecationWarning, module=r"kornia.*")
+        warnings.filterwarnings("error", category=FutureWarning, module=r"kornia.*")
+
+        import kornia  # noqa: F401
+        """
+    )
+    # Trusted, fixed command (the current interpreter running a literal script); no external input.
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"importing kornia raised a deprecation warning:\n{result.stderr}"


### PR DESCRIPTION
## 📝 Description

**Fixes/Relates to:** #3727

`torch.jit.script` is deprecated (PyTorch ≥2.12 emits a deprecation warning, and
it is unsupported on Python 3.14+). Kornia applied `@torch.jit.script` to nine
functions in `kornia/geometry/epipolar/`, which compiles them **at import time**.
As a result, `python -W error -c "import kornia"` fails on affected PyTorch
versions.

This PR removes those import-time decorators. The decorated functions are pure
tensor operations that behave identically in eager mode, so this neither changes
results nor migrates to `torch.compile`/`torch.export` (kept intentionally out of
scope per the issue).

---

## 🛠️ Changes Made
- [x] Removed `@torch.jit.script` from `sampson_epipolar_distance` (`_metrics.py`); ruff dropped the then-unused `import torch`.
- [x] Removed `@torch.jit.script` from `_isclose0`, `run_7point`, `run_8point` (`fundamental.py`).
- [x] Removed `@torch.jit.script` from `_multiply_deg_one_poly`, `_multiply_deg_two_one_poly`, `_determinant_to_polynomial_jit`, `_solve_2x2_tikhonov_safe`, `_null_to_Nister_solution_script` (`essential.py`).
- [x] Added `tests/test_import.py` regression test.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** new `tests/test_import.py::test_import_without_jit_script_deprecation` — imports kornia in a fresh interpreter with the `torch.jit.script` deprecation promoted to an error.
- [x] **Manual Verification:** full `tests/geometry/epipolar/` + `tests/geometry/test_ransac.py` pass identically before and after the change (no behavior delta); `pixi run lint` and `pixi run typecheck` clean.
- [x] **Performance/Edge Cases:** these solvers ran through the TorchScript interpreter in eager mode and now run pure-Python + ATen; the difference is negligible for these linalg-dominated functions. CUDA-gated branches (Sampson matmul, 8-point GEMM) verified on GPU.

---

## 🕵️ AI Usage Disclosure
- [x] 🟡 **AI-assisted:** I used AI for the audit and edits but have manually reviewed and tested every line and can explain the logic.

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a self-review of my code (no ghost variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.

---

## 💭 Additional Context
`torch.jit.script_if_tracing` or lazy compilation
would only move the deprecated call out of the import path; it would still warn at
runtime under `-W error` and won't survive the removal of TorchScript on Python 3.14+.

On PyTorch versions that don't yet emit the deprecation, the
test is a forward-looking guard (passes trivially). It filters specifically on the
`torch.jit.script` message rather than using a blanket `-W error` import, to avoid
coupling to unrelated third-party deprecation warnings.