### PR TITLE
perf(color): branchless hue selection in rgb_to_hsv (8.7x on MPS, byte-identical)

### DIFF
--- a/kornia/color/hsv.py
+++ b/kornia/color/hsv.py
@@ -53,8 +53,8 @@ def rgb_to_hsv(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     if len(image.shape) < 3 or image.shape[-3] != 3:
         raise ValueError(f"Input size must have a shape of (*, 3, H, W). Got {image.shape}")
 
-    max_rgb, argmax_rgb = image.max(-3)
-    min_rgb, _argmin_rgb = image.min(-3)
+    max_rgb = image.amax(-3)
+    min_rgb = image.amin(-3)
     deltac = max_rgb - min_rgb
 
     v = max_rgb
@@ -67,8 +67,12 @@ def rgb_to_hsv(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     h2 = (rc - bc) + 2.0 * deltac
     h3 = (gc - rc) + 4.0 * deltac
 
-    h = torch.stack((h1, h2, h3), dim=-3) / deltac.unsqueeze(-3)
-    h = torch.gather(h, dim=-3, index=argmax_rgb.unsqueeze(-3)).squeeze(-3)
+    # select the sextant of the first maximal channel, matching torch.max(dim) tie-breaking;
+    # branchless selection avoids max/argmax-with-indices and gather, which are ~100x slower
+    # than amax/pointwise ops on MPS and block fusion under torch.compile
+    r, g, b = torch.unbind(image, dim=-3)
+    h = torch.where((r >= g) & (r >= b), h1, torch.where(g >= b, h2, h3))
+    h = h / deltac
     h = (h / 6.0) % 1.0
     h = 2.0 * math.pi * h  # we return 0/2pi output
 

--- a/tests/color/test_hsv.py
+++ b/tests/color/test_hsv.py
@@ -125,7 +125,7 @@ class TestRgbToHsv(BaseTester):
         )
         expected_h = torch.tensor([[0.0, math.pi / 3.0, math.pi, 5.0 * math.pi / 3.0]], device=device, dtype=dtype)
         hsv = kornia.color.rgb_to_hsv(data)
-        self.assert_close(hsv[0], expected_h)
+        self.assert_close(hsv[..., 0, :, :], expected_h)
 
     def test_nan_rgb_to_hsv(self, device, dtype):
         if dtype == torch.float16:

--- a/tests/color/test_hsv.py
+++ b/tests/color/test_hsv.py
@@ -109,6 +109,24 @@ class TestRgbToHsv(BaseTester):
 
         self.assert_close(kornia.color.rgb_to_hsv(data), expected)
 
+    def test_channel_ties(self, device, dtype):
+        # Pins the argmax tie-breaking convention (first maximal channel wins) so that
+        # implementation changes cannot silently alter the hue of achromatic/boundary pixels.
+        # Snippet used to generate expected hues (torch, first-occurrence argmax semantics):
+        # gray r=g=b -> h=0; yellow r=g>b -> pi/3; cyan g=b>r -> pi; magenta r=b>g -> 5*pi/3
+        data = torch.tensor(
+            [
+                [[0.5000, 0.5000, 0.3000, 0.6000]],
+                [[0.5000, 0.5000, 0.7000, 0.2000]],
+                [[0.5000, 0.1000, 0.7000, 0.6000]],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        expected_h = torch.tensor([[0.0, math.pi / 3.0, math.pi, 5.0 * math.pi / 3.0]], device=device, dtype=dtype)
+        hsv = kornia.color.rgb_to_hsv(data)
+        self.assert_close(hsv[0], expected_h)
+
     def test_nan_rgb_to_hsv(self, device, dtype):
         if dtype == torch.float16:
             pytest.skip("not work for half-precision")
@@ -135,6 +153,13 @@ class TestRgbToHsv(BaseTester):
         ops = kornia.color.RgbToHsv().to(device, dtype)
         fcn = kornia.color.rgb_to_hsv
         self.assert_close(ops(img), fcn(img))
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.rand(B, C, H, W, device=device, dtype=dtype)
+        op = kornia.color.rgb_to_hsv
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(img), op_optimized(img))
 
 
 class TestHsvToRgb(BaseTester):
@@ -251,3 +276,10 @@ class TestHsvToRgb(BaseTester):
         ops = kornia.color.HsvToRgb().to(device, dtype)
         fcn = kornia.color.hsv_to_rgb
         self.assert_close(ops(img), fcn(img))
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        B, C, H, W = 2, 3, 4, 4
+        img = torch.rand(B, C, H, W, device=device, dtype=dtype)
+        op = kornia.color.hsv_to_rgb
+        op_optimized = torch_optimizer(op)
+        self.assert_close(op(img), op_optimized(img))


### PR DESCRIPTION
Towards #3914 (mechanism 1 of 2; the `_assert_async` guard follows as a separate PR).

## What

`rgb_to_hsv` computed `image.max(-3)` / `image.min(-3)` (values **and** indices) and used the argmax only to `gather` one of the three hue-sextant formulas; the argmin was never used at all. On MPS the with-indices channel reduction is ~100× slower than the values-only one (34.6 ms vs 0.34 ms at 16×3×256×256 f32), which made `rgb_to_hsv` the dominant cost of `ColorJiggle` (paid twice per call, via `adjust_hue` and `adjust_saturation`).

This PR switches to `amax`/`amin` and selects the hue sextant with a branchless `torch.where` chain that replicates `torch.max(dim)` first-occurrence tie-breaking exactly.

## Eager preservation (byte-to-byte)

Verified against `main` under identical seeds: **20/20 reference tensors byte-identical** (`torch.equal`) — `rgb_to_hsv` outputs *and* input gradients on CPU + MPS for float16/float32/float64, including gray, channel-tie, and 8-bit-quantized inputs, plus seeded end-to-end `ColorJiggle` on both devices. A new `test_channel_ties` pins the tie-breaking convention (gray → h=0, r=g>b → π/3, g=b>r → π, r=b>g → 5π/3) and was verified to fail against a strict-comparison variant. Existing OpenCV-reference `test_unit` values unchanged.

## Compile / script

- `torch.compile(rgb_to_hsv, fullgraph=True)`: 1 graph, 0 breaks, matches eager (the where-chain is pointwise and fuses; the removed `gather` did not).
- New `test_dynamo` added for `rgb_to_hsv` and `hsv_to_rgb` (file had none; `tests/color` is in the PR-time dynamo CI job scope).
- `test_jit` (TorchScript) still green.
- Note: compiled `ColorJiggle` still fails on MPS afterwards, but now at the random-order `transforms[idx]` dispatch (`GuardOnDataDependentSymNode`) — the #3913 param-generator work, not this path.

## Microbenchmark (op level)

Apple M-series, torch 2.9.1, `torch.utils.benchmark` medians, 16×3×256×256 f32:

| op | main | this PR | speedup |
|---|---|---|---|
| `rgb_to_hsv` MPS | 77.8 ms | 8.9 ms | **8.7×** |
| `rgb_to_hsv` CPU (4 threads) | 39.1 ms | 15.8 ms | **2.5×** |

## Flagship augmentation benchmark (class API, param sampling included)

`python benchmarks/augmentation/flagship.py --device {mps,cpu}` (batches 1/8/32, 256², f32) — same box, back-to-back runs, identical harness/baselines. Which kornia gets imported (main `d44abd15` vs this branch) was selected via PYTHONPATH, so the header line prints the worktree commit `4ab69583` in all four runs — the "main" tables ran main's `kornia/` package.

**Headline: ColorJiggle MPS 54/119/48 → 85/222/317 img/s (b1/b8/b32, 6.6× at b32); CPU 107 → 148 img/s at b32 (1.4×).** Throughput now scales with batch size on MPS instead of collapsing. Caveat read honestly: unrelated rows on MPS wobble up to ±30% between runs (laptop thermal/scheduling noise — e.g. HFlip b32 21.4k→17.4k, GaussianBlur 3.2k→4.2k in opposite directions); the CPU tables are stable to ±5%. ColorJiggle's gain is far outside the noise band, consistent across all batches, and matches the op-level microbenchmark. ColorJiggle still trails albumentations (2.5k img/s, uint8+OpenCV on CPU) — see levers below.

### MPS — main

```
# flagship augmentation benchmark — commit 4ab69583 — macOS-26.5.1-arm64-arm-64bit
# torch 2.9.1, kornia 0.9.0rc1, python 3.11.0, opencv 5.0.0, torchvision 0.24.1, albumentations 2.0.8, pillow 12.3.0, kornia_rs 0.1.10
# device=mps, dtype=float32, threads=4, size=256 — throughput img/s
# augmentation classes built once; timed region = parameter sampling + application per call
# kornia/torchvision: batched float BCHW; albumentations/opencv/PIL: uint8 HWC per-image loop (CPU); '-' = skipped
--------------------------------------------------------------------------------------------------------------------
batch=1                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                 2657              -           3303         131784         175945          16002
RandomAffine                          164              -            250           7259              -              -
RandomPerspective                     193              -            173           8124              -              -
RandomResizedCrop                     330              -           1864          28389              -              -
ColorJiggle                            54              -            372           2662              -              -
RandomGaussianBlur                    385              -           1000           6266              -              -
RandomBrightness                      676              -           1213          31854              -              -
RandomGrayscale                      1046              -           1757          58150         100944          19806
--------------------------------------------------------------------------------------------------------------------
batch=8                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                10667              -          11479         135093         182211          14702
RandomAffine                          465              -           1378           7030              -              -
RandomPerspective                     534              -            697           7854              -              -
RandomResizedCrop                    1740              -           9291          27280              -              -
ColorJiggle                           119              -            537           2591              -              -
RandomGaussianBlur                   1772              -           2549           6259              -              -
RandomBrightness                     2100              -           4233          28186              -              -
RandomGrayscale                      3597              -           3414          53168          92362          19304
--------------------------------------------------------------------------------------------------------------------
batch=32                   kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                21426              -          22345          62344          71539          13305
RandomAffine                         1765              -           3261           6651              -              -
RandomPerspective                    1740              -           2154           7497              -              -
RandomResizedCrop                    3560              -          18588          26262              -              -
ColorJiggle                            48              -            541           2568              -              -
RandomGaussianBlur                   3183              -           4859           6054              -              -
RandomBrightness                     5768              -           8907          25584              -              -
RandomGrayscale                      7487              -          11767          39915          75701          18170
--------------------------------------------------------------------------------------------------------------------
```

### MPS — this PR

```
# flagship augmentation benchmark — commit 4ab69583 — macOS-26.5.1-arm64-arm-64bit
# torch 2.9.1, kornia 0.9.0rc1, python 3.11.0, opencv 5.0.0, torchvision 0.24.1, albumentations 2.0.8, pillow 12.3.0, kornia_rs 0.1.10
# device=mps, dtype=float32, threads=4, size=256 — throughput img/s
# augmentation classes built once; timed region = parameter sampling + application per call
# kornia/torchvision: batched float BCHW; albumentations/opencv/PIL: uint8 HWC per-image loop (CPU); '-' = skipped
--------------------------------------------------------------------------------------------------------------------
batch=1                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                 2126              -           1832         134869         181258          16375
RandomAffine                          113              -            242           7180              -              -
RandomPerspective                     188              -            190           8040              -              -
RandomResizedCrop                     354              -           2299          28466              -              -
ColorJiggle                            85              -            282           2657              -              -
RandomGaussianBlur                    440              -            922           6364              -              -
RandomBrightness                      539              -            871          31918              -              -
RandomGrayscale                       824              -           1407          58516         101219          19790
--------------------------------------------------------------------------------------------------------------------
batch=8                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                10552              -          10058         131620         180937          14446
RandomAffine                          343              -            998           7137              -              -
RandomPerspective                     445              -            504           8118              -              -
RandomResizedCrop                    1404              -           8147          27794              -              -
ColorJiggle                           222              -            528           2617              -              -
RandomGaussianBlur                   1464              -           1956           6040              -              -
RandomBrightness                     1693              -           3604          29127              -              -
RandomGrayscale                      3485              -           3225          52876         100564          19554
--------------------------------------------------------------------------------------------------------------------
batch=32                   kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                17437              -          21573          62701          91121          13001
RandomAffine                         1427              -           2722           5976              -              -
RandomPerspective                    1371              -           2040           6982              -              -
RandomResizedCrop                    3879              -          17718          25569              -              -
ColorJiggle                           317              -            544           2526              -              -
RandomGaussianBlur                   4165              -           7820           6040              -              -
RandomBrightness                     3968              -           7521          25729              -              -
RandomGrayscale                      5388              -          10163          40544          85562          19314
--------------------------------------------------------------------------------------------------------------------
```

### CPU — main

```
# flagship augmentation benchmark — commit 4ab69583 — macOS-26.5.1-arm64-arm-64bit
# torch 2.9.1, kornia 0.9.0rc1, python 3.11.0, opencv 5.0.0, torchvision 0.24.1, albumentations 2.0.8, pillow 12.3.0, kornia_rs 0.1.10
# device=cpu, dtype=float32, threads=4, size=256 — throughput img/s
# augmentation classes built once; timed region = parameter sampling + application per call
# kornia/torchvision: batched float BCHW; albumentations/opencv/PIL: uint8 HWC per-image loop (CPU); '-' = skipped
--------------------------------------------------------------------------------------------------------------------
batch=1                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                26595              -          34655         134038         181290          15947
RandomAffine                          832              -           1061           7181              -              -
RandomPerspective                     813              -            639           8127              -              -
RandomResizedCrop                    2445              -           4398          28681              -              -
ColorJiggle                           138              -            336           2551              -              -
RandomGaussianBlur                   1435              -            560           6291              -              -
RandomBrightness                    10926              -          13863          31341              -              -
RandomGrayscale                      9205              -          23179          57750          99807          16866
--------------------------------------------------------------------------------------------------------------------
batch=8                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                15911              -          16244         112247         118096          12738
RandomAffine                          885              -           1328           6195              -              -
RandomPerspective                     869              -            991           7018              -              -
RandomResizedCrop                    4170              -           4518          25695              -              -
ColorJiggle                           116              -            259           2254              -              -
RandomGaussianBlur                   1389              -            283           5795              -              -
RandomBrightness                     6210              -          11300          28020              -              -
RandomGrayscale                      7538              -          25899          58690          89501          19054
--------------------------------------------------------------------------------------------------------------------
batch=32                   kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                10194              -          10254          46202          49981          12073
RandomAffine                          920              -           1433           6064              -              -
RandomPerspective                     848              -           1114           6820              -              -
RandomResizedCrop                    4328              -           3878          23439              -              -
ColorJiggle                           107              -            272           2145              -              -
RandomGaussianBlur                   1116              -            992           5080              -              -
RandomBrightness                     6446              -           9465          15925              -              -
RandomGrayscale                      5396              -          24002          24595          60247          15844
--------------------------------------------------------------------------------------------------------------------
```

### CPU — this PR

```
# flagship augmentation benchmark — commit 4ab69583 — macOS-26.5.1-arm64-arm-64bit
# torch 2.9.1, kornia 0.9.0rc1, python 3.11.0, opencv 5.0.0, torchvision 0.24.1, albumentations 2.0.8, pillow 12.3.0, kornia_rs 0.1.10
# device=cpu, dtype=float32, threads=4, size=256 — throughput img/s
# augmentation classes built once; timed region = parameter sampling + application per call
# kornia/torchvision: batched float BCHW; albumentations/opencv/PIL: uint8 HWC per-image loop (CPU); '-' = skipped
--------------------------------------------------------------------------------------------------------------------
batch=1                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                26706              -          34209         134390         180154          16326
RandomAffine                          857              -           1032           7143              -              -
RandomPerspective                     848              -            619           8196              -              -
RandomResizedCrop                    2477              -           4393          28306              -              -
ColorJiggle                           215              -            334           2436              -              -
RandomGaussianBlur                   1386              -            563           6389              -              -
RandomBrightness                    11164              -          14394          32042              -              -
RandomGrayscale                      9519              -          23475          57870         100658          17131
--------------------------------------------------------------------------------------------------------------------
batch=8                    kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                16401              -          16900          75994          91041          14247
RandomAffine                          894              -           1335           6874              -              -
RandomPerspective                     885              -           1008           7746              -              -
RandomResizedCrop                    3540              -           4297          23149              -              -
ColorJiggle                           178              -            276           2498              -              -
RandomGaussianBlur                   1380              -            314           5998              -              -
RandomBrightness                     6137              -          12549          28381              -              -
RandomGrayscale                      6825              -          26460          48818          90254          18991
--------------------------------------------------------------------------------------------------------------------
batch=32                   kornia (eager) kornia (compil torchvision v2 albumentations         opencv            PIL
--------------------------------------------------------------------------------------------------------------------
RandomHorizontalFlip                10645              -          10764          37708          38863          11089
RandomAffine                          913              -           1401           6216              -              -
RandomPerspective                     850              -           1091           7249              -              -
RandomResizedCrop                    4188              -           3899          21910              -              -
ColorJiggle                           148              -            271           2096              -              -
RandomGaussianBlur                   1135              -            997           5165              -              -
RandomBrightness                     6397              -           9574          15167              -              -
RandomGrayscale                      5524              -          23987          20862          36666          14579
--------------------------------------------------------------------------------------------------------------------
```

## Algorithm source

Same algorithm and conventions as before (OpenCV-style H∈[0,2π) hue; existing hardcoded OpenCV reference values in `test_unit` pass unchanged) — only the selection mechanics changed.

## Remaining levers toward the 10×-vs-albumentations target

This closes the pathological MPS reduction; `ColorJiggle` remains behind albumentations on CPU. Next levers: `hsv_to_rgb`'s 18-plane stack+gather (~13.5 ms MPS), the `_assert_async` MPS fallback (PR 2 of #3914), compile-safe parameter generation (#3913), uint8 fast path, kornia-rs.

## Test log

`tests/color/test_hsv.py --dtype=all` / same `-k dynamo` under `KORNIA_TEST_OPTIMIZER=inductor` / `tests/enhance/test_adjust.py --dtype=all` / `tests/augmentation/test_augmentation.py -k "ColorJiggle or ColorJitter"`:

```
======================== 87 passed, 1 skipped in 0.79s =========================
======================= 2 passed, 22 deselected in 1.83s =======================
======================= 450 passed, 21 skipped in 0.72s ========================
=========== 30 passed, 1 skipped, 372 deselected, 2 xfailed in 0.66s ===========
```

---

Posted on behalf of @ducha-aiki by Claude (Fable 5).
