### PR TITLE
docs(geometry): per-op Convention blocks for transform warps, with convention-pinning tests

### DIFF
--- a/docs/source/geometry.transform.rst
+++ b/docs/source/geometry.transform.rst
@@ -29,9 +29,7 @@ Image 2d transforms
 -------------------
 
 .. autofunction:: affine
-.. autofunction:: affine3d
 .. autofunction:: rotate
-.. autofunction:: rotate3d
 .. autofunction:: translate
 .. autofunction:: scale
 .. autofunction:: shear
@@ -46,6 +44,12 @@ Image 2d transforms
 .. autofunction:: pyrup
 .. autofunction:: build_pyramid
 .. autofunction:: build_laplacian_pyramid
+
+Image 3d transforms
+-------------------
+
+.. autofunction:: affine3d
+.. autofunction:: rotate3d
 
 Matrix transformations
 ----------------------

--- a/docs/source/geometry.transform.rst
+++ b/docs/source/geometry.transform.rst
@@ -29,7 +29,9 @@ Image 2d transforms
 -------------------
 
 .. autofunction:: affine
+.. autofunction:: affine3d
 .. autofunction:: rotate
+.. autofunction:: rotate3d
 .. autofunction:: translate
 .. autofunction:: scale
 .. autofunction:: shear
@@ -37,6 +39,7 @@ Image 2d transforms
 .. autofunction:: vflip
 .. autofunction:: rot180
 .. autofunction:: resize
+.. autofunction:: resize_to_be_divisible
 .. autofunction:: rescale
 .. autofunction:: elastic_transform2d
 .. autofunction:: pyrdown

--- a/docs/source/geometry.transform.rst
+++ b/docs/source/geometry.transform.rst
@@ -22,6 +22,8 @@ Warp operators
 .. autofunction:: warp_grid
 .. autofunction:: warp_grid3d
 .. autofunction:: remap
+.. autofunction:: homography_warp
+.. autofunction:: homography_warp3d
 
 Image 2d transforms
 -------------------
@@ -49,6 +51,7 @@ Matrix transformations
 .. autofunction:: get_perspective_transform3d
 .. autofunction:: get_projective_transform
 .. autofunction:: get_rotation_matrix2d
+.. autofunction:: get_translation_matrix2d
 .. autofunction:: get_shear_matrix2d
 .. autofunction:: get_shear_matrix3d
 .. autofunction:: get_affine_matrix2d
@@ -83,6 +86,7 @@ Module
 .. autoclass:: Resize
 .. autoclass:: Rescale
 .. autoclass:: Affine
+.. autoclass:: BaseWarper
 .. autoclass:: HomographyWarper
 
 

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -727,14 +727,16 @@ def rescale(
     .. image:: _static/img/rescale.png
 
     Convention:
+        - ``factor`` is ``(factor_h, factor_w)`` when a pair — height first (contrast
+          :func:`scale`, whose ``scale_factor`` is x-first)
         - align_corners: ``None`` by default (follows ``torch.nn.functional.interpolate``;
           see the convention block of :func:`resize`)
         - delegates to :func:`resize` after converting ``factor`` to an output ``size``
 
     Args:
         input: The image tensor to be scale with shape of :math:`(B, C, H, W)`.
-        factor: Desired scaling factor in each direction. If scalar, the value is used
-            for both the x- and y-direction.
+        factor: Desired scaling factor as ``(factor_h, factor_w)`` — height first. If scalar,
+            the value is used for both height and width.
         interpolation:  algorithm used for upsampling: ``'nearest'`` | ``'linear'`` | ``'bilinear'`` |
             ``'bicubic'`` | ``'trilinear'`` | ``'area'``.
         align_corners: interpolation flag.
@@ -961,8 +963,8 @@ class Rescale(nn.Module):
         - See the convention block of :func:`rescale`.
 
     Args:
-        factor: Desired scaling factor in each direction. If scalar, the value is used
-            for both the x- and y-direction.
+        factor: Desired scaling factor as ``(factor_h, factor_w)`` — height first. If scalar,
+            the value is used for both height and width.
         interpolation:  algorithm used for upsampling: ``'nearest'`` | ``'linear'`` | ``'bilinear'`` |
             ``'bicubic'`` | ``'trilinear'`` | ``'area'``.
         align_corners: interpolation flag.

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -735,8 +735,8 @@ def rescale(
 
     Args:
         input: The image tensor to be scale with shape of :math:`(B, C, H, W)`.
-        factor: Desired scaling factor as ``(factor_h, factor_w)`` — height first. If scalar,
-            the value is used for both height and width.
+        factor: Desired scaling factor as ``(factor_h, factor_w)`` — height first. If a single
+            float, the value is used for both height and width (an ``int`` raises ``TypeError``).
         interpolation:  algorithm used for upsampling: ``'nearest'`` | ``'linear'`` | ``'bilinear'`` |
             ``'bicubic'`` | ``'trilinear'`` | ``'area'``.
         align_corners: interpolation flag.
@@ -963,8 +963,8 @@ class Rescale(nn.Module):
         - See the convention block of :func:`rescale`.
 
     Args:
-        factor: Desired scaling factor as ``(factor_h, factor_w)`` — height first. If scalar,
-            the value is used for both height and width.
+        factor: Desired scaling factor as ``(factor_h, factor_w)`` — height first. If a single
+            float, the value is used for both height and width (an ``int`` raises ``TypeError``).
         interpolation:  algorithm used for upsampling: ``'nearest'`` | ``'linear'`` | ``'bilinear'`` |
             ``'bicubic'`` | ``'trilinear'`` | ``'area'``.
         align_corners: interpolation flag.

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -597,7 +597,7 @@ def resize(
     .. image:: _static/img/resize.png
 
     Convention:
-        - input: :math:`(B, C, H, W)`; ``size`` is ``(h, w)``
+        - input: :math:`(*, H, W)`; ``size`` is ``(h, w)``
         - align_corners: ``None`` by default (follows ``torch.nn.functional.interpolate``;
           note :func:`warp_perspective`/:func:`rotate` default ``True``)
         - ``side`` resizing preserves aspect ratio using the named side

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -338,7 +338,8 @@ def rotate3d(
     r"""Rotate 3D the tensor anti-clockwise about the centre.
 
     Convention:
-        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left; defaults to the tensor center
+        - ``center`` is ``(x, y, z)`` in pixels, origin at the top-left of the first depth
+          slice (``z = 0``); defaults to the tensor center
         - align_corners: ``False`` by default
         - padding_mode: ``'zeros'`` by default
 

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -144,6 +144,11 @@ def affine(
 
     .. image:: _static/img/warp_affine.png
 
+    Convention:
+        - ``matrix`` is the source→destination **pixel** affine matrix :math:`(B, 2, 3)`
+        - align_corners: ``True`` by default
+        - padding_mode: ``'zeros'`` by default
+
     Args:
         tensor: The image tensor to be warped in shapes of
             :math:`(H, W)`, :math:`(D, H, W)` and :math:`(B, C, H, W)`.
@@ -196,6 +201,11 @@ def affine3d(
     align_corners: bool = False,
 ) -> torch.Tensor:
     r"""Apply an affine transformation to the 3d volume.
+
+    Convention:
+        - ``matrix`` is the source→destination **pixel** affine matrix :math:`(B, 3, 4)`
+        - align_corners: ``False`` by default
+        - padding_mode: ``'zeros'`` by default
 
     Args:
         tensor: The image tensor to be warped in shapes of
@@ -255,6 +265,12 @@ def rotate(
     r"""Rotate the tensor anti-clockwise about the center.
 
     .. image:: _static/img/rotate.png
+
+    Convention:
+        - ``center`` is ``(x, y)`` in pixels, origin at top-left; defaults to the tensor center
+        - positive ``angle`` rotates counter-clockwise as displayed (y-down image axes)
+        - align_corners: ``True`` by default
+        - padding_mode: ``'zeros'`` by default
 
     Args:
         tensor: The image tensor to be warped in shapes of :math:`(B, C, H, W)`.
@@ -320,6 +336,11 @@ def rotate3d(
     align_corners: bool = False,
 ) -> torch.Tensor:
     r"""Rotate 3D the tensor anti-clockwise about the centre.
+
+    Convention:
+        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left; defaults to the tensor center
+        - align_corners: ``False`` by default
+        - padding_mode: ``'zeros'`` by default
 
     Args:
         tensor: The image tensor to be warped in shapes of :math:`(B, C, D, H, W)`.
@@ -387,6 +408,11 @@ def translate(
 
     .. image:: _static/img/translate.png
 
+    Convention:
+        - ``translation`` is ``(dx, dy)`` in pixels
+        - align_corners: ``True`` by default
+        - padding_mode: ``'zeros'`` by default
+
     Args:
         tensor: The image tensor to be warped in shapes of :math:`(B, C, H, W)`.
         translation: tensor containing the amount of pixels to
@@ -436,6 +462,11 @@ def scale(
     r"""Scale the tensor by a factor.
 
     .. image:: _static/img/scale.png
+
+    Convention:
+        - ``center`` is ``(x, y)`` in pixels, origin at top-left; defaults to the tensor center
+        - align_corners: ``True`` by default
+        - padding_mode: ``'zeros'`` by default
 
     Args:
         tensor: The image tensor to be warped in shapes of :math:`(B, C, H, W)`.
@@ -498,6 +529,11 @@ def shear(
 
     .. image:: _static/img/shear.png
 
+    Convention:
+        - ``shear`` is ``(shx, shy)``
+        - align_corners: ``False`` by default
+        - padding_mode: ``'zeros'`` by default
+
     Args:
         tensor: The image tensor to be skewed with shape of :math:`(B, C, H, W)`.
         shear: tensor containing the angle to shear
@@ -559,6 +595,12 @@ def resize(
     r"""Resize the input torch.Tensor to the given size.
 
     .. image:: _static/img/resize.png
+
+    Convention:
+        - input: :math:`(B, C, H, W)`; ``size`` is ``(h, w)``
+        - align_corners: ``None`` by default (follows ``torch.nn.functional.interpolate``;
+          note :func:`warp_perspective`/:func:`rotate` default ``True``)
+        - ``side`` resizing preserves aspect ratio using the named side
 
     Args:
         input: The image tensor to be skewed with shape of :math:`(..., H, W)`.
@@ -643,6 +685,11 @@ def resize_to_be_divisible(
 ) -> torch.Tensor:
     """Resize the input tensor to be divisible by a certain factor.
 
+    Convention:
+        - align_corners: ``None`` by default; see the convention block of :func:`resize`
+        - rounds ``height``/``width`` to the nearest multiple of ``divisible_factor`` before
+          delegating to :func:`resize`
+
     Args:
         input (torch.Tensor): Input tensor to be resized.
         divisible_factor (int): The factor to which the image should be divisible.
@@ -678,6 +725,11 @@ def rescale(
 
     .. image:: _static/img/rescale.png
 
+    Convention:
+        - align_corners: ``None`` by default (follows ``torch.nn.functional.interpolate``;
+          see the convention block of :func:`resize`)
+        - delegates to :func:`resize` after converting ``factor`` to an output ``size``
+
     Args:
         input: The image tensor to be scale with shape of :math:`(B, C, H, W)`.
         factor: Desired scaling factor in each direction. If scalar, the value is used
@@ -712,6 +764,10 @@ def rescale(
 
 class Resize(nn.Module):
     r"""Resize the input torch.Tensor to the given size.
+
+    Convention:
+        - align_corners: ``None`` by default, matching :func:`resize`
+        - See the convention block of :func:`resize`.
 
     Args:
         size: Desired output size. If size is a sequence like (h, w),
@@ -782,6 +838,10 @@ class Resize(nn.Module):
 
 class Affine(nn.Module):
     r"""Apply multiple elementary affine transforms simultaneously.
+
+    Convention:
+        - align_corners: ``True`` by default, matching :func:`affine`
+        - See the convention block of :func:`affine`.
 
     Args:
         angle: Angle in degrees for counter-clockwise rotation around the center. The tensor
@@ -896,6 +956,11 @@ class Affine(nn.Module):
 class Rescale(nn.Module):
     r"""Rescale the input torch.Tensor with the given factor.
 
+    Convention:
+        - align_corners: ``True`` by default (differs from function :func:`rescale`, whose default
+          is ``None``)
+        - See the convention block of :func:`rescale`.
+
     Args:
         factor: Desired scaling factor in each direction. If scalar, the value is used
             for both the x- and y-direction.
@@ -950,6 +1015,10 @@ class Rescale(nn.Module):
 
 class Rotate(nn.Module):
     r"""Rotate the tensor anti-clockwise about the centre.
+
+    Convention:
+        - align_corners: ``True`` by default, matching :func:`rotate`
+        - See the convention block of :func:`rotate`.
 
     Args:
         angle: The angle through which to rotate. The tensor
@@ -1009,6 +1078,10 @@ class Rotate(nn.Module):
 class Translate(nn.Module):
     r"""Translate the tensor in pixel units.
 
+    Convention:
+        - align_corners: ``True`` by default, matching :func:`translate`
+        - See the convention block of :func:`translate`.
+
     Args:
         translation: tensor containing the amount of pixels to
           translate in the x and y direction. The tensor must have a shape of
@@ -1061,6 +1134,10 @@ class Translate(nn.Module):
 
 class Scale(nn.Module):
     r"""Scale the tensor by a factor.
+
+    Convention:
+        - align_corners: ``True`` by default, matching :func:`scale`
+        - See the convention block of :func:`scale`.
 
     Args:
         scale_factor: The scale factor apply. The tensor
@@ -1120,6 +1197,11 @@ class Scale(nn.Module):
 
 class Shear(nn.Module):
     r"""Shear the tensor.
+
+    Convention:
+        - align_corners: ``True`` by default (differs from function :func:`shear`, whose default is
+          ``False``)
+        - See the convention block of :func:`shear`.
 
     Args:
         shear: tensor containing the angle to shear

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -151,11 +151,11 @@ def affine(
 
     Args:
         tensor: The image tensor to be warped in shapes of
-            :math:`(H, W)`, :math:`(D, H, W)` and :math:`(B, C, H, W)`.
+            :math:`(C, H, W)` or :math:`(B, C, H, W)`.
         matrix: The 2x3 affine transformation matrix.
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -209,12 +209,12 @@ def affine3d(
 
     Args:
         tensor: The image tensor to be warped in shapes of
-            :math:`(D, H, W)`, :math:`(C, D, H, W)` and :math:`(B, C, D, H, W)`.
+            :math:`(C, D, H, W)` or :math:`(B, C, D, H, W)`.
         matrix: The affine transformation matrix with shape :math:`(B, 3, 4)`.
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-         `` 'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+         `` 'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -282,7 +282,7 @@ def rotate(
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -352,12 +352,12 @@ def rotate3d(
         roll: The roll angle through which to rotate. The tensor
           must have a shape of (B), where B is batch size.
         center: The center through which to rotate. The tensor
-          must have a shape of (B, 2), where B is batch size and last
-          dimension contains cx and cy.
+          must have a shape of (B, 3), where B is batch size and last
+          dimension contains x, y and z.
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -422,7 +422,7 @@ def translate(
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -481,7 +481,7 @@ def scale(
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -543,7 +543,7 @@ def shear(
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -738,8 +738,6 @@ def rescale(
         interpolation:  algorithm used for upsampling: ``'nearest'`` | ``'linear'`` | ``'bilinear'`` |
             ``'bicubic'`` | ``'trilinear'`` | ``'area'``.
         align_corners: interpolation flag.
-        side: Corresponding side if ``size`` is an integer. Can be one of ``'short'``, ``'long'``, ``'vert'``,
-            or ``'horz'``.
         antialias: if True, then image will be filtered with Gaussian before downscaling.
             No effect for upscaling.
 
@@ -860,7 +858,7 @@ class Affine(nn.Module):
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Raises:
@@ -968,8 +966,6 @@ class Rescale(nn.Module):
         interpolation:  algorithm used for upsampling: ``'nearest'`` | ``'linear'`` | ``'bilinear'`` |
             ``'bicubic'`` | ``'trilinear'`` | ``'area'``.
         align_corners: interpolation flag.
-        side: Corresponding side if ``size`` is an integer. Can be one of ``'short'``, ``'long'``, ``'vert'``,
-            or ``'horz'``.
         antialias: if True, then image will be filtered with Gaussian before downscaling.
             No effect for upscaling.
 
@@ -1030,7 +1026,7 @@ class Rotate(nn.Module):
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -1090,7 +1086,7 @@ class Translate(nn.Module):
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -1151,7 +1147,7 @@ class Scale(nn.Module):
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:
@@ -1211,7 +1207,7 @@ class Shear(nn.Module):
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
 
     Returns:

--- a/kornia/geometry/transform/homography_warper.py
+++ b/kornia/geometry/transform/homography_warper.py
@@ -90,7 +90,7 @@ class HomographyWarper(BaseWarper):
         width: The width of the destination torch.Tensor.
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         normalized_coordinates: whether to use a grid with normalized coordinates.
         align_corners: interpolation flag.
 

--- a/kornia/geometry/transform/homography_warper.py
+++ b/kornia/geometry/transform/homography_warper.py
@@ -32,7 +32,12 @@ __all__ = ["BaseWarper", "HomographyWarper"]
 
 
 class BaseWarper(nn.Module):
-    """Provide a base class for homography-based image warping."""
+    """Provide a base class for homography-based image warping.
+
+    Convention:
+        - subclasses receive ``src_homo_dst`` as the destination→source homography
+
+    """
 
     def __init__(self, height: int, width: int, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -75,6 +80,10 @@ class HomographyWarper(BaseWarper):
     .. math::
 
         X_{dst} = H_{src}^{\{dst\}} * X_{src}
+
+    Convention:
+        - align_corners: ``False`` by default, matching :func:`homography_warp`
+        - See the convention block of :func:`homography_warp`.
 
     Args:
         height: The height of the destination torch.Tensor.

--- a/kornia/geometry/transform/homography_warper.py
+++ b/kornia/geometry/transform/homography_warper.py
@@ -126,7 +126,7 @@ class HomographyWarper(BaseWarper):
         Args:
             src_homo_dst: Homography or homographies (stacked) to
               transform all points in the grid. Shape of the homography
-              has to be :math:`(1, 3, 3)` or :math:`(N, 1, 3, 3)`.
+              has to be :math:`(1, 3, 3)`, :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`.
               The homography assumes normalized coordinates [-1, 1] if
               normalized_coordinates is True.
 

--- a/kornia/geometry/transform/homography_warper.py
+++ b/kornia/geometry/transform/homography_warper.py
@@ -79,7 +79,7 @@ class HomographyWarper(BaseWarper):
 
     .. math::
 
-        X_{dst} = H_{src}^{\{dst\}} * X_{src}
+        X_{src} = H_{src}^{\{dst\}} * X_{dst}
 
     Convention:
         - align_corners: ``False`` by default, matching :func:`homography_warp`

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -86,6 +86,14 @@ def warp_perspective(
         \frac{M^{-1}_{21} x + M^{-1}_{22} y + M^{-1}_{23}}{M^{-1}_{31} x + M^{-1}_{32} y + M^{-1}_{33}}
         \right )
 
+    Convention:
+        - input: :math:`(B, C, H, W)`; ``dsize`` is ``(h, w)``
+        - ``M`` is the source→destination **pixel** homography :math:`(B, 3, 3)`
+          (contrast :func:`homography_warp`, which consumes destination→source normalized)
+        - coordinates: ``(x, y)``, pixel centers, origin at top-left
+        - align_corners: ``True`` by default
+        - padding_mode: ``'zeros'`` by default
+
     Args:
         src: input image with shape :math:`(B, C, H, W)`.
         M: transformation matrix with shape :math:`(B, 3, 3)`.
@@ -185,6 +193,13 @@ def warp_affine(
     .. math::
         \text{dst}(x, y) = \text{src} \left( M_{11} x + M_{12} y + M_{13} ,
         M_{21} x + M_{22} y + M_{23} \right )
+
+    Convention:
+        - input: :math:`(B, C, H, W)`; ``dsize`` is ``(h, w)``
+        - ``M`` is the source→destination **pixel** affine matrix :math:`(B, 2, 3)`
+        - coordinates: ``(x, y)``, pixel centers, origin at top-left
+        - align_corners: ``True`` by default
+        - padding_mode: ``'zeros'`` by default
 
     Args:
         src: input torch.Tensor of shape :math:`(B, C, H, W)`.
@@ -306,6 +321,10 @@ def _fill_and_warp(
 def warp_grid(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
     r"""Compute the grid to warp the coordinates grid by the homography/ies.
 
+    Convention:
+        - ``grid`` coordinates: ``(x, y)`` (last dim), shape :math:`(1, H, W, 2)`
+        - ``src_homo_dst`` is the destination→source homography :math:`(1, 3, 3)` or :math:`(N, 1, 3, 3)`
+
     Args:
         grid: Unwrapped grid of the shape :math:`(1, H, W, 2)`.
         src_homo_dst: Homography or homographies (stacked) to
@@ -330,6 +349,10 @@ def warp_grid(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
 
 def warp_grid3d(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
     r"""Compute the grid to warp the coordinates grid by the homography/ies.
+
+    Convention:
+        - ``grid`` coordinates: ``(x, y, z)`` (last dim), shape :math:`(1, D, H, W, 3)`
+        - ``src_homo_dst`` is the destination→source homography :math:`(1, 4, 4)` or :math:`(N, 1, 4, 4)`
 
     Args:
         grid: Unwrapped grid of the shape :math:`(1, D, H, W, 3)`.
@@ -457,6 +480,11 @@ def get_perspective_transform(points_src: torch.Tensor, points_dst: torch.Tensor
         1 \\
         \end{bmatrix}
 
+    Convention:
+        - points: ``(x, y)``, pixel centers, origin at top-left; shape :math:`(B, 4, 2)`
+        - returns the source→destination **pixel** homography :math:`(B, 3, 3)`
+          (contrast :func:`homography_warp`, which consumes destination→source normalized)
+
     Args:
         points_src: coordinates of quadrangle vertices in the source image with shape :math:`(B, 4, 2)`.
         points_dst: coordinates of the corresponding quadrangle vertices in
@@ -508,6 +536,11 @@ def get_rotation_matrix2d(center: torch.Tensor, angle: torch.Tensor, scale: torc
 
     The transformation maps the rotation center to itself
     If this is not the target, adjust the shift.
+
+    Convention:
+        - ``center`` is ``(x, y)`` in pixels, origin at top-left
+        - positive ``angle`` rotates counter-clockwise as displayed (y-down image axes)
+        - returns :math:`(B, 2, 3)` affine matrix in pixel coordinates
 
     Args:
         center: center of the rotation in the source image with shape :math:`(B, 2)`.
@@ -596,6 +629,12 @@ def remap(
     .. math::
         \text{dst}(x, y) = \text{src}(map_x(x, y), map_y(x, y))
 
+    Convention:
+        - input: :math:`(B, C, H, W)`; ``map_x``/``map_y`` are :math:`(B, H, W)` pixel coordinates
+          unless ``normalized_coordinates=True``
+        - align_corners: ``None`` by default, resolved to ``False`` internally
+        - padding_mode: ``'zeros'`` by default
+
     Args:
         image: the torch.Tensor to remap with shape (B, C, H, W).
           Where C is the number of channels.
@@ -666,6 +705,9 @@ def invert_affine_transform(matrix: torch.Tensor) -> torch.Tensor:
 
     The result is also a 2x3 matrix of the same type as M.
 
+    Convention:
+        - ``matrix`` is the pixel-space affine transform :math:`(B, 2, 3)`; returns its inverse, same shape
+
     Args:
         matrix: original affine transform. The torch.Tensor must be
           in the shape of :math:`(B, 2, 3)`.
@@ -699,6 +741,12 @@ def get_affine_matrix2d(
 ) -> torch.Tensor:
     r"""Compose affine matrix from the components.
 
+    Convention:
+        - ``center`` is ``(x, y)`` in pixels, origin at top-left
+        - positive ``angle`` rotates **clockwise** as displayed — this function negates ``angle``
+          before delegating to :func:`get_rotation_matrix2d`, whose convention is CCW-positive
+        - returns :math:`(B, 3, 3)` affine matrix in pixel coordinates
+
     Args:
         translations: torch.Tensor containing the translation vector with shape :math:`(B, 2)`.
         center: torch.Tensor containing the center vector with shape :math:`(B, 2)`.
@@ -729,6 +777,9 @@ def get_affine_matrix2d(
 
 def get_translation_matrix2d(translations: torch.Tensor) -> torch.Tensor:
     r"""Compose translation matrix from the components.
+
+    Convention:
+        - ``translations`` is ``(dx, dy)`` in pixels; returns :math:`(B, 3, 3)` affine matrix in pixel coordinates
 
     Args:
         translations: torch.Tensor containing the translation vector with shape :math:`(B, 2)`.
@@ -761,6 +812,10 @@ def get_shear_matrix2d(
             1 & b \\
             a & ab + 1 \\
         \end{bmatrix}
+
+    Convention:
+        - ``center`` is ``(x, y)`` in pixels, origin at top-left
+        - returns :math:`(B, 3, 3)` affine matrix in pixel coordinates
 
     Args:
         center: shearing center coordinates of (x, y).
@@ -816,6 +871,13 @@ def get_affine_matrix3d(
 ) -> torch.Tensor:
     r"""Compose 3d affine matrix from the components.
 
+    Convention:
+        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left
+        - ``angles`` are negated before delegating to :func:`get_projective_transform`, whose own
+          rotation convention follows the right-hand rule (see
+          :func:`kornia.geometry.conversions.axis_angle_to_rotation_matrix`)
+        - returns :math:`(B, 4, 4)` affine matrix in pixel coordinates
+
     Args:
         translations: torch.Tensor containing the translation vector (dx,dy,dz) with shape :math:`(B, 3)`.
         center: torch.Tensor containing the center vector (x,y,z) with shape :math:`(B, 3)`.
@@ -831,7 +893,7 @@ def get_affine_matrix3d(
         szy: torch.Tensor containing the shear factor in the zy-direction with shape :math:`(B)`.
 
     Returns:
-        the 3d affine transformation matrix :math:`(B, 3, 3)`.
+        the 3d affine transformation matrix :math:`(B, 4, 4)`.
 
     .. note::
         This function is often used in conjunction with :func:`warp_perspective`.
@@ -878,6 +940,10 @@ def get_shear_matrix3d(
         r = S_{zx} + S_{yx}S_{zy}
         s = S_{xy}S_{zx} + (S_{xy}S_{yx} + 1)S_{zy}
         t = S_{xz}S_{zx} + (S_{xz}S_{yx} + S_{yz})S_{zy} + 1
+
+    Convention:
+        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left
+        - returns :math:`(B, 4, 4)` affine matrix in pixel coordinates
 
     Params:
         center: shearing center coordinates of (x, y, z).
@@ -976,6 +1042,12 @@ def warp_affine3d(
     .. warning::
         This API signature it is experimental and might suffer some changes in the future.
 
+    Convention:
+        - input: :math:`(B, C, D, H, W)`; ``dsize`` is ``(d, h, w)``
+        - ``M`` is the source→destination **pixel** affine matrix :math:`(B, 3, 4)`
+        - align_corners: ``True`` by default
+        - padding_mode: ``'zeros'`` by default
+
     Args:
         src : input torch.Tensor of shape :math:`(B, C, D, H, W)`.
         M: projective transformation matrix of shape :math:`(B, 3, 4)`.
@@ -1026,6 +1098,9 @@ def projection_from_Rt(rmat: torch.Tensor, tvec: torch.Tensor) -> torch.Tensor:
 
     Concatenates the batch of rotations and translations such that :math:`P = [R | t]`.
 
+    Convention:
+        - returns the concatenation :math:`[R | t]` with shape :math:`(*, 3, 4)`
+
     Args:
        rmat: the rotation matrix with shape :math:`(*, 3, 3)`.
        tvec: the translation vector with shape :math:`(*, 3, 1)`.
@@ -1049,6 +1124,13 @@ def get_projective_transform(center: torch.Tensor, angles: torch.Tensor, scales:
         This API signature it is experimental and might suffer some changes in the future.
 
     The function computes the projection matrix given the center and angles per axis.
+
+    Convention:
+        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left
+        - rotation follows the right-hand rule (see
+          :func:`kornia.geometry.conversions.axis_angle_to_rotation_matrix`); a positive rotation
+          about +z is **clockwise on screen** (y-down image axes) — opposite of :func:`get_rotation_matrix2d`
+        - returns the projection matrix :math:`(B, 3, 4)` in pixel coordinates
 
     Args:
         center: center of the rotation (x,y,z) in the source with shape :math:`(B, 3)`.
@@ -1154,6 +1236,10 @@ def get_perspective_transform3d(src: torch.Tensor, dst: torch.Tensor) -> torch.T
         0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & x_5 & y_5 & z_5 & 1 & -x_5*w_5 & -y_5*w_5 & -z_5 * w_5 \\
         0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & x_7 & y_7 & z_7 & 1 & -x_7*w_7 & -y_7*w_7 & -z_7 * w_7 \\
         \end{pmatrix}
+
+    Convention:
+        - points: ``(x, y, z)``, pixel centers, origin at top-left; shape :math:`(B, 8, 3)`
+        - returns the source→destination **pixel** homography :math:`(B, 4, 4)`
 
     Args:
         src: coordinates of quadrangle vertices in the source image with shape :math:`(B, 8, 3)`.
@@ -1331,10 +1417,17 @@ def warp_perspective3d(
         \frac{M_{21} x + M_{22} y + M_{23}}{M_{31} x + M_{32} y + M_{33}}
         \right )
 
+    Convention:
+        - input: :math:`(B, C, D, H, W)`; ``dsize`` is ``(d, h, w)``
+        - ``M`` is the source→destination **pixel** homography :math:`(B, 4, 4)`
+        - align_corners: ``False`` by default (differs from the 2D :func:`warp_perspective`,
+          whose default is ``True``)
+        - border_mode: ``'zeros'`` by default
+
     Args:
         src: input image with shape :math:`(B, C, D, H, W)`.
         M: transformation matrix with shape :math:`(B, 4, 4)`.
-        dsize: size of the output image (height, width).
+        dsize: size of the output image (depth, height, width).
         flags: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         border_mode: padding mode for outside grid values
@@ -1378,6 +1471,16 @@ def homography_warp(
     r"""Warp image patches or tensors by normalized 2D homographies.
 
     See :class:`~kornia.geometry.warp.HomographyWarper` for details.
+
+    Convention:
+        - input: :math:`(N, C, H, W)`
+        - ``src_homo_dst`` is the destination→source homography :math:`(N, 3, 3)`
+          (contrast :func:`warp_perspective`, which consumes source→destination pixel)
+        - ``normalized_homography=True`` by default: ``src_homo_dst`` and ``dsize`` are in
+          normalized :math:`[-1, 1]` coordinates
+        - align_corners: ``False`` by default (only honored when ``normalized_homography=True``;
+          the pixel-homography path currently forces ``True``)
+        - padding_mode: ``'zeros'`` by default
 
     Args:
         patch_src: The image or torch.Tensor to warp. Should be from source of shape :math:`(N, C, H, W)`.
@@ -1452,6 +1555,12 @@ def homography_warp3d(
     normalized_coordinates: bool = True,
 ) -> torch.Tensor:
     r"""Warp image patches or tensors by normalized 3D homographies.
+
+    Convention:
+        - input: :math:`(N, C, D, H, W)`; ``dsize`` is ``(d, h, w)``
+        - ``src_homo_dst`` is the destination→source homography :math:`(N, 4, 4)`, normalized coordinates
+        - align_corners: ``False`` by default
+        - padding_mode: ``'zeros'`` by default
 
     Args:
         patch_src: The image or torch.Tensor to warp. Should be from source of shape :math:`(N, C, D, H, W)`.

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -105,7 +105,7 @@ def warp_perspective(
         fill_value: torch.Tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
 
     Returns:
-        the warped input image :math:`(B, C, H, W)`.
+        the warped input image :math:`(B, C, h, w)`, spatial sizes given by ``dsize``.
 
     Example:
        >>> img = torch.rand(1, 4, 5, 6)
@@ -212,7 +212,7 @@ def warp_affine(
         fill_value: torch.Tensor of shape :math:`(C)` or :math:`(1)` that fills the padding area.
 
     Returns:
-        the warped torch.Tensor with shape :math:`(B, C, H, W)`.
+        the warped torch.Tensor with shape :math:`(B, C, h, w)`, spatial sizes given by ``dsize``.
 
     .. note::
         This function is often used in conjunction with :func:`get_rotation_matrix2d`,
@@ -1063,7 +1063,8 @@ def warp_affine3d(
         align_corners : mode for grid_generation.
 
     Returns:
-        torch.Tensor: the warped 3d torch.tensor with shape :math:`(B, C, D, H, W)`.
+        torch.Tensor: the warped 3d torch.tensor with shape :math:`(B, C, d, h, w)`, spatial sizes
+        given by ``dsize``.
 
     .. note::
         This function is often used in conjunction with :func:`get_perspective_transform3d`.
@@ -1477,9 +1478,10 @@ def homography_warp(
     Convention:
         - input: :math:`(N, C, H, W)`
         - ``src_homo_dst`` is the destination→source homography :math:`(N, 3, 3)`, in normalized
-          :math:`[-1, 1]` coordinates, when ``normalized_homography=True`` (default); with
-          ``normalized_homography=False`` it is consumed as the source→destination **pixel**
-          homography, exactly like :func:`warp_perspective`
+          :math:`[-1, 1]` coordinates by default (``normalized_coordinates=True``), when
+          ``normalized_homography=True`` (default); with ``normalized_homography=False`` it is
+          consumed as the source→destination **pixel** homography, exactly like
+          :func:`warp_perspective`
         - ``dsize`` is ``(h, w)``
         - align_corners: ``False`` by default; ``mode``: ``'bilinear'`` by default (both only
           honored when ``normalized_homography=True`` — the pixel-homography path currently

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -99,7 +99,7 @@ def warp_perspective(
         M: transformation matrix with shape :math:`(B, 3, 3)`.
         dsize: size of the output image (height, width).
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
-        padding_mode: padding mode for outside grid values ``'torch.zeros'`` | ``'border'`` | ``'reflection'``
+        padding_mode: padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'``
             | ``'fill'``.
         align_corners: interpolation flag.
         fill_value: torch.Tensor of shape :math:`(3)` that fills the padding area. Only supported for RGB.
@@ -194,6 +194,8 @@ def warp_affine(
         \text{dst}(x, y) = \text{src} \left( M^{-1}_{11} x + M^{-1}_{12} y + M^{-1}_{13} ,
         M^{-1}_{21} x + M^{-1}_{22} y + M^{-1}_{23} \right )
 
+    where :math:`M^{-1}` is the inverse of the :math:`3 \times 3` homogeneous extension of ``M``.
+
     Convention:
         - input: :math:`(B, C, H, W)`; ``dsize`` is ``(h, w)``
         - ``M`` is the source→destination **pixel** affine matrix :math:`(B, 2, 3)`
@@ -206,7 +208,7 @@ def warp_affine(
         M: affine transformation of shape :math:`(B, 2, 3)`.
         dsize: size of the output image (height, width).
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
-        padding_mode: padding mode for outside grid values ``'torch.zeros'`` | ``'border'`` | ``'reflection'``
+        padding_mode: padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'``
             | ``'fill'``.
         align_corners : mode for grid_generation.
         fill_value: torch.Tensor of shape :math:`(C)` or :math:`(1)` that fills the padding area.
@@ -322,7 +324,7 @@ def warp_grid(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
     r"""Compute the grid to warp the coordinates grid by the homography/ies.
 
     Convention:
-        - ``grid`` coordinates: ``(x, y)`` (last dim), shape :math:`(1, H, W, 2)`
+        - ``grid`` coordinates: ``(x, y)`` (last dim), shape :math:`(1, H, W, 2)` or :math:`(N, H, W, 2)`
         - ``src_homo_dst`` is the destination→source homography :math:`(1, 3, 3)`,
           :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`
 
@@ -352,7 +354,8 @@ def warp_grid3d(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
     r"""Compute the grid to warp the coordinates grid by the homography/ies.
 
     Convention:
-        - ``grid`` coordinates: ``(x, y, z)`` (last dim), shape :math:`(1, D, H, W, 3)`
+        - ``grid`` coordinates: ``(x, y, z)`` (last dim), shape :math:`(1, D, H, W, 3)` or
+          :math:`(N, D, H, W, 3)`
         - ``src_homo_dst`` is the destination→source homography :math:`(1, 4, 4)`,
           :math:`(N, 4, 4)` or :math:`(N, 1, 4, 4)`
 
@@ -647,7 +650,7 @@ def remap(
         mode: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: mode for grid_generation.
         normalized_coordinates: whether the input coordinates are
            normalized in the range of [-1, 1].
@@ -1059,7 +1062,7 @@ def warp_affine3d(
         flags: interpolation mode to calculate output values
           ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values
-          ``'torch.zeros'`` | ``'border'`` | ``'reflection'``.
+          ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners : mode for grid_generation.
 
     Returns:
@@ -1418,7 +1421,9 @@ def warp_perspective3d(
     the specified matrix:
 
     .. math::
-        \text{dst}(x, y, z) = \text{src}\left( M^{-1} \cdot (x, y, z, 1)^{T} \right)
+        \text{dst}(x, y, z) = \text{src}\left( \pi\left( M^{-1} \cdot (x, y, z, 1)^{T} \right) \right)
+
+    where :math:`\pi` divides by the fourth (homogeneous) coordinate.
 
     Convention:
         - input: :math:`(B, C, D, H, W)`; ``dsize`` is ``(d, h, w)``
@@ -1490,8 +1495,9 @@ def homography_warp(
 
     Args:
         patch_src: The image or torch.Tensor to warp. Should be from source of shape :math:`(N, C, H, W)`.
-        src_homo_dst: The homography or torch.stack of homographies from destination to source of shape
-            :math:`(N, 3, 3)`.
+        src_homo_dst: The homography or torch.stack of homographies of shape :math:`(N, 3, 3)` —
+            destination to source when ``normalized_homography=True`` (default), source to
+            destination (pixel) when ``normalized_homography=False``.
         dsize:
           if homography normalized: The height and width of the image to warp.
           if homography not normalized: size of the output image (height, width).

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -803,7 +803,7 @@ def get_translation_matrix2d(translations: torch.Tensor) -> torch.Tensor:
 def get_shear_matrix2d(
     center: torch.Tensor, sx: Optional[torch.Tensor] = None, sy: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
-    r"""Compose shear matrix Bx4x4 from the components.
+    r"""Compose shear matrix Bx3x3 from the components.
 
     Note: Ordered shearing, shear x-axis then y-axis.
 
@@ -1476,8 +1476,9 @@ def homography_warp(
         - input: :math:`(N, C, H, W)`
         - ``src_homo_dst`` is the destination→source homography :math:`(N, 3, 3)`
           (contrast :func:`warp_perspective`, which consumes source→destination pixel)
-        - ``normalized_homography=True`` by default: ``src_homo_dst`` and ``dsize`` are in
+        - ``normalized_homography=True`` by default: ``src_homo_dst`` is in
           normalized :math:`[-1, 1]` coordinates
+        - ``dsize`` is ``(h, w)``
         - align_corners: ``False`` by default (only honored when ``normalized_homography=True``;
           the pixel-homography path currently forces ``True``)
         - padding_mode: ``'zeros'`` by default

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -872,7 +872,8 @@ def get_affine_matrix3d(
     r"""Compose 3d affine matrix from the components.
 
     Convention:
-        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left
+        - ``center`` is ``(x, y, z)`` in pixels, origin at the top-left of the first depth
+          slice (``z = 0``)
         - ``angles`` are negated before delegating to :func:`get_projective_transform`, whose own
           rotation convention follows the right-hand rule (see
           :func:`kornia.geometry.conversions.axis_angle_to_rotation_matrix`)
@@ -942,7 +943,8 @@ def get_shear_matrix3d(
         t = S_{xz}S_{zx} + (S_{xz}S_{yx} + S_{yz})S_{zy} + 1
 
     Convention:
-        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left
+        - ``center`` is ``(x, y, z)`` in pixels, origin at the top-left of the first depth
+          slice (``z = 0``)
         - returns :math:`(B, 4, 4)` affine matrix in pixel coordinates
 
     Params:
@@ -1126,7 +1128,8 @@ def get_projective_transform(center: torch.Tensor, angles: torch.Tensor, scales:
     The function computes the projection matrix given the center and angles per axis.
 
     Convention:
-        - ``center`` is ``(x, y, z)`` in pixels, origin at top-left
+        - ``center`` is ``(x, y, z)`` in pixels, origin at the top-left of the first depth
+          slice (``z = 0``)
         - rotation follows the right-hand rule (see
           :func:`kornia.geometry.conversions.axis_angle_to_rotation_matrix`); a positive rotation
           about +z is **clockwise on screen** (y-down image axes) — opposite of :func:`get_rotation_matrix2d`
@@ -1238,7 +1241,7 @@ def get_perspective_transform3d(src: torch.Tensor, dst: torch.Tensor) -> torch.T
         \end{pmatrix}
 
     Convention:
-        - points: ``(x, y, z)``, pixel centers, origin at top-left; shape :math:`(B, 8, 3)`
+        - points: ``(x, y, z)``, pixel centers, origin at the top-left of the first depth slice; shape :math:`(B, 8, 3)`
         - returns the source→destination **pixel** homography :math:`(B, 4, 4)`
 
     Args:
@@ -1470,17 +1473,18 @@ def homography_warp(
 ) -> torch.Tensor:
     r"""Warp image patches or tensors by normalized 2D homographies.
 
-    See :class:`~kornia.geometry.warp.HomographyWarper` for details.
+    See :class:`~kornia.geometry.transform.HomographyWarper` for details.
 
     Convention:
         - input: :math:`(N, C, H, W)`
-        - ``src_homo_dst`` is the destination→source homography :math:`(N, 3, 3)`
-          (contrast :func:`warp_perspective`, which consumes source→destination pixel)
-        - ``normalized_homography=True`` by default: ``src_homo_dst`` is in
-          normalized :math:`[-1, 1]` coordinates
+        - ``src_homo_dst`` is the destination→source homography :math:`(N, 3, 3)`, in normalized
+          :math:`[-1, 1]` coordinates, when ``normalized_homography=True`` (default); with
+          ``normalized_homography=False`` it is consumed as the source→destination **pixel**
+          homography, exactly like :func:`warp_perspective`
         - ``dsize`` is ``(h, w)``
-        - align_corners: ``False`` by default (only honored when ``normalized_homography=True``;
-          the pixel-homography path currently forces ``True``)
+        - align_corners: ``False`` by default; ``mode``: ``'bilinear'`` by default (both only
+          honored when ``normalized_homography=True`` — the pixel-homography path currently
+          forces ``align_corners=True`` and ``mode='bilinear'``)
         - padding_mode: ``'zeros'`` by default
 
     Args:
@@ -1559,7 +1563,8 @@ def homography_warp3d(
 
     Convention:
         - input: :math:`(N, C, D, H, W)`; ``dsize`` is ``(d, h, w)``
-        - ``src_homo_dst`` is the destination→source homography :math:`(N, 4, 4)`, normalized coordinates
+        - ``src_homo_dst`` is the destination→source homography :math:`(N, 4, 4)`, in normalized
+          :math:`[-1, 1]` coordinates by default (``normalized_coordinates=True``)
         - align_corners: ``False`` by default
         - padding_mode: ``'zeros'`` by default
 

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -361,7 +361,7 @@ def warp_grid3d(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
           has to be :math:`(1, 4, 4)` or :math:`(N, 1, 4, 4)`.
 
     Returns:
-        the transformed grid of shape :math:`(N, H, W, 3)`.
+        the transformed grid of shape :math:`(N, D, H, W, 3)`.
 
     """
     batch_size: int = src_homo_dst.size(0)

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -191,8 +191,8 @@ def warp_affine(
     the specified matrix:
 
     .. math::
-        \text{dst}(x, y) = \text{src} \left( M_{11} x + M_{12} y + M_{13} ,
-        M_{21} x + M_{22} y + M_{23} \right )
+        \text{dst}(x, y) = \text{src} \left( M^{-1}_{11} x + M^{-1}_{12} y + M^{-1}_{13} ,
+        M^{-1}_{21} x + M^{-1}_{22} y + M^{-1}_{23} \right )
 
     Convention:
         - input: :math:`(B, C, H, W)`; ``dsize`` is ``(h, w)``
@@ -323,13 +323,14 @@ def warp_grid(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
 
     Convention:
         - ``grid`` coordinates: ``(x, y)`` (last dim), shape :math:`(1, H, W, 2)`
-        - ``src_homo_dst`` is the destination→source homography :math:`(1, 3, 3)` or :math:`(N, 1, 3, 3)`
+        - ``src_homo_dst`` is the destination→source homography :math:`(1, 3, 3)`,
+          :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`
 
     Args:
         grid: Unwrapped grid of the shape :math:`(1, H, W, 2)`.
         src_homo_dst: Homography or homographies (stacked) to
           transform all points in the grid. Shape of the homography
-          has to be :math:`(1, 3, 3)` or :math:`(N, 1, 3, 3)`.
+          has to be :math:`(1, 3, 3)`, :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`.
 
     Returns:
         the transformed grid of shape :math:`(N, H, W, 2)`.
@@ -352,13 +353,14 @@ def warp_grid3d(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
 
     Convention:
         - ``grid`` coordinates: ``(x, y, z)`` (last dim), shape :math:`(1, D, H, W, 3)`
-        - ``src_homo_dst`` is the destination→source homography :math:`(1, 4, 4)` or :math:`(N, 1, 4, 4)`
+        - ``src_homo_dst`` is the destination→source homography :math:`(1, 4, 4)`,
+          :math:`(N, 4, 4)` or :math:`(N, 1, 4, 4)`
 
     Args:
         grid: Unwrapped grid of the shape :math:`(1, D, H, W, 3)`.
         src_homo_dst: Homography or homographies (stacked) to
           transform all points in the grid. Shape of the homography
-          has to be :math:`(1, 4, 4)` or :math:`(N, 1, 4, 4)`.
+          has to be :math:`(1, 4, 4)`, :math:`(N, 4, 4)` or :math:`(N, 1, 4, 4)`.
 
     Returns:
         the transformed grid of shape :math:`(N, D, H, W, 3)`.
@@ -1415,10 +1417,7 @@ def warp_perspective3d(
     the specified matrix:
 
     .. math::
-        \text{dst} (x, y) = \text{src} \left(
-        \frac{M_{11} x + M_{12} y + M_{13}}{M_{31} x + M_{32} y + M_{33}} ,
-        \frac{M_{21} x + M_{22} y + M_{23}}{M_{31} x + M_{32} y + M_{33}}
-        \right )
+        \text{dst}(x, y, z) = \text{src}\left( M^{-1} \cdot (x, y, z, 1)^{T} \right)
 
     Convention:
         - input: :math:`(B, C, D, H, W)`; ``dsize`` is ``(d, h, w)``
@@ -1438,7 +1437,7 @@ def warp_perspective3d(
         align_corners: interpolation flag.
 
     Returns:
-        the warped input image :math:`(B, C, D, H, W)`.
+        the warped input image :math:`(B, C, d, h, w)`, spatial sizes given by ``dsize``.
 
     .. note::
         This function is often used in conjunction with :func:`get_perspective_transform3d`.
@@ -1572,7 +1571,7 @@ def homography_warp3d(
         patch_src: The image or torch.Tensor to warp. Should be from source of shape :math:`(N, C, D, H, W)`.
         src_homo_dst: The homography or torch.stack of homographies from destination to source of shape
           :math:`(N, 4, 4)`.
-        dsize: The height and width of the image to warp.
+        dsize: The depth, height and width of the volume to warp.
         mode: interpolation mode to calculate output values ``'bilinear'`` | ``'nearest'``.
         padding_mode: padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
@@ -1582,9 +1581,9 @@ def homography_warp3d(
         Patch sampled at locations from source to destination.
 
     Example:
-        >>> input = torch.rand(1, 3, 32, 32)
-        >>> homography = torch.eye(3).view(1, 3, 3)
-        >>> output = homography_warp(input, homography, (32, 32))
+        >>> input = torch.rand(1, 3, 8, 32, 32)
+        >>> homography = torch.eye(4).view(1, 4, 4)
+        >>> output = homography_warp3d(input, homography, (8, 32, 32))
 
     """
     if not src_homo_dst.device == patch_src.device:

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -327,9 +327,12 @@ def warp_grid(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
         - ``grid`` coordinates: ``(x, y)`` (last dim), shape :math:`(1, H, W, 2)` or :math:`(N, H, W, 2)`
         - ``src_homo_dst`` is the destination→source homography :math:`(1, 3, 3)`,
           :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`
+        - only the :math:`(1, H, W, 2)` grid broadcasts over homography batches; a batched grid
+          requires a matching batch of :math:`N` homographies
 
     Args:
-        grid: Unwrapped grid of the shape :math:`(1, H, W, 2)` or :math:`(N, H, W, 2)`.
+        grid: Unwrapped grid of the shape :math:`(1, H, W, 2)`, or :math:`(N, H, W, 2)` with a
+          matching batch of :math:`N` homographies.
         src_homo_dst: Homography or homographies (stacked) to
           transform all points in the grid. Shape of the homography
           has to be :math:`(1, 3, 3)`, :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`.
@@ -358,9 +361,12 @@ def warp_grid3d(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
           :math:`(N, D, H, W, 3)`
         - ``src_homo_dst`` is the destination→source homography :math:`(1, 4, 4)`,
           :math:`(N, 4, 4)` or :math:`(N, 1, 4, 4)`
+        - only the :math:`(1, D, H, W, 3)` grid broadcasts over homography batches; a batched
+          grid requires a matching batch of :math:`N` homographies
 
     Args:
-        grid: Unwrapped grid of the shape :math:`(1, D, H, W, 3)` or :math:`(N, D, H, W, 3)`.
+        grid: Unwrapped grid of the shape :math:`(1, D, H, W, 3)`, or :math:`(N, D, H, W, 3)`
+          with a matching batch of :math:`N` homographies.
         src_homo_dst: Homography or homographies (stacked) to
           transform all points in the grid. Shape of the homography
           has to be :math:`(1, 4, 4)`, :math:`(N, 4, 4)` or :math:`(N, 1, 4, 4)`.
@@ -1506,7 +1512,8 @@ def homography_warp(
         padding_mode: padding mode for outside grid values ``'zeros'`` | ``'border'`` | ``'reflection'``.
         align_corners: interpolation flag.
         normalized_coordinates: Whether the homography assumes [-1, 1] normalized coordinates or not.
-        normalized_homography: show is homography normalized.
+        normalized_homography: whether ``src_homo_dst`` is a normalized (destination→source)
+            homography (``True``, default) or a pixel source→destination homography (``False``).
 
     Return:
         Patch sampled at locations from source to destination.

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -89,7 +89,7 @@ def warp_perspective(
     Convention:
         - input: :math:`(B, C, H, W)`; ``dsize`` is ``(h, w)``
         - ``M`` is the source→destination **pixel** homography :math:`(B, 3, 3)`
-          (contrast :func:`homography_warp`, which consumes destination→source normalized)
+          (contrast :func:`homography_warp`, which by default consumes destination→source normalized)
         - coordinates: ``(x, y)``, pixel centers, origin at top-left
         - align_corners: ``True`` by default
         - padding_mode: ``'zeros'`` by default
@@ -329,7 +329,7 @@ def warp_grid(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
           :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`
 
     Args:
-        grid: Unwrapped grid of the shape :math:`(1, H, W, 2)`.
+        grid: Unwrapped grid of the shape :math:`(1, H, W, 2)` or :math:`(N, H, W, 2)`.
         src_homo_dst: Homography or homographies (stacked) to
           transform all points in the grid. Shape of the homography
           has to be :math:`(1, 3, 3)`, :math:`(N, 3, 3)` or :math:`(N, 1, 3, 3)`.
@@ -360,7 +360,7 @@ def warp_grid3d(grid: torch.Tensor, src_homo_dst: torch.Tensor) -> torch.Tensor:
           :math:`(N, 4, 4)` or :math:`(N, 1, 4, 4)`
 
     Args:
-        grid: Unwrapped grid of the shape :math:`(1, D, H, W, 3)`.
+        grid: Unwrapped grid of the shape :math:`(1, D, H, W, 3)` or :math:`(N, D, H, W, 3)`.
         src_homo_dst: Homography or homographies (stacked) to
           transform all points in the grid. Shape of the homography
           has to be :math:`(1, 4, 4)`, :math:`(N, 4, 4)` or :math:`(N, 1, 4, 4)`.
@@ -488,7 +488,7 @@ def get_perspective_transform(points_src: torch.Tensor, points_dst: torch.Tensor
     Convention:
         - points: ``(x, y)``, pixel centers, origin at top-left; shape :math:`(B, 4, 2)`
         - returns the source→destination **pixel** homography :math:`(B, 3, 3)`
-          (contrast :func:`homography_warp`, which consumes destination→source normalized)
+          (contrast :func:`homography_warp`, which by default consumes destination→source normalized)
 
     Args:
         points_src: coordinates of quadrangle vertices in the source image with shape :math:`(B, 4, 2)`.
@@ -711,7 +711,8 @@ def invert_affine_transform(matrix: torch.Tensor) -> torch.Tensor:
     The result is also a 2x3 matrix of the same type as M.
 
     Convention:
-        - ``matrix`` is the pixel-space affine transform :math:`(B, 2, 3)`; returns its inverse, same shape
+        - ``matrix`` is a :math:`(B, 2, 3)` affine transform in any coordinate convention
+          (pixel or normalized) — pure matrix inversion; the result stays in the input's convention
 
     Args:
         matrix: original affine transform. The torch.Tensor must be
@@ -902,7 +903,7 @@ def get_affine_matrix3d(
         the 3d affine transformation matrix :math:`(B, 4, 4)`.
 
     .. note::
-        This function is often used in conjunction with :func:`warp_perspective`.
+        This function is often used in conjunction with :func:`warp_perspective3d`.
 
     """
     transform: torch.Tensor = get_projective_transform(center, -angles, scale)
@@ -952,7 +953,7 @@ def get_shear_matrix3d(
           slice (``z = 0``)
         - returns :math:`(B, 4, 4)` affine matrix in pixel coordinates
 
-    Params:
+    Args:
         center: shearing center coordinates of (x, y, z).
         sxy: shearing angle along x axis, towards y plane in radiants.
         sxz: shearing angle along x axis, towards z plane in radiants.

--- a/tests/geometry/transform/test_affine.py
+++ b/tests/geometry/transform/test_affine.py
@@ -360,6 +360,9 @@ class TestRotate(BaseTester):
         angle = torch.tensor([90.0], device=device, dtype=dtype)
         transform = kornia.geometry.transform.Rotate(angle)
         self.assert_close(transform(inp), expected, atol=1e-4, rtol=1e-4)
+        # the function's own bare default must match (class and function defaults can diverge
+        # in this module — see Rescale vs rescale — so both APIs are pinned independently)
+        self.assert_close(kornia.geometry.transform.rotate(inp, angle), expected, atol=1e-4, rtol=1e-4)
 
     def test_gradcheck(self, device):
         # test parameters

--- a/tests/geometry/transform/test_affine.py
+++ b/tests/geometry/transform/test_affine.py
@@ -218,6 +218,11 @@ class TestResize(BaseTester):
             dtype=dtype,
         )
         self.assert_close(out, expected, atol=1e-3, rtol=1e-3)
+        # the output above cannot distinguish None from False (they interpolate identically), so
+        # the documented default is additionally pinned on the signature itself
+        import inspect
+
+        assert inspect.signature(kornia.geometry.transform.resize).parameters["align_corners"].default is None
 
     def test_gradcheck(self, device):
         # test parameters

--- a/tests/geometry/transform/test_affine.py
+++ b/tests/geometry/transform/test_affine.py
@@ -188,6 +188,37 @@ class TestResize(BaseTester):
         out = kornia.geometry.transform.resize(inp, 10, align_corners=False, side="horz")
         assert out.shape == (1, 3, 4, 10)
 
+    def test_convention_align_corners_default_none(self, device, dtype):
+        # resize's bare default align_corners=None behaves like align_corners=False (no test in the
+        # suite exercises the bare default; every other call here passes align_corners=False explicitly).
+        if dtype in (torch.float16, torch.bfloat16):
+            pytest.skip("hardcoded-literal pin only reliable at float32/float64 precision")
+        # Snippet used to generate expected:
+        # inp_x = torch.arange(20, dtype=torch.float32) / 20.0
+        # inp = inp_x[None].T @ inp_x[None]
+        # inp = inp[None, None]
+        # expected = kornia.geometry.transform.resize(inp, (5, 5), antialias=False)  # no align_corners passed
+        inp_x = torch.arange(20, device=device, dtype=dtype) / 20.0
+        inp = inp_x[None].T @ inp_x[None]
+        inp = inp[None, None]
+        out = kornia.geometry.transform.resize(inp, (5, 5), antialias=False)
+        expected = torch.tensor(
+            [
+                [
+                    [
+                        [0.0056, 0.0206, 0.0356, 0.0506, 0.0656],
+                        [0.0206, 0.0756, 0.1306, 0.1856, 0.2406],
+                        [0.0356, 0.1306, 0.2256, 0.3206, 0.4156],
+                        [0.0506, 0.1856, 0.3206, 0.4556, 0.5906],
+                        [0.0656, 0.2406, 0.4156, 0.5906, 0.7656],
+                    ]
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        self.assert_close(out, expected, atol=1e-3, rtol=1e-3)
+
     def test_gradcheck(self, device):
         # test parameters
         new_size = 4
@@ -313,6 +344,21 @@ class TestRotate(BaseTester):
         # prepare transformation
         angle = torch.tensor([90.0], device=device, dtype=dtype)
         transform = kornia.geometry.transform.Rotate(angle, align_corners=True)
+        self.assert_close(transform(inp), expected, atol=1e-4, rtol=1e-4)
+
+    def test_convention_align_corners_default_true(self, device, dtype):
+        # rotate/Rotate's bare default align_corners=True (every other test in this class passes
+        # align_corners=True explicitly to Rotate; this exercises the bare default).
+        if dtype in (torch.float16, torch.bfloat16):
+            pytest.skip("hardcoded-literal pin only reliable at float32/float64 precision")
+        # Snippet used to generate expected:
+        # inp = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]])
+        # angle = torch.tensor([90.0])
+        # expected = kornia.geometry.transform.Rotate(angle)(inp)  # no align_corners passed
+        inp = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]], device=device, dtype=dtype)
+        expected = torch.tensor([[[0.0, 0.0], [4.0, 6.0], [3.0, 5.0], [0.0, 0.0]]], device=device, dtype=dtype)
+        angle = torch.tensor([90.0], device=device, dtype=dtype)
+        transform = kornia.geometry.transform.Rotate(angle)
         self.assert_close(transform(inp), expected, atol=1e-4, rtol=1e-4)
 
     def test_gradcheck(self, device):

--- a/tests/geometry/transform/test_homography_warper.py
+++ b/tests/geometry/transform/test_homography_warper.py
@@ -210,6 +210,15 @@ class TestHomographyWarper(BaseTester):
             dtype=dtype,
         )
         self.assert_close(patch_dst, expected, atol=1e-3, rtol=1e-3)
+        # the literal above cannot distinguish False from None (grid_sample treats them alike), so
+        # the documented defaults are additionally pinned on the signatures of both APIs
+        import inspect
+
+        assert (
+            inspect.signature(kornia.geometry.transform.HomographyWarper.__init__).parameters["align_corners"].default
+            is False
+        )
+        assert inspect.signature(kornia.geometry.transform.homography_warp).parameters["align_corners"].default is False
 
     @pytest.mark.parametrize("shape", [(4, 5), (2, 6), (4, 3), (5, 7)])
     def test_translation(self, shape, device, dtype):

--- a/tests/geometry/transform/test_homography_warper.py
+++ b/tests/geometry/transform/test_homography_warper.py
@@ -178,6 +178,39 @@ class TestHomographyWarper(BaseTester):
         self.assert_close(patch_src[..., -1, 0], patch_dst[..., -1, 0], atol=1e-4, rtol=1e-4)
         self.assert_close(patch_src[..., -1, -1], patch_dst[..., -1, -1], atol=1e-4, rtol=1e-4)
 
+    def test_convention_align_corners_default_false(self, device, dtype):
+        # HomographyWarper's bare default align_corners=False (every HomographyWarper construction in
+        # this file passes align_corners=True explicitly; this exercises the bare default), warping an
+        # identity homography over a padding_mode="zeros" grid so that align_corners visibly changes output.
+        if dtype in (torch.float16, torch.bfloat16):
+            pytest.skip("hardcoded-literal pin only reliable at float32/float64 precision")
+        # Snippet used to generate expected:
+        # height, width = 4, 5
+        # patch_src = torch.arange(float(height * width)).view(1, 1, height, width)
+        # dst_homo_src = torch.eye(3)[None]
+        # warper = kornia.geometry.transform.HomographyWarper(height, width)  # no align_corners passed
+        # expected = warper(patch_src, dst_homo_src)
+        height, width = 4, 5
+        patch_src = torch.arange(float(height * width), device=device, dtype=dtype).view(1, 1, height, width)
+        dst_homo_src = eye_like(3, patch_src)
+        warper = kornia.geometry.transform.HomographyWarper(height, width)
+        patch_dst = warper(patch_src, dst_homo_src)
+        expected = torch.tensor(
+            [
+                [
+                    [
+                        [0.0000, 0.3750, 1.0000, 1.6250, 1.0000],
+                        [2.0833, 4.9167, 6.1667, 7.4167, 4.0833],
+                        [5.4167, 11.5833, 12.8333, 14.0833, 7.4167],
+                        [3.7500, 7.8750, 8.5000, 9.1250, 4.7500],
+                    ]
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        self.assert_close(patch_dst, expected, atol=1e-3, rtol=1e-3)
+
     @pytest.mark.parametrize("shape", [(4, 5), (2, 6), (4, 3), (5, 7)])
     def test_translation(self, shape, device, dtype):
         # create input data

--- a/tests/geometry/transform/test_imgwarp.py
+++ b/tests/geometry/transform/test_imgwarp.py
@@ -416,20 +416,27 @@ class TestWarpPerspective(BaseTester):
     def test_convention_normalize_invert_equivalence(self, device, dtype):
         # homography_warp's default normalized_homography=True path (normalize the pixel homography,
         # invert it, then warp with normalized coordinates) is equivalent to warp_perspective's raw
-        # pixel-homography path, given matching align_corners.
+        # pixel-homography path, given matching align_corners. Input size and dsize are deliberately
+        # asymmetric: with equal square sizes normalize and invert commute, so the operation ORDER
+        # (the conventions-page pitfall) would be invisible; at 4x6 -> (3, 5) the inverted order
+        # diverges from this literal by 15.0.
         # Snippet used to generate expected:
-        # x = torch.arange(9.0).view(1, 1, 3, 3)
+        # x = torch.arange(24.0).view(1, 1, 4, 6)
         # H = torch.tensor([[[1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]])
-        # expected = kornia.geometry.transform.warp_perspective(x, H, (3, 3), align_corners=True)
-        x = torch.arange(9.0, device=device, dtype=dtype).view(1, 1, 3, 3)
+        # expected = kornia.geometry.transform.warp_perspective(x, H, (3, 5), align_corners=True)
+        x = torch.arange(24.0, device=device, dtype=dtype).view(1, 1, 4, 6)
         H = torch.tensor([[[1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
-        expected = torch.tensor([[[[0.0, 0.0, 1.0], [0.0, 3.0, 4.0], [0.0, 6.0, 7.0]]]], device=device, dtype=dtype)
+        expected = torch.tensor(
+            [[[[0.0, 0.0, 1.0, 2.0, 3.0], [0.0, 6.0, 7.0, 8.0, 9.0], [0.0, 12.0, 13.0, 14.0, 15.0]]]],
+            device=device,
+            dtype=dtype,
+        )
 
-        wp = kornia.geometry.transform.warp_perspective(x, H, (3, 3), align_corners=True)
+        wp = kornia.geometry.transform.warp_perspective(x, H, (3, 5), align_corners=True)
         self.assert_close(wp, expected, atol=1e-4, rtol=1e-4)
 
-        Hn = kornia.geometry.conversions.normalize_homography(H, (3, 3), (3, 3))
-        hw = kornia.geometry.transform.homography_warp(x, _torch_inverse_cast(Hn), (3, 3), align_corners=True)
+        Hn = kornia.geometry.conversions.normalize_homography(H, (4, 6), (3, 5))
+        hw = kornia.geometry.transform.homography_warp(x, _torch_inverse_cast(Hn), (3, 5), align_corners=True)
         self.assert_close(hw, expected, atol=1e-4, rtol=1e-4)
 
     def test_rotation_inverse(self, device, dtype):

--- a/tests/geometry/transform/test_imgwarp.py
+++ b/tests/geometry/transform/test_imgwarp.py
@@ -192,6 +192,24 @@ class TestRotationMatrix2d(BaseTester):
         # evaluate function gradient
         self.gradcheck(kornia.geometry.get_rotation_matrix2d, (center, angle, scale))
 
+    def test_convention_center_xy_order(self, device, dtype):
+        # get_rotation_matrix2d's center is (x, y): using an asymmetric center (cx=3, cy=1) with 90deg
+        # rotation and unit scale numerically distinguishes x-first from y-first ordering, since
+        # swapping cx/cy would flip the sign/magnitude of M[..., 0, 2] and M[..., 1, 2].
+        if dtype in (torch.float16, torch.bfloat16):
+            pytest.skip("hardcoded-literal pin only reliable at float32/float64 precision")
+        # Snippet used to generate expected:
+        # center = torch.tensor([[3.0, 1.0]])
+        # angle = torch.tensor([90.0])
+        # scale = torch.tensor([[1.0, 1.0]])
+        # expected = kornia.geometry.get_rotation_matrix2d(center, angle, scale)
+        center = torch.tensor([[3.0, 1.0]], device=device, dtype=dtype)
+        angle = torch.tensor([90.0], device=device, dtype=dtype)
+        scale = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
+        M = kornia.geometry.get_rotation_matrix2d(center, angle, scale)
+        expected = torch.tensor([[[0.0, 1.0, 2.0], [-1.0, 0.0, 4.0]]], device=device, dtype=dtype)
+        self.assert_close(M, expected, atol=1e-4, rtol=1e-4)
+
 
 class TestWarpAffine(BaseTester):
     def test_smoke(self, device, dtype):
@@ -394,6 +412,25 @@ class TestWarpPerspective(BaseTester):
         # Same as opencv: cv2.warpPerspective(kornia.tensor_to_image(img_b), homo_ab[0].numpy(), (w, h))
         img_a = kornia.geometry.transform.homography_warp(img_b, homo_ab, (h, w), normalized_homography=False)
         self.assert_close(img_a, expected, atol=1e-4, rtol=1e-4)
+
+    def test_convention_normalize_invert_equivalence(self, device, dtype):
+        # homography_warp's default normalized_homography=True path (normalize the pixel homography,
+        # invert it, then warp with normalized coordinates) is equivalent to warp_perspective's raw
+        # pixel-homography path, given matching align_corners.
+        # Snippet used to generate expected:
+        # x = torch.arange(9.0).view(1, 1, 3, 3)
+        # H = torch.tensor([[[1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]])
+        # expected = kornia.geometry.transform.warp_perspective(x, H, (3, 3), align_corners=True)
+        x = torch.arange(9.0, device=device, dtype=dtype).view(1, 1, 3, 3)
+        H = torch.tensor([[[1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
+        expected = torch.tensor([[[[0.0, 0.0, 1.0], [0.0, 3.0, 4.0], [0.0, 6.0, 7.0]]]], device=device, dtype=dtype)
+
+        wp = kornia.geometry.transform.warp_perspective(x, H, (3, 3), align_corners=True)
+        self.assert_close(wp, expected, atol=1e-4, rtol=1e-4)
+
+        Hn = kornia.geometry.conversions.normalize_homography(H, (3, 3), (3, 3))
+        hw = kornia.geometry.transform.homography_warp(x, _torch_inverse_cast(Hn), (3, 3), align_corners=True)
+        self.assert_close(hw, expected, atol=1e-4, rtol=1e-4)
 
     def test_rotation_inverse(self, device, dtype):
         h, w = 4, 4


### PR DESCRIPTION
Fixes #3923. Stage-2 continuation of the Conventions & Pitfalls work (#3893) — the docstring half of W1, with test enforcement.

## What

`Convention:` rubric blocks in the docstrings of all **39 public symbols** of `kornia/geometry/transform/{imgwarp,affwarp,homography_warper}.py` — the ops behind #2950/#777/#388/#546 — plus **five new `test_convention_*` tests** pinning conventions that no existing test enforced, and **four corrections of wrong existing docstring lines** found by the audit.

Every rubric line is verified, not asserted: defaults are taken verbatim from signatures; behavioral claims (rotation direction, coordinate order, homography normalization direction, `get_projective_transform`'s +z handedness, `get_affine_matrix2d`'s angle-sign flip) were each confirmed by a runnable snippet whose output is recorded in the review artifacts. Where reality is surprising, the docstring says so rather than smoothing it over:

- `Rescale`/`Shear` **classes** default `align_corners=True` while their delegate **functions** default `None`/`False` — each block states its own default with an explicit "differs from" note.
- `homography_warp` honors `align_corners` only on the default `normalized_homography=True` path; the pixel-homography branch currently **forces `True`** (`imgwarp.py:1424-1426`) — documented as-is; the underlying quirk is noted in #3923 as a follow-up bug.

## Convention-pinning tests (rubric line → test)

| Convention | Previously pinned by | Now |
|---|---|---|
| `rotate` bare default `align_corners=True` | nothing (all tests passed it explicitly) | `TestRotate::test_convention_align_corners_default_true` |
| `resize` bare default `align_corners=None` | nothing | `TestResize::test_convention_align_corners_default_none` |
| `HomographyWarper`/`homography_warp` default `align_corners=False` | nothing | `TestHomographyWarper::test_convention_align_corners_default_false` |
| `homography_warp` = `warp_perspective` under normalize-then-invert | nothing (no cross-API test existed) | `TestWarpPerspective::test_convention_normalize_invert_equivalence` |
| `get_rotation_matrix2d` center is `(x, y)` | nothing order-sensitive (all existing tests symmetric) | `TestRotationMatrix2d::test_convention_center_xy_order` (asymmetric center) |
| +90° = CCW as displayed; `dsize`=(h,w); points=(x,y) | already pinned (`test_imgwarp.py::TestWarpAffine/WarpPerspective::test_translation`, `TestRotationMatrix2d::test_90deg_rotation`, audit §B citations in full) | unchanged |

All five new tests use the hardcoded-literal + generation-snippet repo pattern and were mutation-checked (each verified to fail when one expected element is flipped).

## Corrected wrong docstring lines (pre-existing bugs)

- `warp_perspective3d`: `dsize` documented as "(height, width)" but consumed as a 3-tuple → now `(depth, height, width)`.
- `get_affine_matrix3d`: `Returns:` said `(B, 3, 3)`, actually `(B, 4, 4)` (verified by execution).
- `get_shear_matrix2d`: summary said `Bx4x4`, actually `Bx3x3`.
- `docs/source/geometry.transform.rst`: `homography_warp`, `homography_warp3d`, `get_translation_matrix2d`, `BaseWarper` had no autodoc entries at all — the #2950-trap op's docs never rendered. Added.

## Verification

- kornia/ diff is **docstring lines only** — proven with an AST-based check that every changed line falls inside a docstring span (both pre- and post-image); tests/ changes are additive test methods only.
- `tests/geometry/transform/` full runs: cpu `--dtype=all` and mps `--dtype=float32,float16` — failure sets **byte-identical** to a `caa1f9a2` baseline worktree (pre-existing fp16/bf16 tolerance failures; diff of failure lists is empty); +20 new test results all green.
- Sphinx `-W --keep-going` exit 0, zero warnings; rendered HTML inspected — `Convention:` renders as a clean definition list, and the previously-missing symbols now render.
- `pre-commit run` clean on every touched file; doctests 25/25 unchanged.

```
tests/geometry/transform --device=cpu --dtype=all      → 1400 passed, 66 skipped, 133 failed*
tests/geometry/transform --device=mps --dtype=f32,f16  → 641 passed, 90 skipped, 86 failed*
* identical failure sets on unmodified caa1f9a2 (fp16/bf16 tolerance, pre-existing; diff empty)
```

Out of scope, noted in #3923: the `homography_warp` pixel-path `align_corners` bug (behavior fix, not docs); `rotate3d`'s unverified "anti-clockwise" summary claim. Next batches: crops/flips/pyramid/TPS, geometry.conversions, bbox/boxes, camera, augmentation classes.

Algorithm source: n/a — documentation and characterization tests; no numeric code changed.

---

Posted on behalf of @ducha-aiki by Claude (Fable 5).
