### PR TITLE
perf(augmentation): propagate RNG device through container .to()/.cuda()

### DIFF
--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -111,6 +111,19 @@ class _BasicAugmentationBase(nn.Module):
         self.set_rng_device_and_dtype(device, dtype)
         return super().to(*args, **kwargs)
 
+    def _apply(self, fn: Callable[[torch.Tensor], torch.Tensor], *args: Any, **kwargs: Any) -> "_BasicAugmentationBase":
+        # nn.Module.to/.cuda/.cpu/.half move children by recursing through `_apply`, not `.to`,
+        # so a container like `AugmentationSequential(...).to("cuda")` never triggers our `to`
+        # override and leaves parameter sampling on CPU — every forward then generates on the
+        # host and copies to the device (measured ~5x slower on GPU pipelines). Mirror the device
+        # and dtype of the moved tensors onto the random generator so container moves behave like
+        # a direct `.to` on the augmentation.
+        out = super()._apply(fn, *args, **kwargs)
+        probe = fn(torch.zeros((), device=self.device, dtype=self.dtype))
+        dtype = probe.dtype if probe.is_floating_point() else self.dtype
+        self.set_rng_device_and_dtype(probe.device, dtype)
+        return out
+
     def __repr__(self) -> str:
         txt = f"p={self.p}, p_batch={self.p_batch}, same_on_batch={self.same_on_batch}"
         if isinstance(self._param_generator, RandomGeneratorBase):


### PR DESCRIPTION
## Problem

`nn.Module.to()`/`.cuda()`/`.half()` move child modules by recursing through `_apply(fn)` — they never call a child's `.to()`. `_BasicAugmentationBase` only moved its random-parameter generator inside its own `.to()` override, so moving an augmentation **via a container** silently left parameter sampling on CPU:

```python
seq = K.AugmentationSequential(K.ColorJitter(...), K.RandomBrightness(...)).to("cuda")
# image on cuda, but every forward samples params on the CPU RNG and copies them to cuda
```

This is the **recommended** way to build GPU pipelines, so it hit essentially every GPU user. Each forward paid host-side parameter generation + a device copy.

## Measurement (Jetson Orin, 6-op pipeline, batch 32, 224×224, float32)

| build | param-gen device | ms/iter |
|-------|------------------|---------|
| `AugmentationSequential(...).to("cuda")` (before) | **cpu** | ~187 |
| `AugmentationSequential(...).to("cuda")` (after)  | **cuda** | ~40 |
| torchvision v2 (reference) | — | ~20 |

~**4.6×** on the recommended API, closing most of the gap to torchvision v2. (Absolute numbers are directional — the Orin CPU governor makes host-bound timings noisy — but the before/after ratio and the device fix are stable and reproducible.)

## Fix

Override `_apply` on `_BasicAugmentationBase` so container-driven moves mirror the moved tensors' device/dtype onto the generator — making a container `.to()`/`.cuda()` behave exactly like a direct `.to()` on the augmentation.

## Correctness

- **CPU: byte-identical.** The `set_rng_device_and_dtype` guard makes `_apply` a no-op when device/dtype are unchanged, so CPU output is bit-for-bit the same.
- **GPU: no new test failures.** `tests/augmentation/container/` on `--device=cuda` shows the **same** 382 passed / 129 pre-existing failures (broken-cusolver `dlopen`) with and without this change on this Orin. `tests/augmentation/container/` and `tests/augmentation/test_augmentation.py` pass fully on CPU (511 and 323 passed).
- **Behavior note:** container GPU parameter sampling now draws from the CUDA RNG stream — exactly as a direct `aug.to("cuda")` already did. No test depends on the previous CPU-stream-under-a-cuda-container behavior.

## Test log (CPU)

```
tests/augmentation/container/  ... 511 passed, 51 skipped
tests/augmentation/test_augmentation.py ... 323 passed, 60 skipped, 16 xfailed, 5 xpassed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)