### PR TITLE
fix(enhance): move posterize bits tensor onto the input's device

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -813,12 +813,11 @@ def posterize(input: torch.Tensor, bits: Union[int, torch.Tensor]) -> torch.Tens
         raise TypeError(f"bits type is not an int or torch.Tensor. Got {type(bits)}")
 
     if isinstance(bits, int):
-        bits = torch.as_tensor(bits)
+        bits = torch.as_tensor(bits, device=input.device)
 
-    # bits may be a CPU tensor (e.g. user-supplied `torch.tensor([...])`, or the int branch
-    # above via `torch.as_tensor`) while `input` lives on another device (MPS/CUDA). A 0-dim
-    # CPU tensor is silently allowed to mix with any device (PyTorch's "wrapped number" rule),
-    # but multi-element bits tensors are not, so move it onto input's device explicitly.
+    # A user-supplied CPU bits tensor mixes with any device only when 0-dim (PyTorch's "wrapped
+    # number" rule); multi-element CPU tensors hit a device mismatch on MPS/CUDA, so move bits
+    # onto input's device explicitly (no-op when already there).
     bits = bits.to(device=input.device)
 
     # TODO: find a better way to check boundaries on tensors

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -815,6 +815,12 @@ def posterize(input: torch.Tensor, bits: Union[int, torch.Tensor]) -> torch.Tens
     if isinstance(bits, int):
         bits = torch.as_tensor(bits)
 
+    # bits may be a CPU tensor (e.g. user-supplied `torch.tensor([...])`, or the int branch
+    # above via `torch.as_tensor`) while `input` lives on another device (MPS/CUDA). A 0-dim
+    # CPU tensor is silently allowed to mix with any device (PyTorch's "wrapped number" rule),
+    # but multi-element bits tensors are not, so move it onto input's device explicitly.
+    bits = bits.to(device=input.device)
+
     # TODO: find a better way to check boundaries on tensors
     # if not torch.all((bits >= 0) * (bits <= 8)) and bits.dtype == torch.int:
     #     raise ValueError(f"bits must be integers within range [0, 8]. Got {bits}.")


### PR DESCRIPTION
Fixes #3919.

## What

One-line fix: `posterize` never moved `bits` to `input.device`. A 0-dim CPU `bits` (the `int` path) slips through PyTorch's wrapped-number rule, but per-sample / per-batch-channel CPU `bits` tensors hit `RuntimeError: Expected all tensors to be on the same device` in `_right_shift`'s `(2**shift)` on MPS/CUDA. `bits = bits.to(device=input.device)` after the int→tensor conversion; CPU→CPU is a no-op.

## Eager preservation

CPU outputs byte-identical (`torch.equal`) across 21 saved reference tensors: int and 0-dim-tensor `bits` 0..8, per-sample, and per-batch-channel cases, saved before the fix and compared after.

`torch.compile(posterize, fullgraph=True)` compiles both before and after the fix — no regression.

## Test log

```
tests/enhance/test_adjust.py -k Posterize --device=mps --dtype=float32,float16
  before: 4 failed, 16 passed   →   after: 20 passed
tests/enhance/test_adjust.py -k Posterize --device=cpu --dtype=all: 40 passed
tests/enhance/test_adjust.py --device=cpu --dtype=all: 454 passed, 25 skipped (unchanged)
```

Algorithm source: n/a — device-placement bug fix, no numeric change.

---

Posted on behalf of @ducha-aiki by Claude (Fable 5).
