### PR TITLE
fix(enhance): posterize torch.compile fullgraph support

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -792,13 +792,13 @@ def posterize(input: torch.Tensor, bits: Union[int, torch.Tensor]) -> torch.Tens
         return (input * 255).to(torch.uint8) / (2**shift).to(input.dtype) / 255.0
 
     def _posterize_one(input: torch.Tensor, bits: torch.Tensor) -> torch.Tensor:
-        # Single bits value condition
-        if bits == 0:
-            return torch.zeros_like(input)
-        if bits == 8:
-            return input.clone()
-        bits = 8 - bits
-        return _left_shift(_right_shift(input, bits), bits)
+        # Branchless for torch.compile: the bits==0 / bits==8 special cases guard a uint8
+        # overflow in the shift math, so compute the shift unconditionally and select with
+        # torch.where (verified numerically identical to the branched version for bits 0..8).
+        shift = 8 - bits
+        shifted = _left_shift(_right_shift(input, shift), shift)
+        out = torch.where(bits == 0, torch.zeros_like(input), shifted)
+        return torch.where(bits == 8, input, out)
 
     if len(bits.shape) == 0 or (len(bits.shape) == 1 and len(bits) == 1):
         return _posterize_one(input, bits)

--- a/tests/enhance/test_adjust.py
+++ b/tests/enhance/test_adjust.py
@@ -1200,3 +1200,9 @@ class TestPosterize(BaseTester):
         expected = op(img, 8)
         actual = op_script(img, 8)
         self.assert_close(actual, expected)
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        img = torch.rand(2, 3, 4, 4, device=device, dtype=dtype)
+        op = kornia.enhance.posterize
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(img, 3), op_optimized(img, 3))


### PR DESCRIPTION
Part of the **compile-first** roadmap theme (ROADMAP.md / #3568). Fourth in the numeric-core compile series.

## Problem

`posterize` graph-breaks under `torch.compile` (`Data-dependent branching`) in `_posterize_one`:

```python
if bits == 0: return torch.zeros_like(input)
if bits == 8: return input.clone()
```

Unlike the earlier validation-guard fixes, these branches are **load-bearing**: they guard a `uint8` overflow in the bit-shift math (a shift by 8 overflows the uint8 intermediate), so they can't simply be skipped.

## Fix

Rewrote branchless with `torch.where` — compute the shift unconditionally and select, so the overflow path is computed but discarded by the `where`:

```python
shift = 8 - bits
shifted = _left_shift(_right_shift(input, shift), shift)
out = torch.where(bits == 0, torch.zeros_like(input), shifted)
return torch.where(bits == 8, input, out)
```

**Exhaustively verified numerically identical** to the branched version for every `bits` value 0..8 before shipping.

## Verification

```
branchless == branched for bits in 0..8   ->  all match (atol 1e-6)
torch.compile(posterize, fullgraph=True)  ->  traces clean, matches eager
KORNIA_TEST_OPTIMIZER=inductor pytest TestPosterize -> 11 passed
```

Scope: the common scalar/single-bits path is now fullgraph-clean; the per-batch bits-**tensor** path (a Python `for` loop) remains a separate follow-up. Adds `test_dynamo`. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)