### PR TITLE
fix(augmentation): fullgraph-safe fixed-kernel path for RandomMotionBlur

### DIFF
--- a/kornia/augmentation/_2d/intensity/motion_blur.py
+++ b/kornia/augmentation/_2d/intensity/motion_blur.py
@@ -96,6 +96,9 @@ class RandomMotionBlur(IntensityAugmentationBase2D):
         super().__init__(p=p, same_on_batch=same_on_batch, keepdim=keepdim)
         self._param_generator = rg.MotionBlurGenerator(kernel_size, angle, direction)
         self.flags = {"border_type": BorderType.get(border_type), "resample": Resample.get(resample)}
+        # A fixed (int) kernel_size lets us skip the data-dependent kernel-size selection in
+        # apply_transform, keeping that path torch.compile fullgraph-safe.
+        self._fixed_kernel_size: Optional[int] = kernel_size if isinstance(kernel_size, int) else None
 
     def generate_parameters(self, batch_shape: Tuple[int, ...]) -> Dict[str, torch.Tensor]:
         params = super().generate_parameters(batch_shape)
@@ -109,18 +112,22 @@ class RandomMotionBlur(IntensityAugmentationBase2D):
         flags: Dict[str, Any],
         transform: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        # sample a kernel size
-        kernel_size_list: List[int] = params["ksize_factor"].tolist()
-
-        # 1. We have to apply the same kernel size to all samples in the batch, thus we take the previously
-        # selected random index --- `params["idx"][0]` --- to determine the applied kernel size.
-        # 2. The `VideoSequential` flattens the first two dimensions, effectively creating a larger batch.
-        # Its method `VideoSequential.__repeat_param_across_channels__` repeats the previously selected index,
-        # creating a torch.Tensor with equal values. Hence, taking the first one (`params["idx"][0]`) is legit.
-        idx: int = cast(int, params["idx"][0])
+        kernel_size: int
+        if self._fixed_kernel_size is not None:
+            # Fixed kernel size: static value, no data-dependent indexing -> stays fullgraph.
+            kernel_size = self._fixed_kernel_size
+        else:
+            # Sampled from a range. We apply the same kernel size to all samples in the batch,
+            # taking the previously selected random index `params["idx"][0]` to pick it.
+            # (`VideoSequential` flattens the first two dims and repeats that index, so all
+            # entries are equal and taking the first is legit.) This branch is inherently
+            # data-dependent and not fullgraph-compilable.
+            kernel_size_list: List[int] = params["ksize_factor"].tolist()
+            idx: int = cast(int, params["idx"][0])
+            kernel_size = kernel_size_list[idx]
         return motion_blur(
             input,
-            kernel_size=kernel_size_list[idx],
+            kernel_size=kernel_size,
             angle=params["angle_factor"],
             direction=params["direction_factor"],
             border_type=flags["border_type"].name.lower(),

--- a/tests/augmentation/test_motionblur.py
+++ b/tests/augmentation/test_motionblur.py
@@ -92,6 +92,14 @@ class TestRandomMotionBlur(BaseTester):
             fast_mode=False,
         )
 
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        # A fixed (int) kernel size avoids the data-dependent kernel-size selection and
+        # is torch.compile fullgraph-safe.
+        img = torch.rand(2, 3, 16, 16, device=device, dtype=dtype)
+        op = RandomMotionBlur(kernel_size=5, angle=(35.0, 35.0), direction=(0.5, 0.5), p=1.0)
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(img), op_optimized(img))
+
 
 class TestRandomMotionBlur3D(BaseTester):
     # TODO: improve and implement more meaningful smoke tests e.g check for a consistent


### PR DESCRIPTION
Part of the compile-first roadmap. Depends on / stacks on **#3797** (RandomMotionBlur also needs the `_extract_device_dtype` fix to fully compile — that commit is included here until #3797 merges).

## Problem

`RandomMotionBlur.apply_transform` graph-breaks on a data-dependent kernel-size selection:

```python
kernel_size_list = params["ksize_factor"].tolist()
idx = cast(int, params["idx"][0])
... kernel_size=kernel_size_list[idx] ...   # 'Could not extract specialized integer from data-dependent'
```

## Fix

When `kernel_size` is a fixed `int` (the common case), that selection is redundant — `ksize_factor` is constant, so the chosen size is always the same. Store it at construction (`self._fixed_kernel_size`) and use it directly; the range case keeps the (inherently dynamic) sampled path.

The branch is on a **per-instance constant**, so dynamo specializes it — the fixed-kernel path is fullgraph, the range path is unchanged. No `is_compiling` hack.

## Verification

```
torch.compile(RandomMotionBlur(kernel_size=5), fullgraph=True) -> traces clean
eager output == previous code -> byte-identical (torch.equal)
RandomMotionBlur((3,7)) range -> still dynamic, as before (not a regression)
pytest tests/augmentation/test_motionblur.py -> 126 passed (+ new test_dynamo)
```

Honest note: like the other warp/conv augmentations, CPU compile is neutral (memory-bound); the value is fullgraph availability for ONNX export + GPU fusion. Eager is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)