### PR TITLE
ci: fix docs workflow startup failure on pull_request events

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'docs/**'
       - '*.rst'
+      - '.github/workflows/docs.yml'
   workflow_call:
     inputs:
       python-version:
@@ -36,9 +37,12 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: ${{ inputs.fail-fast }}
+      # On direct pull_request events the `inputs` context is empty (the workflow_call
+      # defaults do NOT apply), so fall back explicitly — otherwise fromJSON('') fails
+      # at workflow parse time and the run dies at startup with zero jobs.
+      fail-fast: ${{ inputs.fail-fast || false }}
       matrix:
-        python-version: ${{ fromJSON(inputs.python-version) }}
+        python-version: ${{ fromJSON(inputs.python-version || '["3.11"]') }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Every PR touching `docs/**` currently gets a red X from `docs.yml` with **zero jobs executed** (seen on #3893, #3896, #3898). Root cause: the workflow serves both `workflow_call` (with input defaults) and direct `pull_request` triggers, but on `pull_request` events the `inputs` context is empty — the `workflow_call` defaults do not apply — so `fromJSON(inputs.python-version)` fails at workflow parse time and the run dies at startup.

Fix: explicit fallbacks (`inputs.python-version || '["3.11"]'`, `inputs.fail-fast || false`), matching the values the `workflow_call` defaults would provide. Also adds the workflow file to its own `paths` triggers, so this PR itself exercises the fixed `pull_request` path — the `docs` check on this PR running (instead of dying with zero jobs) is the verification.

Not a required check, so nothing was blocked — but every docs PR since the trigger was added has carried a false-failure X.

Posted on behalf of @ducha-aiki by Claude (Fable 5).
