### PR TITLE
tests: exclude onnxruntime import-time warnings from the no-warnings gate

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -70,11 +70,18 @@ def test_import_emits_no_warnings():
     """
     script = textwrap.dedent(
         """
+        import contextlib
         import warnings
 
         warnings.resetwarnings()
 
         import torch  # noqa: F401  # torch's own import warnings are not kornia's to fix
+
+        # Same for onnxruntime, which kornia.feature.lightglue_onnx imports eagerly when
+        # installed: its import-time platform warnings (e.g. "Unsupported Windows version
+        # (2025server)" on windows-2025 runners) are not kornia's to fix either.
+        with contextlib.suppress(ImportError):
+            import onnxruntime  # noqa: F401
 
         warnings.simplefilter("error")
         import kornia  # noqa: F401


### PR DESCRIPTION
Relates to #3727 / follow-up to #3894.

The strict import gate merged in #3894 fails on Windows Server 2025 runners (which GitHub is rolling out as `windows-latest`): `import kornia` eagerly imports onnxruntime via `kornia.feature.lightglue_onnx` when it is installed, and onnxruntime warns at import — `UserWarning: Unsupported Windows version (2025server)` — which the gate promotes to an error. #3894's own CI passed because its runners still drew Server 2022; **main is currently red on any windows-2025 runner**, and it surfaced on #3898's CI (whose own changes are unrelated).

Fix follows the gate's own scoping ("third-party import warnings are not kornia's to fix"): pre-import onnxruntime alongside torch, guarded by `contextlib.suppress(ImportError)`, before arming the error filter.

**This unblocks #3898** — re-run its failed Windows jobs after this merges.

Verification: `pixi run -e default uv run pytest tests/test_import.py -q` → 2 passed; lint passes.

Posted on behalf of @ducha-aiki by Claude (Fable 5).
