### PR TITLE
test(augmentation): cover the full-forward compile path for flips

### DIFF
--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -889,6 +889,10 @@ class TestRandomHorizontalFlip(BaseTester):
         expected = op(input, params=params)
         compiled = torch.compile(op, fullgraph=True)
         self.assert_close(compiled(input, params=params), expected)
+        # Also compile the full forward (parameters generated internally) so the
+        # parameter-generation path is fullgraph too, not just apply_transform.
+        torch._dynamo.reset()
+        assert torch.compile(RandomHorizontalFlip(p=1.0), fullgraph=True)(input).shape == input.shape
 
     def test_random_hflip(self, device, dtype):
         f = RandomHorizontalFlip(p=1.0, keepdim=True)
@@ -1077,6 +1081,10 @@ class TestRandomVerticalFlip(BaseTester):
         expected = op(input, params=params)
         compiled = torch.compile(op, fullgraph=True)
         self.assert_close(compiled(input, params=params), expected)
+        # Also compile the full forward (parameters generated internally) so the
+        # parameter-generation path is fullgraph too, not just apply_transform.
+        torch._dynamo.reset()
+        assert torch.compile(RandomVerticalFlip(p=1.0), fullgraph=True)(input).shape == input.shape
 
     def test_random_vflip(self, device, dtype):
         f = RandomVerticalFlip(p=1.0)


### PR DESCRIPTION
## Gap

The flip `test_dynamo` tests compile `op(input, params=<pre-generated>)`, which **skips `forward_parameters`**. So the parameter-generation path — batch-prob generation and the `forward_input_shape` handling that #3802/#3807 made fullgraph — was never actually exercised under `torch.compile`. A regression there would pass CI.

## Change

Add a no-`params` assertion to `TestRandomHorizontalFlip.test_dynamo` and `TestRandomVerticalFlip.test_dynamo`:

```python
torch._dynamo.reset()
assert torch.compile(RandomHorizontalFlip(p=1.0), fullgraph=True)(input).shape == input.shape
```

Now the whole forward (parameter generation included) is a defended fullgraph floor via the PR dynamo CI job (#3807). Test-only.

## Verification

```
-k "RandomHorizontalFlip or RandomVerticalFlip" --optimizer=inductor -> 36 passed, 8 skipped, 2 xpassed
```

(This PR's `dynamo` job re-validates on CI torch 2.9.1.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)