### PR TITLE
Point Code of Conduct reports at a working address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at edgar.riba@arraiy.com. All
+reported by contacting the project team at hello@kornia.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
`CODE_OF_CONDUCT.md` directs enforcement reports to **`edgar.riba@arraiy.com`**. Arraiy no longer operates, so Code of Conduct reports have had nowhere to land — quietly, and probably for years. A CoC whose reporting channel is dead is arguably worse than none, because it tells people there is a process when there isn't.

Changed to `hello@kornia.org`, the address published on kornia.org and on the GSoC organisation profile.

## Scope

One line. The other four Arraiy references in the repo are historical and deliberately untouched:

| File | Reference | Why it stays |
|---|---|---|
| `COPYRIGHT` | `Copyright (C) 2017-2019, Arraiy, Inc.` | Copyright history — not mine to rewrite |
| `CITATION.md` | `@misc{Arraiy2018,` | BibTeX key; renaming breaks existing citations |
| `docs/source/get-started/about.rst` | `@misc{Arraiy2018,` | Same key |
| `kornia/geometry/pointcloud.py` | `"comment arraiy generated\n"` | PLY header string; tests may compare it |

## Worth deciding separately

A dedicated `conduct@kornia.org` alias would be better practice than a general contact address for CoC reports, since these are sensitive and `hello@` may have wider readership than you want for them. I used `hello@` because I could verify it is published and in use; I did not want to reference an alias that might not exist.

Also note `profile/README.md` in `kornia/.github` publishes `contact@kornia.org` while the website uses `hello@kornia.org` — worth settling on one.

Found during an org-wide community-health audit. Related: kornia/.github#1 (org-wide defaults, which carries the corrected address for the eight repos that inherit it), kornia/kornia-slam#55 (missing licence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
