### PR TITLE
ci: clamp CPU ISA to AVX2 for torch 2.5.1 Windows legs (0xc000001d)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,17 @@ jobs:
       - name: Install dependencies
         run: pixi run -e ${{ steps.pixi-env.outputs.name }} install
 
+      # torch 2.5.1 Windows wheels crash with STATUS_ILLEGAL_INSTRUCTION (0xc000001d) inside
+      # affine_grid on part of the runner fleet (host-CPU-dependent, hits both windows-2022 and
+      # windows-2025 — the CPU-autocast bf16 path dispatches AVX512 kernels some hosts lack).
+      # Clamp both ISA dispatchers to AVX2 for these legs. Drop when 2.5.1 leaves the matrix.
+      - name: Clamp CPU ISA for torch 2.5.1 on Windows
+        if: runner.os == 'Windows' && startsWith(matrix.pytorch-version, '2.5')
+        shell: bash
+        run: |
+          echo "ATEN_CPU_CAPABILITY=avx2" >> $GITHUB_ENV
+          echo "DNNL_MAX_CPU_ISA=AVX2" >> $GITHUB_ENV
+
       - name: Run tests
         env:
           KORNIA_TEST_DEVICE: cpu


### PR DESCRIPTION
## The failure

Scheduled/push CPU runs on main intermittently fail on the torch 2.5.1 Windows legs — most recently `tests-cpu-windows (windows-2022, float32, 3.12, 2.5.1)` in run [31202681857](https://github.com/kornia/kornia/actions/runs/31202681857):

```
Windows fatal exception: code 0xc000001d
Current thread ...:
  File ".venv\Lib\site-packages\torch\nn\functional.py", line 5210 in affine_grid
  File "kornia\geometry\transform\imgwarp.py", line 1017 in warp_affine3d
  File "kornia\augmentation\_3d\geometric\affine.py", line 179 in apply_transform
tests/augmentation/test_base.py::TestGeometricAugmentationBase3D::test_autocast[cpu-float32-batch_prob0]
```

## Root cause

This is the same `STATUS_ILLEGAL_INSTRUCTION` crash #3903 saw on windows-2025 and avoided by pinning the 2.5.1 legs to windows-2022 — **but it has now reproduced on windows-2022 itself**, while run [31201237588](https://github.com/kornia/kornia/actions/runs/31201237588) (identical config, 19 minutes earlier) was fully green. Same code, same image, different physical host → the crash is **host-CPU-dependent, not image-dependent**. The GitHub Windows runner fleet is heterogeneous; torch 2.5.1's Windows wheel dispatches AVX512-family kernels (the crashing tests are the CPU-autocast/bf16 ones) that some hosts don't support. Which host the job lands on decides the outcome — that's why the #3903 pin looked like a fix during its verification runs.

## The fix

Clamp both native ISA dispatchers to AVX2 for exactly the torch 2.5.1 Windows legs, in the reusable `tests.yml` (so PR and scheduled matrices are both covered):

- `ATEN_CPU_CAPABILITY=avx2` — ATen vectorized-kernel dispatch
- `DNNL_MAX_CPU_ISA=AVX2` — oneDNN JIT dispatch

Coverage is preserved (no tests skipped, no matrix legs dropped); the 2.9.1 legs are untouched. Drop the clamp together with the windows-2022 pin when 2.5.1 leaves the matrix.

## Verification

The crash is host-dependent and Windows-only, so it can't be reproduced locally, and a single green CI run is weak evidence (the pre-fix config also went green when it landed on a good host). What this PR's CI *does* prove is that the env vars are accepted and the full suite passes under the AVX2 clamp on whatever host it draws. Confidence that the illegal-instruction crash is gone accrues over the next scheduled runs; if it ever reproduces **with the clamp active**, the ISA hypothesis is falsified and the fallback is dropping the 2.5.1 Windows legs (2.5.1 stays covered on Ubuntu and macOS).

YAML validated locally (`yaml.safe_load` OK).

Posted on behalf of @ducha-aiki by Claude (Fable 5).
