### PR TITLE
docs(roadmap): record compiled kornia beating torchvision v2 on GPU

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,6 +79,15 @@ classical-CV gaps and hardening the model zoo.
   and a standing improvement list. Early findings: `torch.compile` gives kornia 2–4× on pointwise
   ops and a compiled pipeline already beats torchvision v2 / reaches albumentations parity on CPU;
   kornia-rs is the fastest CPU/`uint8` backend on most ops (motivating the backend item below).
+  *GPU headline (measured on a Jetson Orin, `pipeline.py`, batch 32, 224², a 6-op pipeline
+  including `ColorJitter`): the compiled kornia pipeline runs at **2669 img/s vs torchvision
+  v2's 1536 (~1.7× faster) — while staying end-to-end differentiable**, the regime no other
+  library competes in.* This depended on a device-propagation fix: `nn.Module.to()/.cuda()`
+  move children through `_apply`, bypassing the augmentation's `to()` override, so building a
+  pipeline the recommended way left random-parameter sampling on the CPU (host-bound, ~171
+  img/s eager, and `torch.compile` could not fuse across the per-forward host work). Moving
+  parameter generation onto the module's device (~903 img/s eager) is what lets `inductor`
+  fuse the whole pipeline.
 - **A `kornia-rs` augmentation backend (opt-in).** Add a backend selector (e.g.
   `backend="rust"`) that routes non-differentiable, CPU, `uint8` augmentation through
   `kornia-rs` (`kornia_rs.imgproc` / `kornia_rs.augmentations`), while the PyTorch path


### PR DESCRIPTION
Records the GPU performance milestone: the compiled kornia augmentation pipeline now runs **~1.7× faster than torchvision v2** while staying end-to-end differentiable.

Measured on a Jetson Orin via the repo's own `benchmarks/augmentation/pipeline.py` (batch 32, 224², a 6-op pipeline including `ColorJitter`):

```
kornia (eager)    |   903 img/s
kornia (compiled) |  2669 img/s   <- 1.74x torchvision v2, and differentiable
torchvision v2    |  1536 img/s
albumentations    |   303 img/s
```

Docs-only. Depends on the device-propagation fix in #3825 (moving random-parameter sampling onto the module's device — otherwise container-built pipelines sample on CPU, are host-bound, and `torch.compile` cannot fuse across the per-forward host work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)