### PR TITLE
docs: publish the API stability policy

### DIFF
--- a/docs/source/_extra/llms-full.txt
+++ b/docs/source/_extra/llms-full.txt
@@ -17,6 +17,7 @@ These conventions hold library-wide; per-function docs note any exception.
 - **Devices/dtypes:** ops run on whatever device/dtype the input tensors carry; there is no implicit `.cuda()` or `.float()`.
 
 Full conventions reference with runnable proofs: <https://kornia.readthedocs.io/en/latest/get-started/conventions.html>
+Stability: the core modules (geometry, augmentation, color, filters, enhance, losses, metrics, morphology, io, image) follow a written deprecation policy — public symbols warn for at least one minor release before breaking: <https://kornia.readthedocs.io/en/latest/get-started/stability.html>
 
 ## kornia.geometry — warps, homographies, camera geometry
 

--- a/docs/source/_extra/llms.txt
+++ b/docs/source/_extra/llms.txt
@@ -17,6 +17,7 @@ For the full self-contained reference with runnable examples, fetch [llms-full.t
 
 - [Introduction](https://kornia.readthedocs.io/en/latest/get-started/introduction.html): what Kornia is and the design principles behind it
 - [Conventions & Pitfalls](https://kornia.readthedocs.io/en/latest/get-started/conventions.html): the canonical conventions reference — read before generating Kornia code
+- [API Stability Policy](https://kornia.readthedocs.io/en/latest/get-started/stability.html): which modules are stable, and how deprecation works
 - [Installation](https://kornia.readthedocs.io/en/latest/get-started/installation.html): pip/conda/source installation
 - [Tutorials](https://kornia.github.io/tutorials/): runnable end-to-end examples
 

--- a/docs/source/get-started/stability.rst
+++ b/docs/source/get-started/stability.rst
@@ -41,7 +41,7 @@ The promises (stable core)
 
 1. **Deprecation before removal.** A public symbol is never removed or given
    an incompatible signature in a single step. It first spends at least one
-   minor release wrapped in :func:`kornia.core._compat.deprecated`, which
+   minor release wrapped in ``kornia.core._compat.deprecated``, which
    keeps the old call working while emitting a :class:`DeprecationWarning`
    that names the replacement and the version that introduced the
    deprecation (this is the mechanism the 0.8.3 ``kornia.utils`` →
@@ -55,9 +55,10 @@ The promises (stable core)
 3. **Release notes carry the ledger.** Every deprecation, removal, and
    behavior change in the stable core is listed in the release notes of the
    release that introduces it.
-4. **Imports stay clean.** ``import kornia`` emits no warnings; this is
-   enforced by a CI-gated test (``tests/test_import.py``), so downstream
-   ``-W error`` users are safe.
+4. **Imports stay clean.** Importing kornia emits no warnings of its own —
+   none raised or triggered by kornia's import path, once PyTorch itself is
+   loaded. This is enforced by CI-gated tests (``tests/test_import.py``), so
+   downstream ``-W error`` users are safe.
 5. **Conventions are stable.** The documented
    :doc:`conventions </get-started/conventions>` (tensor layout, coordinate
    order, angle units, homography conventions) are part of the API surface

--- a/docs/source/get-started/stability.rst
+++ b/docs/source/get-started/stability.rst
@@ -1,0 +1,80 @@
+API Stability Policy
+====================
+
+Kornia is depended on by a large installed base (millions of downloads per
+month) and, increasingly, by language models that carry a lagging snapshot of
+the API in their weights. Both are punished by silent churn. This page states
+what you may rely on, per module tier, and what change looks like when it has
+to happen.
+
+Stability tiers
+---------------
+
+**Stable core** — ``kornia.geometry``, ``kornia.augmentation``,
+``kornia.color``, ``kornia.filters``, ``kornia.enhance``, ``kornia.losses``,
+``kornia.metrics``, ``kornia.morphology``, ``kornia.io``, ``kornia.image``,
+``kornia.core``, and the classical (non-pretrained) parts of
+``kornia.feature`` (e.g. detectors, descriptors, matching utilities). The
+promises below apply in full.
+
+**Best-effort** — pre-trained model wrappers (LoFTR, LightGlue, DISK, DeDoDe,
+SAM, and friends in ``kornia.feature``/``kornia.models``), ``kornia.onnx``,
+and the multi-framework ``kornia.transpiler``. These track external
+checkpoints, upstream repositories, and PyTorch internals; they are kept
+working on currently supported PyTorch versions, but their interfaces and
+weights may change with their upstreams, and they may be frozen or split out
+rather than grown.
+
+**Experimental** — ``kornia.contrib`` and anything underscore-prefixed or
+absent from the rendered documentation. No stability promise.
+
+What counts as public API
+-------------------------
+
+A symbol is public when it appears in the rendered documentation at
+`kornia.readthedocs.io <https://kornia.readthedocs.io/en/latest/>`_.
+Underscore-prefixed modules and names, and undocumented helpers, are private
+regardless of importability.
+
+The promises (stable core)
+--------------------------
+
+1. **Deprecation before removal.** A public symbol is never removed or given
+   an incompatible signature in a single step. It first spends at least one
+   minor release wrapped in :func:`kornia.core._compat.deprecated`, which
+   keeps the old call working while emitting a :class:`DeprecationWarning`
+   that names the replacement and the version that introduced the
+   deprecation (this is the mechanism the 0.8.3 ``kornia.utils`` →
+   ``kornia.image`` migration used).
+2. **No silent semantic changes.** Changing a default that alters numerical
+   output (interpolation flags, ``align_corners``, padding modes, coordinate
+   conventions) counts as a breaking change and gets the same
+   deprecation-window treatment. The historical ``align_corners``
+   default flip, which changed results without erroring, is the exact
+   pattern this rule forbids.
+3. **Release notes carry the ledger.** Every deprecation, removal, and
+   behavior change in the stable core is listed in the release notes of the
+   release that introduces it.
+4. **Imports stay clean.** ``import kornia`` emits no warnings; this is
+   enforced by a CI-gated test (``tests/test_import.py``), so downstream
+   ``-W error`` users are safe.
+5. **Conventions are stable.** The documented
+   :doc:`conventions </get-started/conventions>` (tensor layout, coordinate
+   order, angle units, homography conventions) are part of the API surface
+   and covered by the same rules.
+
+Versioning caveat
+-----------------
+
+Kornia is pre-1.0 and follows semver's 0.x semantics: minor releases (0.8 →
+0.9) are where deprecation windows close and breaking changes land; patch
+releases (0.9.0 → 0.9.1) are fixes only. The promises above are what makes
+0.x livable: you get at least one minor release of warnings before anything
+breaks.
+
+Escape hatch
+------------
+
+A change that fixes a correctness bug (wrong math, wrong convention versus
+the documented one) or a security issue may ship without a deprecation
+window. When that happens the release notes say so explicitly.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ Join the community
    get-started/introduction
    get-started/highlights
    get-started/conventions
+   get-started/stability
    get-started/installation
    get-started/precision
    get-started/about


### PR DESCRIPTION
Fixes #3895

Adds `docs/source/get-started/stability.rst` (S6 of the agent-era plan) and links it from the llms files. **This is a policy commitment, so treat the PR as the approval step** — the promises are drafted to match what the project already does in practice:

- **Tiers:** stable core (geometry, augmentation, color, filters, enhance, losses, metrics, morphology, io, image, core, classical feature ops), best-effort (pretrained wrappers, onnx, transpiler), experimental (contrib, underscored/undocumented).
- **Promises:** deprecation-before-removal via the existing `kornia.core._compat.deprecated` mechanism (as used for the 0.8.3 `kornia.utils` migration); semantic default changes (the historical `align_corners` flip, #388/#546) count as breaking; release-notes ledger; warning-free import enforced by `tests/test_import.py`; documented conventions are API surface.
- **0.x caveat** stated honestly: minor releases close deprecation windows; patches are fixes only.

Verification: `pixi run lint` passed; clean `pixi run build-docs` renders `get-started/stability.html`; offline link check passes. The stability.html URL in the llms files 404s until this merges and RTD rebuilds (same pattern as #3891/#3893).

Posted on behalf of @ducha-aiki by Claude (Fable 5).
