### PR TITLE
tests: strict no-warnings gate on kornia import

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -51,3 +51,33 @@ def test_import_without_jit_script_deprecation():
         check=False,
     )
     assert result.returncode == 0, f"importing kornia raised a deprecation warning:\n{result.stderr}"
+
+
+def test_import_emits_no_warnings():
+    """Importing kornia must not emit ANY warning, whatever module raises it.
+
+    Stricter companion to the jit-script guard above: torch is imported first so its own
+    import-time warnings (outside kornia's control, and version-dependent) are excluded,
+    then every warning is promoted to an error for the kornia import itself. This is the
+    honest form of the ``python -W error -c "import kornia"`` gate from
+    https://github.com/kornia/kornia/issues/3727 — it fails on any warning kornia's import
+    path emits or triggers, protecting downstream users who run with ``-W error``.
+    """
+    script = textwrap.dedent(
+        """
+        import warnings
+
+        import torch  # noqa: F401  # torch's own import warnings are not kornia's to fix
+
+        warnings.simplefilter("error")
+        import kornia  # noqa: F401
+        """
+    )
+    # Trusted, fixed command (the current interpreter running a literal script); no external input.
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"importing kornia emitted a warning:\n{result.stderr}"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -49,6 +49,7 @@ def test_import_without_jit_script_deprecation():
         capture_output=True,
         text=True,
         check=False,
+        timeout=300,
     )
     assert result.returncode == 0, f"importing kornia raised a deprecation warning:\n{result.stderr}"
 
@@ -62,10 +63,16 @@ def test_import_emits_no_warnings():
     honest form of the ``python -W error -c "import kornia"`` gate from
     https://github.com/kornia/kornia/issues/3727 — it fails on any warning kornia's import
     path emits or triggers, protecting downstream users who run with ``-W error``.
+
+    ``resetwarnings`` first, so filters inherited from the environment (``PYTHONWARNINGS``,
+    a ``-W`` flag propagated by the test runner) cannot make the torch import fail and
+    cannot pre-arm filters that fight the ``simplefilter("error")`` below.
     """
     script = textwrap.dedent(
         """
         import warnings
+
+        warnings.resetwarnings()
 
         import torch  # noqa: F401  # torch's own import warnings are not kornia's to fix
 
@@ -73,11 +80,12 @@ def test_import_emits_no_warnings():
         import kornia  # noqa: F401
         """
     )
-    # Trusted, fixed command (the current interpreter running a literal script); no external input.
+    # Same trusted, fixed command shape as above.
     result = subprocess.run(  # noqa: S603
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
         check=False,
+        timeout=300,
     )
     assert result.returncode == 0, f"importing kornia emitted a warning:\n{result.stderr}"


### PR DESCRIPTION
Fixes #3727

Batch 3 of the agent-era plan turned out to be mostly done on main already: no `@torch.jit.script` decorators remain in `kornia/` (only `jit.is_scripting()` guards and one `jit.ignore`/`jit.annotate`), `torch.cuda.amp.custom_fwd` was already migrated to `torch.amp.custom_fwd` (#3002, closed), and `torch.solve` is gone (#1223, closed). `python -W error -c "import kornia"` passes on torch 2.9.1 / Python 3.11.

What was missing is a strict regression gate. `tests/test_import.py` already guards the jit-script deprecation specifically; this adds the general form: pre-import torch (its own import-time warnings are torch-version-dependent and not kornia's to fix), then `warnings.simplefilter("error")` and import kornia — so ANY warning kornia's import emits or triggers fails the suite, across the full CI matrix (Python 3.11–3.13 × torch 2.5.1/2.9.1).

**Local verification:**

```
$ pixi run -e default uv run pytest tests/test_import.py -v
tests/test_import.py::test_import_without_jit_script_deprecation PASSED
tests/test_import.py::test_import_emits_no_warnings PASSED
2 passed in 2.79s

$ pixi run lint -> ruff check/format Passed
```

Posted on behalf of @ducha-aiki by Claude (Fable 5).
