### PR TITLE
fix(enhance): make solarize torch.compile fullgraph-safe

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -660,9 +660,10 @@ def _solarize(input: torch.Tensor, thresholds: Union[float, torch.Tensor] = 0.5)
     if isinstance(thresholds, torch.Tensor) and len(thresholds.shape) != 0:
         if not (input.size(0) == len(thresholds) and len(thresholds.shape) == 1):
             raise AssertionError(f"thresholds must be a 1-d vector of shape ({input.size(0)},). Got {thresholds}")
-        # TODO: I am not happy about this line, but no easy to do batch-wise operation
+        # Reshape the per-sample threshold to broadcast over (C, H, W) rather than iterating the
+        # tensor (`for x in thresholds` breaks torch.compile); the `where` below broadcasts identically.
         thresholds = thresholds.to(input.device).to(input.dtype)
-        thresholds = torch.stack([x.expand(*input.shape[-3:]) for x in thresholds])
+        thresholds = thresholds.view([-1] + [1] * (input.ndim - 1))
 
     return torch.where(input < thresholds, input, 1.0 - input)
 
@@ -721,15 +722,20 @@ def solarize(
         if isinstance(additions, float):
             additions = torch.as_tensor(additions)
 
-        if not torch.all((additions < 0.5) * (additions > -0.5)):
-            raise AssertionError(f"The value of 'addition' is between -0.5 and 0.5. Got {additions}.")
+        # `torch._assert_async` keeps this a single traceable path (no Python-level branch on a
+        # tensor value), so `solarize` stays torch.compile fullgraph-safe while still validating.
+        torch._assert_async(
+            ((additions < 0.5) & (additions > -0.5)).all(),
+            "The value of 'addition' is between -0.5 and 0.5.",
+        )
 
         if isinstance(additions, torch.Tensor) and len(additions.shape) != 0:
             if not (input.size(0) == len(additions) and len(additions.shape) == 1):
                 raise AssertionError(f"additions must be a 1-d vector of shape ({input.size(0)},). Got {additions}")
-            # TODO: I am not happy about this line, but no easy to do batch-wise operation
+            # Broadcast the per-sample scalar over (C, H, W) by reshaping instead of iterating the
+            # tensor (`for x in additions` breaks the graph); numerically identical.
             additions = additions.to(input.device).to(input.dtype)
-            additions = torch.stack([x.expand(*input.shape[-3:]) for x in additions])
+            additions = additions.view([-1] + [1] * (input.ndim - 1))
         input = input + additions
         input = input.clamp(0.0, 1.0)
 

--- a/tests/enhance/test_adjust.py
+++ b/tests/enhance/test_adjust.py
@@ -1061,6 +1061,15 @@ class TestSharpness(BaseTester):
         actual = op_script(img, 0.8)
         self.assert_close(actual, expected)
 
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        img = torch.rand(3, 3, 5, 5, device=device, dtype=dtype)
+        op = kornia.enhance.sharpness
+        op_optimized = torch_optimizer(op)
+        # scalar factor (whole batch) and per-sample factor
+        self.assert_close(op(img, 0.5), op_optimized(img, 0.5))
+        factor = torch.tensor([0.3, 0.7, 1.5], device=device, dtype=dtype)
+        self.assert_close(op(img, factor), op_optimized(img, factor))
+
 
 @pytest.mark.skipif(kornia.core.utils.xla_is_available(), reason="issues with xla device")
 class TestSolarize(BaseTester):
@@ -1145,12 +1154,23 @@ class TestSolarize(BaseTester):
 
     def test_dynamo(self, device, dtype, torch_optimizer):
         img = torch.rand(3, 3, 5, 5, device=device, dtype=dtype)
-        op = kornia.enhance.sharpness
+        op = kornia.enhance.solarize
         op_optimized = torch_optimizer(op)
-        # scalar factor (whole batch) and per-sample factor
-        self.assert_close(op(img, 0.5), op_optimized(img, 0.5))
-        factor = torch.tensor([0.3, 0.7, 1.5], device=device, dtype=dtype)
-        self.assert_close(op(img, factor), op_optimized(img, factor))
+        # scalar threshold/addition (whole batch)
+        self.assert_close(op(img, 0.5, 0.1), op_optimized(img, 0.5, 0.1))
+        # per-sample 1-d threshold/addition — the batch-wise path that must stay fullgraph-safe
+        thresholds = torch.tensor([0.3, 0.6, 0.8], device=device, dtype=dtype)
+        additions = torch.tensor([-0.2, 0.0, 0.2], device=device, dtype=dtype)
+        self.assert_close(op(img, thresholds, additions), op_optimized(img, thresholds, additions))
+
+    def test_dynamo_fullgraph(self, device, dtype):
+        img = torch.rand(3, 3, 5, 5, device=device, dtype=dtype)
+        thresholds = torch.tensor([0.3, 0.6, 0.8], device=device, dtype=dtype)
+        additions = torch.tensor([-0.2, 0.0, 0.2], device=device, dtype=dtype)
+        expected = kornia.enhance.solarize(img, thresholds, additions)
+        torch._dynamo.reset()
+        compiled = torch.compile(kornia.enhance.solarize, fullgraph=True)
+        self.assert_close(compiled(img, thresholds, additions), expected)
 
 
 class TestPosterize(BaseTester):


### PR DESCRIPTION
Part of the compile-first roadmap. `solarize` graph-breaks under `fullgraph=True` on the per-sample (1-d tensor) path that `RandomSolarize` uses.

## Three blockers, all on the batch-wise path

1. **Validation branch** — `if not torch.all((additions < 0.5) * (additions > -0.5)): raise AssertionError(...)` is a Python branch on a tensor value. Replaced with `torch._assert_async(((additions < 0.5) & (additions > -0.5)).all(), "...")` — single traceable path, still validates. Only the `TypeError` cases are covered by tests; the range assertion has no test asserting its message.
2 & 3. **Tensor iteration** — `torch.stack([x.expand(*input.shape[-3:]) for x in additions])` (and the same for `thresholds` in `_solarize`) iterates a tensor to broadcast a per-sample scalar over `(C, H, W)`. Replaced with a reshape `view([-1] + [1] * (input.ndim - 1))` that broadcasts identically. No iteration → no graph break, and fewer ops.

## Verification (CPU, torch 2.10)

```
functional byte-equal vs old (1-d thresholds+additions): True
torch.compile(solarize, fullgraph=True): traces clean, matches eager
RandomSolarize(p=1) fullgraph: byte-equal vs eager: True
```

Tests (`--optimizer=inductor`):
```
tests/enhance/test_adjust.py -k "Solarize or Sharpness" -> 27 passed, 2 skipped
```

Also fixes a pre-existing copy-paste bug: `TestSolarize.test_dynamo` was exercising `kornia.enhance.sharpness`. Moved that to `TestSharpness` (which had no dynamo test) and gave `TestSolarize` a proper solarize test plus a `test_dynamo_fullgraph` covering the 1-d path.

Depends on the base being fullgraph-clean (landed in #3802).

🤖 Generated with [Claude Code](https://claude.com/claude-code)