### PR TITLE
refactor(augmentation): route forward state writes through _commit_state chokepoint

### DIFF
--- a/kornia/augmentation/_2d/base.py
+++ b/kornia/augmentation/_2d/base.py
@@ -23,7 +23,7 @@ from torch import float16, float32, float64
 from kornia.augmentation.base import _AugmentationBase
 from kornia.augmentation.utils import _transform_input, _transform_input_by_shape, _validate_input_dtype
 from kornia.core.ops import eye_like
-from kornia.core.utils import is_autocast_enabled, is_exporting
+from kornia.core.utils import is_autocast_enabled
 from kornia.geometry.boxes import Boxes
 from kornia.geometry.keypoints import Keypoints
 
@@ -197,15 +197,11 @@ class RigidAffineAugmentationBase2D(AugmentationBase2D):
             # apply_transform ignores the matrix for these ops, so don't build it here; defer to
             # the first `.transform_matrix` access (e.g. AugmentationSequential propagating to
             # boxes/keypoints/masks). A standalone flip that never reads the matrix skips it.
-            if not is_exporting():
-                self._transform_matrix = None
-                self._lazy_matrix_args = (in_tensor, params, flags)
+            self._commit_state(transform_matrix=None, lazy_matrix_args=(in_tensor, params, flags))
             return self.transform_inputs(in_tensor, params, flags, None)
 
         trans_matrix = self.generate_transformation_matrix(in_tensor, params, flags)
         output = self.transform_inputs(in_tensor, params, flags, trans_matrix)
-        if not is_exporting():
-            self._transform_matrix = trans_matrix
-            self._lazy_matrix_args = None
+        self._commit_state(transform_matrix=trans_matrix, lazy_matrix_args=None)
 
         return output

--- a/kornia/augmentation/base.py
+++ b/kornia/augmentation/base.py
@@ -32,6 +32,9 @@ from kornia.geometry.keypoints import Keypoints
 
 TensorWithTransformMat = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 
+# Sentinel for ``_commit_state`` fields: distinguishes "not provided" from an explicit ``None``.
+_UNSET: Any = object()
+
 
 # Trick mypy into not applying contravariance rules to inputs by defining
 # forward as a value, rather than a function.  See also
@@ -209,6 +212,31 @@ class _BasicAugmentationBase(nn.Module):
             return batch_prob[..., 0]
         return batch_prob
 
+    def _commit_state(
+        self,
+        *,
+        params: Any = _UNSET,
+        transform_matrix: Any = _UNSET,
+        lazy_matrix_args: Any = _UNSET,
+    ) -> None:
+        """Record per-call state on ``self`` for post-call retrieval.
+
+        Covers ``._params`` (and, on the rigid/affine subclass, ``.transform_matrix`` /
+        ``_lazy_matrix_args``). This is the single writer of that state. It is skipped inside a
+        ``torch.export`` capture, which rejects attribute mutation in ``forward``; the captured
+        image output is unchanged — only reading the state back afterwards (meaningless in an
+        exported graph) is skipped. Each field is written only when explicitly passed (``None`` is
+        a valid value, hence the ``_UNSET`` sentinel).
+        """
+        if is_exporting():
+            return
+        if params is not _UNSET:
+            self._params = params
+        if transform_matrix is not _UNSET:
+            self._transform_matrix = transform_matrix
+        if lazy_matrix_args is not _UNSET:
+            self._lazy_matrix_args = lazy_matrix_args
+
     def _process_kwargs_to_params_and_flags(
         self,
         params: Optional[Dict[str, torch.Tensor]] = None,
@@ -223,11 +251,9 @@ class _BasicAugmentationBase(nn.Module):
 
         if save_kwargs:
             params = override_parameters(params, kwargs, in_place=True)
-            if not is_exporting():
-                self._params = params
+            self._commit_state(params=params)
         else:
-            if not is_exporting():
-                self._params = params
+            self._commit_state(params=params)
             params = override_parameters(params, kwargs, in_place=False)
 
         flags = override_parameters(flags, kwargs, in_place=False)


### PR DESCRIPTION
## Why

#3856 made the deterministic transforms `torch.export`-clean by skipping the per-call state stashing under export — via **four scattered** `if not is_exporting(): self._<attr> = ...` guards (two in `_process_kwargs_to_params_and_flags` for `_params`, two in the 2D `apply_func` for `_transform_matrix` / `_lazy_matrix_args`). That's the wrong altitude: adding any new retrievable-state field or caller means finding and repeating the guard, and the follow-up container export work would multiply the sites (~15).

## What

Introduce a single **`_AugmentationBase._commit_state(**fields)`** — the one writer of that per-call state, with the `is_exporting()` skip in **one place**. Each field is written only when explicitly passed; an `_UNSET` sentinel distinguishes "not provided" from a genuine `None` (which the lazy-matrix branch commits). The four call sites become `self._commit_state(...)`, and `_2d/base.py` drops its now-unused `is_exporting` import.

This is **PR-1 of the export-clean RFC** — lands the chokepoint pattern that the container refactor will reuse.

## No behavior change

Pure refactor. Verified:
- Eager still stores `._params` and `.transform_matrix` (`is_exporting()` is False → `_commit_state` writes).
- `torch.export` still skips them — the deterministic-transform export test **5 pass on a `torch==2.9.1` venv and on 2.10**.
- Fullgraph intact — HFlip/Affine 0 graph breaks.
- **545 pass** across `tests/augmentation/container`, `_2d`, `test_base.py`; broad `test_augmentation.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)