### PR TITLE
chore(ruff): enable flake8-pie (PIE) rules

### DIFF
--- a/kornia/augmentation/_3d/mix/transplantation.py
+++ b/kornia/augmentation/_3d/mix/transplantation.py
@@ -27,5 +27,3 @@ class RandomTransplantation3D(RandomTransplantation, AugmentationBase3D):  # typ
     3D version of the :class:`kornia.augmentation.RandomTransplantation` augmentation intended to be used with
     :class:`kornia.augmentation.AugmentationSequential`. The interface is identical to the 2D version.
     """
-
-    pass

--- a/kornia/augmentation/random_generator/_2d/resize.py
+++ b/kornia/augmentation/random_generator/_2d/resize.py
@@ -60,7 +60,6 @@ class ResizeGenerator(RandomGeneratorBase):
     def make_samplers(self, device: Union[str, torch.device, None], dtype: torch.dtype) -> None:
         self.device = device
         self.dtype = dtype
-        pass
 
     def forward(self, batch_shape: Tuple[int, ...], same_on_batch: bool = False) -> Dict[str, torch.Tensor]:
         batch_size = batch_shape[0]

--- a/kornia/core/exceptions.py
+++ b/kornia/core/exceptions.py
@@ -34,8 +34,6 @@ __all__ = [
 class BaseError(Exception):
     """Base exception class for all Kornia errors."""
 
-    pass
-
 
 class ShapeError(BaseError):
     """Raised when tensor shape validation fails.
@@ -119,5 +117,3 @@ class DeviceError(BaseError):
 
 class ImageError(BaseError):
     """Raised when image-specific validation fails."""
-
-    pass

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -112,7 +112,7 @@ class PatchDominantGradientOrientation(nn.Module):
         wo0_big = (1.0 - wo1_big) * mag
         wo1_big = wo1_big * mag
         ang_bins_list = []
-        for i in range(0, self.num_ang_bins):
+        for i in range(self.num_ang_bins):
             ang_bins_i = F.adaptive_avg_pool2d(
                 (bo0_big == i).to(patch.dtype) * wo0_big + (bo1_big == i).to(patch.dtype) * wo1_big, (1, 1)
             )

--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -208,7 +208,7 @@ class SIFTDescriptor(nn.Module):
         ang_bins = torch.cat(
             [
                 self.pk((bo0_big == i).to(input.dtype) * wo0_big + (bo1_big == i).to(input.dtype) * wo1_big)
-                for i in range(0, self.num_ang_bins)
+                for i in range(self.num_ang_bins)
             ],
             1,
         )
@@ -368,7 +368,7 @@ class DenseSIFTDescriptor(nn.Module):
                 self.bin_pooling_kernel(
                     (bo0_big == i).to(input.dtype) * wo0_big + (bo1_big == i).to(input.dtype) * wo1_big
                 )
-                for i in range(0, self.num_ang_bins)
+                for i in range(self.num_ang_bins)
             ],
             1,
         )

--- a/kornia/feature/sold2/backbones.py
+++ b/kornia/feature/sold2/backbones.py
@@ -195,7 +195,7 @@ class Hourglass(nn.Module):
 
     def _make_residual(self, block: Type[Bottleneck2D], num_blocks: int, planes: int) -> nn.Module:
         layers = []
-        for _ in range(0, num_blocks):
+        for _ in range(num_blocks):
             layers.append(block(planes * self.expansion, planes))
         return nn.Sequential(*layers)
 

--- a/kornia/onnx/utils.py
+++ b/kornia/onnx/utils.py
@@ -103,7 +103,7 @@ class ONNXLoader(CachedDownloader):
                 )
             return onnx.load(file_path)  # type:ignore
 
-        elif model_name.startswith("http://") or model_name.startswith("https://"):
+        elif model_name.startswith(("http://", "https://")):
             cache_dir = kwargs.get("cache_dir", None) or kornia_config.hub_onnx_dir
             kwargs.update({"cache_dir": cache_dir})
             file_path = cls.download_to_cache(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ select = [
   "ICN",  # flake8-import-conventions
   "INT",  # flake8-gettext
   "NPY",  # NumPy-specific rules
+  "PIE",  # flake8-pie
   "PL",  # Pylint
   "PYI",  # flake8-pyi
   "RSE",  # flake8-raise
@@ -257,7 +258,6 @@ select = [
   # "PD",   # pandas-vet
   # "PERF", # Perflint
   # "PGH",  # pygrep-hooks
-  # "PIE",  # flake8-pie
   # "PT",   # flake8-pytest-style
   # "PTH",  # flake8-use-pathlib
   # "Q",    # flake8-quotes
@@ -276,6 +276,7 @@ ignore = [
   "PLC0415",  # `import` should be at the top-level of a file
   "PLW2901",  # Allow overwritten values on loops
   "PLW1641",  # Object does not implement `__hash__` method
+  "PIE796",  # Enums intentionally use duplicate values as aliases (e.g. DataKey.IMAGE/INPUT)
   "UP007",  # Prefer Optional[], Union[] over | due to torch jit scripting
   "UP006",  # Prefer List[], over list due to torch jit scripting
   "UP035",  # Ignore deprecated typing because of jit scripting


### PR DESCRIPTION
## What

Ticks another rule set on the ruff code-health tracker **#2445** (only `B` was checked off before). Enables **PIE** (flake8-pie) and fixes the fallout.

## Note on the tracker framing

While picking this up I confirmed ruff is **already enforced on every PR** — the required `pre-commit.ci - pr` check runs `ruff-check` + `ruff-format` from `.pre-commit-config.yaml`. So #2445 is about progressively enabling more *rule categories*, which is what this does; no new workflow is needed.

## Changes

Enabled `PIE` in `[tool.ruff.lint].select` and fixed all 9 real violations:
- **PIE790** unnecessary `pass` ×4 (classes/methods that already have a docstring body)
- **PIE808** unnecessary `range` start (`range(0, n)` → `range(n)`) ×4
- **PIE810** `startswith("http://") or startswith("https://")` → `startswith(("http://", "https://"))` in `kornia/onnx/utils.py`

**PIE796** (non-unique enums) is added to `ignore` — `DataKey` and `BoundingBoxDataFormat` intentionally use duplicate values as aliases (`IMAGE`/`INPUT`, `LABEL`/`CLASS`, `CXCYWH`/`CENTER_XYWH`), which is a valid pattern, not a bug.

## Verification

```
ruff check .          -> All checks passed!
ruff format --check . -> 776 files already formatted
pytest tests/feature -k 'sift or orientation' --dtype=float32 -> 37 passed
```

All fixes are mechanical and behavior-preserving (pass-removal leaves docstring bodies intact; `range`/`startswith` rewrites are semantically identical).

## AI disclosure

Authored with Claude Code per AI_POLICY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)