### PR TITLE
test(augmentation): guard mix augs against partial-batch corruption

### DIFF
--- a/tests/augmentation/test_augmentation_mix.py
+++ b/tests/augmentation/test_augmentation_mix.py
@@ -122,6 +122,21 @@ class TestRandomMixUpV2(BaseTester):
         self.assert_close(out_label[:, 1], torch.tensor([0, 1], device=device, dtype=dtype))
         self.assert_close(out_label[:, 2], lam, rtol=1e-4, atol=1e-4)
 
+    @pytest.mark.parametrize("p", [0.0, 0.5])
+    def test_partial_batch_passthrough(self, p, device, dtype):
+        # See TestRandomJigsaw.test_partial_batch_passthrough: output batch size must
+        # match the input and unselected samples must be left byte-identical.
+        torch.manual_seed(0)
+        f = RandomMixUpV2(p=p, data_keys=["input"])
+
+        input = torch.rand((12, 3, 8, 8), device=device, dtype=dtype)
+        output = f(input)
+
+        assert output.shape == input.shape
+        untouched = ~(f._params["batch_prob"] > 0.5)
+        if untouched.any():
+            self.assert_close(output[untouched], input[untouched])
+
 
 class TestRandomCutMixV2(BaseTester):
     def test_smoke(self):
@@ -268,6 +283,21 @@ class TestRandomCutMixV2(BaseTester):
             out_label[0, :, 2], torch.tensor([0.5000, 0.5000], device=device, dtype=dtype), rtol=1e-4, atol=1e-4
         )
 
+    @pytest.mark.parametrize("p", [0.0, 0.5])
+    def test_partial_batch_passthrough(self, p, device, dtype):
+        # See TestRandomJigsaw.test_partial_batch_passthrough: output batch size must
+        # match the input and unselected samples must be left byte-identical.
+        torch.manual_seed(0)
+        f = RandomCutMixV2(p=p, data_keys=["input"], use_correct_lambda=True)
+
+        input = torch.rand((12, 3, 8, 8), device=device, dtype=dtype)
+        output = f(input)
+
+        assert output.shape == input.shape
+        untouched = ~(f._params["batch_prob"] > 0.5)
+        if untouched.any():
+            self.assert_close(output[untouched], input[untouched])
+
 
 class TestRandomMosaic(BaseTester):
     def test_smoke(self):
@@ -368,7 +398,10 @@ class TestRandomMosaic(BaseTester):
             dtype=dtype,
         )
 
-        f(input, boxes)
+        out_image, _ = f(input, boxes)
+        # Mosaic resizes to output_size, so we can't assert pass-through identity, but the
+        # batch dimension must be preserved regardless of how many samples are selected.
+        assert out_image.shape[0] == input.shape[0]
 
 
 class TestRandomJigsaw(BaseTester):
@@ -421,6 +454,24 @@ class TestRandomJigsaw(BaseTester):
         input = torch.randn((12, 3, 256, 256), device=device, dtype=dtype)
 
         f(input)
+
+    @pytest.mark.parametrize("p", [0.0, 0.5])
+    def test_partial_batch_passthrough(self, p, device, dtype):
+        # Regression for the partial-batch corruption where apply_transform sliced the
+        # batch down to the to-apply subset and returned it as the whole output.
+        # The output batch size must always equal the input, and samples that were not
+        # selected for the transform must pass through byte-identical.
+        torch.manual_seed(76)
+        f = RandomJigsaw(grid=(2, 2), p=p, data_keys=["input"])
+
+        input = torch.randn((12, 3, 16, 16), device=device, dtype=dtype)
+        output = f(input)
+
+        assert output.shape == input.shape
+        to_apply = f._params["batch_prob"] > 0.5
+        untouched = ~to_apply
+        if untouched.any():
+            self.assert_close(output[untouched], input[untouched])
 
 
 class TestRandomTransplantation(BaseTester):


### PR DESCRIPTION
## What

Adds regression coverage for the partial-batch corruption class of bug — the one where `RandomJigsaw` silently shrank an 8-image batch to 4 (fixed in #3779). That bug reached `main` because the mix augmentations' `test_p` methods only called `f(input)` and asserted nothing about the result.

## Tests added

For the shape-preserving mix augs (`RandomJigsaw`, `RandomMixUpV2`, `RandomCutMixV2`), a `test_partial_batch_passthrough` at p=0.0 and p=0.5 that asserts:
- output batch size equals input batch size (catches the exact jigsaw failure)
- samples **not** selected for the transform (`~(batch_prob > 0.5)`) are left **byte-identical**

For `RandomMosaic` (which resizes to `output_size`, so identity can't hold), strengthened the existing `test_p` to assert the batch dimension is preserved.

## Proof it works

Temporarily reverted the #3779 jigsaw fix and confirmed the new test fails with exactly the original symptom:

```
FAILED TestRandomJigsaw::test_partial_batch_passthrough[cpu-float32-0.5]
  - assert torch.Size([5, 3, 16, 16]) == torch.Size([12, 3, 16, 16])
```

Restored the fix → all green.

## Test log

```
pytest tests/augmentation/test_augmentation_mix.py --dtype=float32
=== 48 passed (was 42; +6 new) ===
```

ruff check + format clean.

## AI disclosure

Authored with Claude Code per AI_POLICY.md; regression proven by reverting the fix under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)