### PR TITLE
perf(augmentation): shared kernel for same_on_batch RandomGaussianBlur

### DIFF
--- a/kornia/augmentation/_2d/intensity/gaussian_blur.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_blur.py
@@ -100,6 +100,11 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         transform: Optional[Tensor] = None,
     ) -> Tensor:
         sigma = params["sigma"].unsqueeze(-1).expand(-1, 2)
+        if self.same_on_batch:
+            # Every sample shares one sigma, so pass a single (1, 2) sigma: gaussian_blur2d then
+            # builds one kernel and convolves the batch depthwise (groups=C) instead of B distinct
+            # kernels (groups=B*C). Same result, far less kernel-construction and conv work.
+            sigma = sigma[:1]
         return self._gaussian_blur2d_fn(
             input,
             kernel_size=self.flags["kernel_size"],


### PR DESCRIPTION
## What

When `same_on_batch=True`, every sample shares one sigma — so pass a single `(1, 2)` sigma to `gaussian_blur2d` instead of `(B, 2)`. It then builds **one** Gaussian kernel and convolves the batch depthwise (`groups=C`) rather than constructing B distinct kernels and running a `groups=B*C` grouped conv.

```python
sigma = params["sigma"].unsqueeze(-1).expand(-1, 2)
if self.same_on_batch:
    sigma = sigma[:1]
```

## Correctness

Byte-identical — under `same_on_batch` all sampled sigmas are equal (verified), and `gaussian_blur2d` with a `(1, 2)` sigma on a batch produces the same result as the `(B, 2)` all-equal case. Verified against `main` under a fixed seed. `tests/augmentation -k GaussianBlur`: 6 passed.

## Perf

GPU `same_on_batch` `RandomGaussianBlur` ~24 → ~16 ms (batch 16, 3×3, Jetson Orin). Further gains for this path (non-separable single 2D conv for small kernels) are possible but hardware-dependent; this change is the unambiguous, byte-identical part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)