### PR TITLE
remove deprecated torch.cuda.amp fallback in lightglue

### DIFF
--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -44,11 +44,7 @@ def math_clamp(x, min_, max_):  # type: ignore
     return min(max(x, min_), max_)
 
 
-AMP_CUSTOM_FWD_F32 = (
-    torch.amp.custom_fwd(cast_inputs=torch.float32, device_type="cuda")
-    if hasattr(torch, "amp") and hasattr(torch.amp, "custom_fwd")
-    else torch.cuda.amp.custom_fwd(cast_inputs=torch.float32)
-)
+AMP_CUSTOM_FWD_F32 = torch.amp.custom_fwd(cast_inputs=torch.float32, device_type="cuda")
 
 
 @AMP_CUSTOM_FWD_F32


### PR DESCRIPTION
## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request) for details.

**Fixes/Relates to:** Fixes #3773

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- Removed the deprecated legacy fallback `torch.cuda.amp.custom_fwd` inside `kornia/feature/lightglue.py`.
- Refactored `AMP_CUSTOM_FWD_F32` to directly use modern `torch.amp.custom_fwd`, aligning with the minimum environment requirement of `torch>=2.0.0`.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** Ran `pixi run test-module tests/feature/test_lightglue.py`
- [x] **Manual Verification:** Executed `pixi run typecheck` locally to confirm the original deprecation warning diagnostic has completely vanished.
---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** - I used AI for assistance with environment tracking and local git workflow isolation but have manually reviewed, written, and verified the final Python implementation line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works.

---

## 💭 Additional Context
Below is the output log proving verification that typecheck diagnostics are clean:
```text
pixi run typecheck                                                                    
✨ Pixi task (typecheck in default): ty check kornia
All checks passed!
```