### PR TITLE
test(models): bump timeout on remaining ONNX-export tests

### DIFF
--- a/tests/models/test_dexined_onnx.py
+++ b/tests/models/test_dexined_onnx.py
@@ -20,6 +20,7 @@ import pytest
 from kornia.models.dexined import DexiNed
 
 
+@pytest.mark.timeout(120)
 def test_dexined_to_onnx(tmp_path):
     """Ensure `DexiNed.to_onnx` exports a valid ONNX model and saves the file."""
     onnx = pytest.importorskip("onnx")

--- a/tests/models/test_object_detector.py
+++ b/tests/models/test_object_detector.py
@@ -52,6 +52,7 @@ class TestObjectDetector(BaseTester):
             assert torch.all(dets[:, 1] >= 0.3)
 
     @pytest.mark.slow
+    @pytest.mark.timeout(120)
     @pytest.mark.skipif(torch_version_lt(2, 0, 0), reason="Unsupported ONNX opset version: 16")
     @pytest.mark.parametrize("variant", ("resnet50d", "hgnetv2_l"))
     def test_onnx(self, device, dtype, tmp_path: Path, variant: str):


### PR DESCRIPTION
## What

Follow-up to #3779. Tonight's scheduled coverage run (first since #3779 merged) confirmed the three original failures are **fixed** — but surfaced a third full-model ONNX-export test hitting the same 30s global `pytest-timeout`:

```
FAILED tests/models/test_dexined_onnx.py::test_dexined_to_onnx - Failed: Timeout (>30.0s)
```

These export tests flake load-dependently (whichever heavy export happens to run when the runner is busy), which is why #3779 only caught `rtdetr` and `sam`. Applying the same `@pytest.mark.timeout(120)` to the two remaining full-model export tests:

- `test_dexined_to_onnx` (DexiNed) — the one that failed tonight
- `TestObjectDetector::test_onnx` (RTDETR, `@slow` — runs under the coverage job's `--slow`) — same model class as the already-bumped `rtdetr` test, so at the same risk

## Verified against real CI

The scheduled run on current main (post-#3779) shows the previously-failing jobs now green: `docs` ✓, `coverage/overall (float64)` ✓, `coverage/dynamo (float32)` ✓. This PR closes the last ONNX-timeout gap.

ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)