### PR TITLE
perf(augmentation): single-region fast path for same_on_batch RandomErasing

### DIFF
--- a/kornia/augmentation/_2d/intensity/erasing.py
+++ b/kornia/augmentation/_2d/intensity/erasing.py
@@ -94,12 +94,28 @@ class RandomErasing(IntensityAugmentationBase2D):
         transform: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         _, _, h, w = input.size()
+        values = params["values"].view(-1, 1, 1, 1).to(input)
+
+        if self.same_on_batch:
+            # Every sample shares one rectangle, so write that single region directly instead of
+            # building a full-image mask and `where`-blending the whole tensor. Equivalent to the
+            # masked path (the mask covers [x, x+width) x [y, y+height), clipped to the image), but
+            # touches only the erased box — much cheaper for a batch (matches torchvision's slice).
+            # Read the four shared box coords in a single device sync (one ``tolist``) rather than
+            # four separate ``int(...)`` calls.
+            xs, ys, box_w, box_h = (
+                torch.stack([params["xs"][0], params["ys"][0], params["widths"][0], params["heights"][0]])
+                .long()
+                .tolist()
+            )
+            transformed = input.clone()
+            transformed[:, :, ys : ys + box_h, xs : xs + box_w] = values
+            return transformed
+
         # Broadcast the per-sample fill value (B, 1, 1, 1) and the single-channel mask (B, 1, H, W)
         # directly in `torch.where` instead of `repeat`-materializing both to full (B, C, H, W).
         # `where` broadcasts to the input shape, so the result is identical while allocating two
         # small tensors instead of two image-sized ones.
-        values = params["values"].view(-1, 1, 1, 1).to(input)
-
         bboxes = bbox_generator(params["xs"], params["ys"], params["widths"], params["heights"])
         mask = bbox_to_mask(bboxes, w, h).unsqueeze(1).to(input)  # (B, 1, H, W)
         transformed = torch.where(mask == 1.0, values, input)


### PR DESCRIPTION
## What

Stacks on #3828. When `same_on_batch=True`, every sample shares one erase rectangle — so write that single region directly instead of building a full-image mask and `torch.where`-blending the entire `(B, C, H, W)` tensor:

```python
if self.same_on_batch:
    xs, ys, box_w, box_h = torch.stack([...]).long().tolist()  # one sync
    transformed = input.clone()
    transformed[:, :, ys:ys+box_h, xs:xs+box_w] = values
    return transformed
```

This is what torchvision does for a batch. The per-sample path is unchanged.

## Correctness

Byte-identical to the masked path — verified against the mask branch under a fixed seed (the mask covers `[x, x+width) x [y, y+height)` clipped to the image, exactly the sliced region). `tests/augmentation -k Erasing`: 21 passed.

## Perf

GPU `same_on_batch` `RandomErasing` **14 → 3.5 ms** (batch 16, 224², Jetson Orin), ~4×. The erase itself is ~0.26 ms — **faster than torchvision's 0.86 ms**; the residual 3 ms is parameter sampling (host overhead, amortizes on faster CPUs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)