### PR TITLE
perf(augmentation): faster fullgraph flip transform-matrix construction

### DIFF
--- a/kornia/augmentation/_2d/geometric/horizontal_flip.py
+++ b/kornia/augmentation/_2d/geometric/horizontal_flip.py
@@ -76,20 +76,16 @@ class RandomHorizontalFlip(GeometricAugmentationBase2D):
     def compute_transformation(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], flags: Dict[str, Any]
     ) -> torch.Tensor:
-        # Build the 3x3 flip matrix from the width as a *tensor* rather than `int(w)`.
-        # `int(tensor)` lowers to `.item()`, which breaks torch.compile fullgraph on some torch
-        # versions (data-dependent scalar). Tensor construction is fullgraph-safe everywhere and
-        # numerically identical to `[[-1, 0, w - 1], [0, 1, 0], [0, 0, 1]]`.
+        # Build the 3x3 flip matrix as a constant literal plus the (tensor) width, rather than
+        # `int(w)`. `int(tensor)` lowers to `.item()`, which breaks torch.compile fullgraph on
+        # some torch versions; a Python-float literal is fine (constant-folded) and adding the
+        # width tensor into entry [0, 2] gives `w - 1` — numerically identical to
+        # `[[-1, 0, w - 1], [0, 1, 0], [0, 0, 1]]`, and ~1.8x cheaper than stacking 9 scalars.
         w = params["forward_input_shape"][-1].to(device=input.device, dtype=input.dtype)
-        one = torch.ones((), device=input.device, dtype=input.dtype)
-        zero = torch.zeros((), device=input.device, dtype=input.dtype)
-        flip_mat: torch.Tensor = torch.stack(
-            [
-                torch.stack([-one, zero, w - one]),
-                torch.stack([zero, one, zero]),
-                torch.stack([zero, zero, one]),
-            ]
+        flip_mat: torch.Tensor = torch.tensor(
+            [[-1.0, 0.0, -1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device=input.device, dtype=input.dtype
         )
+        flip_mat[0, 2] = flip_mat[0, 2] + w
 
         return flip_mat.expand(input.shape[0], 3, 3)
 

--- a/kornia/augmentation/_2d/geometric/vertical_flip.py
+++ b/kornia/augmentation/_2d/geometric/vertical_flip.py
@@ -67,20 +67,16 @@ class RandomVerticalFlip(GeometricAugmentationBase2D):
     def compute_transformation(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], flags: Dict[str, Any]
     ) -> torch.Tensor:
-        # Build the 3x3 flip matrix from the height as a *tensor* rather than `int(h)`.
-        # `int(tensor)` lowers to `.item()`, which breaks torch.compile fullgraph on some torch
-        # versions (data-dependent scalar). Tensor construction is fullgraph-safe everywhere and
-        # numerically identical to `[[1, 0, 0], [0, -1, h - 1], [0, 0, 1]]`.
+        # Build the 3x3 flip matrix as a constant literal plus the (tensor) height, rather than
+        # `int(h)`. `int(tensor)` lowers to `.item()`, which breaks torch.compile fullgraph on
+        # some torch versions; a Python-float literal is fine (constant-folded) and adding the
+        # height tensor into entry [1, 2] gives `h - 1` — numerically identical to
+        # `[[1, 0, 0], [0, -1, h - 1], [0, 0, 1]]`, and ~1.8x cheaper than stacking 9 scalars.
         h = params["forward_input_shape"][-2].to(device=input.device, dtype=input.dtype)
-        one = torch.ones((), device=input.device, dtype=input.dtype)
-        zero = torch.zeros((), device=input.device, dtype=input.dtype)
-        flip_mat: torch.Tensor = torch.stack(
-            [
-                torch.stack([one, zero, zero]),
-                torch.stack([zero, -one, h - one]),
-                torch.stack([zero, zero, one]),
-            ]
+        flip_mat: torch.Tensor = torch.tensor(
+            [[1.0, 0.0, 0.0], [0.0, -1.0, -1.0], [0.0, 0.0, 1.0]], device=input.device, dtype=input.dtype
         )
+        flip_mat[1, 2] = flip_mat[1, 2] + h
 
         return flip_mat.expand(input.shape[0], 3, 3)
 


### PR DESCRIPTION
Part of the GPU-speed-leadership push. Cuts per-call host overhead on the flips (the ops furthest behind torchvision v2 on GPU), where profiling showed the matrix build is ~26% of the forward.

## Change

The flip transform matrix was built with `torch.stack` of nine scalar tensors (from #3807's fullgraph fix) — correct but slow. Build it as a constant float literal plus the tensor width/height added into the one varying entry:

```python
w = params["forward_input_shape"][-1].to(device=input.device, dtype=input.dtype)
flip_mat = torch.tensor([[-1.0, 0.0, -1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device=..., dtype=...)
flip_mat[0, 2] = flip_mat[0, 2] + w   # -> w - 1
```

Still fullgraph-safe (the literal is constant-folded; no `int(tensor)` that lowered to a graph-breaking `.item()`), and ~1.8× cheaper than stacking nine scalars.

## Verification

- **Byte-identical** output *and* `transform_matrix` vs `main` for HFlip and VFlip (fixed seed).
- `torch.compile(fullgraph=True)` traces clean and matches eager.
- Micro-bench (matrix build): 92µs → 52µs. Forward (CPU, batch 16, 64²): HFlip 403→378µs, VFlip 398→372µs.
- Tests: `-k "RandomHorizontalFlip or RandomVerticalFlip" --optimizer=inductor` → 34 passed, 8 skipped, 2 xpassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)