### PR TITLE
fix(filters): cast dissolving inputs to the VAE dtype, not only device

### DIFF
--- a/kornia/filters/dissolving.py
+++ b/kornia/filters/dissolving.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import os
 from typing import Any
 
@@ -140,7 +142,7 @@ class _DissolvingWraper_HF:
     @torch.no_grad()
     def encode_tensor_to_latent(self, image: torch.Tensor) -> torch.Tensor:
         with torch.no_grad():
-            # The VAE weights stay in the pipeline dtype (float32), so inputs of any
+            # The VAE weights stay in the pipeline dtype (e.g. float32), so inputs of any
             # user dtype (e.g. float64) must be cast to it, not only moved to the device.
             image = (image / 0.5 - 1).to(device=self.model.device, dtype=self.model.vae.dtype)
             latents = self.model.vae.encode(image)["latent_dist"].sample()
@@ -149,7 +151,7 @@ class _DissolvingWraper_HF:
 
     @torch.no_grad()
     def decode_tensor_to_latent(self, latents: torch.Tensor) -> torch.Tensor:
-        # Perform in-place detach to reduce memory usage and copies
+        # Detach from autograd, then match the VAE device/dtype (allocates only on mismatch).
         latents = latents.detach().to(device=self.model.device, dtype=self.model.vae.dtype)
         latents = latents * (1.0 / 0.18215)  # Fused division as multiplication (faster)
         # Reduce attribute lookups by localizing frequently used attributes

--- a/kornia/filters/dissolving.py
+++ b/kornia/filters/dissolving.py
@@ -140,7 +140,9 @@ class _DissolvingWraper_HF:
     @torch.no_grad()
     def encode_tensor_to_latent(self, image: torch.Tensor) -> torch.Tensor:
         with torch.no_grad():
-            image = (image / 0.5 - 1).to(self.model.device)
+            # The VAE weights stay in the pipeline dtype (float32), so inputs of any
+            # user dtype (e.g. float64) must be cast to it, not only moved to the device.
+            image = (image / 0.5 - 1).to(device=self.model.device, dtype=self.model.vae.dtype)
             latents = self.model.vae.encode(image)["latent_dist"].sample()
             latents = latents * 0.18215
         return latents
@@ -148,7 +150,7 @@ class _DissolvingWraper_HF:
     @torch.no_grad()
     def decode_tensor_to_latent(self, latents: torch.Tensor) -> torch.Tensor:
         # Perform in-place detach to reduce memory usage and copies
-        latents = latents.detach()
+        latents = latents.detach().to(device=self.model.device, dtype=self.model.vae.dtype)
         latents = latents * (1.0 / 0.18215)  # Fused division as multiplication (faster)
         # Reduce attribute lookups by localizing frequently used attributes
         vae_decode = self.model.vae.decode


### PR DESCRIPTION
Fixes 3908 (https://github.com/kornia/kornia/issues/3908).

The scheduled `coverage / slow (float64)` job fails in `TestStableDiffusionDissolving` with `RuntimeError: Input type (double) and bias type (float) should be the same`. Root cause: `encode_tensor_to_latent` does `.to(self.model.device)` — device only — while the SD VAE weights stay in the pipeline dtype (float32), so the float64 suite's double input crashes in the VAE's first conv. `decode_tensor_to_latent` has the same latent-dtype hole for caller-provided latents.

Fix: cast to `self.model.vae.dtype` alongside the device move in both entry points. This matches the contract the test already documents ("the model internally converts latents to its own dtype", `tests/filters/test_dissolving.py:49`) and keeps float32 behavior byte-identical (the cast is a no-op there). Output stays in the model dtype, as the tests expect.

Reproduced locally before the fix (same three failures as CI), verified after:

```
# before (main):
FAILED tests/filters/test_dissolving.py::TestStableDiffusionDissolving::test_encode_tensor_to_latent[cpu-float64]
FAILED tests/filters/test_dissolving.py::TestStableDiffusionDissolving::test_decode_tensor_to_latent[cpu-float64]
FAILED tests/filters/test_dissolving.py::TestStableDiffusionDissolving::test_dissolve[cpu-float64]
3 failed, 2 passed, 1 warning in 535.83s (0:08:55)

# after (this branch):
$ KORNIA_TEST_RUNSLOW=true pixi run test tests/filters/test_dissolving.py --dtype=float32,float64
8 passed, 1 warning in 55.42s
$ pixi run lint
ruff check...Passed
ruff format...Passed
```

Algorithm source: n/a — dtype-handling fix in the existing HF-diffusers wrapper.

Posted on behalf of @ducha-aiki by Claude (Fable 5).
