### PR TITLE
ci: extend the Windows AVX2 ISA clamp to every torch version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,12 +88,13 @@ jobs:
       - name: Install dependencies
         run: pixi run -e ${{ steps.pixi-env.outputs.name }} install
 
-      # torch 2.5.1 Windows wheels crash with STATUS_ILLEGAL_INSTRUCTION (0xc000001d) inside
-      # affine_grid on part of the runner fleet (host-CPU-dependent, hits both windows-2022 and
-      # windows-2025 — the CPU-autocast bf16 path dispatches AVX512 kernels some hosts lack).
-      # Clamp both ISA dispatchers to AVX2 for these legs. Drop when 2.5.1 leaves the matrix.
-      - name: Clamp CPU ISA for torch 2.5.1 on Windows
-        if: runner.os == 'Windows' && startsWith(matrix.pytorch-version, '2.5')
+      # torch Windows wheels crash with STATUS_ILLEGAL_INSTRUCTION (0xc000001d) inside
+      # affine_grid on part of the runner fleet — observed on torch 2.5.1 AND 2.9.1, on both
+      # windows-2022 and windows-2025 (host-CPU-dependent: the CPU-autocast bf16 path
+      # dispatches AVX512 kernels some hosts don't actually execute). Clamp both ISA
+      # dispatchers to AVX2 on every Windows leg.
+      - name: Clamp CPU ISA on Windows
+        if: runner.os == 'Windows'
         shell: bash
         run: |
           echo "ATEN_CPU_CAPABILITY=avx2" >> $GITHUB_ENV


### PR DESCRIPTION
Follow-up to #3907, which scoped the `ATEN_CPU_CAPABILITY`/`DNNL_MAX_CPU_ISA=AVX2` clamp to torch 2.5.1 — the same `0xc000001d` (STATUS_ILLEGAL_INSTRUCTION) crash inside `affine_grid` just reproduced on **torch 2.9.1 / windows-latest / Python 3.13** in PR #3909's CI:

```
Windows fatal exception: code 0xc000001d
  File "...torch\nn\functional.py", line 5210 in affine_grid
  File "kornia\geometry\transform\imgwarp.py", line 1017 in warp_affine3d
tests/augmentation/test_base.py::TestGeometricAugmentationBase3D::test_autocast[...]
```

That falsifies the version-specific scoping. All four sightings now share one signature — CPU-autocast tests → bf16 kernels in `affine_grid` → illegal instruction — across torch 2.5.1 and 2.9.1, windows-2022 and windows-2025. Consistent explanation: a subset of the heterogeneous Windows runner fleet advertises AVX512-BF16 the VM doesn't actually execute, so any torch's oneDNN/ATen dispatch can emit the fatal instruction; which host a job draws decides the outcome.

Fix: drop the `startsWith(matrix.pytorch-version, '2.5')` condition — clamp every Windows leg to AVX2 (oneDNN falls back to its reference bf16 path; autocast tests still exercise the same logic). Once this proves out over the scheduled runs, the #3903 windows-2022 pin can be reverted as a cleanup since the image was never the variable.

YAML validated locally. After merge, PR #3909 needs a branch update (not a re-run — re-runs use the original workflow snapshot) to pick the clamp up.

Posted on behalf of @ducha-aiki by Claude (Fable 5).
