### PR TITLE
fix(geometry): raise clear error in crop_by_indices for mismatched box sizes

### DIFF
--- a/kornia/geometry/transform/crop2d.py
+++ b/kornia/geometry/transform/crop2d.py
@@ -370,7 +370,12 @@ def crop_by_indices(
 
     if size is None:
         h, w = infer_bbox_shape(src)
-        size = h.unique(sorted=False), w.unique(sorted=False)
+        if B > 0 and not ((h == h[0]).all() and (w == w[0]).all()):
+            raise ValueError(
+                "All boxes in the batch must have the same height and width when `size` is None. "
+                "Please pass `size` explicitly when box dimensions vary across the batch."
+            )
+        size = (int(h[0].item()), int(w[0].item())) if B > 0 else (0, 0)
     out = torch.empty(B, C, *size, device=input_tensor.device, dtype=input_tensor.dtype)
     # Find out the cropped shapes that need to be resized.
     for i, _ in enumerate(out):

--- a/kornia/geometry/transform/crop2d.py
+++ b/kornia/geometry/transform/crop2d.py
@@ -370,7 +370,7 @@ def crop_by_indices(
 
     if size is None:
         h, w = infer_bbox_shape(src)
-        if B > 0 and not ((h == h[0]).all() and (w == w[0]).all()):
+        if B > 0 and ((h != h[0]).any() | (w != w[0]).any()).item():
             raise ValueError(
                 "All boxes in the batch must have the same height and width when `size` is None. "
                 "Please pass `size` explicitly when box dimensions vary across the batch."

--- a/tests/geometry/transform/test_crop2d.py
+++ b/tests/geometry/transform/test_crop2d.py
@@ -303,6 +303,20 @@ class TestCropByIndices(BaseTester):
         expected = op(img, torch.tensor([[[0, 0], [1, 0], [1, 1], [0, 1]]]))
         self.assert_close(actual, expected, rtol=1e-4, atol=1e-4)
 
+    def test_crop_by_indices_variable_sizes_exception(self, device, dtype):
+        img = torch.rand(2, 3, 20, 20, device=device, dtype=dtype)
+        src_box = torch.tensor(
+            [
+                [[0, 0], [4, 0], [4, 4], [0, 4]],  # 5x5 box
+                [[0, 0], [9, 0], [9, 9], [0, 9]],  # 10x10 box
+            ],
+            dtype=dtype,
+            device=device,
+        )
+
+        with pytest.raises(ValueError, match="All boxes in the batch must have the same height and width"):
+            kornia.geometry.transform.crop_by_indices(img, src_box, size=None)
+
 
 class TestCropSizeValidation:
     """Tests that crop functions properly reject invalid size arguments."""


### PR DESCRIPTION
Fixes #3769

## 📝 Description
Fixes a TypeError in crop_by_indices when the crop boxes in a batch are different sizes and no explicit `size` is given.

**⚠️ Issue Link **: https://github.com/kornia/kornia/issues/3769#issuecomment-4968278203

**Fixes/Relates to:**  #3769

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [x] Added a check in `crop_by_indices()` that compares every box's height/width against the first box before trying to auto-infer the output size.
- [x] Removed the old `h.unique(sorted=False), w.unique(sorted=False)` line — it only worked because `.unique()` happened to collapse to one value when all boxes matched. If they didn't match, it silently broke. Now it either raises a clear error explaining what went wrong, or computes the size directly as plain ints when all boxes do match.
- [x] Added a test (`test_crop_by_indices_variable_sizes_exception`) that reproduces the original crash and checks the new error message.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** Found this bug by testing crop_by_indices with differently-sized crop boxes (5x5 and 10x10), a case the docstring implies should work. Traced it to how `.unique()` was used for size inference, added a regression test, and confirmed the fix raises a clear ValueError instead of the old TypeError. Ran the full test suite to confirm no regressions.

- [x] **Manual Verification:** Reproduced the TypeError on the unmodified code first, then confirmed the fix replaces it with the intended error. Also verified passing size= directly still works fine with mismatched boxes.

- [ ] **Performance/Edge Cases:** N/A

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
