### PR TITLE
perf(enhance): vectorize per-sample posterize (16x GPU, now fullgraph)

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -809,27 +809,24 @@ def posterize(input: torch.Tensor, bits: Union[int, torch.Tensor]) -> torch.Tens
     if len(bits.shape) == 0 or (len(bits.shape) == 1 and len(bits) == 1):
         return _posterize_one(input, bits)
 
-    res = []
     if len(bits.shape) == 1:
         if bits.shape[0] != input.shape[0]:
             raise AssertionError(
                 f"Batch size must be equal between bits and input. Got {bits.shape[0]}, {input.shape[0]}."
             )
 
-        for i in range(input.shape[0]):
-            res.append(_posterize_one(input[i], bits[i]))
-        return torch.stack(res, dim=0)
+        # Broadcast the per-sample bits over (B, C, H, W) and posterize in one vectorised call
+        # instead of a Python loop over the batch (which launched a kernel per sample).
+        return _posterize_one(input, bits.view(-1, *([1] * (input.ndim - 1))))
 
     if bits.shape != input.shape[: len(bits.shape)]:
         raise AssertionError(
             "Batch and channel must be equal between bits and input. "
             f"Got {bits.shape}, {input.shape[: len(bits.shape)]}."
         )
-    _input = input.view(-1, *input.shape[len(bits.shape) :])
-    _bits = bits.flatten()
-    for i in range(input.shape[0]):
-        res.append(_posterize_one(_input[i], _bits[i]))
-    return torch.stack(res, dim=0).reshape(*input.shape)
+    # Broadcast per-(batch, channel) bits over the spatial dims and posterize in one call.
+    _bits = bits.view(*bits.shape, *([1] * (input.ndim - bits.ndim)))
+    return _posterize_one(input, _bits)
 
 
 @perform_keep_shape_image


### PR DESCRIPTION
`posterize` with per-sample `bits` (shape `(B,)` or `(B, C)`) looped over the batch:

```python
for i in range(input.shape[0]):
    res.append(_posterize_one(input[i], bits[i]))
return torch.stack(res, dim=0)
```

— a kernel launch per sample and a data-dependent loop that graph-breaks `torch.compile`.

## Fix

`_posterize_one` is already elementwise (bit-shift + `torch.where` on `bits`), so broadcast the per-sample/per-channel bits over the spatial dims and call it **once**:

```python
return _posterize_one(input, bits.view(-1, *([1] * (input.ndim - 1))))   # (B,) case
```

Byte-identical (verified vs the per-sample path on CPU and GPU), and now `fullgraph`-clean.

## Result

| posterize (per-sample bits, 16×3×64²) | loop | vectorized | speedup |
|---|--:|--:|--:|
| CPU | 6160 µs | 2651 µs | 2.3× |
| **GPU** | 15169 µs | 919 µs | **16.5×** |

`RandomPosterize` now compiles fullgraph; `tests/enhance/test_adjust.py` → 126 passed; `-k Posterize` under inductor passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)