### PR TITLE
chore: remove dead code (discarded validate_bbox calls, vestigial params)

### DIFF
--- a/kornia/augmentation/container/base.py
+++ b/kornia/augmentation/container/base.py
@@ -156,8 +156,6 @@ class SequentialBase(BasicSequentialBase):
         *args : a list of kornia augmentation and image operation modules.
         same_on_batch: apply the same transformation across the batch.
             If None, it will not overwrite the function-wise settings.
-        return_transform: if ``True`` return the matrix describing the transformation
-            applied to each. If None, it will not overwrite the function-wise settings.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
             to the batch form (False). If None, it will not overwrite the function-wise settings.
 
@@ -173,25 +171,22 @@ class SequentialBase(BasicSequentialBase):
     def update_attribute(
         self,
         same_on_batch: Optional[bool] = None,
-        return_transform: Optional[bool] = None,
         keepdim: Optional[bool] = None,
     ) -> None:
         """Propagate sequence-level flags to child augmentation modules.
 
         Args:
             same_on_batch: Override for ``same_on_batch``.
-            return_transform: Reserved for compatibility with older interfaces.
             keepdim: Override for ``keepdim``.
         """
         for mod in self.children():
-            # MixAugmentation does not have return transform
             if isinstance(mod, (_AugmentationBase, K.MixAugmentationBaseV2)):
                 if same_on_batch is not None:
                     mod.same_on_batch = same_on_batch
                 if keepdim is not None:
                     mod.keepdim = keepdim
             if isinstance(mod, SequentialBase):
-                mod.update_attribute(same_on_batch, return_transform, keepdim)
+                mod.update_attribute(same_on_batch, keepdim)
 
     @property
     def same_on_batch(self) -> Optional[bool]:

--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -138,7 +138,6 @@ def infer_bbox_shape(boxes: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         (tensor([2., 2.]), tensor([2., 3.]))
 
     """
-    validate_bbox(boxes)
     width: torch.Tensor = boxes[:, 1, 0] - boxes[:, 0, 0] + 1
     height: torch.Tensor = boxes[:, 2, 1] - boxes[:, 0, 1] + 1
     return height, width

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -23,7 +23,6 @@ import torch
 from torch import Size
 
 from kornia.core.ops import eye_like
-from kornia.geometry.bbox import validate_bbox
 from kornia.geometry.linalg import transform_points
 
 __all__ = ["Boxes", "Boxes3D"]
@@ -127,7 +126,6 @@ def _boxes_to_quadrilaterals(boxes: torch.Tensor, mode: str = "xyxy", validate_b
             quadrilaterals = boxes.clone()
         else:
             raise ValueError(f"Unknown mode {mode}")
-        not validate_boxes or validate_bbox(quadrilaterals)
     elif mode.startswith("xy"):
         if mode == "xyxy":
             height, width = boxes[..., 3] - boxes[..., 1], boxes[..., 2] - boxes[..., 0]

--- a/kornia/geometry/grid.py
+++ b/kornia/geometry/grid.py
@@ -76,11 +76,6 @@ def create_meshgrid(
         xs = (xs / (width - 1) - 0.5) * 2
         ys = (ys / (height - 1) - 0.5) * 2
     # generate grid by stacking coordinates
-    # TODO: torchscript doesn't like `torch_version_ge`
-    # if torch_version_ge(1, 13, 0):
-    #     x, y = torch.meshgrid([xs, ys], indexing="xy")
-    #     return torch.stack([x, y], -1).unsqueeze(0)  # 1xHxWx2
-    # TODO: remove after we drop support of old versions
     base_grid: torch.Tensor = torch.stack(torch.meshgrid([xs, ys], indexing="ij"), dim=-1)  # WxHx2
     return base_grid.permute(1, 0, 2).unsqueeze(0)  # 1xHxWx2
 

--- a/kornia/geometry/transform/crop2d.py
+++ b/kornia/geometry/transform/crop2d.py
@@ -23,7 +23,7 @@ from torch import nn
 
 from kornia.constants import Resample
 from kornia.core.check import KORNIA_CHECK_SHAPE
-from kornia.geometry.bbox import infer_bbox_shape, validate_bbox
+from kornia.geometry.bbox import infer_bbox_shape
 
 from .affwarp import resize
 from .imgwarp import get_perspective_transform, warp_affine
@@ -250,10 +250,6 @@ def crop_by_boxes(
         RuntimeError: solve_cpu: For batch 0: U(2,2) is zero, singular U.
 
     """
-    if validate_boxes:
-        validate_bbox(src_box)
-        validate_bbox(dst_box)
-
     if len(input_tensor.shape) != 4:
         raise AssertionError(f"Only torch.Tensor with shape (B, C, H, W) supported. Got {input_tensor.shape}.")
 


### PR DESCRIPTION
## What

Trim of genuinely-dead **internal** code — no public API removed, byte-identical behavior. From a classified dead-code audit; this PR is the SAFE-DEAD/VESTIGIAL tier only.

- **Discarded `validate_bbox` calls.** `validate_bbox` returns a bool and *never raises*, so calling it and dropping the result validates nothing (a precedent removal is already noted in `bbox.py`). Removed the three discarded call sites — `bbox.py` `infer_bbox_shape`, `boxes.py` `_boxes_to_quadrilaterals` (vertices branch), `crop2d.py` `crop_by_boxes` — and the now-unused imports. The `validate_bbox` **function stays** (public, `__all__`, tested). The real `validate_boxes` width/height check in `_boxes_to_quadrilaterals` is untouched.
- **`update_attribute(return_transform=...)`** — the param was only forwarded to its own recursion, never applied to any module; all three real callers omit it. Dropped the param, the pass-through, and the stale class-docstring entry.
- **Commented-out dead branch** in `grid.py` (an old `torch_version_ge(1, 13, 0)` block).

## Verified

51 bbox/boxes + 42 crop + 511 container tests pass; ruff clean.

## Not in this PR (needs a deprecation cycle / release decision)

An audit also surfaced **overdue deprecated public API** — `angle_axis_*`/`*_angle_axis` aliases (deprecated 0.7.0), the sold2 dict-config path ("remove in v0.8.0"), and the `*_t` gaussian shims (bogus `version="6.9.10"` tag). Those are breaking removals for a release + changelog, not this chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)