### PR TITLE
ci: run torch 2.5.1 Windows legs on windows-2022

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -69,6 +69,28 @@ jobs:
           # macOS only runs float32 tests
           - os: macos-latest
             pytorch-dtype: "float64"
+          # torch 2.5.1 wheels crash with STATUS_ILLEGAL_INSTRUCTION (0xc000001d) in
+          # affine_grid on the windows-2025 runner image (now rolling out as
+          # windows-latest); run those legs on windows-2022 via `include` below.
+          - os: windows-latest
+            pytorch-version: "2.5.1"
+        include:
+          - os: windows-2022
+            pytorch-dtype: "float32"
+            python-version: "3.11"
+            pytorch-version: "2.5.1"
+          - os: windows-2022
+            pytorch-dtype: "float64"
+            python-version: "3.11"
+            pytorch-version: "2.5.1"
+          - os: windows-2022
+            pytorch-dtype: "float32"
+            python-version: "3.12"
+            pytorch-version: "2.5.1"
+          - os: windows-2022
+            pytorch-dtype: "float64"
+            python-version: "3.12"
+            pytorch-version: "2.5.1"
 
     uses: ./.github/workflows/tests.yml
     with:

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -123,6 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: ["windows-latest"]
         pytorch-dtype: ["float32", "float64"]
         python-version: ["3.11", "3.12", "3.13"]
         pytorch-version: ["2.5.1", "2.9.1"]
@@ -130,10 +131,31 @@ jobs:
           # PyTorch 2.5.1 doesn't have wheels for Python 3.13 on Windows
           - python-version: "3.13"
             pytorch-version: "2.5.1"
+          # torch 2.5.1 wheels crash with STATUS_ILLEGAL_INSTRUCTION (0xc000001d) on
+          # the windows-2025 runner image; run those legs on windows-2022 instead.
+          - os: windows-latest
+            pytorch-version: "2.5.1"
+        include:
+          - os: windows-2022
+            pytorch-dtype: "float32"
+            python-version: "3.11"
+            pytorch-version: "2.5.1"
+          - os: windows-2022
+            pytorch-dtype: "float64"
+            python-version: "3.11"
+            pytorch-version: "2.5.1"
+          - os: windows-2022
+            pytorch-dtype: "float32"
+            python-version: "3.12"
+            pytorch-version: "2.5.1"
+          - os: windows-2022
+            pytorch-dtype: "float64"
+            python-version: "3.12"
+            pytorch-version: "2.5.1"
 
     uses: ./.github/workflows/tests.yml
     with:
-      os: "windows-latest"
+      os: ${{ matrix.os }}
       python-version: '["${{ matrix.python-version }}"]'
       pytorch-version: '["${{ matrix.pytorch-version }}"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}


### PR DESCRIPTION
Third casualty of GitHub's windows-2025 runner rollout (after #3899's onnxruntime warning): torch 2.5.1 wheels crash with `STATUS_ILLEGAL_INSTRUCTION` (`0xc000001d`) inside `torch.nn.functional.affine_grid` on the `windows-2025-vs2026` image. Observed **identically on two consecutive runs** of PR #3887's `tests (windows-latest, float32, 3.11, 2.5.1)` leg — deterministic, not runner lottery — and it will fail every PR that draws the new image.

Fix: exclude `windows-latest × 2.5.1` from the PR and scheduled matrices and re-add those legs (3.11/3.12 × float32/float64) pinned to `windows-2022` via `include`. torch 2.9.1 legs stay on `windows-latest`. Coverage is unchanged; only the runner image for the old-torch legs is pinned.

This unblocks #3887 (docstring fix, red only on this leg). Sunset note: drop the pin when torch 2.5.1 leaves the support matrix, or if a newer 2.5.x/runner image resolves the crash.

Verification: YAML parses; matrix arithmetic — PR workflow previously ran windows 2.5.1 legs {3.11, 3.12} × {float32, float64} = 4 jobs, the include re-adds exactly those 4 on windows-2022.

Posted on behalf of @ducha-aiki by Claude (Fable 5).
