### PR TITLE
fix(augmentation): make Resize compute_transformation fullgraph-safe

### DIFF
--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -22,7 +22,6 @@ import torch
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
 from kornia.constants import Resample
-from kornia.core.ops import eye_like
 from kornia.geometry.transform import crop_by_transform_mat, get_perspective_transform, resize
 
 
@@ -64,9 +63,12 @@ class Resize(GeometricAugmentationBase2D):
     def compute_transformation(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], flags: Dict[str, Any]
     ) -> torch.Tensor:
-        if params["output_size"] == input.shape[-2:]:
-            return eye_like(3, input)
-
+        # NOTE: a former `if params["output_size"] == input.shape[-2:]: return eye_like(...)`
+        # short-circuit was dead code — comparing a tensor to a ``torch.Size`` falls back to
+        # identity ``==`` and is *always* Python ``False``, so the branch never ran. It also
+        # graph-broke torch.compile (a Python ``if`` on a would-be tensor). Dropped; the
+        # perspective transform below already yields identity when src == dst, so behaviour is
+        # byte-identical.
         transform: torch.Tensor = torch.as_tensor(
             get_perspective_transform(params["src"], params["dst"]), dtype=input.dtype, device=input.device
         )

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -4677,12 +4677,9 @@ class TestResize:
         assert out.shape == (1, 1, 4, 5)
         assert aug.inverse(out).shape == (1, 1, 4, 6)
 
-    @pytest.mark.xfail(
-        reason="Resize.apply_transform still reads output_size via `.tolist()`, which breaks "
-        "fullgraph under inductor on torch<2.10. Needs a static-size path (follow-up).",
-        strict=False,
-    )
     def test_dynamo(self, device, dtype):
+        # A tuple output size resizes the whole batch in one call and the transform matrix is
+        # built without a data-dependent branch, so Resize is fullgraph-safe and matches eager.
         img = torch.rand(3, 3, 20, 24, device=device, dtype=dtype)
         aug = Resize(size=(16, 16))
         torch._dynamo.reset()


### PR DESCRIPTION
Follow-up to #3807 (which xfailed `TestResize.test_dynamo`). Now the compile-clean-core CI dynamo job covers Resize too.

## Blocker

`Resize.compute_transformation` opened with:

```python
if params["output_size"] == input.shape[-2:]:
    return eye_like(3, input)
```

This graph-breaks `torch.compile(fullgraph=True)`:

```
torch._dynamo.exc.Unsupported: torch.* op returned non-Tensor
  ... resize.py compute_transformation ...
```

## The branch was also dead

`params["output_size"]` is a `[B, 2]` tensor; `input.shape[-2:]` is a `torch.Size`. `tensor == torch.Size` doesn't broadcast — it falls back to identity `==` and returns **Python `False`** unconditionally (probed directly). So the `eye_like` short-circuit **never executed** — Resize always computed the perspective transform, which yields identity anyway when `src == dst`.

## Fix

Delete the dead, graph-breaking branch. Byte-identical — verified output **and** `transform_matrix` byte-equal vs `main` across three cases:

```
tuple_resize (16,16)   out-equal=True  tm-equal=True
tuple_noop  (20,24)    out-equal=True  tm-equal=True
int_side     16        out-equal=True  tm-equal=True
```

Removes the now-unused `eye_like` import. Un-xfails `TestResize.test_dynamo` (passes under inductor).

## Verification

```
Resize -k (inductor):                 9 passed, 1 skipped
augmentation/container/ (uses Resize): 506 passed, 51 skipped
torch.compile(Resize((16,16)), fullgraph=True): COMPILE OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)