### PR TITLE
fix(geometry): make bbox_to_mask (RandomErasing) torch.compile fullgraph-safe

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -224,7 +224,10 @@ def bbox_to_mask(boxes: torch.Tensor, width: int, height: int) -> torch.Tensor:
                  [0., 0., 0., 0., 0.]]])
 
     """
-    validate_bbox(boxes)
+    # NOTE: `validate_bbox`'s boolean result was previously computed here and discarded — it
+    # never raised, so it performed no validation while adding a data-dependent graph break
+    # (`torch.any(...)` -> Python `if`) that blocked torch.compile fullgraph (e.g. RandomErasing,
+    # which builds its mask through this function). Dropped; behaviour is byte-identical.
     # zero padding the surroundings
     yy = torch.arange(height, device=boxes.device, dtype=boxes.dtype).view(height, 1)
     xx = torch.arange(width, device=boxes.device, dtype=boxes.dtype).view(1, width)

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -2567,6 +2567,15 @@ class TestRectangleRandomErasing(BaseTester):
         res = f(input)
         self.assert_close(res[0], res[1])
 
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        torch.manual_seed(0)
+        input = torch.rand(2, 3, 11, 7, device=device, dtype=dtype)
+        op = RandomErasing(p=1.0)
+        params = op.forward_parameters(input.shape)
+        expected = op(input, params=params)
+        compiled = torch.compile(op, fullgraph=True)
+        self.assert_close(compiled(input, params=params), expected)
+
     @pytest.mark.slow
     def test_gradcheck(self, device):
         # test parameters


### PR DESCRIPTION
Part of the compile-first roadmap. Unblocks `RandomErasing` under `torch.compile(fullgraph=True)`.

## Blocker

`bbox_to_mask` began with:

```python
validate_bbox(boxes)   # result discarded
```

`validate_bbox` returns a `bool` (`True`/`False`) and **never raises**, so discarding its result performs no validation. But computing it runs `if torch.any(width_diff > 1e-4): return False` — a Python branch on a tensor value, which graph-breaks:

```
torch._dynamo.exc.Unsupported: Data-dependent branching
```

`RandomErasing.apply_transform` builds its erase mask via `bbox_to_mask`, so this discarded call was its sole fullgraph blocker.

## Fix

Remove the dead call. Byte-identical:

```
bbox_to_mask sample output: unchanged (matches docstring)
RandomErasing(p=1) fullgraph output byte-equal to eager: True
```

`validate_bbox` itself is untouched and remains covered by `tests/geometry/test_bbox.py`.

## Verification (CPU, torch 2.10)

```
tests/geometry/test_bbox.py + test_boxes.py                       -> 51 passed
tests/augmentation container + auto_operation (use bbox_to_mask)  -> 53 passed, 50 skipped
RandomErasing -k, --optimizer=inductor (incl new test_dynamo)     -> 20 passed, 1 skipped
```

Adds `TestRectangleRandomErasing.test_dynamo` (fullgraph, byte-equal vs eager).

The identical discarded-`validate_bbox` pattern also sits in `infer_bbox_shape`, `crop2d`, and `Boxes.__init__` — left as follow-ups to keep this PR scoped to the erasing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)