### PR TITLE
fix(color): apply_colormap torch.compile fullgraph support

### DIFF
--- a/kornia/color/colormap.py
+++ b/kornia/color/colormap.py
@@ -238,7 +238,13 @@ def apply_colormap(input_tensor: torch.Tensor, colormap: ColorMap) -> torch.Tens
 
     B, C, H, W = input_tensor.shape
     input_tensor = input_tensor.reshape(B, C, -1)
-    max_value = 1.0 if input_tensor.max() <= 1.0 else 255.0
+    # torch.where instead of a Python ternary on input_tensor.max() so the op is
+    # torch.compile fullgraph-safe (branching on a tensor value breaks the graph).
+    max_value = torch.where(
+        input_tensor.max() <= 1.0,
+        torch.tensor(1.0, device=input_tensor.device, dtype=torch.float),
+        torch.tensor(255.0, device=input_tensor.device, dtype=torch.float),
+    )
     input_tensor = input_tensor.float().div_(max_value)
 
     colors = colormap.colors.permute(1, 0)


### PR DESCRIPTION
Part of the **compile-first** roadmap theme (ROADMAP.md / #3568). Sixth in the numeric-core compile series.

## Problem

`apply_colormap` graph-breaks under `torch.compile` at a data-dependent normalization heuristic:

```python
max_value = 1.0 if input_tensor.max() <= 1.0 else 255.0
```

The Python ternary branches on `input_tensor.max()` (a tensor value).

## Fix

Replaced with `torch.where`, preserving exact behavior — divide by 1.0 for already-normalized [0, 1] input, by 255.0 for [0, 255] input.

## Verification

```
torch.compile(apply_colormap, fullgraph=True) -> traces clean, matches eager
  for both normalized [0,1] and uint8 [0,255] inputs (atol 1e-5)
doctest kornia/color/colormap.py -> 3 passed
KORNIA_TEST_OPTIMIZER=inductor pytest test_colormap -> 62 passed (incl. existing test_dynamo)
```

ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)