### PR TITLE
perf(augmentation): skip identity+blend in transform-matrix at p=1

### DIFF
--- a/kornia/augmentation/_2d/base.py
+++ b/kornia/augmentation/_2d/base.py
@@ -106,6 +106,17 @@ class RigidAffineAugmentationBase2D(AugmentationBase2D):
         in_tensor = self.transform_tensor(input)
 
         trans_matrix_applied = self.compute_transformation(in_tensor, params=params, flags=flags)
+
+        if self.p == 1.0 and self.p_batch == 1.0:
+            # Always applied (static probabilities): the blend selects the computed matrix
+            # everywhere, so it equals `trans_matrix_applied`. Skip building the identity and
+            # the `where` — this is a hot per-call cost (~40% of a flip's forward is the matrix
+            # path) that the image output never needs. Mirrors the `transform_inputs` fast path.
+            trans_matrix = trans_matrix_applied
+            if is_autocast_enabled():
+                trans_matrix = trans_matrix.type(input.dtype)
+            return trans_matrix
+
         trans_matrix_identity = self.identity_matrix(in_tensor)
 
         if is_autocast_enabled():


### PR DESCRIPTION
Part of the GPU-performance-leadership roadmap item. Attacks the wrapper overhead that dominates cheap augmentations.

## Finding

Profiling `RandomHorizontalFlip.forward` (cumulative):

```
forward                          0.227
  apply_func                     0.206
    generate_transformation_matrix 0.096   <- 42% of forward
    transform_inputs             0.100
  hflip (the actual op)          0.045
```

`generate_transformation_matrix` builds a per-sample identity (`eye_like`) and a `where`-blend against the computed matrix on **every** call. But the geometric image path (`hflip`, `affine`, …) ignores the matrix — it's only stored for the `.transform_matrix` property. At static probability the blend result is unconditionally the computed matrix, so the identity + `where` are pure overhead.

## Fix

Add the `p == 1.0 and p_batch == 1.0` static fast path already merged for `transform_inputs` (#3800): return `trans_matrix_applied` directly. Since `torch.where(all_true, applied, identity) == applied`, this is byte-identical. The `p < 1` path is untouched.

## Verification

Byte-identical vs `main` — **output and `transform_matrix`** — for HFlip / VFlip / Rotate / Resize / Affine at p=1:

```
HFlip   output byte-equal=True  transform_matrix byte-equal=True
VFlip   output byte-equal=True  transform_matrix byte-equal=True
Rotate  output byte-equal=True  transform_matrix byte-equal=True
Resize  output byte-equal=True  transform_matrix byte-equal=True
Affine  output byte-equal=True  transform_matrix byte-equal=True
```

Tests (CPU, float32):
```
tests/augmentation/test_augmentation.py  -k Flip/Rotation/Affine/Resize/Perspective/Crop -> 104 passed, 20 skipped, 6 xfailed
tests/augmentation/container/                                                             -> 511 passed, 51 skipped
```

## Benchmark (CPU, batch 16, 64²)

| op (p=1) | main | this PR | speedup |
|----------|-----:|--------:|--------:|
| HFlip | 553 µs | 386 µs | **1.43×** |
| VFlip | 525 µs | 379 µs | **1.38×** |
| Rotate | 8204 µs | 7822 µs | 1.05× (warp-dominated, expected) |
| HFlip **p=0.5** | 886 µs | 882 µs | unchanged (full path) |

Fewer host ops on the hot path also reduce launch/orchestration overhead in the compiled + CUDA-graph regime, which is the strategic target for GPU-batched augmentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)