### PR TITLE
fix(enhance): make adjust_gamma torch.compile-compatible

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -292,11 +292,13 @@ def adjust_gamma(
     gamma = gamma.to(input.device).to(input.dtype)
     gain = gain.to(input.device).to(input.dtype)
 
-    if (gamma < 0.0).any():
-        raise ValueError(f"Gamma must be non-negative. Got {gamma}")
+    # `bool(tensor)` is untraceable by dynamo; skip the data-dependent validation under compile.
+    if not torch.compiler.is_compiling():
+        if (gamma < 0.0).any():
+            raise ValueError(f"Gamma must be non-negative. Got {gamma}")
 
-    if (gain < 0.0).any():
-        raise ValueError(f"Gain must be non-negative. Got {gain}")
+        if (gain < 0.0).any():
+            raise ValueError(f"Gain must be non-negative. Got {gain}")
 
     for _ in range(len(input.shape) - len(gamma.shape)):
         gamma = torch.unsqueeze(gamma, dim=-1)

--- a/tests/enhance/test_adjust.py
+++ b/tests/enhance/test_adjust.py
@@ -291,6 +291,13 @@ class TestAdjustGamma(BaseTester):
         img = torch.ones(batch_size, channels, height, width, device=device, dtype=torch.float)
         self.gradcheck(kornia.enhance.adjust_gamma, (img, 1.0, 2.0))
 
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        op = kornia.enhance.adjust_gamma
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(img, 1.5), op_optimized(img, 1.5))
+
 
 class TestAdjustContrast(BaseTester):
     @pytest.mark.parametrize("shape", [(3, 4, 4), (2, 3, 3, 3), (4, 3, 3, 1, 1)])


### PR DESCRIPTION
Part of the **compile-first** roadmap theme (see ROADMAP.md / #3568).

## Problem

`adjust_gamma` graph-breaks under `torch.compile`:

```
torch.compile(adjust_gamma, fullgraph=True)  ->  Unsupported: Data-dependent branching
```

The break comes from the gamma/gain validation (`if (gamma < 0.0).any(): raise ...`) — `bool(tensor)` is untraceable by dynamo.

## Fix

Guard the validation behind `torch.compiler.is_compiling()`, exactly matching the established pattern already in `kornia/filters/gaussian.py`. Eager behavior is unchanged — negative gamma/gain still raises; the check is only skipped under compile, where inputs are already trusted at trace time.

Adds a `test_dynamo` to `TestAdjustGamma` (following the sibling `adjust_sigmoid`/`adjust_log` tests) so the compile-clean state is locked in.

## Verification

```
torch.compile(adjust_gamma, fullgraph=True)  ->  traces cleanly, matches eager (atol 1e-6)
eager adjust_gamma(x, gamma=-1.0)            ->  still raises ValueError
KORNIA_TEST_OPTIMIZER=inductor pytest TestAdjustGamma -> 10 passed
```

ruff clean. Small, self-contained; more numeric-core compile guards to follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)