### PR TITLE
perf(color): branchless sextant selection in hsv_to_rgb (fixes MPS inductor compile, 4x compiled CPU)

### DIFF
--- a/kornia/color/hsv.py
+++ b/kornia/color/hsv.py
@@ -112,11 +112,24 @@ def hsv_to_rgb(image: torch.Tensor) -> torch.Tensor:
     t: torch.Tensor = v * (1.0 - (1.0 - f) * s)
 
     hi = hi.long().clamp_(0, 5)
-    indices: torch.Tensor = torch.stack([hi, hi + 6, hi + 12], dim=-3)
-    out = torch.stack((v, q, p, p, t, v, t, v, v, q, p, p, p, p, t, v, v, q), dim=-3)
-    out = torch.gather(out, -3, indices)
 
-    return out
+    # branchless per-channel sextant selection, replacing an 18-plane stack + gather: gather blocks
+    # pointwise fusion under torch.compile (the stack+gather graph fails to compile on the MPS
+    # inductor backend) and materializing an 18-plane buffer costs extra memory traffic in eager.
+    # Each where-chain reproduces one row of the original [v,q,p,p,t,v / t,v,v,q,p,p / p,p,t,v,v,q]
+    # table indexed by hi, selecting (not recomputing) the same p/q/t/v tensors; the sextant masks
+    # are computed once and reused across R/G/B instead of being recomputed per channel.
+    m0 = hi == 0
+    m1 = hi == 1
+    m2 = hi == 2
+    m3 = hi == 3
+    m4 = hi == 4
+
+    r = torch.where(m0, v, torch.where(m1, q, torch.where(m2, p, torch.where(m3, p, torch.where(m4, t, v)))))
+    g = torch.where(m0, t, torch.where(m1, v, torch.where(m2, v, torch.where(m3, q, torch.where(m4, p, p)))))
+    b = torch.where(m0, p, torch.where(m1, p, torch.where(m2, t, torch.where(m3, v, torch.where(m4, v, q)))))
+
+    return torch.stack((r, g, b), dim=-3)
 
 
 class RgbToHsv(nn.Module):

--- a/tests/color/test_hsv.py
+++ b/tests/color/test_hsv.py
@@ -256,6 +256,53 @@ class TestHsvToRgb(BaseTester):
         data[:, 0] -= 4 * math.pi
         self.assert_close(f(data), expected, low_tolerance=True)
 
+    def test_sextant_boundaries(self, device, dtype):
+        # Pins outputs at exact sextant-boundary hues (h = k*pi/3 for k=0..6, s=0.6, v=0.8) plus
+        # s=0 gray and v=0 black edge cases, so a branchless rewrite of the sextant selection
+        # cannot silently swap a p/q/t/v value in any of the six sextants.
+        # Snippet used to generate expected (current stack+gather implementation):
+        # h = torch.tensor([k * math.pi / 3.0 for k in range(7)], dtype=torch.float64)
+        # s = torch.full((7,), 0.6, dtype=torch.float64)
+        # v = torch.full((7,), 0.8, dtype=torch.float64)
+        # data = torch.stack([h, s, v], dim=1).view(7, 3, 1, 1)
+        # expected = kornia.color.hsv_to_rgb(data)  # <-- print and paste below
+        h = torch.tensor([k * math.pi / 3.0 for k in range(7)], device=device, dtype=dtype)
+        s = torch.full((7,), 0.6, device=device, dtype=dtype)
+        v = torch.full((7,), 0.8, device=device, dtype=dtype)
+        data = torch.stack([h, s, v], dim=1).view(7, 3, 1, 1)
+        expected = torch.tensor(
+            [
+                [0.8, 0.32, 0.32],
+                [0.8, 0.8, 0.32],
+                [0.32, 0.8, 0.32],
+                [0.32, 0.8, 0.8],
+                [0.32, 0.32, 0.8],
+                [0.8, 0.32, 0.8],
+                [0.8, 0.32, 0.32],
+            ],
+            device=device,
+            dtype=dtype,
+        ).view(7, 3, 1, 1)
+        # k=6 (h=2*pi) rounds imprecisely at float16 and can land a hair over the sextant-0
+        # boundary; loosen tolerance rather than special-case the dtype.
+        self.assert_close(kornia.color.hsv_to_rgb(data), expected, low_tolerance=True)
+
+        # s=0 gray: output must equal v on every channel regardless of hue
+        hg = torch.tensor([0.0, math.pi / 2, math.pi, 3 * math.pi / 2, 2 * math.pi - 0.01], device=device, dtype=dtype)
+        sg = torch.zeros(5, device=device, dtype=dtype)
+        vg = torch.tensor([0.0, 0.25, 0.5, 0.75, 1.0], device=device, dtype=dtype)
+        data_gray = torch.stack([hg, sg, vg], dim=1).view(5, 3, 1, 1)
+        expected_gray = vg.view(5, 1, 1, 1).expand(5, 3, 1, 1)
+        self.assert_close(kornia.color.hsv_to_rgb(data_gray), expected_gray)
+
+        # v=0 black: output must be zero regardless of hue/saturation
+        hk = torch.tensor([0.0, math.pi / 2, math.pi, 3 * math.pi / 2, 2 * math.pi - 0.01], device=device, dtype=dtype)
+        sk = torch.tensor([0.0, 0.3, 0.6, 0.9, 1.0], device=device, dtype=dtype)
+        vk = torch.zeros(5, device=device, dtype=dtype)
+        data_black = torch.stack([hk, sk, vk], dim=1).view(5, 3, 1, 1)
+        expected_black = torch.zeros(5, 3, 1, 1, device=device, dtype=dtype)
+        self.assert_close(kornia.color.hsv_to_rgb(data_black), expected_black)
+
     @pytest.mark.grad()
     def test_gradcheck(self, device, dtype):
         B, C, H, W = 2, 3, 4, 4

--- a/tests/color/test_hsv.py
+++ b/tests/color/test_hsv.py
@@ -287,6 +287,29 @@ class TestHsvToRgb(BaseTester):
         # boundary; loosen tolerance rather than special-case the dtype.
         self.assert_close(kornia.color.hsv_to_rgb(data), expected, low_tolerance=True)
 
+        # Mid-sextant hues (f=0.25): at exact boundaries f=0 collapses q==v and t==p, so a p/t or
+        # q/v swap would go unnoticed there; with f=0.25 all four of p=0.32, q=0.68, t=0.44, v=0.8
+        # are distinct and every sextant's full selection is pinned.
+        # Snippet used to generate expected (current stack+gather implementation):
+        # hm = torch.tensor([(k + 0.25) * math.pi / 3.0 for k in range(6)], dtype=torch.float64)
+        # data_mid = torch.stack([hm, torch.full((6,), 0.6), torch.full((6,), 0.8)], 1).view(6, 3, 1, 1)
+        # expected_mid = kornia.color.hsv_to_rgb(data_mid)  # <-- print and paste below
+        hm = torch.tensor([(k + 0.25) * math.pi / 3.0 for k in range(6)], device=device, dtype=dtype)
+        data_mid = torch.stack([hm, torch.full_like(hm, 0.6), torch.full_like(hm, 0.8)], dim=1).view(6, 3, 1, 1)
+        expected_mid = torch.tensor(
+            [
+                [0.8, 0.44, 0.32],
+                [0.68, 0.8, 0.32],
+                [0.32, 0.8, 0.44],
+                [0.32, 0.68, 0.8],
+                [0.44, 0.32, 0.8],
+                [0.8, 0.32, 0.68],
+            ],
+            device=device,
+            dtype=dtype,
+        ).view(6, 3, 1, 1)
+        self.assert_close(kornia.color.hsv_to_rgb(data_mid), expected_mid, low_tolerance=True)
+
         # s=0 gray: output must equal v on every channel regardless of hue
         hg = torch.tensor([0.0, math.pi / 2, math.pi, 3 * math.pi / 2, 2 * math.pi - 0.01], device=device, dtype=dtype)
         sg = torch.zeros(5, device=device, dtype=dtype)


### PR DESCRIPTION
Fixes #3921. Companion to #3915 (rgb_to_hsv) — same discipline, other direction of the ColorJiggle RGB↔HSV round-trip.

## What

`hsv_to_rgb` materialized an 18-plane `stack` and `gather`ed 3 planes out of it. The gather graph **fails to compile on the MPS inductor backend** (`InductorError`, generated Metal kernel; reproduced independently on torch 2.9.1) and blocks pointwise fusion on CPU. Replaced with branchless `torch.where` chains over the clamped integer `hi` — the five sextant masks are computed once and shared across R/G/B (a first draft recomputing them per channel measurably regressed eager and was discarded), selecting the **same** `p/q/t/v` tensors as the gather table.

## Eager preservation (byte-to-byte)

`torch.equal` on outputs **and gradients** vs the current implementation: cpu/mps × f16/f32/f64 (no f64 on MPS), 5 input categories (random, sextant boundaries, gray s=0, black v=0, quantized), 30/30 identical; plus seeded end-to-end `ColorJiggle` equality on cpu and mps. New `test_sextant_boundaries` pins all six sextants + gray/black edge cases with hardcoded literals (generation snippet in-test) and was verified to fail against a deliberately q/t-swapped variant.

## Benchmarks (Apple M-series, torch 2.9.1, 16×3×256×256 f32, medians, same box back-to-back)

| config | before (stack+gather) | after (branchless) |
|---|---|---|
| eager MPS | 13.15 ms | 12.24 ms |
| eager CPU (4 threads) | 27.65 ms | 23.80 ms |
| compiled CPU | 11.5 ms | **2.7 ms (4.3×)** |
| compiled MPS | **InductorError — does not compile** | **2.8 ms** |

`torch.compile(fullgraph=True)`: 1 graph, 0 breaks, matches eager on both backends.

## Test log

```
tests/color/test_hsv.py --device=cpu --dtype=all            → 91 passed, 1 skipped
tests/color/test_hsv.py --device=mps --dtype=float32,float16 → 41 passed, 5 skipped
KORNIA_TEST_OPTIMIZER=inductor -k dynamo (cpu and mps)       → 2 passed each
ruff format + check clean
```

Algorithm source: unchanged algorithm (same HSV→RGB sextant table, OpenCV-convention H∈[0,2π]); only the selection mechanics changed — existing hardcoded `test_unit` values pass untouched.

---

Posted on behalf of @ducha-aiki by Claude (Fable 5).
