### PR TITLE
fix(augmentation): make CenterCrop (slice mode) torch.compile fullgraph-safe

### DIFF
--- a/kornia/augmentation/_2d/geometric/center_crop.py
+++ b/kornia/augmentation/_2d/geometric/center_crop.py
@@ -22,7 +22,7 @@ import torch
 from kornia.augmentation import random_generator as rg
 from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
 from kornia.constants import Resample
-from kornia.geometry.transform import crop_by_indices, crop_by_transform_mat, get_perspective_transform
+from kornia.geometry.transform import crop_by_transform_mat, get_perspective_transform
 
 
 class CenterCrop(GeometricAugmentationBase2D):
@@ -138,7 +138,17 @@ class CenterCrop(GeometricAugmentationBase2D):
                 flags["align_corners"],
             )
         if flags["cropping_mode"] == "slice":  # uses advanced slicing to crop
-            return crop_by_indices(input, params["src"], flags["size"])
+            # A centered crop of a static size is deterministic: the crop box is uniform across
+            # the batch and depends only on the (symbolic) input shape, so slice directly instead
+            # of routing through `crop_by_indices`, whose `x.unique()` uniformity probe and
+            # `int(coord_tensor[i])` indexing break torch.compile fullgraph. The offsets match
+            # `center_crop_generator` (`int(dim/2 - size/2)` == `(dim - size) // 2` for size <=
+            # dim, which the generator guarantees) and the slice equals the requested size, so
+            # this is byte-identical.
+            crop_h, crop_w = int(flags["size"][0]), int(flags["size"][1])
+            top = (input.shape[-2] - crop_h) // 2
+            left = (input.shape[-1] - crop_w) // 2
+            return input[..., top : top + crop_h, left : left + crop_w]
         raise NotImplementedError(f"Not supported type: {flags['cropping_mode']}.")
 
     def inverse_transform(

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -2967,6 +2967,15 @@ class TestRandomGrayscale(BaseTester):
 
 
 class TestCenterCrop(BaseTester):
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        # slice cropping mode: a static-size centered crop is fullgraph-safe and matches eager.
+        input = torch.rand(2, 3, 20, 24, device=device, dtype=dtype)
+        op = CenterCrop((16, 10))
+        params = op.forward_parameters(input.shape)
+        expected = op(input, params=params)
+        compiled = torch.compile(op, fullgraph=True)
+        self.assert_close(compiled(input, params=params), expected)
+
     def test_no_transform(self, device, dtype):
         inp = torch.rand(1, 2, 4, 4, device=device, dtype=dtype)
         out = CenterCrop(2)(inp)


### PR DESCRIPTION
Part of the compile-first roadmap — the shape-changing crop spine (after Resize #3808).

## Blocker

`CenterCrop.apply_transform` in the default `slice` mode calls `crop_by_indices`, which graph-breaks `fullgraph=True` twice:

```
GuardOnDataDependentSymNode: Could not guard on data-dependent expression ...
  crop_by_indices: len(x1.unique(sorted=False)) ...   # uniformity probe
  ... int(y1[i]) ...                                   # .item() indexing
```

## Fix

A centered crop of a static size is deterministic — the crop box is uniform across the batch and depends only on the input shape. So slice directly instead of routing through the general `crop_by_indices`:

```python
crop_h, crop_w = int(flags["size"][0]), int(flags["size"][1])
top  = (input.shape[-2] - crop_h) // 2
left = (input.shape[-1] - crop_w) // 2
return input[..., top : top + crop_h, left : left + crop_w]
```

Offsets come from `input.shape` (**symint** arithmetic — fullgraph-safe; deliberately *not* `int(coord_tensor)`, which lowers to `.item()` and breaks — the lesson from #3807). They match `center_crop_generator` exactly: `int(dim/2 - size/2) == (dim - size) // 2` for `size <= dim`, which the generator asserts. The slice already equals the requested size (no resize/pad path for center crop), so it's byte-identical.

## Verification

Byte-identical vs `main` — output **and** `transform_matrix` — across crop shapes:

```
even_sq (16,16)  out-equal=True  tm-equal=True
rect    (16,10)  out-equal=True  tm-equal=True
odd     (15,17)  out-equal=True  tm-equal=True
int_sz   8       out-equal=True  tm-equal=True
CenterCrop((16,10)) fullgraph: byte-equal to eager = True
```

Tests (CPU):
```
-k CenterCrop (inductor):                            18 passed, 3 skipped, 2 xfailed
CenterCropAlternative + container (uses CenterCrop):  520 passed, 53 skipped
```

The `resample` cropping mode is untouched. Adds `TestCenterCrop.test_dynamo`; removes the now-unused `crop_by_indices` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)