### PR TITLE
fix(losses): mask_ignore_pixels torch.compile fullgraph (unblocks dice/focal/tversky)

### DIFF
--- a/kornia/losses/_utils.py
+++ b/kornia/losses/_utils.py
@@ -48,7 +48,10 @@ def mask_ignore_pixels(
 
     target_mask = target != ignore_index
 
-    if target_mask.all():
+    # Data-dependent early-out (skip masking when nothing is ignored). Guard it under
+    # torch.compile: returning the all-True mask instead of None just makes callers apply
+    # a no-op mask, which keeps the result identical while staying fullgraph-safe.
+    if not torch.compiler.is_compiling() and target_mask.all():
         return target, None
 
     # map invalid pixels to a valid class (0)


### PR DESCRIPTION
Part of the **compile-first** roadmap theme (ROADMAP.md / #3568). Seventh in the compile series — and the highest-leverage one: a single change to the shared `mask_ignore_pixels` helper unblocks **three** losses.

## Problem

`dice_loss`, `focal_loss`, and `tversky_loss` all call `kornia/losses/_utils.py::mask_ignore_pixels`, which graph-breaks under `torch.compile`:

```python
if target_mask.all():   # data-dependent -> graph break
    return target, None
```

## Fix

The early-out is a pure optimization — when nothing is ignored it skips masking by returning `None`. Returning the all-True mask instead just makes the caller apply a no-op mask (multiply by all-ones), so the result is identical. Guarded under `torch.compiler.is_compiling()`.

## Verification

```
torch.compile(fullgraph=True) for dice / focal / tversky:
  no-ignore    -> traces clean, matches eager (atol 1e-5)
  with-ignore  -> traces clean, matches eager (atol 1e-5)
KORNIA_TEST_OPTIMIZER=inductor pytest tests/losses -k 'dice or focal or tversky' -> 128 passed
```

The three losses' existing `test_dynamo` tests now exercise a fullgraph-clean path. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)