### PR TITLE
perf(geometry): build bbox_generator corners by stacking, not indexed adds

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -368,16 +368,22 @@ def bbox_generator(
             f"`width`({width.device}), `height`({height.device})."
         )
 
-    bbox = torch.tensor([[[0, 0], [0, 0], [0, 0], [0, 0]]], device=x_start.device, dtype=x_start.dtype).repeat(
-        1 if x_start.dim() == 0 else len(x_start), 1, 1
+    # Build the four corners (TL, TR, BR, BL) directly by stacking instead of allocating a zero
+    # tensor and mutating it with six indexed in-place adds (each of which is a separate kernel /
+    # copy). `.view(-1)` treats a scalar input as batch-1, matching the previous ``repeat`` shape.
+    x0 = x_start.view(-1)
+    y0 = y_start.view(-1)
+    x1 = x0 + width.view(-1) - 1
+    y1 = y0 + height.view(-1) - 1
+    bbox = torch.stack(
+        [
+            torch.stack([x0, y0], dim=-1),
+            torch.stack([x1, y0], dim=-1),
+            torch.stack([x1, y1], dim=-1),
+            torch.stack([x0, y1], dim=-1),
+        ],
+        dim=-2,
     )
-
-    bbox[:, :, 0] += x_start.view(-1, 1)
-    bbox[:, :, 1] += y_start.view(-1, 1)
-    bbox[:, 1, 0] += width - 1
-    bbox[:, 2, 0] += width - 1
-    bbox[:, 2, 1] += height - 1
-    bbox[:, 3, 1] += height - 1
 
     return bbox
 


### PR DESCRIPTION
## What

`bbox_generator` allocated a zeros tensor and mutated it with **six indexed in-place adds**, each a separate kernel/copy (they showed up as `aten::copy_` on the `RandomErasing` per-forward path). Build the four corners directly by stacking:

```python
x0, y0 = x_start.view(-1), y_start.view(-1)
x1 = x0 + width.view(-1) - 1
y1 = y0 + height.view(-1) - 1
bbox = torch.stack([
    torch.stack([x0, y0], -1),  # top-left
    torch.stack([x1, y0], -1),  # top-right
    torch.stack([x1, y1], -1),  # bottom-right
    torch.stack([x0, y1], -1),  # bottom-left
], dim=-2)
```

## Correctness

Byte-identical for scalar and batched, integer and float inputs (verified against `main` under a fixed seed; `.view(-1)` reproduces the previous batch-1 shape for scalar inputs). `tests/geometry/test_boxes.py` + erasing/mask tests pass (84 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)