### PR TITLE
fix(core): make torch version checks torch.compile fullgraph-safe

### DIFF
--- a/kornia/core/_compat.py
+++ b/kornia/core/_compat.py
@@ -19,10 +19,9 @@
 import warnings
 from functools import wraps
 from inspect import isclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Tuple
 
 import torch
-from packaging import version
 
 
 def torch_version() -> str:
@@ -35,6 +34,37 @@ def torch_version() -> str:
         The clean version string (e.g., "2.0.1" from "2.0.1+cu118").
     """
     return torch.__version__.partition("+")[0]
+
+
+def _parse_torch_version(v: str) -> Tuple[int, int, int]:
+    """Parse ``torch.__version__`` into a ``(major, minor, patch)`` int tuple.
+
+    Build metadata (``+cu118``) and any pre-release/dev suffix on a component
+    (``2.4.0rc1``) are dropped, so the result orders identically to the release
+    versions Kornia compares against. Computed once at import time so the
+    ``torch_version_*`` comparators never run a string method — those are the
+    calls ``torch.compile``'s dynamo tracer cannot lower, and reaching them on a
+    hot path (e.g. ``is_autocast_enabled`` in the augmentation base) breaks the
+    whole graph.
+    """
+    base = v.partition("+")[0]
+    parts = base.split(".")
+    nums = []
+    for part in parts[:3]:
+        digits = ""
+        for ch in part:
+            if not ch.isdigit():
+                break
+            digits += ch
+        nums.append(int(digits) if digits else 0)
+    while len(nums) < 3:
+        nums.append(0)
+    return (nums[0], nums[1], nums[2])
+
+
+# Parsed once at import: subsequent comparisons are pure integer-tuple compares,
+# which dynamo constant-folds cleanly (unlike ``partition``/``packaging.version``).
+_TORCH_VERSION: Tuple[int, int, int] = _parse_torch_version(torch.__version__)
 
 
 def torch_version_lt(major: int, minor: int, patch: int) -> bool:
@@ -50,8 +80,7 @@ def torch_version_lt(major: int, minor: int, patch: int) -> bool:
         False otherwise.
 
     """
-    _version = version.parse(torch_version())
-    return _version < version.parse(f"{major}.{minor}.{patch}")
+    return _TORCH_VERSION < (major, minor, patch)
 
 
 def torch_version_le(major: int, minor: int, patch: int) -> bool:
@@ -67,8 +96,7 @@ def torch_version_le(major: int, minor: int, patch: int) -> bool:
         False otherwise.
 
     """
-    _version = version.parse(torch_version())
-    return _version <= version.parse(f"{major}.{minor}.{patch}")
+    return _TORCH_VERSION <= (major, minor, patch)
 
 
 def torch_version_ge(major: int, minor: int, patch: Optional[int] = None) -> bool:
@@ -95,11 +123,9 @@ def torch_version_ge(major: int, minor: int, patch: Optional[int] = None) -> boo
         >>> torch_version_ge(3, 0, 0)  # True if PyTorch >= 3.0.0
         False
     """
-    _version = version.parse(torch_version())
     if patch is None:
-        return _version >= version.parse(f"{major}.{minor}")
-    else:
-        return _version >= version.parse(f"{major}.{minor}.{patch}")
+        return _TORCH_VERSION[:2] >= (major, minor)
+    return _TORCH_VERSION >= (major, minor, patch)
 
 
 def _emit_deprecation_warning(

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -881,6 +881,15 @@ class TestRandomHorizontalFlip(BaseTester):
         repr = "RandomHorizontalFlip(p=0.5, p_batch=1.0, same_on_batch=False)"
         assert str(f) == repr
 
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        torch.manual_seed(0)
+        input = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
+        op = RandomHorizontalFlip(p=1.0)
+        params = op.forward_parameters(input.shape)
+        expected = op(input, params=params)
+        compiled = torch.compile(op, fullgraph=True)
+        self.assert_close(compiled(input, params=params), expected)
+
     def test_random_hflip(self, device, dtype):
         f = RandomHorizontalFlip(p=1.0, keepdim=True)
         f1 = RandomHorizontalFlip(p=0.0, keepdim=True)
@@ -1059,6 +1068,15 @@ class TestRandomVerticalFlip(BaseTester):
         f = RandomVerticalFlip(p=0.5)
         repr = "RandomVerticalFlip(p=0.5, p_batch=1.0, same_on_batch=False)"
         assert str(f) == repr
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        torch.manual_seed(0)
+        input = torch.rand(2, 3, 4, 5, device=device, dtype=dtype)
+        op = RandomVerticalFlip(p=1.0)
+        params = op.forward_parameters(input.shape)
+        expected = op(input, params=params)
+        compiled = torch.compile(op, fullgraph=True)
+        self.assert_close(compiled(input, params=params), expected)
 
     def test_random_vflip(self, device, dtype):
         f = RandomVerticalFlip(p=1.0)


### PR DESCRIPTION
Part of the compile-first roadmap. Fixes a **shared** fullgraph blocker sitting under the whole augmentation family.

## The blocker

`torch_version_lt/le/ge` (in `kornia/core/_compat.py`) called `torch.__version__.partition("+")` and `packaging.version.parse(...)` **on every call**. Dynamo has no lowering for those string / third-party calls, so any op that reaches them under `fullgraph=True` breaks the graph:

```
torch._dynamo.exc.Unsupported: Attempted to call torch.__version__.partition, got unsupported return value ('2.10.0', '', '')
```

`is_autocast_enabled()` calls `torch_version_ge(2, 4)` and runs inside the augmentation base `forward`, so this broke fullgraph compilation for the stochastic augmentation family. `RandomHorizontalFlip` / `RandomVerticalFlip` are fully compile-clean *except* for this shared helper.

## The fix

Parse `torch.__version__` **once at import** into a `(major, minor, patch)` int tuple (`_TORCH_VERSION`); the three comparators now do pure integer-tuple comparisons, which dynamo constant-folds. Build metadata (`+cu126`) and any pre-release/dev suffix on a component are dropped — ordering is identical to the old `partition("+")[0]` + `packaging` path for every release version Kornia compares against. Removes the `packaging` import from this module.

No numeric-core / eager behavior change — the comparators return the same bools; only the augmentation *compiled* path is unblocked.

## Verification (CPU, torch 2.10)

```
# flips now compile fullgraph, byte-identical to eager
HFlip: fullgraph OK  byte-equal=True
VFlip: fullgraph OK  byte-equal=True

# comparator correctness sanity (torch 2.10.0)
torch_version_ge(2,4)=True  ge(3,0,0)=False  ge(2,10,1)=False
lt(2,10,1)=True  le(2,10,0)=True  -> all pass

# targeted tests
pytest -k "HorizontalFlip or VerticalFlip"      -> 34 passed, 8 skipped, 2 xpassed
pytest tests/color/test_gray.py ...deprecated   -> 38 passed
pytest --doctest-modules kornia/core/_compat.py -> 1 passed
pytest ...::TestRandom{H,V}Flip::test_dynamo --optimizer=inductor -> 2 passed
```

(`TestResize::test_dynamo` fails on this Jetson's torch 2.10 both with and without this change — a pre-existing `.tolist()` graph break in `Resize`, unrelated.)

## Benchmark (touched function)

`torch.utils.benchmark`, avoiding the per-call `packaging.version.parse` allocation:

| call | before | after | speedup |
|------|-------:|------:|--------:|
| `torch_version_ge(2,4)` | 6107 ns | 315 ns | **19.4x** |

`is_autocast_enabled()` (called on every augmentation forward) drops to ~1.0 µs accordingly.

Adds `test_dynamo` (fullgraph, byte-equal vs eager) to both flip classes to keep this a defended floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)