### PR TITLE
perf(augmentation): vectorize RandomChannelShuffle (12x GPU, now fullgraph)

### DIFF
--- a/kornia/augmentation/_2d/intensity/channel_shuffle.py
+++ b/kornia/augmentation/_2d/intensity/channel_shuffle.py
@@ -63,7 +63,8 @@ class RandomChannelShuffle(IntensityAugmentationBase2D):
         flags: Dict[str, Any],
         transform: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        out = torch.empty_like(input)
-        for i in range(out.shape[0]):
-            out[i] = input[i, params["channels"][i]]
-        return out
+        # Gather the per-sample channel permutation in one vectorised advanced-index instead of
+        # a Python loop over the batch (which launched a kernel per sample and blocked
+        # torch.compile). `channels` is (B, C); indexing input[(B,1), (B,C)] gives (B, C, H, W).
+        batch_index = torch.arange(input.shape[0], device=input.device).view(-1, 1)
+        return input[batch_index, params["channels"]]


### PR DESCRIPTION
The per-op sweep flagged `RandomChannelShuffle` with the worst `torch.compile` regression (0.24× on GPU). Root cause: `apply_transform` gathered the per-sample channel permutation with a **Python loop over the batch** —

```python
out = torch.empty_like(input)
for i in range(out.shape[0]):
    out[i] = input[i, params["channels"][i]]
return out
```

— a kernel launch per sample, and a data-dependent loop that graph-breaks.

## Fix

One vectorised advanced index:

```python
batch_index = torch.arange(input.shape[0], device=input.device).view(-1, 1)
return input[batch_index, params["channels"]]   # (B,1)+(B,C) -> (B, C, H, W)
```

Byte-identical (verified), and now `torch.compile(fullgraph=True)`-clean — so it also fixes the compile regression.

## Result

| | loop | vectorized | speedup |
|---|--:|--:|--:|
| gather CPU (16×3×64²) | 934 µs | 217 µs | **4.3×** |
| gather GPU | 1740 µs | 137 µs | **12.3×** |

Full `tests/augmentation/` suite passes (2289); `-k ChannelShuffle` under inductor passes; GPU forward ~41k img/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)