### PR TITLE
docs: add Conventions & Pitfalls master page

### DIFF
--- a/docs/source/_extra/llms-full.txt
+++ b/docs/source/_extra/llms-full.txt
@@ -148,7 +148,7 @@ img = img[None]  # most ops want (B, C, H, W)
 6. Radians where degrees are expected — rotation angles are degrees.
 7. Uint8 `[0, 255]` tensors — ops expect float `[0, 1]`; divide by 255 first.
 8. Augmenting image and mask through two separate augmentation calls — the random parameters will differ; use one `AugmentationSequential` with `data_keys`.
-9. Feeding `homography_warp` a source→destination pixel homography — it expects destination→source, normalized to [-1, 1] (`normalize_homography(torch.inverse(M), size_src, size_dst)`), and defaults to `align_corners=False` unlike `warp_perspective`.
+9. Feeding `homography_warp` a source→destination pixel homography — it expects destination→source, normalized to [-1, 1]: normalize the forward homography FIRST, then invert (`torch.inverse(normalize_homography(M, size_src, size_dst))`). It also defaults to `align_corners=False` unlike `warp_perspective`.
 10. Mixing `axis_angle_to_rotation_matrix` (right-hand rule, math convention — screen-clockwise for +z on y-down images) with `rotate` (screen-counter-clockwise) without negating the angle.
 11. Treating `kornia.geometry.bbox.infer_bbox_shape` width/height as exclusive — they are inclusive (`x_right - x_left + 1`): corners (1,1),(2,2) give width 2.
 12. Quaternions in XYZW order — `kornia.geometry.quaternion.Quaternion` uses WXYZ (scalar first).

--- a/docs/source/_extra/llms-full.txt
+++ b/docs/source/_extra/llms-full.txt
@@ -11,7 +11,7 @@ These conventions hold library-wide; per-function docs note any exception.
 - **Image layout:** float tensors `(B, C, H, W)`, channel order RGB, values in `[0, 1]`. The batched 4D layout is accepted everywhere; some op families (e.g. color conversions) also take `(*, C, H, W)` with arbitrary leading dims. When unsure, use `(B, C, H, W)` — add the batch dim with `img[None]`.
 - **Point coordinates:** `(x, y)` order, where x indexes columns and y indexes rows. A point tensor for N points is `(B, N, 2)`.
 - **Sizes:** output sizes and `dsize` arguments are `(h, w)` order — the OPPOSITE axis order from points.
-- **Angles:** degrees, not radians. Positive angle = counter-clockwise rotation as displayed, with the origin at the top-left corner (OpenCV convention).
+- **Angles:** degrees in the 2D image APIs (`rotate`, `get_rotation_matrix2d`, `RandomRotation`); radians in the 3D/conversion APIs (`axis_angle_to_rotation_matrix`, `So3`; convert with `deg2rad`/`rad2deg`). Positive 2D angle = counter-clockwise rotation as displayed, with the origin at the top-left corner (OpenCV convention).
 - **Transformation matrices:** batched. Homographies are `(B, 3, 3)`, affine matrices `(B, 2, 3)`. They act on pixel coordinates unless the function name or a flag says `normalized`. To apply a `(3, 3)` matrix, add the batch dim: `M[None]`.
 - **`align_corners`:** `warp_perspective` and `warp_affine` default to `align_corners=True`; `resize` defaults to `align_corners=None` (PyTorch's native default per interpolation mode). When mixing Kornia warps with `torch.nn.functional.interpolate` or `grid_sample`, pass `align_corners` explicitly everywhere.
 - **Devices/dtypes:** ops run on whatever device/dtype the input tensors carry; there is no implicit `.cuda()` or `.float()`.

--- a/docs/source/_extra/llms-full.txt
+++ b/docs/source/_extra/llms-full.txt
@@ -16,6 +16,8 @@ These conventions hold library-wide; per-function docs note any exception.
 - **`align_corners`:** `warp_perspective` and `warp_affine` default to `align_corners=True`; `resize` defaults to `align_corners=None` (PyTorch's native default per interpolation mode). When mixing Kornia warps with `torch.nn.functional.interpolate` or `grid_sample`, pass `align_corners` explicitly everywhere.
 - **Devices/dtypes:** ops run on whatever device/dtype the input tensors carry; there is no implicit `.cuda()` or `.float()`.
 
+Full conventions reference with runnable proofs: <https://kornia.readthedocs.io/en/latest/get-started/conventions.html>
+
 ## kornia.geometry — warps, homographies, camera geometry
 
 The differentiated core: differentiable, batched geometric transforms with no OpenCV/torchvision equivalent.
@@ -146,6 +148,12 @@ img = img[None]  # most ops want (B, C, H, W)
 6. Radians where degrees are expected — rotation angles are degrees.
 7. Uint8 `[0, 255]` tensors — ops expect float `[0, 1]`; divide by 255 first.
 8. Augmenting image and mask through two separate augmentation calls — the random parameters will differ; use one `AugmentationSequential` with `data_keys`.
+9. Feeding `homography_warp` a source→destination pixel homography — it expects destination→source, normalized to [-1, 1] (`normalize_homography(torch.inverse(M), size_src, size_dst)`), and defaults to `align_corners=False` unlike `warp_perspective`.
+10. Mixing `axis_angle_to_rotation_matrix` (right-hand rule, math convention — screen-clockwise for +z on y-down images) with `rotate` (screen-counter-clockwise) without negating the angle.
+11. Treating `kornia.geometry.bbox.infer_bbox_shape` width/height as exclusive — they are inclusive (`x_right - x_left + 1`): corners (1,1),(2,2) give width 2.
+12. Quaternions in XYZW order — `kornia.geometry.quaternion.Quaternion` uses WXYZ (scalar first).
+13. Expecting hue in `[0, 360]` or `[0, 1]` — `rgb_to_hsv` returns radians `[0, 2π)`.
+14. Wrong `data_keys` box format — `"bbox"` means 4-corner `(B, 4, 2)`; coordinate formats are `"bbox_xyxy"` / `"bbox_xywh"`.
 
 ## Links
 

--- a/docs/source/_extra/llms.txt
+++ b/docs/source/_extra/llms.txt
@@ -16,6 +16,7 @@ For the full self-contained reference with runnable examples, fetch [llms-full.t
 ## Get started
 
 - [Introduction](https://kornia.readthedocs.io/en/latest/get-started/introduction.html): what Kornia is and the design principles behind it
+- [Conventions & Pitfalls](https://kornia.readthedocs.io/en/latest/get-started/conventions.html): the canonical conventions reference — read before generating Kornia code
 - [Installation](https://kornia.readthedocs.io/en/latest/get-started/installation.html): pip/conda/source installation
 - [Tutorials](https://kornia.github.io/tutorials/): runnable end-to-end examples
 

--- a/docs/source/_extra/llms.txt
+++ b/docs/source/_extra/llms.txt
@@ -6,7 +6,7 @@ Conventions every code generator must know before writing Kornia code:
 
 - Images are float tensors with values in `[0, 1]`; the batched layout `(B, C, H, W)` is accepted everywhere. Some op families (e.g. color conversions) also take `(*, C, H, W)` with arbitrary leading dims. Add a batch dim with `img[None]` if needed.
 - Point coordinates are `(x, y)` ordered (x = column axis, y = row axis); output sizes and `dsize` arguments are `(h, w)` ordered.
-- Angles are in degrees; a positive angle rotates counter-clockwise as displayed (origin at the top-left corner, matching OpenCV).
+- Angles are in degrees in the 2D image APIs (`rotate`, `get_rotation_matrix2d`) and radians in the 3D/conversion APIs (`axis_angle_*`, `So3`); a positive 2D angle rotates counter-clockwise as displayed (origin at the top-left corner, matching OpenCV).
 - `warp_perspective` / `warp_affine` default to `align_corners=True`; `resize` defaults to `align_corners=None` (the PyTorch interpolation default). Do not assume they match.
 - Transformation matrices are batched: homographies `(B, 3, 3)`, affine `(B, 2, 3)`, operating on pixel coordinates unless the function name or a flag says `normalized`.
 - `kornia.augmentation.AugmentationSequential` applies one sampled transform consistently across image / mask / bbox / keypoints and can invert it with `.inverse()`.

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -225,9 +225,7 @@ Quick self-review for generated code, most common first:
 12. Quaternions constructed in XYZW order — Kornia uses WXYZ.
 13. Expecting hue in ``[0, 360]`` or ``[0, 1]`` — ``rgb_to_hsv`` returns
     radians ``[0, 2π)``.
-14. Assuming ``resize`` and ``warp_*`` sample pixels identically — their
-    ``align_corners`` defaults differ (see table).
-15. Wrong ``data_keys`` box format — ``"bbox"`` means 4-corner ``(B, 4, 2)``;
+14. Wrong ``data_keys`` box format — ``"bbox"`` means 4-corner ``(B, 4, 2)``;
     use ``"bbox_xyxy"``/``"bbox_xywh"`` for coordinate formats.
 
 .. tip::

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -96,9 +96,12 @@ Transformation matrices and homographies
 - :func:`kornia.geometry.transform.homography_warp` is different on every
   axis: it takes the **destination→source** homography, **normalized** to
   ``[-1, 1]`` by default (``normalized_homography=True``), and defaults to
-  ``align_corners=False``. Convert a pixel source→destination homography
-  with :func:`kornia.geometry.conversions.normalize_homography` plus
-  ``torch.inverse``:
+  ``align_corners=False``. Convert a pixel source→destination homography by
+  normalizing it FIRST with
+  :func:`kornia.geometry.conversions.normalize_homography` (which expects
+  the forward src→dst homography) and inverting AFTER — inverting first
+  with unswapped sizes is silently wrong whenever the source and
+  destination sizes differ:
 
 .. code-block:: python
 
@@ -109,9 +112,9 @@ Transformation matrices and homographies
     img = torch.rand(1, 1, 8, 8)
     M = torch.tensor([[[1.0, 0.0, 2.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]]])  # src->dst, pixels
 
-    a = warp_perspective(img, M, (8, 8))
-    M_norm_inv = normalize_homography(torch.inverse(M), (8, 8), (8, 8))
-    b = homography_warp(img, M_norm_inv, (8, 8), align_corners=True)
+    a = warp_perspective(img, M, (16, 8))  # note: dst size differs from src
+    M_norm_inv = torch.inverse(normalize_homography(M, (8, 8), (16, 8)))  # normalize, THEN invert
+    b = homography_warp(img, M_norm_inv, (16, 8), align_corners=True)
     assert torch.allclose(a, b, atol=1e-5)
 
 ``align_corners`` defaults

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -1,0 +1,235 @@
+Conventions & Pitfalls
+======================
+
+Every Kornia function follows the conventions below unless its documentation
+explicitly says otherwise. If you are generating code (human or LLM), read
+this page first — nearly every subtle Kornia bug is a convention mismatch,
+not a math error.
+
+Image tensors
+-------------
+
+- Images are 4D float tensors ``(B, C, H, W)``, channel order **RGB**, values
+  in ``[0, 1]``. The batched layout is accepted everywhere; some op families
+  (e.g. color conversions) also accept ``(*, C, H, W)`` with arbitrary
+  leading dims.
+- Ops run on the device/dtype of their inputs. There is no implicit
+  ``.cuda()``, ``.float()``, or value rescaling.
+- Convert NumPy HWC images with :func:`kornia.image.image_to_tensor`
+  (``kornia.utils.image_to_tensor`` is deprecated since 0.8.3):
+
+.. code-block:: python
+
+    import numpy as np
+    import torch
+    import kornia
+
+    np_img = (np.random.rand(48, 64, 3) * 255).astype(np.uint8)  # (H, W, C) uint8
+    t = kornia.image.image_to_tensor(np_img)[None].float() / 255.0  # (1, 3, 48, 64) in [0, 1]
+
+Coordinates and sizes
+---------------------
+
+- Point coordinates are ``(x, y)``: x indexes **columns**, y indexes
+  **rows**, origin at the **top-left** pixel. Keypoint tensors are
+  ``(B, N, 2)``.
+- Sizes and ``dsize`` arguments are ``(h, w)`` — the *opposite* order from
+  points. ``warp_perspective(img, M, dsize=(2, 8))`` produces a 2-row,
+  8-column image.
+- Normalized coordinates, where used, are ``[-1, 1]`` in both axes,
+  identical to :func:`torch.nn.functional.grid_sample`.
+  :func:`kornia.geometry.create_meshgrid` returns a normalized grid by
+  default (``normalized_coordinates=True``).
+
+Angles and rotations
+--------------------
+
+- Angles are **degrees** in the 2D image APIs (``rotate``,
+  ``get_rotation_matrix2d``, ``RandomRotation``), and **radians** in the
+  3D/conversion APIs (``axis_angle_to_rotation_matrix``, ``So3``;
+  ``rad2deg``/``deg2rad`` exist to convert).
+- 2D image rotations: positive angle rotates **counter-clockwise as
+  displayed** (top-left origin, matching OpenCV):
+
+.. code-block:: python
+
+    import torch
+    from kornia.geometry.transform import rotate
+
+    img = torch.zeros(1, 1, 5, 5)
+    img[0, 0, 1, 3] = 1.0  # marker up-right of center
+    out = rotate(img, torch.tensor([90.0]))
+    assert out[0, 0].round().nonzero().tolist() == [[1, 1]]  # moved up-LEFT: CCW on screen
+
+- 3D rotation conversions follow the **right-hand rule in math convention**.
+  Because image y points *down*, a positive rotation about +z from
+  :func:`kornia.geometry.conversions.axis_angle_to_rotation_matrix` moves
+  image points **clockwise on screen** — the opposite screen direction from
+  ``rotate(img, +angle)``. Do not mix the two without negating the angle:
+
+.. code-block:: python
+
+    import torch
+    from kornia.geometry.conversions import axis_angle_to_rotation_matrix
+
+    R = axis_angle_to_rotation_matrix(torch.tensor([[0.0, 0.0, torch.pi / 2]]))
+    # math convention: (1, 0) -> (0, 1). With y down on screen, that points DOWNWARD.
+    assert torch.allclose(R[0, :2, :2], torch.tensor([[0.0, -1.0], [1.0, 0.0]]), atol=1e-6)
+
+- Quaternions use **WXYZ** coefficient order (scalar first):
+
+.. code-block:: python
+
+    from kornia.geometry.quaternion import Quaternion
+
+    q = Quaternion.identity()
+    assert q.data.tolist() == [1.0, 0.0, 0.0, 0.0]  # w, x, y, z
+
+Transformation matrices and homographies
+----------------------------------------
+
+- Transformation matrices are **batched**: homographies ``(B, 3, 3)``,
+  affine ``(B, 2, 3)``. Add the batch dim to a single matrix with
+  ``M[None]``.
+- :func:`kornia.geometry.transform.warp_perspective` takes the
+  **source→destination** homography in **pixel** coordinates.
+- :func:`kornia.geometry.transform.homography_warp` is different on every
+  axis: it takes the **destination→source** homography, **normalized** to
+  ``[-1, 1]`` by default (``normalized_homography=True``), and defaults to
+  ``align_corners=False``. Convert a pixel source→destination homography
+  with :func:`kornia.geometry.conversions.normalize_homography` plus
+  ``torch.inverse``:
+
+.. code-block:: python
+
+    import torch
+    from kornia.geometry.conversions import normalize_homography
+    from kornia.geometry.transform import homography_warp, warp_perspective
+
+    img = torch.rand(1, 1, 8, 8)
+    M = torch.tensor([[[1.0, 0.0, 2.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0]]])  # src->dst, pixels
+
+    a = warp_perspective(img, M, (8, 8))
+    M_norm_inv = normalize_homography(torch.inverse(M), (8, 8), (8, 8))
+    b = homography_warp(img, M_norm_inv, (8, 8), align_corners=True)
+    assert torch.allclose(a, b, atol=1e-5)
+
+``align_corners`` defaults
+--------------------------
+
+Defaults are **not uniform** across the library. When mixing Kornia warps
+with ``torch.nn.functional.interpolate``/``grid_sample``, pass
+``align_corners`` explicitly everywhere.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Function
+     - ``align_corners`` default
+   * - ``warp_perspective``, ``warp_affine``, ``rotate``
+     - ``True``
+   * - ``resize``
+     - ``None`` (PyTorch's per-mode default)
+   * - ``homography_warp``
+     - ``False``
+
+Bounding boxes
+--------------
+
+- The ``kornia.geometry.bbox`` module uses ``(B, 4, 2)`` corner format:
+  clockwise from top-left, ``(x, y)`` per corner.
+- Width/height are **inclusive**:
+  :func:`kornia.geometry.bbox.infer_bbox_shape` computes
+  ``width = x_right - x_left + 1``. A box with corners (1,1) and (2,2) has
+  width 2, not 1:
+
+.. code-block:: python
+
+    import torch
+    from kornia.geometry.bbox import infer_bbox_shape
+
+    boxes = torch.tensor([[[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0]]])
+    h, w = infer_bbox_shape(boxes)
+    assert (h.item(), w.item()) == (2.0, 2.0)
+
+- :class:`kornia.augmentation.AugmentationSequential` accepts three box
+  formats via ``data_keys``: ``"bbox"`` (4-corner), ``"bbox_xyxy"``, and
+  ``"bbox_xywh"``. Keypoints are ``"keypoints"``, ``(B, N, 2)`` in
+  ``(x, y)``.
+
+Color
+-----
+
+- ``rgb_to_hsv`` returns hue in **radians** ``[0, 2π)`` — not degrees, not
+  ``[0, 1]``:
+
+.. code-block:: python
+
+    import torch
+    import kornia
+
+    green = torch.zeros(1, 3, 1, 1)
+    green[0, 1] = 1.0
+    hue = kornia.color.rgb_to_hsv(green)[0, 0].item()
+    assert abs(hue - 2.0943951) < 1e-4  # 120 degrees = 2*pi/3 radians
+
+Augmentations
+-------------
+
+- One :class:`kornia.augmentation.AugmentationSequential` call applies the
+  SAME sampled transform to every registered data type; ``.inverse()``
+  undoes the geometric part for all of them. Never augment image and mask
+  through two separate calls — the random draws will differ.
+
+.. code-block:: python
+
+    import torch
+    import kornia.augmentation as K
+
+    aug = K.AugmentationSequential(
+        K.RandomAffine(degrees=30.0, p=1.0),
+        data_keys=["input", "mask", "keypoints"],
+    )
+    image = torch.rand(1, 3, 64, 64)
+    mask = (torch.rand(1, 1, 64, 64) > 0.5).float()
+    kpts = torch.tensor([[[16.0, 16.0], [48.0, 32.0]]])
+    img_out, mask_out, kpts_out = aug(image, mask, kpts)
+    img_back, mask_back, kpts_back = aug.inverse(img_out, mask_out, kpts_out)
+    assert (kpts_back - kpts).abs().max() < 1e-3
+
+Pitfall checklist
+-----------------
+
+Quick self-review for generated code, most common first:
+
+1. ``(H, W, C)`` NumPy array passed where a tensor is expected — convert
+   with ``kornia.image.image_to_tensor(np_img)[None]``.
+2. ``(w, h)`` passed to a ``dsize``/``size`` argument — they are ``(h, w)``.
+3. ``(y, x)`` (row, col) point order — points are ``(x, y)``.
+4. Assuming uniform ``align_corners`` defaults — see the table above.
+5. Unbatched ``(3, 3)`` homography — add the batch dim: ``M[None]``.
+6. Radians passed to the degree APIs (``rotate``, ``get_rotation_matrix2d``)
+   or degrees passed to the radian APIs (``axis_angle_*``).
+7. Uint8 ``[0, 255]`` values where float ``[0, 1]`` is expected.
+8. Image and mask augmented through two separate augmentation calls.
+9. ``homography_warp`` fed a source→destination pixel homography — it wants
+   destination→source, normalized (or pass ``normalized_homography=False``).
+10. Mixing ``axis_angle_to_rotation_matrix`` (math convention; screen-
+    clockwise for +z) with ``rotate`` (screen-counter-clockwise) without
+    negating the angle.
+11. Treating ``infer_bbox_shape`` output as exclusive width/height — it is
+    inclusive (``+ 1``).
+12. Quaternions constructed in XYZW order — Kornia uses WXYZ.
+13. Expecting hue in ``[0, 360]`` or ``[0, 1]`` — ``rgb_to_hsv`` returns
+    radians ``[0, 2π)``.
+14. Assuming ``resize`` and ``warp_*`` sample pixels identically — their
+    ``align_corners`` defaults differ (see table).
+15. Wrong ``data_keys`` box format — ``"bbox"`` means 4-corner ``(B, 4, 2)``;
+    use ``"bbox_xyxy"``/``"bbox_xywh"`` for coordinate formats.
+
+.. tip::
+
+   Machine-readable copies of these conventions live at
+   `llms.txt <https://kornia.readthedocs.io/en/latest/llms.txt>`_ and
+   `llms-full.txt <https://kornia.readthedocs.io/en/latest/llms-full.txt>`_
+   at the docs root.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,6 +92,7 @@ Join the community
 
    get-started/introduction
    get-started/highlights
+   get-started/conventions
    get-started/installation
    get-started/precision
    get-started/about


### PR DESCRIPTION
Fixes #3892

Adds `docs/source/get-started/conventions.rst` — the canonical "what convention does this function use" page (W1 of the agent-era plan), covering tensor layout, (x,y) vs (h,w) ordering, 2D-vs-3D rotation direction, `warp_perspective` vs `homography_warp` homography direction/normalization, per-function `align_corners` defaults, bbox inclusive arithmetic, quaternion WXYZ order, hue range, and a 15-item pitfall checklist. Every code block carries its own asserts and was executed against this checkout; the two llms files link to and extend from the page (write-once policy).

Addresses the convention-confusion issue class: #2950, #777, #1142, #317.

**Verification — empirical checks (kornia 0.9.0rc1, torch 2.9.1):**

```
bbox (1,1)-(2,2) h,w: 2.0 2.0                       (inclusive +1 confirmed, #1142)
homography_warp(dst->src normalized) == warp_perspective(src->dst pixel): True   (#2950)
axis_angle +90deg about z, R[:2,:2]: [[-0., -1.], [1., -0.]]   (math convention)
rotate(+90) marker (row1,col3) -> [[1, 1]]           (screen-CCW; opposite of axis_angle on y-down)
identity quaternion coeffs: [1.0, 0.0, 0.0, 0.0]     (WXYZ)
hue(red), hue(green): 0.0 2.094395                   (radians, 2pi/3)
meshgrid default range: -1.0 1.0
bbox_xyxy inverse round-trip max err: 0.0
```

**Verification — all 8 page code blocks executed (asserts inside are the tests):**

```
block 0..7: OK
```

**Verification — llms files and links:**

```
$ python3 .github/scripts/check_doc_links.py --offline
35 markdown file(s), 210 external link(s)  ...  no dead links (exit 0)
$ pixi run lint  -> ruff check/format Passed
$ pixi run build-docs -> get-started/conventions.html, llms.txt, llms-full.txt all in build root
```

The conventions.html URL inside the llms files will 404 until this merges and RTD rebuilds `latest` (same pattern as #3891).

Posted on behalf of @ducha-aiki by Claude (Fable 5).
