### PR TITLE
feat(augmentation): RandomGrayscale supports multispectral (N-channel) input

### DIFF
--- a/kornia/augmentation/_2d/intensity/grayscale.py
+++ b/kornia/augmentation/_2d/intensity/grayscale.py
@@ -17,10 +17,12 @@
 
 from typing import Any, Dict, Optional
 
+import torch
 from torch import Tensor
 
 from kornia.augmentation._2d.intensity.base import IntensityAugmentationBase2D
 from kornia.color import rgb_to_grayscale
+from kornia.core.check import KORNIA_CHECK
 
 
 class RandomGrayscale(IntensityAugmentationBase2D):
@@ -28,9 +30,15 @@ class RandomGrayscale(IntensityAugmentationBase2D):
 
     .. image:: _static/img/RandomGrayscale.png
 
+    Works for multispectral imagery too (e.g. satellite data with 4-13+ bands): for a non-RGB
+    channel count the grayscale is the weighted average across *all* channels, broadcast back to
+    the input channel count. This makes the augmentation usable outside the 3-channel RGB regime.
+
     Args:
-        rgb_weights: Weights that will be applied on each channel (RGB).
-            The sum of the weights should add up to one.
+        rgb_weights: Per-channel weights applied when reducing to grayscale — one weight per input
+            channel (three, for the usual RGB case). If ``None``, RGB inputs use the standard
+            luminance weights and multispectral inputs weight every band equally. The weights
+            should sum to one.
         p: probability of the image to be transformed to grayscale.
         same_on_batch: apply the same transformation across the batch.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
@@ -41,7 +49,8 @@ class RandomGrayscale(IntensityAugmentationBase2D):
         - Output: :math:`(B, C, H, W)`
 
     .. note::
-        This function internally uses :func:`kornia.color.rgb_to_grayscale`.
+        For 3-channel RGB inputs this uses :func:`kornia.color.rgb_to_grayscale`; multispectral
+        inputs use a weighted channel average.
 
     Examples:
         >>> rng = torch.manual_seed(0)
@@ -77,8 +86,23 @@ class RandomGrayscale(IntensityAugmentationBase2D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        # Return (*, 3, H, W) by repeating the single grayscale channel — a contiguous copy,
-        # like the old code, but without its wasted `ones_like` allocation+fill (which was
-        # immediately overwritten).
-        gray = rgb_to_grayscale(input, rgb_weights=self.rgb_weights)
-        return gray.repeat(*([1] * (input.ndim - 3)), 3, 1, 1)
+        num_channels = input.shape[-3]
+        lead = (1,) * (input.ndim - 3)  # leading (batch) dims to broadcast/repeat over
+        if num_channels == 3:
+            # RGB luminance path — byte-identical to the previous behaviour.
+            gray = rgb_to_grayscale(input, rgb_weights=self.rgb_weights)
+        else:
+            # Multispectral (e.g. satellite, 4-13+ bands): weighted average over all channels,
+            # using ``rgb_weights`` (one per channel) or equal weights when unset.
+            weights = self.rgb_weights
+            if weights is None:
+                weights = torch.full((num_channels,), 1.0 / num_channels, device=input.device, dtype=input.dtype)
+            else:
+                KORNIA_CHECK(
+                    weights.numel() == num_channels,
+                    f"rgb_weights needs one weight per channel: got {weights.numel()} for {num_channels}.",
+                )
+                weights = weights.to(input)
+            gray = (input * weights.view(*lead, num_channels, 1, 1)).sum(-3, keepdim=True)
+        # Broadcast the single grayscale channel back to the input channel count (a contiguous copy).
+        return gray.repeat(*lead, num_channels, 1, 1)

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -2768,6 +2768,22 @@ class TestRandomGamma(BaseTester):
 
 
 class TestRandomGrayscale(BaseTester):
+    def test_multispectral(self, device, dtype):
+        # Non-RGB channel counts (e.g. satellite imagery) grayscale to the weighted average
+        # across all bands, broadcast back to the input channel count.
+        x = torch.rand(2, 7, 8, 8, device=device, dtype=dtype)
+        out = RandomGrayscale(p=1.0)(x)
+        assert out.shape == x.shape
+        expected = x.mean(dim=1, keepdim=True).expand(-1, 7, -1, -1)  # equal weights by default
+        self.assert_close(out, expected)
+        # every output band is identical (a true grayscale)
+        self.assert_close(out[:, 0], out[:, 3])
+        # custom per-band weights are honoured; a wrong length is rejected
+        weights = torch.full((7,), 1.0 / 7, device=device, dtype=dtype)
+        self.assert_close(RandomGrayscale(rgb_weights=weights, p=1.0)(x), expected)
+        with pytest.raises(Exception):
+            RandomGrayscale(rgb_weights=torch.ones(4, device=device, dtype=dtype), p=1.0)(x)
+
     # TODO: improve and implement more meaningful smoke tests e.g check for a consistent
     # return values such a Tensor variable.
     @pytest.mark.xfail(reason="might fail under windows OS due to printing preicision.")


### PR DESCRIPTION
## Why

`RandomGrayscale` required 3-channel RGB (`rgb_to_grayscale` raises otherwise), so users with **satellite / multispectral imagery** (4–13+ bands) couldn't use it. TorchGeo — a heavy kornia user — reimplemented its own MSI grayscale by subclassing `IntensityAugmentationBase2D` precisely because of this gap ([`torchgeo/transforms/color.py`](https://github.com/torchgeo/torchgeo/blob/main/torchgeo/transforms/color.py)). kornia maintainers invited upstreaming it (torchgeo#3108).

## What

`apply_transform` now handles any channel count:
- **3-channel RGB** → unchanged, still routes through `kornia.color.rgb_to_grayscale` (luminance weights). **Byte-identical** to before (verified: grayscale sum `185.839239` on both `main` and this branch).
- **N-channel (multispectral)** → grayscale is the weighted average across *all* bands, broadcast back to the input channel count. Weights come from `rgb_weights` (one per channel) or default to equal weighting — torchgeo's MSI convention. A wrong-length weights tensor is rejected.

Previously non-RGB input *raised*; now it works — a pure capability add, no behaviour change for existing RGB users.

## Tests

Added `test_multispectral` (7-band): equal-weight average, every output band identical (a true grayscale), custom weights honoured, wrong-length weights rejected. Existing 16 grayscale tests pass (float32/float64); docstring doctest passes.

Addresses the multispectral color-op gap flagged by TorchGeo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)