### PR TITLE
fix(augmentation): torch.compile-safe batch-prob gate (unblocks the whole module)

### DIFF
--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -175,8 +175,25 @@ class _BasicAugmentationBase(nn.Module):
         else:
             batch_prob = (torch.rand(1, device=self.device) < p_batch).to(self.dtype)
 
-        if batch_prob.sum() == 1:
-            elem_prob: torch.Tensor
+        elem_prob: torch.Tensor
+        if not torch.compiler.is_compiling():
+            # Eager keeps the exact original control flow so RNG draws are unchanged.
+            if batch_prob.sum() == 1:
+                if p == 1:
+                    elem_prob = torch.ones(batch_shape[0], device=self.device, dtype=self.dtype)
+                elif p == 0:
+                    elem_prob = torch.zeros(batch_shape[0], device=self.device, dtype=self.dtype)
+                elif same_on_batch:
+                    elem_prob = (torch.rand(1, device=self.device) < p).to(self.dtype).expand(batch_shape[0])
+                else:
+                    elem_prob = (torch.rand(batch_shape[0], device=self.device) < p).to(self.dtype)
+                batch_prob = batch_prob * elem_prob
+            else:
+                batch_prob = batch_prob.repeat(batch_shape[0])
+        else:
+            # Compile: branchless equivalent of the `batch_prob.sum() == 1` gate. batch_prob
+            # is (1,) in {0, 1}; multiplying by the per-sample gate yields zeros for a
+            # deselected batch and elem_prob for a selected one, avoiding the graph break.
             if p == 1:
                 elem_prob = torch.ones(batch_shape[0], device=self.device, dtype=self.dtype)
             elif p == 0:
@@ -186,8 +203,6 @@ class _BasicAugmentationBase(nn.Module):
             else:
                 elem_prob = (torch.rand(batch_shape[0], device=self.device) < p).to(self.dtype)
             batch_prob = batch_prob * elem_prob
-        else:
-            batch_prob = batch_prob.repeat(batch_shape[0])
 
         if len(batch_prob.shape) == 2:
             return batch_prob[..., 0]


### PR DESCRIPTION
Part of the **compile-first** roadmap theme (ROADMAP.md / #3568) — the **highest-leverage** fix in the series.

## Problem

**Every** augmentation graph-breaks under `torch.compile` at the shared base-class gate in `__batch_prob_generator__` (`kornia/augmentation/base.py`):

```python
if batch_prob.sum() == 1:   # data-dependent branch on a tensor value
    ...
```

Because it's in the common base class, it blocks the entire `kornia.augmentation` module from compiling.

## Fix

Split on `torch.compiler.is_compiling()`:

- **Eager** keeps the *exact* original control flow — byte-identical RNG draws, zero behavior change.
- **Compile** uses the branchless equivalent: `batch_prob` is `(1,)` in {0, 1}, so `batch_prob * elem_prob` yields zeros for a deselected batch and `elem_prob` for a selected one — identical to the branched result, without the graph break.

The eager/compile split guarantees no existing test can regress (eager path is unchanged).

## Impact

Unblocks the module's compile path. Now trace fullgraph: `RandomBrightness`, `RandomHorizontalFlip`, `RandomGaussianBlur`, `Normalize`, `RandomInvert`, `RandomChannelShuffle`, and more. (`ColorJitter` and `RandomAffine` have separate op-specific breaks downstream — left as follow-ups.)

## Verification

```
eager pytest tests/augmentation --dtype=float32 -> 2280 passed (unchanged)
torch.compile(fullgraph=True): RandomBrightness/HFlip/GaussianBlur/Normalize/Invert/ChannelShuffle -> all trace clean
```

ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)