### PR TITLE
perf(enhance): make batched equalize torch.compile fullgraph

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -926,11 +926,9 @@ def _scale_channel_batched(input: torch.Tensor) -> torch.Tensor:
     n = shape[0] * shape[1]
     scaled = input.reshape(n, -1) * 255.0  # (N, P)
 
-    min_, max_ = input.min(), input.max()
-    if min_.item() < 0.0 and not torch.isclose(min_, torch.as_tensor(0.0, dtype=min_.dtype)):
-        raise ValueError(f"Values in the input torch.Tensor must greater or equal to 0.0. Found {min_.item()}.")
-    if max_.item() > 1.0 and not torch.isclose(max_, torch.as_tensor(1.0, dtype=max_.dtype)):
-        raise ValueError(f"Values in the input torch.Tensor must lower or equal to 1.0. Found {max_.item()}.")
+    # Input is expected in [0, 1] (see the docstring). Out-of-range values are clamped into the
+    # 256-bin range below rather than raising: the previous ``.item()`` range check forced two
+    # device syncs and broke ``torch.compile`` fullgraph for no correctness benefit on valid input.
 
     # Per-plane 256-bin histogram matching ``torch.histc(x, 256, 0, 255)`` bin placement.
     bins = torch.clamp((scaled * (256.0 / 255.0)).floor().long(), 0, 255)


### PR DESCRIPTION
## What

`_scale_channel_batched` validated the input range with `min_.item()`/`max_.item()` — two device syncs that also **broke `torch.compile` fullgraph** (data-dependent Python `if` → graph break). The batched histogram already `torch.clamp`s bins into the 256-bin range, so out-of-range input is handled without the check. Drop it; the `[0, 1]` expectation is documented on `equalize`.

## Result

`RandomEqualize` now compiles **fullgraph (0 graph breaks, was 2)**. Byte-identical for valid `[0, 1]` input (the only behavior change: out-of-range input is now clamped rather than raising — no test covered that path). `equalize` / `equalize3d` / `RandomEqualize` tests pass.

Part of the compile-first augmentation pass (most ops are already fullgraph; this closes one of the two remaining breakers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)