### PR TITLE
docs: fix generate_examples crash after kornia.utils namespace removal

### DIFF
--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -89,7 +89,7 @@ def draw_bbox_kpts(imgs: torch.Tensor, bboxes: torch.Tensor, keypoints: torch.Te
         rectangle2[..., n, 2] = keypoints[..., n, 0] + 2
         rectangle2[..., n, 3] = keypoints[..., n, 1] + 2
     color = torch.tensor([0, 0, 1]).repeat(imgs.shape[0], imgs.shape[1], 1)
-    imgs_draw = K.utils.draw_rectangle(imgs_draw, rectangle2, color=color, fill=True)
+    imgs_draw = K.image.draw_rectangle(imgs_draw, rectangle2, color=color, fill=True)
 
     return imgs_draw
 
@@ -242,7 +242,7 @@ def main():
 
         output = torch.cat([img_in[0], img_in[1], img_aug], dim=-1)
         # save the output image
-        out_np = K.utils.tensor_to_image((output * 255.0).byte())
+        out_np = K.image.tensor_to_image((output * 255.0).byte())
         cv2.imwrite(str(OUTPUT_PATH / f"{aug_name}.png"), out_np)
         sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
         print(f"Generated image example for {aug_name}. {sig}")
@@ -263,7 +263,7 @@ def main():
 
         output = torch.cat([img_in[0], img_in[1], img_aug[0]], dim=-1)
         # save the output image
-        out_np = K.utils.tensor_to_image((output * 255.0).byte())
+        out_np = K.image.tensor_to_image((output * 255.0).byte())
         cv2.imwrite(str(OUTPUT_PATH / f"{aug_name}.png"), out_np)
         sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
         print(f"Generated image example for {aug_name}. {sig}")
@@ -323,7 +323,7 @@ def main():
         output = torch.cat([inp[0], *(out[i] for i in range(out.size(0)))], dim=-1)
 
         # save the output image
-        out_np = K.utils.tensor_to_image((output * 255.0).byte())
+        out_np = K.image.tensor_to_image((output * 255.0).byte())
         cv2.imwrite(str(OUTPUT_PATH / f"{aug_name}.png"), out_np)
         sig = f"{aug_name}({', '.join([str(a) for a in args])}, p=1.0)"
         print(f"Generated image example for {aug_name}. {sig}")


### PR DESCRIPTION
## What

Replaces the four remaining `K.utils.*` calls in `docs/generate_examples.py` with their new homes: `K.image.draw_rectangle` (1 site) and `K.image.tensor_to_image` (3 sites).

## Why

The deprecation-hygiene cleanup removed the top-level `kornia.utils` import, but `conf.py` executes `generate_examples.main()` on every docs build. Any **fresh** checkout (i.e. every ReadTheDocs PR build) now dies during Sphinx config evaluation with:

```
AttributeError: module 'kornia' has no attribute 'utils'
```

This is currently failing the `docs/readthedocs.org:kornia` check on all open dependabot PRs (#3866, #3689, #3668 — e.g. https://app.readthedocs.org/projects/kornia/builds/33961875/). Builds of `latest` on main still pass only because the RTD checkout for that version has the example images cached from before the removal, so the crashing code path is skipped.

## Proof of execution

`generate_examples.main()` run locally end-to-end with the fix:

```
...
Generated image example for response function KeyNet
Generated image example for response function DISK
Generated image example for response function ALIKED
Generated image example for response function XFeat
generate_examples.main() completed OK
```

`pixi run lint`: ruff check Passed, ruff format Passed.

Note: code snippets in `docs/source/models.rst` / `onnx.rst` still mention `kornia.utils.sample.get_sample_images` — those are non-executed code blocks, left for a follow-up.

Posted on behalf of @ducha-aiki by Claude (Fable 5).
