### PR TITLE
fix(augmentation): correct + clean up the torch.export container path

### DIFF
--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -281,8 +281,7 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
             # NOTE: only for images are supported for 3D.
             if isinstance(arg, AugmentationBase3D):
                 self.contains_3d_augmentation = True
-        if not is_exporting():
-            self._transform_matrix = None
+        self._transform_matrix = None
         self.extra_args = extra_args or {DataKey.MASK: {"resample": Resample.NEAREST, "align_corners": None}}
 
     def clear_state(self) -> None:
@@ -539,11 +538,9 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
                 if len(data_keys) > 1 and DataKey.INPUT in data_keys:
                     idx = data_keys.index(DataKey.INPUT)
                     if output_type == "pt":
+                        # ``self._output_image`` already holds ``_output_image`` here, so the old
+                        # per-key rebind was a no-op; just store the whole output.
                         self._output_image = _output_image
-                        if isinstance(_output_image, dict):
-                            self._output_image[original_keys[idx]] = _output_image[original_keys[idx]]
-                        else:
-                            self._output_image[idx] = _output_image[idx]
                     elif isinstance(_output_image, dict):
                         self._output_image[original_keys[idx]] = _output_image[original_keys[idx]]
                     else:

--- a/kornia/augmentation/container/image.py
+++ b/kornia/augmentation/container/image.py
@@ -274,7 +274,7 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
                 param = ParamItem(name, mod_param)
             else:
                 param = ParamItem(name, None)
-            batch_shape = _get_new_batch_shape(param, batch_shape)
+            batch_shape = _get_new_batch_shape(param, batch_shape, module)
             params.append(param)
         return params
 
@@ -398,7 +398,7 @@ class ImageSequential(ImageSequentialBase, ImageModuleForSequentialMixIn):
         return _output_image
 
 
-def _get_new_batch_shape(param: ParamItem, batch_shape: torch.Size) -> torch.Size:
+def _get_new_batch_shape(param: ParamItem, batch_shape: torch.Size, module: Optional[nn.Module] = None) -> torch.Size:
     """Get the new batch shape if the augmentation changes the image size.
 
     Note:
@@ -417,12 +417,18 @@ def _get_new_batch_shape(param: ParamItem, batch_shape: torch.Size) -> torch.Siz
 
     # Carefully avoid evaluating expression multiple times; batch_prob is often a 1-element torch.Tensor
     if "output_size" in data:
-        # Under ``torch.export`` the sampled ``output_size`` is an unbacked tensor, so the tracked
-        # shape can't be turned into a static ``torch.Size``. Skip the shape-tracking entirely:
-        # it only feeds parameter generation for *subsequent* children, and export runs on concrete
-        # tensors, so a shape-changing transform followed by nothing shape-dependent is unaffected.
         if is_exporting():
-            return batch_shape
+            # The sampled ``output_size`` is an unbacked tensor under export (no python int for
+            # ``torch.Size``). Use the module's static ``flags["size"]`` — known at construction —
+            # so the tracked shape stays correct for a *subsequent* shape-dependent child (e.g. a
+            # resample-mode crop after a resize). Fall back to leaving the shape unchanged when the
+            # size isn't statically available.
+            size = getattr(module, "flags", {}).get("size") if module is not None else None
+            if size is None:
+                return batch_shape
+            new_batch_shape = list(batch_shape)
+            new_batch_shape[-2:] = size
+            return torch.Size(new_batch_shape)
         # Inline check for common PyTorch float torch.Tensor case
         batch_prob = data.get("batch_prob", None)
         if batch_prob is None:

--- a/kornia/core/mixin/image_module.py
+++ b/kornia/core/mixin/image_module.py
@@ -25,6 +25,7 @@ import torch
 
 from kornia.core.external import PILImage as Image
 from kornia.core.external import numpy as np
+from kornia.core.utils import is_exporting
 
 
 class ImageModuleMixIn:
@@ -198,6 +199,16 @@ class ImageModuleMixIn:
         if isinstance(output_image, list | tuple):
             return type(output_image)([self._detach_tensor_to_cpu(out) for out in output_image])  # type: ignore
         raise RuntimeError(f"Unexpected object {output_image} with a type of `{type(output_image)}`")
+
+    def _store_output_image(self, output_image: Any, output_type: str) -> None:
+        """Cache the forward output for the ``.plot()`` / ``.show()`` helpers.
+
+        Skipped inside a ``torch.export`` capture: caching mutates module state in ``forward``,
+        which ``torch.export`` (torch <= 2.9) rejects. The captured output is unaffected.
+        """
+        if is_exporting():
+            return
+        self._output_image = self._detach_tensor_to_cpu(output_image) if output_type == "pt" else output_image
 
     def show(self, n_row: Optional[int] = None, backend: str = "pil", display: bool = True) -> Optional[Any]:
         """Return PIL images.

--- a/kornia/core/module.py
+++ b/kornia/core/module.py
@@ -23,7 +23,6 @@ from torch import nn
 
 from .mixin.image_module import ImageModuleMixIn
 from .mixin.onnx import ONNXExportMixin
-from .utils import is_exporting
 
 
 class ImageModule(nn.Module, ImageModuleMixIn, ONNXExportMixin):
@@ -94,13 +93,7 @@ class ImageModule(nn.Module, ImageModuleMixIn, ONNXExportMixin):
                 input_names_to_handle=input_names_to_handle, output_type=output_type
             )(super().__call__)
             _output_image = decorated_forward(*inputs, **kwargs)
-            if not is_exporting():
-                # ``_output_image`` is an eager-only cache for ``.plot()``; storing it mutates
-                # module state, which ``torch.export`` (torch <= 2.9) rejects inside ``forward``.
-                if output_type == "pt":
-                    self._output_image = self._detach_tensor_to_cpu(_output_image)
-                else:
-                    self._output_image = _output_image
+            self._store_output_image(_output_image, output_type)
         else:
             _output_image = super().__call__(*inputs, **kwargs)
         return _output_image
@@ -174,13 +167,7 @@ class ImageSequential(nn.Sequential, ImageModuleMixIn, ONNXExportMixin):
                 input_names_to_handle=input_names_to_handle, output_type=output_type
             )(super().__call__)
             _output_image = decorated_forward(*inputs, **kwargs)
-            if not is_exporting():
-                # ``_output_image`` is an eager-only cache for ``.plot()``; storing it mutates
-                # module state, which ``torch.export`` (torch <= 2.9) rejects inside ``forward``.
-                if output_type == "pt":
-                    self._output_image = self._detach_tensor_to_cpu(_output_image)
-                else:
-                    self._output_image = _output_image
+            self._store_output_image(_output_image, output_type)
         else:
             _output_image = super().__call__(*inputs, **kwargs)
         return _output_image

--- a/tests/augmentation/test_torch_export.py
+++ b/tests/augmentation/test_torch_export.py
@@ -100,10 +100,18 @@ def _seq_crop_pad() -> torch.nn.Module:
     return K.AugmentationSequential(_normalize(), K.CenterCrop(20), K.PadTo((24, 24)), data_keys=["input"])
 
 
+def _seq_resize_then_resample_crop() -> torch.nn.Module:
+    # A resample-mode crop bakes its geometry from the *tracked* batch shape at parameter-generation
+    # time, so a preceding size change must update that shape under export — otherwise the crop uses
+    # the stale pre-resize shape and the exported output silently diverges from eager.
+    return K.AugmentationSequential(K.Resize((16, 16)), K.CenterCrop(8, cropping_mode="resample"), data_keys=["input"])
+
+
 TORCH_EXPORT_CONTAINERS: list[Tuple[str, Callable[[], torch.nn.Module]]] = [
     ("Seq[Norm,Bright]", _seq_pointwise),
     ("Seq[Norm,Resize]", _seq_resize),
     ("Seq[Norm,CenterCrop,PadTo]", _seq_crop_pad),
+    ("Seq[Resize,CenterCrop-resample]", _seq_resize_then_resample_crop),
 ]
 
 


### PR DESCRIPTION
Code-review follow-ups to #3858 (found by `/code-review`).

## 🔴 Correctness (silent wrong output)
`_get_new_batch_shape` skipped shape-tracking under `torch.export`, so a shape-**dependent** child after a size change baked its geometry from the *stale* pre-resize shape. `AugmentationSequential(Resize((16,16)), CenterCrop(8, cropping_mode="resample"))` exported → output **≠ eager** (verified). Slice-mode crop and pointwise dodged it (they re-derive from the runtime tensor), so #3858's tests missed it.

**Fix:** under export, track the shape from the module's **static `flags["size"]`** (known at construction) instead of the unbacked sampled `output_size` tensor. Resample-crop-after-resize now matches eager — added as a regression test.

## Cleanups
- Unguard the `__init__` `self._transform_matrix = None` (init runs before any capture; guarding it left it unset if a container was built during a capture).
- Dedup the byte-identical `_output_image` guarded store from both `ImageModule.__call__` / `ImageSequential.__call__` into one `ImageModuleMixIn._store_output_image` helper.
- Drop a dead no-op inner branch in the container `_output_image` block (per-key rebind assigned a key to its own value).

## Verified
- Export tests **8 pass** on a `torch==2.9.1` venv and 2.10 (incl. the new resample regression).
- Eager unchanged — **511 container tests pass**, `.plot()` cache intact, ruff clean.

Out of scope (documented in #3858): box/keypoint/mask propagation under export (matrix threading) and export-after-eager order-dependence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)