### PR TITLE
fix(feature): apply drop_path2 to FFN residual in DeDoDe transformer …

### DIFF
--- a/kornia/feature/dedode/transformer/layers/block.py
+++ b/kornia/feature/dedode/transformer/layers/block.py
@@ -153,7 +153,7 @@ class Block(nn.Module):
             )
         elif self.training and self.sample_drop_ratio > 0.0:
             x = x + self.drop_path1(attn_residual_func(x))
-            x = x + self.drop_path1(ffn_residual_func(x))  # FIXME: drop_path2
+            x = x + self.drop_path2(ffn_residual_func(x))
         else:
             x = x + attn_residual_func(x)
             x = x + ffn_residual_func(x)

--- a/tests/feature/test_dedode.py
+++ b/tests/feature/test_dedode.py
@@ -19,6 +19,35 @@ import pytest
 import torch
 
 from kornia.feature.dedode import DeDoDe
+from kornia.feature.dedode.transformer.layers.block import Block
+
+
+class TestDeDoDeBlock:
+    def test_drop_path2_applied_to_ffn_residual(self, device, dtype):
+        # Regression test: `Block.forward` must route the attention residual through
+        # `drop_path1` and the FFN residual through `drop_path2`. A prior copy-paste
+        # bug applied `drop_path1` to both, silently ignoring `drop_path2`.
+        block = Block(dim=8, num_heads=2, drop_path=0.05).to(device, dtype)
+        block.train()
+
+        calls = {"drop_path1": 0, "drop_path2": 0}
+        orig_dp1, orig_dp2 = block.drop_path1.forward, block.drop_path2.forward
+
+        def spy_dp1(x):
+            calls["drop_path1"] += 1
+            return orig_dp1(x)
+
+        def spy_dp2(x):
+            calls["drop_path2"] += 1
+            return orig_dp2(x)
+
+        block.drop_path1.forward = spy_dp1
+        block.drop_path2.forward = spy_dp2
+
+        x = torch.randn(2, 4, 8, device=device, dtype=dtype)
+        block(x)
+
+        assert calls == {"drop_path1": 1, "drop_path2": 1}
 
 
 @pytest.mark.skip(reason="DeDoDe is ummaintained")


### PR DESCRIPTION
## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [[Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request)](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request) for details.

**Fixes/Relates to:** #3780

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [x] Fixed copy-paste bug in `Block.forward()` (kornia/feature/dedode/transformer/layers/block.py): the FFN residual branch was incorrectly passed through `drop_path1` instead of `drop_path2`, leaving the `FIXME: drop_path2` comment unresolved.
- [x] Added a regression test (`TestDeDoDeBlock.test_drop_path2_applied_to_ffn_residual` in tests/feature/test_dedode.py) that spies on both `drop_path1` and `drop_path2` to confirm each is called exactly once, on the correct residual branch.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** Added `tests/feature/test_dedode.py::TestDeDoDeBlock::test_drop_path2_applied_to_ffn_residual`. Ran locally:

```
pytest tests/feature/test_dedode.py -v -k "block"

tests/feature/test_dedode.py::TestDeDoDeBlock::test_drop_path2_applied_to_ffn_residual[cpu-float32] PASSED [100%]
================================== 1 passed, 2 deselected in 3.62s ==================================
```

- [x] **Manual Verification:** Before applying the fix, ran the same spy-based check manually and confirmed the bug: `drop_path1` was called twice and `drop_path2` was never called. After the one-line fix, `drop_path1` and `drop_path2` are each called exactly once, on the attention and FFN residuals respectively.
- [x] **Performance/Edge Cases:** This is a stateless routing fix (`DropPath` is stateless and, prior to this fix, both instances shared the same `drop_path` probability), so no numerical behavior changes for existing configurations. The fix only matters if `drop_path1`/`drop_path2` are ever assigned different rates.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project (verified via `pre-commit run`: ruff check, ruff format, codespell, license header — all passed).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Root cause: `Block.__init__` creates two independent `DropPath` instances (`drop_path1` for the attention sublayer, `drop_path2` for the FFN sublayer). In `forward()`, when `training=True` and `0.0 < sample_drop_ratio <= 0.1`, both residual branches were routed through `drop_path1`, leaving `drop_path2` dead code. This didn't change output today (both instances share the same probability), but would silently break if the two rates ever diverge.

Reference: `DropPath` (stochastic depth) implementation follows the pattern from [[facebookresearch/dino](https://github.com/facebookresearch/dino/blob/master/vision_transformer.py)](https://github.com/facebookresearch/dino/blob/master/vision_transformer.py) and [[rwightman/pytorch-image-models](https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/drop.py)](https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/drop.py), as already referenced in the file's header comments.