### PR TITLE
perf(filters): don't format the sigma tensor on every gaussian_blur2d call

### DIFF
--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -101,7 +101,11 @@ def gaussian_blur2d(
     KORNIA_CHECK_SHAPE(sigma, ["B", "2"])
     # `bool()` on a tensor is untraceable by dynamo; skip the data-dependent check under compile.
     if not torch.compiler.is_compiling():
-        KORNIA_CHECK(bool((sigma > 0).all()), f"sigma must be positive, got {sigma}")
+        # Only interpolate `sigma` into the message when the check actually fails: a plain
+        # f-string here would format the whole `sigma` tensor (a costly tensor->str) on every
+        # eager call even when it passes — which dominated the eager Gaussian-blur runtime.
+        positive = bool((sigma > 0).all())
+        KORNIA_CHECK(positive, "sigma must be positive" if positive else f"sigma must be positive, got {sigma}")
 
     if separable:
         ky, kx = _unpack_2d_ks(kernel_size)


### PR DESCRIPTION
## What

The sigma positivity check formatted the **entire `sigma` tensor to a string on every call**, even when it passed:

```python
KORNIA_CHECK(bool((sigma > 0).all()), f"sigma must be positive, got {sigma}")
```

Python evaluates the f-string argument before calling `KORNIA_CHECK`, so `sigma.__format__` (a costly `torch._tensor_str` walk over every element) ran on every eager `gaussian_blur2d` — it dominated the runtime. Only interpolate `sigma` when the check actually fails:

```python
positive = bool((sigma > 0).all())
KORNIA_CHECK(positive, "sigma must be positive" if positive else f"sigma must be positive, got {sigma}")
```

## Correctness

Byte-identical behavior — same `BaseError` and message on failure. All 145 `tests/filters/test_gaussian.py` pass (including the three `sigma must be positive` exception tests).

## Perf

GPU eager **~2.5×** on `RandomGaussianBlur` (24 → 9.8 ms, batch 32, 224², Jetson Orin). Benefits **every** `gaussian_blur2d` / `GaussianBlur` caller, not just the augmentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)