### PR TITLE
release: 0.9.0rc1

### DIFF
--- a/kornia/__init__.py
+++ b/kornia/__init__.py
@@ -245,4 +245,4 @@ def one_hot(*args: Any, **kwargs: Any) -> Any:
 
 
 # Version variable
-__version__ = "0.8.3"
+__version__ = "0.9.0rc1"


### PR DESCRIPTION
Version bump to **0.9.0rc1** (release candidate). `hatch` reads the version from `kornia/__init__.py`; PyPI publishes on GitHub Release. `CHANGELOG.md` is not touched (unmaintained since 0.6.11 — kornia uses GitHub Release notes).

## ⚠️ Before tagging the release
Merge the open follow-ups first — especially **#3861**, which fixes a **silent-wrong-output** bug in the container `torch.export` path (a resample-mode crop after a resize used a stale shape). Also #3860 (docs), #3862 (dead-code trim).

## Draft release notes (for the GitHub Release)

**kornia 0.9.0rc1** — headline: **compile-first, deployable augmentations**.

### 🚀 Highlights
- **`torch.export` support** — deterministic transforms (`Normalize`/`Denormalize`/`Resize`/`CenterCrop`/`PadTo`) and `AugmentationSequential` pipelines now capture cleanly and match eager, on torch 2.9.1 and 2.10 (#3856, #3858).
- **`torch.compile` fullgraph sweep** — ~20 ops across augmentation / enhance / color / filters / losses / geometry made graph-break-free, with a PR-time `dynamo` CI job on the CI torch version (#3786–#3809, #3841, #3842, #3802, #3797, #3793, #3794).
- **Performance** — equalize **18×**, `elastic_transform2d` **40×**, `RandomChannelShuffle` **12×**, posterize **16×** (GPU); lazy transform-matrix (up to **2.9×**); RNG-device propagation through container `.to()`/`.cuda()`; the compiled pipeline beats torchvision v2 (#3817, #3832, #3823, #3824, #3820, #3825, #3828, #3839).

### ✨ New Features
- Multispectral (N-channel) `RandomGrayscale` (#3853)
- `PatchMix` augmentation (#3664)
- Deterministic `ColorJitter` order, fullgraph-safe (#3799)
- `correlate2d` / `convolve2d` / `correlate3d` / `convolve3d` aliases (#3604)
- Optional image shape-mismatch support (#3600)

### 🐛 Fixes
- cusolver-free warps + closed-form 3×3 inverse — geometric ops run on the Jetson wheel (#3834, #3840)
- `transform_points` returns empty unchanged for 0-point input (#3855)
- ONNX-exportability regressions (#3779); sharpness device/dtype (#3830); `median_blur` B=0; LightGlue empty keypoints (#3584); `BgrToRgba` (#3673)

### 🧹 Internal
- `_commit_state` state-write chokepoint (#3857); `_blend_by_prob` dispatch DRY (#3844); dead-override + dead-code removal (#3843, #3862)

### 📖 Docs
- Honest benchmark framing + `[0,1]` input footgun note (#3850); custom-augmentation guide fix (#3852); base-class hierarchy diagram (#3860); torch.export/compile/ONNX deployment section (#3859)

🤖 Generated with [Claude Code](https://claude.com/claude-code)