### PR TITLE
refactor(augmentation): drop 6 dead base-class method overrides

### DIFF
--- a/kornia/augmentation/_2d/geometric/base.py
+++ b/kornia/augmentation/_2d/geometric/base.py
@@ -136,16 +136,6 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
 
         return output
 
-    def apply_non_transform_box(
-        self,
-        input: Boxes,
-        params: Dict[str, torch.Tensor],
-        flags: Dict[str, Any],
-        transform: Optional[torch.Tensor] = None,
-    ) -> Boxes:
-        """Process boxes corresponding to the inputs that are no transformation applied."""
-        return input
-
     def apply_transform_box(
         self,
         input: Boxes,
@@ -161,16 +151,6 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
         input = self.apply_non_transform_box(input, params, flags, transform)
         return input.transform_boxes_(transform)
 
-    def apply_non_transform_keypoint(
-        self,
-        input: Keypoints,
-        params: Dict[str, torch.Tensor],
-        flags: Dict[str, Any],
-        transform: Optional[torch.Tensor] = None,
-    ) -> Keypoints:
-        """Process keypoints corresponding to the inputs that are no transformation applied."""
-        return input
-
     def apply_transform_keypoint(
         self,
         input: Keypoints,
@@ -185,16 +165,6 @@ class GeometricAugmentationBase2D(RigidAffineAugmentationBase2D):
             transform = self.transform_matrix
         input = self.apply_non_transform_keypoint(input, params, flags, transform)
         return input.transform_keypoints_(transform)
-
-    def apply_non_transform_class(
-        self,
-        input: torch.Tensor,
-        params: Dict[str, torch.Tensor],
-        flags: Dict[str, Any],
-        transform: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Process class tags corresponding to the inputs that are no transformation applied."""
-        return input
 
     def apply_transform_class(
         self,

--- a/kornia/augmentation/_2d/intensity/base.py
+++ b/kornia/augmentation/_2d/intensity/base.py
@@ -46,12 +46,6 @@ class IntensityAugmentationBase2D(RigidAffineAugmentationBase2D):
     def compute_transformation(self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any]) -> Tensor:
         return self.identity_matrix(input)
 
-    def apply_non_transform(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
-        # For the images where batch_prob == False.
-        return input
-
     def apply_non_transform_mask(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
@@ -72,19 +66,9 @@ class IntensityAugmentationBase2D(RigidAffineAugmentationBase2D):
     ) -> Boxes:
         return input
 
-    def apply_non_transform_keypoint(
-        self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Keypoints:
-        return input
-
     def apply_transform_keypoint(
         self, input: Keypoints, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Keypoints:
-        return input
-
-    def apply_non_transform_class(
-        self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
-    ) -> Tensor:
         return input
 
     def apply_transform_class(


### PR DESCRIPTION
## What

`IntensityAugmentationBase2D` and `GeometricAugmentationBase2D` each re-declared `apply_non_transform_box` / `_keypoint` / `_class` (plus Intensity's `apply_non_transform`) with bodies **byte-identical** to the inherited `_AugmentationBase` versions — all just `return input`.

Removed the 6 redundant overrides. The MRO has no intervening override, so every call site — including `GeometricAugmentationBase2D.apply_transform_box`/`_keypoint`, which invoke the non-transform variant internally — now resolves to the identical parent method.

## Kept (real overrides, not touched)

- Intensity's `apply_transform_mask` / `_keypoint` / `_class` — these turn the parent's `NotImplementedError` into pass-through.
- The plural `apply_non_transform_boxes` / `apply_transform_boxes` — called by `mix/base.py`.

## Correctness

Byte-identical output verified through a mixed `RandomBrightness` + `RandomAffine` `AugmentationSequential` over `input`/`bbox`/`keypoints`/`mask`/`class` — every md5 matches `main`. **545 passed / 51 skipped** across `tests/augmentation/container`, `_2d`, and `test_base.py`.

Pure maintainability cleanup — no behavior or API change. Part of the compile-first / infra-simplification pass (with #3841, #3842).

🤖 Generated with [Claude Code](https://claude.com/claude-code)