### PR TITLE
fix(core): _extract_device_dtype torch.compile fullgraph (unblocks Rotation/Affine/Perspective/Shear)

### DIFF
--- a/kornia/core/utils.py
+++ b/kornia/core/utils.py
@@ -113,7 +113,10 @@ def _extract_device_dtype(tensor_list: List[Optional[Any]]) -> Tuple[torch.devic
                     expected_device=device,
                 )
     if device is None:
-        device = torch.get_default_device()
+        # `torch.empty(0).device` reads the current default device and, unlike
+        # `torch.get_default_device()`, is traceable by dynamo — so this helper stays
+        # fullgraph-compilable even when a caller can't prove a tensor is in the list.
+        device = torch.empty(0).device
     if dtype is None:
         dtype = torch.get_default_dtype()
     return (device, dtype)


### PR DESCRIPTION
Part of the compile-first roadmap. High-leverage shared-helper fix — one line unblocks the geometric augmentations.

## Problem

`_extract_device_dtype` (`kornia/core/utils.py`) graph-breaks at:

```python
device = torch.get_default_device()   # 'torch.* op returned non-Tensor'
```

It's called by the shared plain-uniform param generator. Even though that branch is usually dead at runtime (a param tensor provides the device), dynamo can't prove a tensor is in the list — `self.samplers` is an opaque list-of-tuples attribute — so it speculatively traces the default-device branch and breaks. This blocks **RandomRotation, RandomAffine, RandomPerspective, shear, RandomPosterize** and other plain-uniform augmentations.

## Fix

```python
device = torch.empty(0).device
```

`torch.empty(0).device` reads the same current default device but is **traceable** (a tensor op), unlike `torch.get_default_device()`. Genuine single-path fix — identical eager behavior, no `is_compiling` guard.

## Impact

Verified fullgraph now: `RandomRotation`, `RandomAffine`, `RandomPerspective`, shear, `RandomPosterize`.

## Verification

```
torch.compile(fullgraph=True): Rotation/Affine/Perspective/Shear/Posterize -> all trace clean
pytest tests/augmentation -k 'Affine or Rotation or Perspective or Shear' -> 33 passed
pytest tests/utils -> 11 passed  (eager unchanged)
```

Honest note: on **CPU**, compiling these warp ops is neutral-to-slightly-slower (grid_sample is memory-bound, no CPU fusion win) — but eager is unchanged, and fullgraph availability is what matters: it's **required for ONNX export** (Goal 2) and enables **GPU grid_sample fusion**. The value is unblocking the graph, not a CPU speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)