### PR TITLE
fix(enhance): move sharpness factor onto the input device/dtype

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -855,6 +855,10 @@ def sharpness(input: torch.Tensor, factor: Union[float, torch.Tensor]) -> torch.
     """
     if not isinstance(factor, torch.Tensor):
         factor = torch.as_tensor(factor, device=input.device, dtype=input.dtype)
+    else:
+        # Match the input's device/dtype (as adjust_brightness/contrast do). Augmentation
+        # generators may sample the factor on a different device (e.g. CPU) than the image.
+        factor = factor.to(device=input.device, dtype=input.dtype)
 
     if len(factor.size()) != 0 and factor.shape != torch.Size([input.size(0)]):
         raise AssertionError(


### PR DESCRIPTION
## What

`sharpness()` moved the `factor` to the input's device only when it was a **non-tensor** scalar; a tensor factor was used as-is:

```python
if not isinstance(factor, torch.Tensor):
    factor = torch.as_tensor(factor, device=input.device, dtype=input.dtype)
# (tensor factor left on whatever device it came from)
```

Augmentation parameter generators sample the factor on the RNG device (CPU by default), so `RandomSharpness(...).to("cuda")` raised `Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!` at the final blend. Add the tensor branch, matching `adjust_brightness` / `adjust_contrast`:

```python
else:
    factor = factor.to(device=input.device, dtype=input.dtype)
```

## Correctness

Byte-identical on CPU (verified against `main` under a fixed seed). Unblocks `RandomSharpness` on GPU (previously raised).

## Tests

```
tests/enhance tests/augmentation -k sharpness --device=cpu ... 26 passed, 8 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)