### PR TITLE
perf(geometry): warp_affine accepts a single shared transform for a batch

### DIFF
--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -209,13 +209,20 @@ def warp_affine(
         raise ValueError(f"Input M must be a Bx2x3 torch.Tensor. Got {M.shape}")
 
     B, C, H, W = src.size()
+    B_M = M.shape[0]
 
     M_3x3: torch.Tensor = convert_affinematrix_to_homography(M)
     dst_norm_trans_src_norm: torch.Tensor = normalize_homography(M_3x3, (H, W), dsize)
 
     src_norm_trans_dst_norm = _torch_inverse_cast(dst_norm_trans_src_norm)
 
-    grid = F.affine_grid(src_norm_trans_dst_norm[:, :2, :], [B, C, dsize[0], dsize[1]], align_corners=align_corners)
+    # Generate the grid from the matrix batch. When a single shared transform is passed for a
+    # batch of images (``M`` is ``1x2x3`` with ``src`` ``BxCxHxW``), build one grid and expand it
+    # (a stride-0 view, no copy) instead of materializing B identical grids — this is what makes a
+    # batch-shared warp as cheap as torchvision's. When ``B_M == B`` (per-sample) nothing changes.
+    grid = F.affine_grid(src_norm_trans_dst_norm[:, :2, :], [B_M, C, dsize[0], dsize[1]], align_corners=align_corners)
+    if B_M == 1 and B > 1:
+        grid = grid.expand(B, -1, -1, -1)
 
     if padding_mode == "fill":
         if fill_value is None:


### PR DESCRIPTION
## What

`warp_affine` required the transform-matrix batch to equal the image batch. When a batch shares **one** transform (`M` is `1x2x3`, `src` is `BxCxHxW`) it now builds a single grid and `expand`s it (a stride-0 view, no copy) rather than needing B identical grids:

```python
grid = F.affine_grid(..., [B_M, C, H, W], ...)
if B_M == 1 and B > 1:
    grid = grid.expand(B, -1, -1, -1)
```

This mirrors how torchvision applies one grid to a whole batch, and is the building block for batch-shared (`same_on_batch`) augmentation fast paths.

## Correctness

Byte-identical: a `1x2x3` matrix and the equivalent `Bx2x3` produce max diff `0.0`. When `B_M == B` (per-sample, the default) the path is unchanged. `warp_affine` tests pass (26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)