### PR TITLE
fix(contrib): distance_transform torch.compile fullgraph support

### DIFF
--- a/kornia/contrib/distance_transform.py
+++ b/kornia/contrib/distance_transform.py
@@ -49,7 +49,10 @@ def _distance_transform_2d_impl(image: torch.Tensor, kernel_size: int, h: float)
         cdt = torch.nan_to_num(cdt, nan=0.0, posinf=0.0, neginf=0.0)
 
         mask = cdt > 0
-        if not mask.any():
+        # Early exit is a pure optimization: once no pixels remain, the remaining
+        # iterations are no-ops (out += 0*mask, where(False,...) leaves boundary). Skip
+        # the data-dependent break under compile so the graph stays static/fullgraph-safe.
+        if not torch.compiler.is_compiling() and not mask.any():
             break
 
         offset: int = i * k_half
@@ -80,7 +83,10 @@ def _distance_transform_3d_impl(image: torch.Tensor, kernel_size: int, h: float)
         cdt = torch.nan_to_num(cdt, nan=0.0, posinf=0.0, neginf=0.0)
 
         mask = cdt > 0
-        if not mask.any():
+        # Early exit is a pure optimization: once no pixels remain, the remaining
+        # iterations are no-ops (out += 0*mask, where(False,...) leaves boundary). Skip
+        # the data-dependent break under compile so the graph stays static/fullgraph-safe.
+        if not torch.compiler.is_compiling() and not mask.any():
             break
 
         offset: int = i * k_half


### PR DESCRIPTION
Part of the **compile-first** roadmap theme (ROADMAP.md / #3568). Third in the numeric-core compile series (after adjust_gamma, adjust_contrast).

## Problem

`distance_transform` graph-breaks under `torch.compile` (`Data-dependent branching`) at the early-exit inside its iteration loop, in both the 2D and 3D implementations:

```python
mask = cdt > 0
if not mask.any():   # data-dependent -> graph break
    break
```

## Fix

The early exit is a **pure optimization**: once no pixels remain, the remaining iterations are provably no-ops —

- `out = out + (offset + cdt) * mask.to(dtype)` with an all-False mask adds zero,
- `boundary = torch.where(mask, signal_ones, boundary)` with all-False leaves `boundary` unchanged.

So skipping the break under compile produces the identical result; eager keeps the speedup. Guarded both sites with `torch.compiler.is_compiling()`.

## Verification

```
torch.compile(distance_transform, fullgraph=True)  ->  2D and 3D trace clean, match eager (atol 1e-5)
KORNIA_TEST_OPTIMIZER=inductor pytest test_conv_distance_transformer -> 16 passed
```

The existing `test_dynamo` already covers 2D+3D; this upgrades it from tolerating a graph break to fullgraph-clean. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)