### PR TITLE
fix(geometry): closed-form 3x3 inverse in warp/normalize (cusolver-free)

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -25,7 +25,7 @@ import torch.nn.functional as F
 from kornia.constants import pi
 from kornia.core._compat import deprecated
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
-from kornia.core.utils import _torch_inverse_cast
+from kornia.core.utils import _inverse_3x3_closed_form, _torch_inverse_cast
 
 __all__ = [
     "ARKitQTVecs_to_ColmapQTVecs",
@@ -1088,7 +1088,9 @@ def normalize_homography(
     # compute the transformation pixel/norm for src/dst
     src_norm_trans_src_pix: torch.Tensor = normal_transform_pixel(src_h, src_w).to(dst_pix_trans_src_pix)
 
-    src_pix_trans_src_norm = _torch_inverse_cast(src_norm_trans_src_pix)
+    # Closed-form 3x3 inverse of the (well-conditioned) pixel-normalization matrix: cusolver-free,
+    # so homography normalization runs on the Jetson wheel where ``torch.linalg.inv`` dlopen-fails.
+    src_pix_trans_src_norm = _inverse_3x3_closed_form(src_norm_trans_src_pix)
     dst_norm_trans_dst_pix: torch.Tensor = normal_transform_pixel(dst_h, dst_w).to(dst_pix_trans_src_pix)
 
     # compute chain transformations

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -133,7 +133,11 @@ def warp_perspective(
     # we F.normalize the 3x3 transformation matrix and convert to 3x4
     dst_norm_trans_src_norm: torch.Tensor = normalize_homography(M, (H, W), (h_out, w_out))  # Bx3x3
 
-    src_norm_trans_dst_norm = _torch_inverse_cast(dst_norm_trans_src_norm)  # Bx3x3
+    # Closed-form 3x3 inverse (pure arithmetic) instead of ``torch.linalg.inv``: numerically
+    # equivalent for these well-conditioned transforms, and it runs where the LAPACK/cusolver
+    # backend is unavailable (e.g. the Jetson wheel, where ``linalg.inv`` dlopen-fails and would
+    # otherwise crash every warp on GPU).
+    src_norm_trans_dst_norm = _inverse_3x3_closed_form(dst_norm_trans_src_norm)  # Bx3x3
 
     # this piece of code substitutes F.affine_grid since it does not support 3x3
     grid = (
@@ -213,7 +217,9 @@ def warp_affine(
     M_3x3: torch.Tensor = convert_affinematrix_to_homography(M)
     dst_norm_trans_src_norm: torch.Tensor = normalize_homography(M_3x3, (H, W), dsize)
 
-    src_norm_trans_dst_norm = _torch_inverse_cast(dst_norm_trans_src_norm)
+    # Closed-form 3x3 inverse (see warp_perspective) — cusolver-free, so affine warps run on the
+    # Jetson wheel where ``torch.linalg.inv`` dlopen-fails.
+    src_norm_trans_dst_norm = _inverse_3x3_closed_form(dst_norm_trans_src_norm)
 
     grid = F.affine_grid(src_norm_trans_dst_norm[:, :2, :], [B, C, dsize[0], dsize[1]], align_corners=align_corners)
 


### PR DESCRIPTION
## Problem

`warp_affine`, `warp_perspective`, and `normalize_homography` invert their 3×3 transform matrices with `torch.linalg.inv`. On the Jetson wheel that **dlopen-fails** (missing cusolver), so every geometric augmentation — `RandomRotation`, `RandomAffine`, `RandomPerspective`, `Resize`, and any warp — **crashes on GPU**:

```
RuntimeError: Error in dlopen: ... libtorch_cuda_linalg.so ... undefined symbol ... cusolver
```

## Fix

Use the existing `_inverse_3x3_closed_form` (adjugate/determinant, pure arithmetic — already used as the ONNX-tracing fallback) for these three well-conditioned 3×3 inverses. Pure arithmetic needs no LAPACK/cusolver backend.

Scope is deliberately narrow: only the warp/normalize matrices (well-conditioned affine/perspective normalization). The general `_torch_inverse_cast` is left as `torch.linalg.inv`, so numerically-sensitive paths (e.g. essential-matrix decomposition) are unchanged.

## Correctness

Numerically equivalent for well-conditioned transforms. **708 passed** across `tests/geometry/transform/`, `test_conversions.py`, `test_homography.py`, and `test_essential.py` (the sensitive essential-matrix decomposition still passes — it uses the untouched general path).

## Result

On a Jetson Orin, `RandomRotation`, `RandomAffine`, and `Resize` now run on GPU (previously raised). Beyond Jetson, this drops a LAPACK dependency for the common warp path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)