### PR TITLE
fix(enhance): adjust_contrast torch.compile support + validation fix

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -369,7 +369,9 @@ def adjust_contrast(image: torch.Tensor, factor: Union[float, torch.Tensor], cli
     while len(factor.shape) != len(image.shape):
         factor = factor[..., None]
 
-    KORNIA_CHECK(any(factor >= 0), "Contrast factor must be positive.")
+    # `bool(tensor)` is untraceable by dynamo; skip the data-dependent validation under compile.
+    if not torch.compiler.is_compiling():
+        KORNIA_CHECK(bool((factor >= 0).all()), "Contrast factor must be positive.")
 
     # Apply contrast factor to each channel
     img_adjust: torch.Tensor = image * factor

--- a/tests/enhance/test_adjust.py
+++ b/tests/enhance/test_adjust.py
@@ -573,6 +573,13 @@ class TestAdjustContrast(BaseTester):
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.enhance.adjust_contrast_with_mean_subtraction, (img, 2.0))
 
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.ones(B, C, H, W, device=device, dtype=dtype)
+        op = kornia.enhance.adjust_contrast
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(img, 1.5), op_optimized(img, 1.5))
+
 
 class TestAdjustBrightness(BaseTester):
     @pytest.mark.parametrize("shape", [(3, 4, 4), (2, 3, 3, 3), (4, 3, 3, 1, 1)])


### PR DESCRIPTION
Part of the **compile-first** roadmap theme (ROADMAP.md / #3568). Second in the numeric-core compile-guard series (after adjust_gamma).

## Problem

`adjust_contrast` graph-breaks under `torch.compile` (`Data-dependent branching`) at:

```python
KORNIA_CHECK(any(factor >= 0), "Contrast factor must be positive.")
```

## Fix — two issues in one line

1. **Compile:** guard the validation behind `torch.compiler.is_compiling()` (same pattern as `filters/gaussian.py` and adjust_gamma).
2. **Latent bug:** `any(factor >= 0)` (Python builtin over the tensor) is `True` if **any** element is non-negative — so `factor = [-5.0, 0.5]` wrongly passed validation. Corrected to `(factor >= 0).all()` to match the documented "must be positive" contract.

Adds `test_dynamo` to `TestAdjustContrast`.

## Verification

```
torch.compile(adjust_contrast, fullgraph=True) -> traces clean, matches eager (atol 1e-5)
adjust_contrast(x, [-5.0, 0.5])                -> now correctly raises (was silently accepted)
KORNIA_TEST_OPTIMIZER=inductor pytest TestAdjustContrast -> 20 passed
```

No existing test uses a negative contrast factor, so the stricter validation is safe. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)