### PR TITLE
fix: use float32 for internal label IDs in connected_components to avoid float16 precision collisions

### DIFF
--- a/kornia/contrib/connected_components.py
+++ b/kornia/contrib/connected_components.py
@@ -64,11 +64,11 @@ def connected_components(image: torch.Tensor, num_iterations: int = 100) -> torc
 
     # allocate the output tensors for labels
     B, _, _, _ = image_view.shape
-    out = torch.arange(1, B * H * W + 1, device=image.device, dtype=image.dtype).view((-1, 1, H, W))
+    out = torch.arange(1, B * H * W + 1, device=image.device, dtype=torch.float32).view((-1, 1, H, W))
     out[~mask] = 0
 
     for _ in range(num_iterations):
         out = F.max_pool2d(out, kernel_size=3, stride=1, padding=1)
         out = torch.mul(out, mask)  # mask using element-wise multiplication
 
-    return out.view_as(image)
+    return out.to(image.dtype).view_as(image)

--- a/tests/contrib/test_connected_component.py
+++ b/tests/contrib/test_connected_component.py
@@ -92,7 +92,7 @@ class TestConnectedComponents(BaseTester):
 
         out = kornia.contrib.connected_components(img, num_iterations=10)
         self.assert_close(out, expected)
-        
+
     def test_float16_precision_no_collision(self, device):
         """Regression test for a silent correctness bug: label IDs used to be
         generated using the input image's own dtype via torch.arange(...,

--- a/tests/contrib/test_connected_component.py
+++ b/tests/contrib/test_connected_component.py
@@ -92,6 +92,24 @@ class TestConnectedComponents(BaseTester):
 
         out = kornia.contrib.connected_components(img, num_iterations=10)
         self.assert_close(out, expected)
+        
+    def test_float16_precision_no_collision(self, device):
+        """Regression test for a silent correctness bug: label IDs used to be
+        generated using the input image's own dtype via torch.arange(...,
+        dtype=image.dtype). float16 can only represent integers exactly up to
+        2**11 = 2048, so on any image larger than that, two genuinely
+        disconnected components could receive colliding IDs and end up with
+        the same final label, with no error or warning."""
+        W, H = 8, 3000  # H * W = 24000 pixels, well past float16's exact-integer limit
+        img = torch.zeros(1, 1, H, W, device=device)
+        img[0, 0, 2051, 0] = 1.0  # component A
+        img[0, 0, 2053, 0] = 1.0  # component B, 2 rows away -> not connected
+
+        out = kornia.contrib.connected_components(img.to(torch.float16), num_iterations=150)
+
+        label_a = out[0, 0, 2051, 0]
+        label_b = out[0, 0, 2053, 0]
+        assert label_a != label_b, "two disconnected components must not share a label"
 
     def test_gradcheck(self, device):
         B, C, H, W = 2, 1, 4, 4


### PR DESCRIPTION
Fixes #3864


## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue.
ISSUE LINK:  https://github.com/kornia/kornia/issues/3864

**Fixes/Relates to:** #3864

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [x]  Changed connected_components() to always generate internal label IDs using torch.float32, instead of inheriting the input image's dtype
- [x]  Cast the final output back to the original input dtype before returning, so the function's public behavior stays unchanged for callers


---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** Added test_float16_precision_no_collision to tests/contrib/test_connected_component.py — builds a 3000×8 image with two single-pixel regions that are clearly disconnected, and asserts they get different labels under float16. Ran the full test file locally: 9 passed.
- [x] **Manual Verification:** Ran a reproduction script before and after the change. Before the fix, float16 gave the two disconnected pixels the exact same label. After the fix, float16 and float32 agree, and both correctly report the pixels as distinct components.
- [x] **Performance/Edge Cases:** Re-ran the existing test suite to confirm nothing else broke — all 9 tests in the file pass.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
