### PR TITLE
ci: skip issue-triage guardrails for maintainer-authored issues

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -35,7 +35,7 @@ jobs:
             }
 
             if (isMaintainer) {
-              core.info(`@${author} has write access; skipping triage label and welcome message.`);
+              core.info(`@${author} has write access or above; skipping triage label and welcome message.`);
               return;
             }
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -13,10 +13,32 @@ jobs:
     name: Triage New Issue
     runs-on: ubuntu-latest
     steps:
-      - name: Add triage label
+      - name: Triage new issue
         uses: actions/github-script@v9
         with:
           script: |
+            const author = context.payload.issue.user.login;
+
+            // The triage label and wait-for-assignment message exist to route
+            // external contributors; maintainers (write access or above)
+            // triage their own issues.
+            let isMaintainer = false;
+            try {
+              const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author
+              });
+              isMaintainer = ['admin', 'maintain', 'write'].includes(perm.permission);
+            } catch (error) {
+              core.warning(`Could not determine permission for @${author}: ${error.message}`);
+            }
+
+            if (isMaintainer) {
+              core.info(`@${author} has write access; skipping triage label and welcome message.`);
+              return;
+            }
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -24,10 +46,6 @@ jobs:
               labels: ['triage']
             });
 
-      - name: Post welcome message
-        uses: actions/github-script@v9
-        with:
-          script: |
             const welcomeMessage = '## ⚠️ Before Submitting a PR\n\n' +
               'Please wait for a maintainer to approve and assign this issue to you or someone else before submitting a PR. ' +
               'PRs submitted without prior approval and assignment may be closed. ' +


### PR DESCRIPTION
Companion to the pr-validation change merged in #3891 (the same guardrail-noise problem, surfaced again on issue #3895): `issue-triage.yml` posted the '⚠️ Before Submitting a PR — please wait for a maintainer to approve and assign' comment (and added the `triage` label) on every new issue, including issues opened by maintainers about their own planned work. The workflow now checks the issue author's repo permission via `getCollaboratorPermissionLevel` and skips both steps for write access and above, with a try/catch fallback to the old behavior if the permission lookup fails.

Verified: YAML parses; embedded script passes `node --check`; the permission endpoint returns `read` (HTTP 200) for arbitrary non-collaborators on this public repo, so the fallback path is for genuine API failures only.

Posted on behalf of @ducha-aiki by Claude (Fable 5).
