### PR TITLE
perf(geometry): 40x faster elastic_transform2d via separable Gaussian

### DIFF
--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -21,8 +21,8 @@ import torch
 import torch.nn.functional as F
 
 from kornia.core.check import KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
-from kornia.filters import filter2d
-from kornia.filters.kernels import get_gaussian_kernel2d
+from kornia.filters import filter2d_separable
+from kornia.filters.kernels import get_gaussian_kernel1d
 from kornia.geometry.grid import create_meshgrid
 
 __all__ = ["elastic_transform2d"]
@@ -84,15 +84,20 @@ def elastic_transform2d(
     KORNIA_CHECK_SHAPE(noise, ["B", "C", "H", "W"])
 
     device, dtype = image.device, image.dtype
-    # if isinstance(sigma, tuple):
-    #    sigma_t = torch.tensor(sigma, device=device, dtype=dtype)
+
+    # Normalise sigma to a (B, 2) = (sigma_y, sigma_x) tensor, matching get_gaussian_kernel2d.
     if isinstance(sigma, torch.Tensor):
         sigma = sigma.expand(2)[None, ...]
-    #        sigma = sigma.to(device=device, dtype=dtype)
+    else:
+        sigma = torch.tensor([sigma], device=device, dtype=dtype)
+    ksize_y, ksize_x = kernel_size
+    sigma_y, sigma_x = sigma[:, 0, None], sigma[:, 1, None]
 
-    # Get Gaussian kernel for 'y' and 'x' displacement
-    kernel_x = get_gaussian_kernel2d(kernel_size, sigma)  # _t[0].expand(2).unsqueeze(0))
-    kernel_y = get_gaussian_kernel2d(kernel_size, sigma)  # _t[1].expand(2).unsqueeze(0))
+    # The Gaussian used to smooth the displacement field is separable, so filter with two 1-D
+    # passes rather than a full (ksize_y x ksize_x) 2-D convolution: numerically identical up to
+    # float-accumulation order (~1e-7) and ~30-60x cheaper for the default (63, 63) kernel.
+    kernel_1d_x = get_gaussian_kernel1d(ksize_x, sigma_x, device=device, dtype=dtype)
+    kernel_1d_y = get_gaussian_kernel1d(ksize_y, sigma_y, device=device, dtype=dtype)
 
     if isinstance(alpha, torch.Tensor):
         alpha_x = alpha[0]
@@ -101,12 +106,9 @@ def elastic_transform2d(
         alpha_x = torch.tensor(alpha[0], device=device, dtype=dtype)
         alpha_y = torch.tensor(alpha[1], device=device, dtype=dtype)
 
-    # Convolve over a random displacement matrix and scale them with 'alpha'
-    disp_x = noise[:, :1]
-    disp_y = noise[:, 1:]
-
-    disp_x = filter2d(disp_x, kernel=kernel_y, border_type="constant") * alpha_x
-    disp_y = filter2d(disp_y, kernel=kernel_x, border_type="constant") * alpha_y
+    # Convolve over the random displacement matrix and scale by 'alpha'.
+    disp_x = filter2d_separable(noise[:, :1], kernel_1d_x, kernel_1d_y, border_type="constant") * alpha_x
+    disp_y = filter2d_separable(noise[:, 1:], kernel_1d_x, kernel_1d_y, border_type="constant") * alpha_y
 
     # torch.stack and F.normalize displacement
     disp = torch.cat([disp_x, disp_y], 1).permute(0, 2, 3, 1)


### PR DESCRIPTION
Fact-driven: a per-op benchmark sweep of the whole augmentation surface flagged `RandomElasticTransform` as the slowest by a wide margin — **12 img/s** (batch 16, 64²), ~1000× slower than a flip.

## Root cause (profiled)

97% of the forward is one `filter2d` call: a **full 2-D convolution of the displacement field with the default 63×63 Gaussian kernel** (~500 ms/call). The kernel was also computed twice, identically.

## Fix

The Gaussian is **separable**, so a 63×63 2-D convolution == a 1×63 then 63×1 pass — ~30–60× fewer multiplies. Swap `filter2d(get_gaussian_kernel2d(...))` for `filter2d_separable(get_gaussian_kernel1d(...) ×2)`, drop the duplicate kernel build and the dead commented code.

## Result

```
RandomElasticTransform forward: 12 -> 494 img/s  (41x)
```

Numerically equivalent (not byte-identical): max diff vs `main` **1.9e-6** across default / asymmetric / small-kernel cases (float-accumulation order only) — well within the op's existing `atol=1e-3` test. Still `torch.compile(fullgraph=True)`-clean and differentiable (gradcheck passes).

## Verification

```
tests/geometry/transform/test_elastic_transform.py   -> 11 passed
tests/augmentation -k Elastic                        -> 6 passed
fullgraph compile matches eager (atol 1e-4)          -> True
```

Part of the GPU-speed-leadership push — this is the biggest single per-op win the sweep surfaced. Follow-ups from the same sweep: MedianBlur (103 img/s), Clahe/Equalize (histogram), and the GaussianBlur/MotionBlur `torch.compile` **regression** (compile makes CPU conv-bound ops 3–4× slower).

🤖 Generated with [Claude Code](https://claude.com/claude-code)