### PR TITLE
perf(augmentation): trim redundant work in transform_inputs hot path

### DIFF
--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -315,8 +315,6 @@ class _AugmentationBase(_BasicAugmentationBase):
             self._params if params is None else params, flags, **kwargs
         )
 
-        batch_prob = params["batch_prob"]
-        to_apply = torch.atleast_1d(batch_prob > 0.5)
         ori_shape = input.shape
         in_tensor = self.transform_tensor(input)
 
@@ -329,8 +327,11 @@ class _AugmentationBase(_BasicAugmentationBase):
             # transformed one. Skip the non-transform branch and the blend entirely — this
             # also makes shape-changing augmentations (e.g. Resize) fullgraph-compilable,
             # since the data-dependent shape comparison / `to_apply.any()` fallback is avoided.
+            # (The `to_apply` gate is only needed on the p < 1 path below, so it is not computed
+            # here.)
             output = output_transformed
         else:
+            to_apply = torch.atleast_1d(params["batch_prob"] > 0.5)
             output_not_transformed = self.apply_non_transform(in_tensor, params, flags, transform=transform)
             if (
                 output_transformed.shape == output_not_transformed.shape
@@ -347,10 +348,9 @@ class _AugmentationBase(_BasicAugmentationBase):
         if is_autocast_enabled():
             output = output.type(input.dtype)
 
+        # `_transform_output_shape` only reshapes (preserves dtype), so no second autocast cast is
+        # needed after it — the cast above already restored `input.dtype`.
         output = _transform_output_shape(output, ori_shape) if self.keepdim else output
-
-        if is_autocast_enabled():
-            output = output.type(input.dtype)
         return output
 
     def transform_masks(


### PR DESCRIPTION
Two byte-identical cuts on the path **every** augmentation forward takes.

## Changes

1. **`to_apply` computed only when needed.** `to_apply = atleast_1d(batch_prob > 0.5)` ran unconditionally but is only used on the `p < 1` blend branch — the `p == 1` fast path (the common deterministic case) never reads it. Moved into the `else`.
2. **Dropped a redundant autocast cast.** After the `is_autocast` cast, `_transform_output_shape` only *reshapes* (preserves dtype), so the second `is_autocast_enabled()` cast that followed it re-applied the same dtype — a no-op. Removed.

## Safe

- **Byte-identical** output across `p=1`, `p=0.5`, `keepdim`, and ColorJitter (verified vs main).
- `tests/augmentation/` — **2289 passed**, 0 failed, covering the autocast and keepdim paths the second cut touches.

## Effect

Removes serial per-call host overhead:

| op (CPU, 16×3×64²) | main | this PR | speedup |
|---|--:|--:|--:|
| RandomInvert | 84690 | 116007 | **1.37×** |
| RandomBrightness | 48459 | 54922 | 1.13× |

GPU-neutral (the removed ops are tiny async kernels there); the win is on the CPU/dataloader path where host overhead is serial. Also removes dead work — a small readability win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)