### PR TITLE
test(augmentation): guard RandomEqualize full-forward fullgraph

### DIFF
--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -355,6 +355,11 @@ class TestRandomEqualizeAlternative(CommonTests):
     def param_set(self, request):
         return request.param
 
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        # Guards the batched-histogram fullgraph path (#3841): the full forward, including
+        # parameter generation, must compile without a graph break — not just apply_transform.
+        _assert_dynamo_fullgraph(lambda: RandomEqualize(p=1.0), self, device, dtype)
+
     def test_random_p_1(self):
         input_tensor = torch.arange(20.0, device=self.device, dtype=self.dtype) / 20
         input_tensor = input_tensor.repeat(1, 2, 20, 1)


### PR DESCRIPTION
## What

Adds a `test_dynamo` for `RandomEqualize` covering the **full** `op(input)` forward (parameter generation in-graph), locking in the fullgraph path that #3841 created via the batched `scatter_add` histogram.

## Context

While adding full-forward dynamo coverage (#3845) I initially recorded that equalize still broke on a residual `.item()` — that was a **stale-checkout measurement** (local `main` hadn't pulled #3841). On current `main`, `RandomEqualize` full forward is **0 breaks**, compiles `fullgraph=True`, and matches eager byte-for-byte. This test guards that so it can't silently regress.

Uses the shared `_assert_dynamo_fullgraph` helper from #3845. Passes under `--optimizer=inductor` (the dynamo job); deselected in the normal matrix (name-based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)