### PR TITLE
fix(enhance): rename first arg to 'input' for perform_keep_shape_image functions

### DIFF
--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -602,8 +602,7 @@ def jpeg_codec_differentiable(
     if jpeg_quality.shape[0] != 1:
         KORNIA_CHECK(
             jpeg_quality.shape[0] == input.shape[0],
-            f"Batch dimensions do not match. "
-            f"Got {input.shape[0]} images and {jpeg_quality.shape[0]} JPEG qualities.",
+            f"Batch dimensions do not match. Got {input.shape[0]} images and {jpeg_quality.shape[0]} JPEG qualities.",
         )
     # keep jpeg_quality same device as input torch.Tensor
     jpeg_quality = jpeg_quality.to(device, dtype)

--- a/kornia/enhance/jpeg.py
+++ b/kornia/enhance/jpeg.py
@@ -476,7 +476,7 @@ def _perform_padding(image: torch.Tensor) -> tuple[torch.Tensor, int, int]:
 
 @perform_keep_shape_image
 def jpeg_codec_differentiable(
-    image_rgb: torch.Tensor,
+    input: torch.Tensor,
     jpeg_quality: torch.Tensor,
     quantization_table_y: torch.Tensor | None = None,
     quantization_table_c: torch.Tensor | None = None,
@@ -510,7 +510,7 @@ def jpeg_codec_differentiable(
         There we provide an optimized Rust implementation for fast JPEG loading.
 
     Args:
-        image_rgb: the RGB image to be coded.
+        input: the RGB image to be coded.
         jpeg_quality: JPEG quality in the range :math:`[0, 100]` controlling the compression strength.
         quantization_table_y: quantization table for Y channel. Default: `None`, which will load the standard
           quantization table.
@@ -518,10 +518,10 @@ def jpeg_codec_differentiable(
           quantization table.
 
     Shape:
-        - image_rgb: :math:`(*, 3, H, W)`.
-        - jpeg_quality: :math:`(1)` or :math:`(B)` (if used batch dim. needs to match w/ image_rgb).
-        - quantization_table_y: :math:`(8, 8)` or :math:`(B, 8, 8)` (if used batch dim. needs to match w/ image_rgb).
-        - quantization_table_c: :math:`(8, 8)` or :math:`(B, 8, 8)` (if used batch dim. needs to match w/ image_rgb).
+        - input: :math:`(*, 3, H, W)`.
+        - jpeg_quality: :math:`(1)` or :math:`(B)` (if used batch dim. needs to match w/ input).
+        - quantization_table_y: :math:`(8, 8)` or :math:`(B, 8, 8)` (if used batch dim. needs to match w/ input).
+        - quantization_table_c: :math:`(8, 8)` or :math:`(B, 8, 8)` (if used batch dim. needs to match w/ input).
 
     Return:
         JPEG coded image of the shape :math:`(B, 3, H, W)`
@@ -555,18 +555,18 @@ def jpeg_codec_differentiable(
 
     """
     # Check that inputs are tensors
-    KORNIA_CHECK_IS_TENSOR(image_rgb)
+    KORNIA_CHECK_IS_TENSOR(input)
     KORNIA_CHECK_IS_TENSOR(jpeg_quality)
     # Get device and dtype
-    dtype: Union[torch.dtype, None] = image_rgb.dtype
-    device: Union[str, torch.device, None] = image_rgb.device
+    dtype: Union[torch.dtype, None] = input.dtype
+    device: Union[str, torch.device, None] = input.device
     # Use default QT if QT is not given
     quantization_table_y = _get_default_qt_y(device, dtype) if quantization_table_y is None else quantization_table_y
     quantization_table_c = _get_default_qt_c(device, dtype) if quantization_table_c is None else quantization_table_c
     KORNIA_CHECK_IS_TENSOR(quantization_table_y)
     KORNIA_CHECK_IS_TENSOR(quantization_table_c)
     # Check shape of inputs
-    KORNIA_CHECK_SHAPE(image_rgb, ["*", "3", "H", "W"])
+    KORNIA_CHECK_SHAPE(input, ["*", "3", "H", "W"])
     KORNIA_CHECK_SHAPE(jpeg_quality, ["B"])
     # Add batch dimension to quantization tables if needed
     if quantization_table_y.ndim == 2:
@@ -583,27 +583,27 @@ def jpeg_codec_differentiable(
         f"got [{jpeg_quality.amin().item()}, {jpeg_quality.amax().item()}]. Consider clipping jpeg_quality.",
     )
     # Pad the image to a shape dividable by 16
-    image_rgb, h_pad, w_pad = _perform_padding(image_rgb)
+    input, h_pad, w_pad = _perform_padding(input)
     # Get height and shape
-    H, W = image_rgb.shape[-2:]
+    H, W = input.shape[-2:]
     # Check matching batch dimensions
     if quantization_table_y.shape[0] != 1:
         KORNIA_CHECK(
-            quantization_table_y.shape[0] == image_rgb.shape[0],
+            quantization_table_y.shape[0] == input.shape[0],
             f"Batch dimensions do not match. "
-            f"Got {image_rgb.shape[0]} images and {quantization_table_y.shape[0]} quantization tables (Y).",
+            f"Got {input.shape[0]} images and {quantization_table_y.shape[0]} quantization tables (Y).",
         )
     if quantization_table_c.shape[0] != 1:
         KORNIA_CHECK(
-            quantization_table_c.shape[0] == image_rgb.shape[0],
+            quantization_table_c.shape[0] == input.shape[0],
             f"Batch dimensions do not match. "
-            f"Got {image_rgb.shape[0]} images and {quantization_table_c.shape[0]} quantization tables (C).",
+            f"Got {input.shape[0]} images and {quantization_table_c.shape[0]} quantization tables (C).",
         )
     if jpeg_quality.shape[0] != 1:
         KORNIA_CHECK(
-            jpeg_quality.shape[0] == image_rgb.shape[0],
+            jpeg_quality.shape[0] == input.shape[0],
             f"Batch dimensions do not match. "
-            f"Got {image_rgb.shape[0]} images and {jpeg_quality.shape[0]} JPEG qualities.",
+            f"Got {input.shape[0]} images and {jpeg_quality.shape[0]} JPEG qualities.",
         )
     # keep jpeg_quality same device as input torch.Tensor
     jpeg_quality = jpeg_quality.to(device, dtype)
@@ -612,7 +612,7 @@ def jpeg_codec_differentiable(
     quantization_table_c = quantization_table_c.to(device, dtype)
     # Perform encoding
     y_encoded, cb_encoded, cr_encoded = _jpeg_encode(
-        image_rgb=image_rgb,
+        image_rgb=input,
         jpeg_quality=jpeg_quality,
         quantization_table_c=quantization_table_c,
         quantization_table_y=quantization_table_y,

--- a/kornia/enhance/normalize.py
+++ b/kornia/enhance/normalize.py
@@ -302,7 +302,9 @@ def denormalize(data: torch.Tensor, mean: Union[torch.Tensor, float], std: Union
 
 
 @perform_keep_shape_image
-def normalize_min_max(x: torch.Tensor, min_val: float = 0.0, max_val: float = 1.0, eps: float = 1e-6) -> torch.Tensor:
+def normalize_min_max(
+    input: torch.Tensor, min_val: float = 0.0, max_val: float = 1.0, eps: float = 1e-6
+) -> torch.Tensor:
     r"""Normalise an image/video torch.Tensor by MinMax and re-scales the value between a range.
 
     The data is normalised using the following formulation:
@@ -313,7 +315,7 @@ def normalize_min_max(x: torch.Tensor, min_val: float = 0.0, max_val: float = 1.
     where :math:`a` is :math:`\text{min_val}` and :math:`b` is :math:`\text{max_val}`.
 
     Args:
-        x: The image torch.Tensor to be normalised with shape :math:`(*, C, H, W)`.
+        input: The image torch.Tensor to be normalised with shape :math:`(*, C, H, W)`.
         min_val: The minimum value for the new range.
         max_val: The maximum value for the new range.
         eps: Float number to avoid zero division.
@@ -330,8 +332,8 @@ def normalize_min_max(x: torch.Tensor, min_val: float = 0.0, max_val: float = 1.
         tensor(1.0000)
 
     """
-    if not isinstance(x, torch.Tensor):
-        raise TypeError(f"data should be a torch.Tensor. Got: {type(x)}.")
+    if not isinstance(input, torch.Tensor):
+        raise TypeError(f"data should be a torch.Tensor. Got: {type(input)}.")
 
     if not isinstance(min_val, float):
         raise TypeError(f"'min_val' should be a float. Got: {type(min_val)}.")
@@ -339,10 +341,10 @@ def normalize_min_max(x: torch.Tensor, min_val: float = 0.0, max_val: float = 1.
     if not isinstance(max_val, float):
         raise TypeError(f"'max_val' should be a float. Got: {type(max_val)}.")
 
-    shape = x.shape
+    shape = input.shape
     B, C = shape[0], shape[1]
 
-    x_reshaped = x.view(B, C, -1)
+    x_reshaped = input.view(B, C, -1)
     x_min = x_reshaped.min(-1, keepdim=True)[0]  # Shape: (B, C, 1)
     x_max = x_reshaped.max(-1, keepdim=True)[0]  # Shape: (B, C, 1)
 

--- a/tests/enhance/test_jpeg.py
+++ b/tests/enhance/test_jpeg.py
@@ -33,6 +33,14 @@ class TestDiffJPEG(BaseTester):
         assert img_jpeg is not None
         assert img_jpeg.shape == img.shape
 
+    def test_keyword_argument(self, device, dtype) -> None:
+        """Regression test for #3745: the image must be passable via the ``input=`` keyword."""
+        B, H, W = 2, 32, 32
+        img = torch.rand(B, 3, H, W, device=device, dtype=dtype)
+        jpeg_quality = torch.randint(low=0, high=100, size=(B,), device=device, dtype=dtype)
+        img_jpeg = kornia.enhance.jpeg_codec_differentiable(input=img, jpeg_quality=jpeg_quality)
+        self.assert_close(img_jpeg, kornia.enhance.jpeg_codec_differentiable(img, jpeg_quality))
+
     def test_smoke_not_div_by_16(self, device, dtype) -> None:
         """This test standard usage."""
         B, H, W = 2, 33, 33

--- a/tests/enhance/test_normalize.py
+++ b/tests/enhance/test_normalize.py
@@ -376,3 +376,12 @@ class TestNormalizeMinMax(BaseTester):
 
         # Verify shape is preserved
         assert out.shape == input_shape
+
+    def test_keyword_argument(self, device, dtype):
+        # Regression test for #3745: the perform_keep_shape_image wrapper binds the
+        # first argument as `input`, so passing the image by keyword must use `input=`
+        # and match the documented signature.
+        x = torch.rand(1, 2, 4, 5, device=device, dtype=dtype)
+        out_kwarg = kornia.enhance.normalize_min_max(input=x, min_val=-1.0, max_val=1.0)
+        out_positional = kornia.enhance.normalize_min_max(x, min_val=-1.0, max_val=1.0)
+        self.assert_close(out_kwarg, out_positional)


### PR DESCRIPTION
## 📝 Description

**Fixes/Relates to:** #3745

Maintainer @edgarriba gave the go-ahead to send a fixing PR in the issue thread.

`@perform_keep_shape_image` (`kornia/image/utils.py`) wraps the decorated function with `_wrapper(input, *args, **kwargs)`. Although `@wraps(f)` makes `inspect.signature` *report* the original parameter names, the runtime callable is `_wrapper`, whose first parameter is hardcoded as `input`. Any function using this decorator must therefore name its first parameter `input`, or a keyword call using the real name fails with `missing 1 required positional argument: 'input'`.

Of the 7 functions using this decorator, 5 already use `input` (`posterize`, `sharpness`, `equalize`, `equalize_clahe`, `in_range`). Only `normalize_min_max` (`x`) and `jpeg_codec_differentiable` (`image_rgb`) were inconsistent — these are the ones the issue reports as broken.

---

## 🛠️ Changes Made
- [x] `normalize_min_max`: rename first parameter `x` → `input` (signature, docstring, body).
- [x] `jpeg_codec_differentiable`: rename first parameter `image_rgb` → `input` (signature, docstring, body). The undecorated `_jpeg_encode` helper and the `JPEGCodecDifferentiable` module keep their own parameter names (not wrapped by the decorator, so unaffected).
- [x] Add regression tests asserting the `input=` keyword call works.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** added `TestNormalizeMinMax::test_keyword_argument` and `TestDiffJPEG::test_keyword_argument`.
- [x] **Manual Verification:** reproduced the original report, now passes:

```
$ python -c "import torch; from kornia.enhance import normalize_min_max as n; print('kw ok', n(input=torch.zeros(1,1,8,8)).shape)"
kw ok torch.Size([1, 1, 8, 8])

$ python -m pytest tests/enhance/test_normalize.py -k MinMax -q
18 passed, 1 skipped, 28 deselected in 0.50s

$ python -m pytest tests/enhance/test_jpeg.py -k "keyword or smoke" -q
3 passed, 9 deselected in 0.42s

$ python -m pytest --doctest-modules kornia/enhance/normalize.py -q
5 passed in 0.29s

$ ruff check kornia/enhance/normalize.py kornia/enhance/jpeg.py
All checks passed!
```

- [x] **Edge Cases:** 2D/3D/4D+ inputs still round-trip through the wrapper (existing `test_2d_tensor`, `test_3d_*` pass); positional calls are unchanged.

---

## 🕵️ AI Usage Disclosure
- [x] 🟡 **AI-assisted:** I used AI for the mechanical rename and test scaffolding, and have manually reviewed and tested every line.

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (maintainer @edgarriba invited a fixing PR on 2026-06-29)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.

---

## 💭 Additional Context
The alternative fix — rewriting `perform_keep_shape_image` to honor arbitrary first-parameter names — was rejected as higher-risk: it touches shared infrastructure used by all 7 decorated functions, whereas the rename aligns the two outliers with the existing convention and PyTorch's own `input` naming.
