### PR TITLE
perf(enhance): skip torch._assert_async value checks on MPS (no-kernel CPU fallback syncs per call)

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -34,6 +34,19 @@ from kornia.core.utils import _torch_histc_cast
 from kornia.image.utils import perform_keep_shape_image, perform_keep_shape_video
 
 
+def _assert_async_value_check(cond: torch.Tensor, msg: str) -> None:
+    """Validate a tensor condition without graph breaks or hidden device syncs.
+
+    ``torch._assert_async`` keeps the check fullgraph-compilable (a Python ``if tensor: raise``
+    would break the graph), but ``aten::_assert_async`` has no MPS kernel — the CPU fallback
+    materializes ``cond`` and drains the queued stream on every call, so on MPS the check is
+    skipped instead.
+    """
+    if cond.device.type == "mps":
+        return
+    torch._assert_async(cond, msg)
+
+
 def adjust_saturation_raw(image: torch.Tensor, factor: Union[float, torch.Tensor]) -> torch.Tensor:
     r"""Adjust color saturation of an image.
 
@@ -292,10 +305,8 @@ def adjust_gamma(
     gamma = gamma.to(input.device).to(input.dtype)
     gain = gain.to(input.device).to(input.dtype)
 
-    # torch._assert_async keeps the value check while staying fullgraph-compilable (a Python
-    # `if tensor: raise` would break the graph).
-    torch._assert_async((gamma >= 0.0).all(), "Gamma must be non-negative.")
-    torch._assert_async((gain >= 0.0).all(), "Gain must be non-negative.")
+    _assert_async_value_check((gamma >= 0.0).all(), "Gamma must be non-negative. Clamp it first: gamma.clamp_min(0.0).")
+    _assert_async_value_check((gain >= 0.0).all(), "Gain must be non-negative. Clamp it first: gain.clamp_min(0.0).")
 
     for _ in range(len(input.shape) - len(gamma.shape)):
         gamma = torch.unsqueeze(gamma, dim=-1)
@@ -368,8 +379,10 @@ def adjust_contrast(image: torch.Tensor, factor: Union[float, torch.Tensor], cli
     while len(factor.shape) != len(image.shape):
         factor = factor[..., None]
 
-    # torch._assert_async keeps the value check while staying fullgraph-compilable.
-    torch._assert_async((factor >= 0).all(), "Contrast factor must be positive.")
+    _assert_async_value_check(
+        (factor >= 0).all(),
+        "Contrast factor must be non-negative. Sample it from a non-negative range or clamp: factor.clamp_min(0.0).",
+    )
 
     # Apply contrast factor to each channel
     img_adjust: torch.Tensor = image * factor
@@ -722,11 +735,9 @@ def solarize(
         if isinstance(additions, float):
             additions = torch.as_tensor(additions)
 
-        # `torch._assert_async` keeps this a single traceable path (no Python-level branch on a
-        # tensor value), so `solarize` stays torch.compile fullgraph-safe while still validating.
-        torch._assert_async(
+        _assert_async_value_check(
             ((additions < 0.5) & (additions > -0.5)).all(),
-            "The value of 'addition' is between -0.5 and 0.5.",
+            "The addition must be in the open range (-0.5, 0.5). Clamp it first, e.g. additions.clamp(-0.49, 0.49).",
         )
 
         if isinstance(additions, torch.Tensor) and len(additions.shape) != 0:

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -274,6 +274,11 @@ def adjust_gamma(
     .. note::
        See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
 
+    .. note::
+       The non-negativity check on ``gamma``/``gain`` runs on CPU and CUDA (via ``torch._assert_async``).
+       On MPS it is skipped: the op has no MPS kernel and its CPU fallback would synchronize the
+       device on every call, so invalid values do not raise there.
+
     Example:
         >>> x = torch.ones(1, 1, 2, 2)
         >>> adjust_gamma(x, 1.0, 2.0)
@@ -305,8 +310,14 @@ def adjust_gamma(
     gamma = gamma.to(input.device).to(input.dtype)
     gain = gain.to(input.device).to(input.dtype)
 
-    _assert_async_value_check((gamma >= 0.0).all(), "Gamma must be non-negative. Clamp it first: gamma.clamp_min(0.0).")
-    _assert_async_value_check((gain >= 0.0).all(), "Gain must be non-negative. Clamp it first: gain.clamp_min(0.0).")
+    _assert_async_value_check(
+        (gamma >= 0.0).all(),
+        "Gamma must be non-negative. Clamp it first: max(gamma, 0.0) for floats, gamma.clamp_min(0.0) for tensors.",
+    )
+    _assert_async_value_check(
+        (gain >= 0.0).all(),
+        "Gain must be non-negative. Clamp it first: max(gain, 0.0) for floats, gain.clamp_min(0.0) for tensors.",
+    )
 
     for _ in range(len(input.shape) - len(gamma.shape)):
         gamma = torch.unsqueeze(gamma, dim=-1)
@@ -353,6 +364,11 @@ def adjust_contrast(image: torch.Tensor, factor: Union[float, torch.Tensor], cli
     .. note::
        See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
 
+    .. note::
+       The non-negativity check on ``factor`` runs on CPU and CUDA (via ``torch._assert_async``).
+       On MPS it is skipped: the op has no MPS kernel and its CPU fallback would synchronize the
+       device on every call, so invalid values do not raise there.
+
     Example:
         >>> import torch
         >>> x = torch.ones(1, 1, 2, 2)
@@ -381,7 +397,8 @@ def adjust_contrast(image: torch.Tensor, factor: Union[float, torch.Tensor], cli
 
     _assert_async_value_check(
         (factor >= 0).all(),
-        "Contrast factor must be non-negative. Sample it from a non-negative range or clamp: factor.clamp_min(0.0).",
+        "Contrast factor must be non-negative. Clamp it first: max(factor, 0.0) for floats, "
+        "factor.clamp_min(0.0) for tensors.",
     )
 
     # Apply contrast factor to each channel
@@ -706,6 +723,11 @@ def solarize(
     Returns:
         The solarized images with shape :math:`(*, C, H, W)`.
 
+    .. note::
+       The range check on ``additions`` runs on CPU and CUDA (via ``torch._assert_async``).
+       On MPS it is skipped: the op has no MPS kernel and its CPU fallback would synchronize the
+       device on every call, so invalid values do not raise there.
+
     Example:
         >>> x = torch.rand(1, 4, 3, 3)
         >>> out = solarize(x, thresholds=0.5, additions=0.)
@@ -737,7 +759,8 @@ def solarize(
 
         _assert_async_value_check(
             ((additions < 0.5) & (additions > -0.5)).all(),
-            "The addition must be in the open range (-0.5, 0.5). Clamp it first, e.g. additions.clamp(-0.49, 0.49).",
+            "The addition must be in the open range (-0.5, 0.5). Clamp it first: min(max(additions, -0.49), 0.49) "
+            "for floats, additions.clamp(-0.49, 0.49) for tensors.",
         )
 
         if isinstance(additions, torch.Tensor) and len(additions.shape) != 0:

--- a/tests/enhance/test_adjust.py
+++ b/tests/enhance/test_adjust.py
@@ -369,14 +369,17 @@ class TestAdjustContrast(BaseTester):
 
     def test_mps_skips_value_check(self, device, dtype):
         # aten::_assert_async has no MPS kernel; its CPU fallback forces a full device sync per
-        # call. On MPS the value check is skipped entirely (documented in adjust_contrast), so
-        # even an invalid factor must go through without raising or falling back to CPU.
+        # call. On MPS the value check is skipped entirely (see the note in the adjust_contrast
+        # docstring), so even an invalid factor must go through without raising, and the output
+        # must stay on the device with the requested dtype.
         if device.type != "mps":
             pytest.skip("pins the MPS-only no-CPU-fallback behavior")
         img = torch.rand(1, 3, 4, 4, device=device, dtype=dtype)
         factor = torch.tensor([-0.5], device=device, dtype=dtype)
         out = kornia.enhance.adjust_contrast(img, factor)
         assert out.shape == img.shape
+        assert out.device == img.device
+        assert out.dtype == img.dtype
 
     def test_factor_one_with_mean_subtraction(self, device, dtype):
         # prepare input data

--- a/tests/enhance/test_adjust.py
+++ b/tests/enhance/test_adjust.py
@@ -359,6 +359,25 @@ class TestAdjustContrast(BaseTester):
         f = kornia.enhance.AdjustContrast(1.0)
         self.assert_close(f(data), expected)
 
+    def test_negative_factor_errors(self, device, dtype):
+        if device.type != "cpu":
+            pytest.skip("value asserts are synchronous only on CPU (async on CUDA, skipped on MPS)")
+        img = torch.rand(1, 3, 4, 4, device=device, dtype=dtype)
+        factor = torch.tensor([-0.5], device=device, dtype=dtype)
+        with pytest.raises(RuntimeError, match="non-negative"):
+            kornia.enhance.adjust_contrast(img, factor)
+
+    def test_mps_skips_value_check(self, device, dtype):
+        # aten::_assert_async has no MPS kernel; its CPU fallback forces a full device sync per
+        # call. On MPS the value check is skipped entirely (documented in adjust_contrast), so
+        # even an invalid factor must go through without raising or falling back to CPU.
+        if device.type != "mps":
+            pytest.skip("pins the MPS-only no-CPU-fallback behavior")
+        img = torch.rand(1, 3, 4, 4, device=device, dtype=dtype)
+        factor = torch.tensor([-0.5], device=device, dtype=dtype)
+        out = kornia.enhance.adjust_contrast(img, factor)
+        assert out.shape == img.shape
+
     def test_factor_one_with_mean_subtraction(self, device, dtype):
         # prepare input data
         data = torch.tensor(


### PR DESCRIPTION
Fixes #3914 (mechanism 2 of 2; mechanism 1 is #3915).

## What

`aten::_assert_async` has no MPS kernel. PyTorch's CPU fallback materializes the condition tensor, which drains the queued MPS stream on **every call** — a hidden full device sync (plus a `UserWarning` per site). The three affected sites (`adjust_gamma` ×2, `adjust_contrast`, `solarize` in `kornia/enhance/adjust.py`) now route through a private `_assert_async_value_check` helper that keeps the fullgraph-safe `torch._assert_async` on CPU/CUDA and skips the check on MPS, where the only way to evaluate it is to sync. Messages upgraded to state the fix (W4, e.g. "Contrast factor must be non-negative. Sample it from a non-negative range or clamp: factor.clamp_min(0.0).").

Behavior change is confined to **invalid inputs on MPS**: they no longer raise (there is no async assert to raise them without a per-call sync); valid-input outputs are untouched on every backend. Both behaviors are pinned by new tests (`test_negative_factor_errors` on CPU, `test_mps_skips_value_check` on MPS), written first and watched fail (TDD: the MPS one fails on `main` with `RuntimeError` from the CPU fallback).

## Compile

`torch.compile(adjust_contrast, fullgraph=True)`: 1 graph, 0 breaks, matches eager — the `cond.device.type` branch resolves at trace time (static device metadata), so eager and compiled run the same path per device; this is not an `is_compiling` split. `tests/enhance/test_adjust.py -k dynamo` under `KORNIA_TEST_OPTIMIZER=inductor`: 7 passed, 1 skipped.

## Benchmark (op level)

Apple M-series, torch 2.9.1, `torch.utils.benchmark` medians, 16×3×256×256 f32 on MPS, tensor-valued factors, same box back-to-back (before = `d44abd15`):

| op (MPS) | main | this PR | speedup |
|---|---|---|---|
| `adjust_contrast` | 4.87 ms | 2.46 ms | **2.0×** |
| `adjust_gamma` (2 asserts) | 7.03 ms | 5.08 ms | **1.4×** |
| `solarize` | 7.79 ms | 4.36 ms | **1.8×** |

CPU/CUDA are unaffected by construction (same `torch._assert_async` call as before; the helper adds one Python call and a device-type string compare, below measurement noise). Within `ColorJiggle` this is the smaller mechanism (~2% end-to-end — the dominant one was `rgb_to_hsv`, #3915); standalone `adjust_contrast`/`solarize` users on MPS get the full win, and the per-call `aten::_assert_async` fallback `UserWarning` spam is gone.

## Algorithm source

No algorithm change — validation plumbing only; the guarded-assert pattern follows the existing fullgraph-safe convention already in this file.

## Test log

```
tests/enhance/test_adjust.py --dtype=all --device=cpu   → 454 passed, 25 skipped
tests/enhance/test_adjust.py --dtype=float32,float16 --device=mps
                                                        → 216 passed, 29 skipped, 4 failed*
KORNIA_TEST_OPTIMIZER=inductor ... -k dynamo            → 7 passed, 1 skipped
```

\* The 4 MPS failures are `TestPosterize::test_cardinality[mps-float16-…]` device-mismatch errors that reproduce identically with `main`'s `kornia/enhance/adjust.py` (verified by flipping only that file back to `d44abd15`) — pre-existing `posterize`-on-MPS issue, untouched by this PR.

---

Posted on behalf of @ducha-aiki by Claude (Fable 5).
