### PR TITLE
docs(augmentation): document the base-class hierarchy

### DIFF
--- a/docs/source/augmentation.base.rst
+++ b/docs/source/augmentation.base.rst
@@ -15,6 +15,29 @@ location of image pixels and `IntensityAugmentationBase2D` that preserves the pi
 generic `AugmentationBase2D` that allows higher freedom for customized augmentation design.
 
 
+The Base-Class Hierarchy
+------------------------
+
+The bases form a chain, each layer adding one concern and shared by several subclasses — so pick the
+*shallowest* base that already does what you need:
+
+.. code-block:: text
+
+   nn.Module
+   └─ _BasicAugmentationBase          parameter sampling + the forward skeleton
+      ├─ _AugmentationBase            dispatch to image / mask / box / keypoint / class data keys
+      │  ├─ AugmentationBase2D        2D tensor validation  (subclass for a fully custom 2D op)
+      │  │  └─ RigidAffineAugmentationBase2D     transform-matrix machinery
+      │  │     ├─ IntensityAugmentationBase2D    pointwise ops — override apply_transform
+      │  │     └─ GeometricAugmentationBase2D    warp ops — also override compute_transformation
+      │  └─ AugmentationBase3D … (the 3D mirror of the 2D chain)
+      └─ MixAugmentationBaseV2        mix ops (MixUp / CutMix) — bypass the per-key dispatch
+
+Each level is a distinct, reused axis (sampling, data-key dispatch, 2D vs 3D, rigid-matrix vs free-form,
+intensity vs geometric); the four ``*Base2D`` classes are public API that external code subclasses.
+For a custom augmentation, subclass ``IntensityAugmentationBase2D`` or ``GeometricAugmentationBase2D``.
+
+
 The Predefined Augmentation Routine
 -----------------------------------
 


### PR DESCRIPTION
## What

Adds a tree diagram + one-line role per layer to the augmentation base-class docs.

## Why

The augmentation bases are a six-level chain, which *reads* as complexity but is actually clean separation of concerns. An investigation into flattening it found it **cannot** be simplified without breaking things:

| Layer | Role | Subclasses |
|-------|------|------------|
| `_BasicAugmentationBase` | param sampling + forward skeleton | `_AugmentationBase` **+ MixAugmentationBaseV2** |
| `_AugmentationBase` | data-key dispatch (img/mask/box/kpt/class) | `AugmentationBase2D` **+ 3D** |
| `AugmentationBase2D` | 2D tensor validation | `RigidAffine` **+ Elastic/Fisheye/ThinPlate** |
| `RigidAffineAugmentationBase2D` | transform-matrix machinery | `Intensity` + `Geometric` |
| `IntensityAugmentationBase2D` | pointwise | 35 augs |
| `GeometricAugmentationBase2D` | warp + inverse | 12 augs |

Every layer is a distinct axis shared by multiple subclasses — nothing is vestigial (mix ops bypass the per-key dispatch layer), and the four `*Base2D` classes are public API that external code (e.g. TorchGeo) subclasses. So the right fix for "the hierarchy is complex" is **legibility, not restructuring**.

Docs only. Points custom-augmentation authors at the base to subclass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)