### PR TITLE
tests(filters): migrate remaining test classes to BaseTester

### DIFF
--- a/tests/filters/test_dissolving.py
+++ b/tests/filters/test_dissolving.py
@@ -21,6 +21,8 @@ import torch
 from kornia.core._compat import torch_version_le
 from kornia.filters.dissolving import StableDiffusionDissolving
 
+from testing.base import BaseTester
+
 WEIGHTS_CACHE_DIR = "weights/"
 
 
@@ -29,7 +31,7 @@ WEIGHTS_CACHE_DIR = "weights/"
     torch_version_le(2, 0, 1),
     reason="Skipped for torch versions <= 2.0.1: transformers clip model needs distributed tensor.",
 )
-class TestStableDiffusionDissolving:
+class TestStableDiffusionDissolving(BaseTester):
     @pytest.fixture(scope="class")
     def sdm_2_1(self):
         return StableDiffusionDissolving(version="1.5", cache_dir=WEIGHTS_CACHE_DIR)
@@ -42,18 +44,22 @@ class TestStableDiffusionDissolving:
     def test_init(self, sdm_2_1):
         assert isinstance(sdm_2_1, StableDiffusionDissolving), "Initialization failed"
 
-    def test_encode_tensor_to_latent(self, sdm_2_1, dummy_image):
+    def test_encode_tensor_to_latent(self, sdm_2_1, dummy_image, device, dtype):
+        dummy_image = dummy_image.to(device, dtype)
+        # Note: the model internally converts latents to its own dtype, so we don't strictly check output dtype match
         latents = sdm_2_1.model.encode_tensor_to_latent(dummy_image)
         assert isinstance(latents, torch.Tensor), "Latent encoding failed"
         assert latents.shape == (1, 4, 8, 8), "Latent shape mismatch"
 
-    def test_decode_tensor_to_latent(self, sdm_2_1, dummy_image):
+    def test_decode_tensor_to_latent(self, sdm_2_1, dummy_image, device, dtype):
+        dummy_image = dummy_image.to(device, dtype)
         latents = sdm_2_1.model.encode_tensor_to_latent(dummy_image)
         reconstructed_image = sdm_2_1.model.decode_tensor_to_latent(latents)
         assert isinstance(reconstructed_image, torch.Tensor), "Latent decoding failed"
         assert reconstructed_image.shape == dummy_image.shape, "Reconstructed image shape mismatch"
 
-    def test_dissolve(self, sdm_2_1, dummy_image):
+    def test_dissolve(self, sdm_2_1, dummy_image, device, dtype):
+        dummy_image = dummy_image.to(device, dtype)
         step_number = 500  # Test with a middle step
         dissolved_image = sdm_2_1(dummy_image, step_number)
         assert isinstance(dissolved_image, torch.Tensor), "Dissolve failed"

--- a/tests/filters/test_filters.py
+++ b/tests/filters/test_filters.py
@@ -1113,13 +1113,13 @@ class TestFilter2D_fftconv(BaseTester):
         self.assert_close(actual, expected)
 
 
-class TestCorrelate2d:
+class TestCorrelate2d(BaseTester):
     def test_equivalent_to_filter2d_corr(self, device, dtype):
         inp = torch.rand(1, 1, 7, 8, device=device, dtype=dtype)
         kernel = torch.rand(1, 3, 3, device=device, dtype=dtype)
         expected = filter2d(inp, kernel, behaviour="corr")
         result = correlate2d(inp, kernel)
-        assert torch.allclose(result, expected)
+        self.assert_close(result, expected)
 
     @pytest.mark.parametrize("border_type", ["constant", "reflect", "replicate", "circular"])
     @pytest.mark.parametrize("padding", ["same", "valid"])
@@ -1130,13 +1130,13 @@ class TestCorrelate2d:
         assert isinstance(out, torch.Tensor)
 
 
-class TestConvolve2d:
+class TestConvolve2d(BaseTester):
     def test_equivalent_to_filter2d_conv(self, device, dtype):
         inp = torch.rand(1, 1, 7, 8, device=device, dtype=dtype)
         kernel = torch.rand(1, 3, 3, device=device, dtype=dtype)
         expected = filter2d(inp, kernel, behaviour="conv")
         result = convolve2d(inp, kernel)
-        assert torch.allclose(result, expected)
+        self.assert_close(result, expected)
 
     def test_differs_from_correlate_asymmetric_kernel(self, device, dtype):
         inp = torch.rand(1, 1, 7, 8, device=device, dtype=dtype)
@@ -1147,19 +1147,19 @@ class TestConvolve2d:
         assert not torch.allclose(corr, conv)
 
 
-class TestCorrelate3d:
+class TestCorrelate3d(BaseTester):
     def test_equivalent_to_filter3d_corr(self, device, dtype):
         inp = torch.rand(1, 1, 5, 7, 8, device=device, dtype=dtype)
         kernel = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
         expected = filter3d(inp, kernel, behaviour="corr")
         result = correlate3d(inp, kernel)
-        assert torch.allclose(result, expected)
+        self.assert_close(result, expected)
 
 
-class TestConvolve3d:
+class TestConvolve3d(BaseTester):
     def test_equivalent_to_filter3d_conv(self, device, dtype):
         inp = torch.rand(1, 1, 5, 7, 8, device=device, dtype=dtype)
         kernel = torch.rand(1, 3, 3, 3, device=device, dtype=dtype)
         expected = filter3d(inp, kernel, behaviour="conv")
         result = convolve3d(inp, kernel)
-        assert torch.allclose(result, expected)
+        self.assert_close(result, expected)


### PR DESCRIPTION
## 📝 Description

Fixes #2752

Migrates the remaining unmigrated test classes in the `tests/filters/` module to use `BaseTester` as the parent class, as part of the ongoing tracker issue.

---

## 🛠️ Changes Made

### `tests/filters/test_filters.py`
- [x] `TestCorrelate2d` — Added `BaseTester` as parent; replaced `assert torch.allclose(...)` with `self.assert_close(...)`
- [x] `TestConvolve2d` — Added `BaseTester` as parent; replaced `assert torch.allclose(...)` with `self.assert_close(...)`
- [x] `TestCorrelate3d` — Added `BaseTester` as parent; replaced `assert torch.allclose(...)` with `self.assert_close(...)`
- [x] `TestConvolve3d` — Added `BaseTester` as parent; replaced `assert torch.allclose(...)` with `self.assert_close(...)`

### `tests/filters/test_dissolving.py`
- [x] `TestStableDiffusionDissolving` — Added `BaseTester` as parent; injected `device` and `dtype` fixtures into test signatures; added `.to(device, dtype)` tensor casting

**Note:** `TestConvolve2d.test_differs_from_correlate_asymmetric_kernel` retains `assert not torch.allclose(corr, conv)` — this is a *negative* assertion (confirming tensors are different), which is correct to keep since `BaseTester` has no `assert_not_close`.

None of these 5 classes had `test_gradcheck` methods, so no `tensor_to_gradcheck_var` removal was needed.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** Ran the full `test_filters.py` suite — **112 passed, 3 skipped, 0 failures** (Python 3.11, CPU)
- [x] **Manual Verification:** Confirmed all 5 migrated classes now receive `device`/`dtype` fixtures via `BaseTester` parametrization (visible as `[cpu-float32]` test suffixes)
- [x] **Edge Cases:** Verified `test_dissolving.py` collects correctly (5 tests) — full execution requires model weights so it's gated behind `@pytest.mark.slow`

**Local test output:**
$ python -m pytest tests/filters/test_filters.py -v ======================== 112 passed, 3 skipped in 1.52s =========================

---

## 🕵️ AI Usage Disclosure
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.

---

## 💭 Additional Context
This is my first contribution to Kornia! All test classes in `tests/filters/` now inherit from `BaseTester` — the module is fully migrated.