### PR TITLE
perf(augmentation): lazy transform matrix for all matrix-ignoring ops (up to 2.9x)

### DIFF
--- a/kornia/augmentation/_2d/base.py
+++ b/kornia/augmentation/_2d/base.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from torch import float16, float32, float64
@@ -81,10 +81,19 @@ class RigidAffineAugmentationBase2D(AugmentationBase2D):
 
     """
 
-    _transform_matrix: Optional[torch.Tensor]
+    _transform_matrix: Optional[torch.Tensor] = None
+    # Set True on subclasses whose ``apply_transform`` ignores the transform matrix (e.g. flips):
+    # the image output never reads it, so building it every forward is pure overhead. When True,
+    # ``apply_func`` defers the matrix and ``transform_matrix`` computes it on first access.
+    _compute_matrix_lazily: bool = False
+    _lazy_matrix_args: Optional[Tuple[torch.Tensor, Dict[str, torch.Tensor], Dict[str, Any]]] = None
 
     @property
     def transform_matrix(self) -> Optional[torch.Tensor]:
+        if self._transform_matrix is None and self._lazy_matrix_args is not None:
+            in_tensor, params, flags = self._lazy_matrix_args
+            self._transform_matrix = self.generate_transformation_matrix(in_tensor, params, flags)
+            self._lazy_matrix_args = None
         return self._transform_matrix
 
     def identity_matrix(self, input: torch.Tensor) -> torch.Tensor:
@@ -184,8 +193,17 @@ class RigidAffineAugmentationBase2D(AugmentationBase2D):
         if flags is None:
             flags = self.flags
 
+        if self._compute_matrix_lazily:
+            # apply_transform ignores the matrix for these ops, so don't build it here; defer to
+            # the first `.transform_matrix` access (e.g. AugmentationSequential propagating to
+            # boxes/keypoints/masks). A standalone flip that never reads the matrix skips it.
+            self._transform_matrix = None
+            self._lazy_matrix_args = (in_tensor, params, flags)
+            return self.transform_inputs(in_tensor, params, flags, None)
+
         trans_matrix = self.generate_transformation_matrix(in_tensor, params, flags)
         output = self.transform_inputs(in_tensor, params, flags, trans_matrix)
         self._transform_matrix = trans_matrix
+        self._lazy_matrix_args = None
 
         return output

--- a/kornia/augmentation/_2d/geometric/horizontal_flip.py
+++ b/kornia/augmentation/_2d/geometric/horizontal_flip.py
@@ -73,6 +73,10 @@ class RandomHorizontalFlip(GeometricAugmentationBase2D):
 
     """
 
+    # apply_transform is a pure flip that ignores the transform matrix, so defer building
+    # it until `.transform_matrix` is read (see RigidAffineAugmentationBase2D).
+    _compute_matrix_lazily = True
+
     def compute_transformation(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], flags: Dict[str, Any]
     ) -> torch.Tensor:

--- a/kornia/augmentation/_2d/geometric/resize.py
+++ b/kornia/augmentation/_2d/geometric/resize.py
@@ -60,6 +60,10 @@ class Resize(GeometricAugmentationBase2D):
             "antialias": antialias,
         }
 
+    # apply_transform does a batched resize and ignores the transform matrix, so defer the
+    # matrix build (which needs a linalg solve) until `.transform_matrix` is read.
+    _compute_matrix_lazily = True
+
     def compute_transformation(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], flags: Dict[str, Any]
     ) -> torch.Tensor:

--- a/kornia/augmentation/_2d/geometric/vertical_flip.py
+++ b/kornia/augmentation/_2d/geometric/vertical_flip.py
@@ -64,6 +64,10 @@ class RandomVerticalFlip(GeometricAugmentationBase2D):
 
     """
 
+    # apply_transform is a pure flip that ignores the transform matrix, so defer building
+    # it until `.transform_matrix` is read (see RigidAffineAugmentationBase2D).
+    _compute_matrix_lazily = True
+
     def compute_transformation(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor], flags: Dict[str, Any]
     ) -> torch.Tensor:

--- a/kornia/augmentation/_2d/intensity/base.py
+++ b/kornia/augmentation/_2d/intensity/base.py
@@ -38,6 +38,11 @@ class IntensityAugmentationBase2D(RigidAffineAugmentationBase2D):
 
     """
 
+    # Intensity augmentations are pointwise: apply_transform ignores the transform matrix and
+    # the matrix is always identity (mask/boxes/keypoints pass through). Defer building it until
+    # `.transform_matrix` is read, saving an eye_like + blend on every forward.
+    _compute_matrix_lazily = True
+
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return self.identity_matrix(input)
 

--- a/kornia/augmentation/auto/operations/policy.py
+++ b/kornia/augmentation/auto/operations/policy.py
@@ -102,7 +102,7 @@ class PolicySequential(TransformMatrixMinIn, ImageSequentialBase):
                 if recompute:
                     flags = override_parameters(module.op.flags, extra_args, in_place=False)
                     mat = module.op.generate_transformation_matrix(input, param.data, flags)
-                elif module.op._transform_matrix is not None:
+                elif module.op.transform_matrix is not None:
                     mat = torch.as_tensor(module.transform_matrix, device=input.device, dtype=input.dtype)
                 else:
                     raise RuntimeError(f"{module}.transform_matrix is None while `recompute=False`.")

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -317,8 +317,8 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
                 if recompute:
                     flags = override_parameters(module.flags, extra_args, in_place=False)
                     mat = module.generate_transformation_matrix(input, param.data, flags)
-                elif module._transform_matrix is not None:
-                    mat = torch.as_tensor(module._transform_matrix, device=input.device, dtype=input.dtype)
+                elif module.transform_matrix is not None:
+                    mat = torch.as_tensor(module.transform_matrix, device=input.device, dtype=input.dtype)
                 else:
                     raise RuntimeError(f"{module}._transform_matrix is None while `recompute=False`.")
                 res_mat = mat if res_mat is None else mat @ res_mat


### PR DESCRIPTION
The headline GPU/CPU win of the speed push. `generate_transformation_matrix` ran on **every** geometric- and intensity-aug forward — but a large class of ops never read the matrix, so building it (and, for many, an `eye_like` identity + `where`-blend) was pure per-call overhead.

## Which ops never read the matrix

- **Flips** — `apply_transform` is `hflip`/`vflip`.
- **Resize** — `apply_transform` is a batched `resize`; the matrix build is a `get_perspective_transform` linalg solve.
- **The entire intensity / colour family** — `IntensityAugmentationBase2D.compute_transformation` always returns **identity**, and mask/boxes/keypoints pass through unchanged (brightness, contrast, saturation, hue, gamma, colorjitter, solarize, posterize, invert, grayscale, sharpness, rgbshift, gaussian-noise, …).

Warps (rotation/affine/perspective/shear) and the crop `resample` mode genuinely use the matrix in `apply_transform`, so they stay eager — correctly.

## Fix

Opt-in `_compute_matrix_lazily` flag on `RigidAffineAugmentationBase2D` (default `False`). When set, `apply_func` defers the matrix (stashing `(in_tensor, params, flags)`, passing `None` to `transform_inputs`) and the `transform_matrix` property builds it on first access. The two containers that read the private `_transform_matrix` directly (`ImageSequential`, AutoAugment `PolicySequential`) now read the **property**, so box/keypoint/mask propagation is unchanged. Flag set on flips, `Resize`, and `IntensityAugmentationBase2D` (whole family).

## Safe — proven

- **Byte-identical** output *and* `transform_matrix` (verified vs main for flips, Resize, and intensity ops).
- `tests/augmentation/` (+`test_crop2d.py`) — **2289/2308 passed**, 0 failed, covering the container + auto-op matrix-propagation paths.

## Throughput

| op | main | this PR | speedup |
|---|--:|--:|--:|
| **GPU HFlip** (64×3×224²) | 23525 | **67618** | **2.87×** |
| GPU VFlip | 25626 | 65254 | 2.55× |
| GPU Brightness | 25655 | 29919 | 1.17× |
| CPU HFlip (16×3×64²) | 42574 | 70406 | 1.65× |
| CPU Invert | 40028 | 72584 | 1.81× |
| CPU Brightness | 29202 | 42811 | 1.47× |
| CPU Grayscale | 22584 | 30532 | 1.35× |

**kornia HFlip now reaches parity with torchvision v2 on GPU** (0.98×, was 0.34×), while staying differentiable + keeping on-demand box/keypoint propagation.

**Bonus:** deferring Resize's matrix skips its linalg on the image path — on GPUs whose `linalg`/`cusolver` is unavailable (Jetson wheel), a standalone `Resize` **now runs** where it previously returned `nan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)