### PR TITLE
docs(policy): gate contributions on evidence, not permission

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,124 +1,55 @@
 name: 🐛 Bug Report
-description: Create a report to help us improve
+description: Something is broken or gives wrong results
 title: "[Bug]: "
-labels: ["bug", "help wanted"]
+labels: ["bug"]
 
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report!
+        Thanks for the report! Please search existing issues first.
 
-        **Before submitting:**
-        - [ ] I have searched existing issues to ensure this bug hasn't been reported
-        - [ ] I have checked the [help wanted issues](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) list
-        - [ ] I have read the [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md)
-
-        ---
-
-        **⚠️ Important: Before submitting a PR**
-
-        If you plan to fix this bug yourself:
-
-        1. **Wait for maintainer approval**: A maintainer must review and approve this issue first
-        2. **Wait for assignment**: You must be assigned to this issue by a maintainer before submitting a PR
-        3. **Do not start work until assigned**: PRs submitted without prior issue approval and assignment may be closed
-
-        This helps us ensure the issue aligns with project goals, avoid duplicate work, and coordinate contributions effectively. See the [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request) for more details.
+        **Want to fix it yourself?** You don't need permission: send a PR with a test
+        that fails on `main` plus your fix — see the
+        [green lane](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution).
 
   - type: textarea
-    id: describe-bug
+    id: what-happened
     attributes:
-      label: 🐛 Describe the bug
-      description: A clear and concise description of what the bug is.
-      placeholder: |
-        Example: When I call function X with parameters Y, I get error Z instead of the expected result.
+      label: What happened?
+      description: What went wrong, and what did you expect instead? Include the error message if there is one.
     validations:
       required: true
 
   - type: textarea
-    id: reproduction-steps
+    id: reproduction
     attributes:
-      label: 🔄 Steps to Reproduce
-      description: Steps to reproduce the behavior. Include minimal code example if possible.
-      value: |
-        1.
-        2.
-        3.
-        ...
-      render: bash
-    validations:
-      required: true
-
-  - type: textarea
-    id: code-example
-    attributes:
-      label: 💻 Minimal Code Example
-      description: If applicable, provide a minimal code example that reproduces the bug
+      label: Minimal reproduction
+      description: The smallest code snippet that shows the problem. This is the single most useful thing you can give us.
       placeholder: |
-        ```python
+        import torch
         import kornia
-        # Your minimal code here
-        ```
+        # ...
       render: python
-    validations:
-      required: false
-
-  - type: textarea
-    id: expected-behavior
-    attributes:
-      label: ✅ Expected behavior
-      description: A clear and concise description of what you expected to happen.
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual-behavior
-    attributes:
-      label: ❌ Actual behavior
-      description: What actually happened? Include error messages if any.
     validations:
       required: true
 
   - type: textarea
     id: environment
     attributes:
-      label: 🔧 Environment
-      description: Please provide your environment details
+      label: Environment
       value: |
         - Kornia version:
         - PyTorch version:
         - Python version:
-        - OS (e.g., Linux, macOS, Windows):
-        - Installation method (pip, conda, from source):
-        - CUDA/cuDNN version (if applicable):
-        - GPU model (if applicable):
-
-        You can also run:
-        ```bash
-        wget https://raw.githubusercontent.com/pytorch/pytorch/main/torch/utils/collect_env.py
-        # For security purposes, please check the contents of collect_env.py before running it.
-        python collect_env.py
-        ```
-      render: shell
+        - OS / device (CPU, CUDA, MPS):
     validations:
       required: true
 
   - type: textarea
     id: additional-context
     attributes:
-      label: 📝 Additional context
-      description: Add any other context, screenshots, or relevant information about the problem here.
+      label: Anything else?
+      description: Screenshots, related issues, suspicions about the cause — anything that helps.
     validations:
       required: false
-
-  - type: checkboxes
-    id: contribution-intent
-    attributes:
-      label: 🤝 Contribution Intent
-      description: Are you planning to contribute a fix for this bug?
-      options:
-        - label: I plan to submit a PR to fix this bug
-          required: false
-        - label: I'm reporting this bug but not planning to fix it
-          required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -38,6 +38,11 @@ body:
     id: environment
     attributes:
       label: Environment
+      description: |
+        Easiest: paste the output of this one-liner (add `python -m torch.utils.collect_env` for full GPU detail):
+        ```
+        python -c "import kornia, torch, sys, platform; print(f'kornia {kornia.__version__} | torch {torch.__version__} | python {sys.version.split()[0]} | {platform.platform()} | cuda {torch.version.cuda} (avail={torch.cuda.is_available()}) | mps={torch.backends.mps.is_available()}')"
+        ```
       value: |
         - Kornia version:
         - PyTorch version:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,124 +1,44 @@
 name: 🚀 Feature Request
-description: Suggest an idea or new feature for this project
+description: Suggest an idea or new feature
 title: "[Feature]: "
-labels: ["enhancement", "help wanted"]
+labels: ["enhancement"]
 
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting a new feature!
+        Thanks for the suggestion! Please search existing issues first.
 
-        **Before submitting:**
-        - [ ] I have searched existing issues to ensure this feature hasn't been requested
-        - [ ] I have checked the [help wanted issues](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) list
-        - [ ] I have read the [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md)
-        - [ ] This feature aligns with Kornia's focus on end-to-end vision models and SOTA Vision/Robotics models
+        Two honest notes before you write:
 
-        ---
-
-        **⚠️ Important: Before submitting a PR**
-
-        If you plan to implement this feature yourself:
-
-        1. **Wait for maintainer approval**: A maintainer must review and approve this issue first
-        2. **Wait for assignment**: You must be assigned to this issue by a maintainer before submitting a PR
-        3. **Do not start work until assigned**: PRs submitted without prior issue approval and assignment may be closed
-
-        This helps us ensure the issue aligns with project goals, avoid duplicate work, and coordinate contributions effectively. See the [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request) for more details.
+        - Features are **discuss-first**: if you want to implement this yourself, wait for a
+          maintainer to confirm the scope here before writing code — it protects you from
+          building something we can't merge. See
+          [which lane is your contribution?](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution)
+        - Kornia currently focuses on hardening its differentiable geometry / CV core rather
+          than growing breadth — new model integrations are mostly frozen. Proposals in the
+          core areas have much better odds.
 
   - type: textarea
-    id: feature-description
+    id: what-and-why
     attributes:
-      label: 🚀 Feature Description
-      description: A clear and concise description of the feature you'd like to see
-      placeholder: |
-        Example: Add support for X model/functionality that enables Y use case.
-    validations:
-      required: true
-
-  - type: dropdown
-    id: feature-category
-    attributes:
-      label: 📂 Feature Category
-      description: What category does this feature belong to?
-      options:
-        - VLM/VLA Models (Vision Language Models/Agents) - Priority
-        - Robotics Models
-        - Image Processing
-        - Augmentation
-        - Feature Detection/Matching
-        - Geometry
-        - Loss Functions
-        - Models (General)
-        - Documentation
-        - Testing Infrastructure
-        - Other
-    validations:
-      required: true
-
-  - type: textarea
-    id: motivation
-    attributes:
-      label: 💡 Motivation
-      description: |
-        What problem does this feature solve? Why is this feature needed?
-        If this is related to another GitHub issue, please link it here.
-      placeholder: |
-        Example: I'm always frustrated when [problem]. This feature would help by [benefit].
+      label: What, and why?
+      description: What should kornia do, and what problem does it solve for you?
     validations:
       required: true
 
   - type: textarea
     id: proposed-solution
     attributes:
-      label: 💭 Proposed Solution
-      description: A clear and concise description of what you want to happen. Include API design if applicable.
-      placeholder: |
-        Example: Add a new function `kornia.feature.new_function()` that accepts X and returns Y.
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: 🔄 Alternatives Considered
-      description: A clear and concise description of any alternative solutions or features you've considered
-    validations:
-      required: false
-
-  - type: textarea
-    id: use-cases
-    attributes:
-      label: 🎯 Use Cases
-      description: Describe specific use cases or examples where this feature would be valuable
+      label: Sketch of the API or approach (optional)
+      description: If you have an idea how it could look — a function signature, a reference implementation or paper — put it here.
     validations:
       required: false
 
   - type: textarea
     id: additional-context
     attributes:
-      label: 📝 Additional Context
-      description: Add any other context, mockups, diagrams, or references about the feature request here.
+      label: Anything else?
+      description: Alternatives you considered, use cases, references, mockups.
     validations:
       required: false
-
-  - type: checkboxes
-    id: contribution-intent
-    attributes:
-      label: 🤝 Contribution Intent
-      description: Are you planning to contribute this feature?
-      options:
-        - label: I plan to submit a PR to implement this feature
-          required: false
-        - label: I'm requesting this feature but not planning to implement it
-          required: false
-
-  - type: markdown
-    attributes:
-      value: |
-        ---
-
-        #### 📚 Consider also contributing to Kornia universe projects:
-
-        - [**Tutorials**](https://github.com/kornia/tutorials): Our repository containing the tutorials.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Follow the coding standards and best practices defined in [CONTRIBUTING.md](../C
 
 AI-based reviewers (e.g. GitHub Copilot, CodeRabbit) must follow the repository's AI usage policy and review rules.
 
-For the complete and authoritative AI reviewer instructions, see [AI_POLICY.md](../AI_POLICY.md), section 3.
+For the governing contribution policy, see [AI_POLICY.md](../AI_POLICY.md). This file contains the canonical operational instructions for AI reviewers.
 
 When generating or reviewing suggestions, prefer:
 - Enforcing the coding standards in [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,10 +12,10 @@ Follow the coding standards and best practices defined in [CONTRIBUTING.md](../C
 
 ### Core Principles:
 - The policy gates on **verification and accountability**, not on how much AI was used
-- Every functional change must carry pasted proof of local execution (test logs)
-- The submitter must be able to explain every line; unexplainable code fails review
-- AI-generated PRs are acceptable when honestly disclosed, verified, and explainable; mislabeled disclosure or imaginary verification is grounds for closure
-- Hallucinated or redundant comments are the fastest tell of an unreviewed PR — flag them
+- Every functional change carries pasted test logs as execution evidence — evidence is ranked per AI_POLICY.md Rule 1 (oracle/invariant-backed test > failing-test repro > CI > local logs); logs alone are provenance, not proof
+- The submitter owns the code and must be able to address targeted questions about it (algorithms, shapes, edge cases, design); the failure condition is an unresolved correctness or ownership concern, never eloquence or language fluency
+- AI-generated PRs are acceptable when honestly disclosed and verified; only **demonstrable deception** (verification that never ran, fabricated logs) is grounds for closure — never an arguable 🟡/🔴 classification
+- Hallucinated or redundant comments are a code-quality defect — flag them as such
 
 ## Instructions for AI Reviewers (Copilot / CodeRabbit)
 
@@ -26,7 +26,7 @@ For the complete and authoritative AI reviewer instructions, see [AI_POLICY.md](
 When generating or reviewing suggestions, prefer:
 - Enforcing the coding standards in [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards)
 - Enforcing the AI usage rules and review heuristics defined in [AI_POLICY.md](../AI_POLICY.md)
-- Highlighting missing tests, missing proof of local execution, and misuse of `kornia` vs. raw PyTorch utilities
+- Highlighting missing tests, missing execution evidence (test logs, oracle-backed expected values), and misuse of `kornia` vs. raw PyTorch utilities
 ## Key Guidelines
 
 - **Code style**: Follow PEP8, use 120 character line length, Ruff linting, and f-strings
@@ -53,10 +53,10 @@ When reviewing code changes, verify:
 - Code complies with [AI_POLICY.md](../AI_POLICY.md)
 - Tests are included for new functionality
 - Code passes `pixi run lint` and `pixi run typecheck`
-- PR includes proof of local test execution (test logs)
+- PR includes pasted test logs as execution evidence
 - Code uses `kornia` utilities instead of reinventing existing functionality
 - Comments are written in English, are non-redundant, and reflect genuine understanding of the code
-- The AI Usage Disclosure section is completed; if code quality signals (hallucinated comments, reinvented utilities) contradict the disclosure, note the mismatch
+- The AI Usage Disclosure section is completed. **Never infer AI use from code or writing style** — poor code is not evidence of AI use, and disclosure classification is not litigated (see AI_POLICY.md Rule 4). Flag quality problems (hallucinated comments, reinvented utilities) as quality problems in their own right, not as disclosure evidence
 
 ## Lane-Aware PR Review
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,10 +11,11 @@ Follow the coding standards and best practices defined in [CONTRIBUTING.md](../C
 **CRITICAL**: All contributions must comply with the [AI_POLICY.md](../AI_POLICY.md). Review that document for complete requirements.
 
 ### Core Principles:
-- Code and comments must not be direct, unreviewed outputs of AI agents
-- All AI-assisted contributions require human oversight and validation
-- Ensure code logic reflects genuine understanding, not copied AI output
-- The submitter is the Sole Responsible Author for every line of code
+- The policy gates on **verification and accountability**, not on how much AI was used
+- Every functional change must carry pasted proof of local execution (test logs)
+- The submitter must be able to explain every line; unexplainable code fails review
+- AI-generated PRs are acceptable when honestly disclosed, verified, and explainable; mislabeled disclosure or imaginary verification is grounds for closure
+- Hallucinated or redundant comments are the fastest tell of an unreviewed PR — flag them
 
 ## Instructions for AI Reviewers (Copilot / CodeRabbit)
 
@@ -48,35 +49,46 @@ pixi run doctest    # Documentation tests
 
 When reviewing code changes, verify:
 
-- Code and comments are not direct, unreviewed AI agent outputs
 - Code follows guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)
 - Code complies with [AI_POLICY.md](../AI_POLICY.md)
 - Tests are included for new functionality
 - Code passes `pixi run lint` and `pixi run typecheck`
 - PR includes proof of local test execution (test logs)
 - Code uses `kornia` utilities instead of reinventing existing functionality
-- Comments are written in English and verified by a human with a good understanding of the code
+- Comments are written in English, are non-redundant, and reflect genuine understanding of the code
+- The AI Usage Disclosure section is completed; if code quality signals (hallucinated comments, reinvented utilities) contradict the disclosure, note the mismatch
 
-## PR-Issue Alignment Review
+## Lane-Aware PR Review
 
-When reviewing pull requests, ensure strict alignment with the linked issue:
+Kornia uses a two-lane contribution model (see
+[CONTRIBUTING.md](../CONTRIBUTING.md#which-lane-is-your-contribution)). Determine the
+PR's lane from its template declaration and content, then apply the matching checks.
 
-1. **Issue Link Verification**:
-   - Verify the PR description contains a valid issue reference (e.g., "Fixes #123" or "Closes #123")
-   - Confirm the linked issue exists and is open (or was open when the PR was created)
+1. **Green lane** (test-first bug fixes, verified docs fixes, `help wanted` issues,
+   benchmark results) — no issue link or assignment is required. Verify instead:
+   - Bug fixes: the PR contains a new test and states that it fails on `main` without
+     the fix; test logs are pasted
+   - Docs fixes: the PR description shows the verification snippet that was run
+   - `help wanted` PRs: the referenced issue carries the `help wanted` label and the
+     PR meets the acceptance criteria stated in that issue; if another open PR
+     already addresses the same issue, note it
+   - Benchmark contributions: results follow the `benchmarks/` `--contribute` format
+   - The PR does NOT introduce new features, new public APIs, or behavior changes —
+     if it does, it is not green lane; ask for the discuss-first process
 
-2. **Assignment Verification**:
-   - Check that the PR author is assigned to the linked issue
-   - If not assigned, request that a maintainer assign the issue before proceeding with review
+2. **Discuss-first lane** (features, API changes, behavior/default/convention changes,
+   models, large refactors):
+   - Verify the PR description contains a valid issue reference (e.g., "Fixes #123")
+   - Verify a maintainer confirmed the scope on the linked issue (a confirming
+     comment or label; formal assignment is optional)
+   - **Scope matching (critical)**: the PR implementation strictly matches what the
+     issue describes; changes beyond that scope should be split into separate
+     issues/PRs
+   - **Behavior/default/convention changes deserve maximum scrutiny**: in a geometry
+     library, changed semantics break users silently. Confirm the issue discussion
+     explicitly acknowledges the behavior change and its migration path
 
-3. **Scope Matching**:
-   - **Critical**: Verify that the PR implementation strictly matches what the issue describes
-   - The PR should not include changes beyond the scope of the linked issue
-   - If the PR includes additional features or changes not mentioned in the issue, request that those be split into separate issues/PRs
-   - Compare the PR description, code changes, and tests against the issue description to ensure alignment
-
-4. **Issue Approval Status**:
-   - Verify the linked issue has been reviewed and approved by a maintainer
-   - Issues with the `triage` label may not have been fully reviewed yet
-
-**Reviewer Action**: If the PR does not match the issue scope or requirements, clearly explain the mismatch and request that the PR be updated to strictly align with the issue, or that additional changes be moved to separate issues/PRs.
+**Reviewer Action**: If requirements for the PR's lane are not met, explain exactly
+what is missing (which evidence for green lane; which confirmation for discuss-first)
+rather than issuing a generic warning. Never recommend closure based on subjective
+quality opinions alone — anchor findings in the objective criteria above.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,10 @@
 ## 📝 Description
 
-**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#pull-request) for details.
+**Which lane is this PR?** (see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))
+- [ ] 🟢 **Green lane** — test-first bug fix / verified docs fix / [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue / benchmark results. No prior issue needed.
+- [ ] 🟠 **Discuss-first lane** — feature or behavior change, with maintainer scope confirmation on the linked issue.
 
-**Fixes/Relates to:** # (issue number)
-
-**Important**:
-- Ensure you are assigned to the linked issue before submitting this PR
-- This PR should strictly implement what the linked issue describes
-- Do not include changes beyond the scope of the linked issue
+**Fixes/Relates to:** # (issue number, if any)
 
 ---
 
@@ -18,27 +15,35 @@
 ---
 
 ## 🧪 How Was This Tested?
+
+Paste your local test log here (required for functional changes):
+
+```
+$ pixi run test tests/...
+```
+
 - [ ] **Unit Tests:** (List new/updated tests)
+- [ ] **Bug fixes only:** my new test fails on `main` without this fix
 - [ ] **Manual Verification:** (Describe the steps you took)
 - [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)
 
 ---
 
 ## 🕵️ AI Usage Disclosure
-*Check one of the following:*
-- [ ] 🟢 **No AI used.**
-- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
-- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).
+
+*Honest answer required — none of these is a bad answer (see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md)):*
+- [ ] 🟢 **Human-written.**
+- [ ] 🟡 **AI-assisted:** AI helped with boilerplate/refactoring/drafts; I reviewed and tested every line.
+- [ ] 🔴 **AI-generated:** an agent produced most of this PR; I verified it and can explain every line.
 
 ---
 
 ## 🚦 Checklist
-- [ ] I am assigned to the linked issue (required before PR submission)
-- [ ] The linked issue has been approved by a maintainer
-- [ ] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
+- [ ] I have pasted the local test log above (proof it runs on my machine).
+- [ ] I have performed a **self-review** (no ghost comments, no reinvented `kornia` utilities).
 - [ ] My code follows the existing style guidelines of this project.
-- [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] Discuss-first lane only: a maintainer confirmed the scope on the linked issue.
 - [ ] (Optional) I have attached screenshots/recordings for UI changes.
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 $ pixi run test tests/...
 ```
 
-## AI disclosure *(honest answer required — none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
+## AI disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
 - [ ] 🟢 **Human-written**
 - [ ] 🟡 **AI-assisted** — AI helped; I reviewed and tested every line
 - [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified it and can explain every line

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,5 @@ $ pixi run test tests/...
 
 ## AI disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
 - [ ] 🟢 **Human-written**
-- [ ] 🟡 **AI-assisted** — AI helped; I reviewed and tested every line
-- [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified it and can explain every line
+- [ ] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests
+- [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified the result and can address reviewer questions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 $ pixi run test tests/...
 ```
 
-## AI disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
+## AI Usage Disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
 - [ ] 🟢 **Human-written**
 - [ ] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests
 - [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified the result and can address reviewer questions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,52 +1,22 @@
-## 📝 Description
-
-**Which lane is this PR?** (see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))
+## Which lane? *(check one — see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))*
 - [ ] 🟢 **Green lane** — test-first bug fix / verified docs fix / [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue / benchmark results. No prior issue needed.
-- [ ] 🟠 **Discuss-first lane** — feature or behavior change, with maintainer scope confirmation on the linked issue.
+- [ ] 🟠 **Discuss-first** — feature or behavior change; a maintainer confirmed the scope on the linked issue.
 
-**Fixes/Relates to:** # (issue number, if any)
+**Fixes/Relates to:** # *(issue number, if any)*
 
----
+## What does this PR do?
 
-## 🛠️ Changes Made
-- [ ] Item 1
-- [ ] Item 2
+<!-- A few sentences. For bug fixes: which test fails on main without this fix? -->
 
----
+## Test log
 
-## 🧪 How Was This Tested?
-
-Paste your local test log here (required for functional changes):
+<!-- Paste your local test run (required for functional changes): -->
 
 ```
 $ pixi run test tests/...
 ```
 
-- [ ] **Unit Tests:** (List new/updated tests)
-- [ ] **Bug fixes only:** my new test fails on `main` without this fix
-- [ ] **Manual Verification:** (Describe the steps you took)
-- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)
-
----
-
-## 🕵️ AI Usage Disclosure
-
-*Honest answer required — none of these is a bad answer (see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md)):*
-- [ ] 🟢 **Human-written.**
-- [ ] 🟡 **AI-assisted:** AI helped with boilerplate/refactoring/drafts; I reviewed and tested every line.
-- [ ] 🔴 **AI-generated:** an agent produced most of this PR; I verified it and can explain every line.
-
----
-
-## 🚦 Checklist
-- [ ] I have pasted the local test log above (proof it runs on my machine).
-- [ ] I have performed a **self-review** (no ghost comments, no reinvented `kornia` utilities).
-- [ ] My code follows the existing style guidelines of this project.
-- [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] Discuss-first lane only: a maintainer confirmed the scope on the linked issue.
-- [ ] (Optional) I have attached screenshots/recordings for UI changes.
-
----
-
-## 💭 Additional Context
-Add any other context or screenshots about the pull request here.
+## AI disclosure *(honest answer required — none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
+- [ ] 🟢 **Human-written**
+- [ ] 🟡 **AI-assisted** — AI helped; I reviewed and tested every line
+- [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified it and can explain every line

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -46,10 +46,13 @@ jobs:
               labels: ['triage']
             });
 
-            const welcomeMessage = '## ⚠️ Before Submitting a PR\n\n' +
-              'Please wait for a maintainer to approve and assign this issue to you or someone else before submitting a PR. ' +
-              'PRs submitted without prior approval and assignment may be closed. ' +
-              'See our [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md) for details.';
+            const welcomeMessage = '## 👋 Thanks for opening an issue!\n\n' +
+              'A maintainer will take a look. If you want to contribute a fix, here is how it works:\n\n' +
+              '- **Bug you can reproduce?** You do not need to wait for anyone: send a PR with a test ' +
+              'that fails on `main` plus your fix — that failing test is your permission slip (🟢 green lane).\n' +
+              '- **Feature or behavior change?** Please wait for a maintainer to confirm the scope on this ' +
+              'issue before writing code (🟠 discuss-first lane) — it protects you from building something we cannot merge.\n\n' +
+              'See [Which lane is your contribution?](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution) for details.';
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,8 +26,9 @@ jobs:
             const prAuthor = pr.user.login;
 
             // Extract issue numbers from PR description
-            // Matches patterns like: Fixes #123, Closes #456, Relates to #789, etc.
-            const issuePattern = /(?:fixes?|closes?|resolves?|relates?\s+to|see|refs?)\s+#(\d+)/gi;
+            // Matches patterns like: Fixes #123, Closes #456, Relates to #789, and the
+            // template's own label form "**Fixes/Relates to:** #123".
+            const issuePattern = /(?:fixes?|closes?|resolves?|relates?\s+to|see|refs?)[\s:*]*#(\d+)/gi;
             const matches = [...prBody.matchAll(issuePattern)];
             const issueNumbers = [...new Set(matches.map(m => parseInt(m[1])))];
 
@@ -79,6 +80,12 @@ jobs:
 
             if (isMaintainer) {
               // no warnings: fall through so any stale warning comment gets deleted
+            } else if (greenLane && discussLane) {
+              // Checkboxes are not mutually exclusive on GitHub; don't guess a lane.
+              warnings.push('ℹ️ **Both lanes are checked**: please keep exactly one — 🟢 green lane (test-first bug fix, verified docs fix, `help wanted` issue, benchmark results) or 🟠 discuss-first (features and behavior changes). See the [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution).');
+              for (const issueNumber of issueNumbers) {
+                await checkIssueExists(issueNumber);
+              }
             } else if (greenLane && !discussLane) {
               // Green lane: no issue link or assignment required. Only sanity-check
               // any issues the author chose to reference.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -53,7 +53,7 @@ jobs:
             // Two-lane model (CONTRIBUTING.md#which-lane-is-your-contribution):
             // green lane needs no issue; discuss-first needs a linked, scope-confirmed issue.
             const greenLane = /-\s*\[x\]\s*🟢\s*\*\*Green lane/i.test(prBody);
-            const discussLane = /-\s*\[x\]\s*🟠\s*\*\*Discuss-first lane/i.test(prBody);
+            const discussLane = /-\s*\[x\]\s*🟠\s*\*\*Discuss-first/i.test(prBody);
 
             // Referenced issues should exist and be open regardless of lane.
             const checkIssueExists = async (issueNumber) => {

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -50,42 +50,52 @@ jobs:
               core.warning(`Could not determine permission for @${prAuthor}: ${error.message}`);
             }
 
+            // Two-lane model (CONTRIBUTING.md#which-lane-is-your-contribution):
+            // green lane needs no issue; discuss-first needs a linked, scope-confirmed issue.
+            const greenLane = /-\s*\[x\]\s*🟢\s*\*\*Green lane/i.test(prBody);
+            const discussLane = /-\s*\[x\]\s*🟠\s*\*\*Discuss-first lane/i.test(prBody);
+
+            // Referenced issues should exist and be open regardless of lane.
+            const checkIssueExists = async (issueNumber) => {
+              try {
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+                if (issue.data.state === 'closed') {
+                  warnings.push(`⚠️ **Issue #${issueNumber} is closed**: The linked issue #${issueNumber} is already closed. Please ensure you're linking to the correct issue.`);
+                }
+                return issue;
+              } catch (error) {
+                if (error.status === 404) {
+                  warnings.push(`❌ **Issue #${issueNumber} not found**: The linked issue #${issueNumber} does not exist. Please check the issue number.`);
+                } else {
+                  warnings.push(`⚠️ **Error checking issue #${issueNumber}**: ${error.message}`);
+                }
+                return null;
+              }
+            };
+
             if (isMaintainer) {
               // no warnings: fall through so any stale warning comment gets deleted
-            } else if (issueNumbers.length === 0) {
-              warnings.push('❌ **No linked issue found**: This PR does not reference any issue. Please link to an issue using "Fixes #123" or "Closes #123" in the PR description.');
-            } else {
-              // Check each linked issue
+            } else if (greenLane && !discussLane) {
+              // Green lane: no issue link or assignment required. Only sanity-check
+              // any issues the author chose to reference.
               for (const issueNumber of issueNumbers) {
-                try {
-                  const issue = await github.rest.issues.get({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber
-                  });
-
-                  if (issue.data.state === 'closed') {
-                    warnings.push(`⚠️ **Issue #${issueNumber} is closed**: The linked issue #${issueNumber} is already closed. Please ensure you're linking to the correct issue.`);
-                  }
-
-                  // Check if PR author is assigned to the issue
-                  const assignees = issue.data.assignees.map(a => a.login);
-                  if (assignees.length === 0) {
-                    warnings.push(`⚠️ **Issue #${issueNumber} has no assignee**: This issue has not been assigned to anyone. Please wait for a maintainer to assign it to you before submitting a PR.`);
-                  } else if (!assignees.includes(prAuthor)) {
-                    warnings.push(`⚠️ **Assignment mismatch**: You (@${prAuthor}) are not assigned to issue #${issueNumber}. The issue is assigned to: ${assignees.map(a => `@${a}`).join(', ')}. Please wait for a maintainer to assign the issue to you.`);
-                  }
-
-                  // Check if issue has triage label (indicating it might not be approved yet)
-                  const labels = issue.data.labels.map(l => l.name);
-                  if (labels.includes('triage')) {
-                    warnings.push(`ℹ️ **Issue #${issueNumber} is still in triage**: This issue may not have been reviewed and approved by a maintainer yet. Please ensure the issue has been approved before submitting a PR.`);
-                  }
-                } catch (error) {
-                  if (error.status === 404) {
-                    warnings.push(`❌ **Issue #${issueNumber} not found**: The linked issue #${issueNumber} does not exist. Please check the issue number.`);
-                  } else {
-                    warnings.push(`⚠️ **Error checking issue #${issueNumber}**: ${error.message}`);
+                await checkIssueExists(issueNumber);
+              }
+            } else {
+              if (!greenLane && !discussLane) {
+                warnings.push('ℹ️ **Pick a lane**: Please check one of the lane boxes in the PR description — 🟢 green lane (test-first bug fix, verified docs fix, `help wanted` issue, benchmark results: no issue needed) or 🟠 discuss-first (features and behavior changes: linked, scope-confirmed issue required). See the [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution).');
+              }
+              if (issueNumbers.length === 0) {
+                warnings.push('❌ **No linked issue found**: Features and behavior changes need a linked issue where a maintainer confirmed the scope (use "Fixes #123" or "Closes #123"). If this PR is actually a test-first bug fix, verified docs fix, `help wanted` item, or benchmark contribution, check the 🟢 green-lane box instead — no issue needed.');
+              } else {
+                for (const issueNumber of issueNumbers) {
+                  const issue = await checkIssueExists(issueNumber);
+                  if (issue && issue.data.labels.map(l => l.name).includes('triage')) {
+                    warnings.push(`ℹ️ **Issue #${issueNumber} is still in triage**: A maintainer has not yet confirmed the scope of this issue. For features and behavior changes, please get a scope confirmation on the issue before investing significant work — it protects you from building something we cannot merge.`);
                   }
                 }
               }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - uses: actions/stale@v11
         with:
-          stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs within 7 days. Thank you for your contributions!"
-          close-pr-message: "This pull request has been automatically closed due to inactivity. Feel free to reopen it if you would like to continue working on it."
+          stale-pr-message: "This pull request has been quiet for a while, so we're marking it stale to keep the queue readable. If you're still working on it, any comment or push resets the clock. If you're waiting on *us* (a review or an answer), say so — a maintainer will add the `awaiting-review` label, which stops this timer. Otherwise it will be closed in 7 days; you can reopen anytime."
+          close-pr-message: "Closed for inactivity to keep the queue readable — this is bookkeeping, not a rejection. Feel free to reopen whenever you're ready to continue."
           days-before-pr-stale: 15
           days-before-pr-close: 7
           stale-pr-label: "stale"
-          exempt-pr-labels: "pinned,work-in-progress,on-hold"
+          exempt-pr-labels: "pinned,work-in-progress,on-hold,awaiting-review"
           days-before-issue-stale: -1
           days-before-issue-close: -1

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,76 +1,110 @@
 # 🤖 Kornia AI & Authorship Policy
 
-**Version:** 1.0
-**Enforcement:** Strict
-**Applicability:** All Pull Requests (Human & Bot)
+**Version:** 2.0
+**Applies to:** every pull request, human or bot.
 
-## 1. Core Philosophy
+## Why this policy exists — the honest version
 
-Kornia accepts AI-assisted code (e.g., using Copilot, Cursor, etc.), but strictly rejects AI-generated contributions where the submitter acts merely as a proxy. The submitter is the **Sole Responsible Author** for every line of code, comment, and design decision.
+AI tools can now produce code that looks right in seconds. Some of it is genuinely
+good. A lot of it compiles, reads confidently, and is quietly wrong — and reviewing it
+costs a volunteer maintainer far more time than generating it cost the submitter.
+Around application deadlines (GSoC and similar) we have received whole waves of these.
 
-## 2. The 3 Laws of Contribution
+At the same time, let's be honest about ourselves: **Kornia maintainers use AI tools
+heavily** — including entire agent-written pull requests. Banning "AI-generated code"
+would be hypocritical, and it would also miss the point. What we have learned by
+working this way is that the difference between an excellent AI-built PR and a useless
+one is never the tool. It is whether every claim was **executed and verified**, and
+whether a **human stands behind the result** and can explain it.
 
-### Law 1: Proof of Verification
+So this policy does not gate on how much AI you used. It gates on two things:
 
-AI tools frequently write code that looks correct but fails execution. Therefore, "vibe checks" are insufficient.
+1. **Verification** — did you actually run it, and can you show us?
+2. **Accountability** — do you understand it, and will you answer for it?
 
-**Requirement:** Every PR introducing functional changes must include a pasted snippet of the local test logs (e.g., `pixi run test ...`). This is mandatory for all contributors and is particularly important for first-time contributors.
+Unverified code is a problem. Unexplainable code is a problem. AI is neither.
 
-**Failure Condition:** If a PR lacks execution proof and contains complex logic, it will be flagged as **Unverified**.
+## The rules
 
-**Requirement:** All PRs must be previously discussed in [Discord](https://discord.gg/HfnywwpBnD) or via a [GitHub issue](https://github.com/kornia/kornia/issues) before implementation. The PR must reference the discussion or issue.
+### Rule 1 — Show us it runs
 
-**Requirement:** Implementations must be based on an existing library reference (e.g., PyTorch, OpenCV, scikit-image, etc.) that must be provided in the PR description for verification. This reference serves as proof that the implementation follows established algorithms and is not hallucinated.
+Code that "looks correct" is not enough, no matter who or what wrote it.
 
-### Law 2: The Hallucination & Redundancy Ban
+- Every PR with functional changes includes a pasted snippet of your local test run
+  (e.g. `pixi run test tests/...`).
+- Bug fixes should arrive **test-first**: a test that fails on `main` and passes with
+  your fix is the single most convincing thing a PR can contain. It is also your fast
+  lane past most of our process — see the green lane in
+  [CONTRIBUTING.md](CONTRIBUTING.md#which-lane-is-your-contribution).
+- New implementations name their reference (PyTorch, OpenCV, scikit-image, a paper) in
+  the PR description, so reviewers can check the algorithm is real and not hallucinated.
 
-AI models often hallucinate comments or reinvent existing utilities.
+### Rule 2 — Don't reinvent kornia
 
-**Requirement:** You must use existing `kornia` utilities and never reinvent the wheel, except for when the utility is not available.
+AI tools love writing helpers that already exist. Search `kornia` first and use the
+existing utility; if you genuinely can't, say why in the PR. Writing a new
+`def warp_affine...` when kornia already has one is grounds for immediate rejection.
 
-**Failure Condition:** Creating new helper functions (e.g., `def warp_affine...`) when a Kornia equivalent exists is grounds for immediate rejection.
+### Rule 3 — Be able to explain it
 
-**Failure Condition:** "Ghost Comments" (comments explaining logic that was deleted or doesn't exist) will result in a request for a full manual rewrite. Redundant comments are not allowed. Example: "This function returns the input tensor".
+If a reviewer asks how a function works, you can walk them through it — the math, the
+shapes, the edge cases. Answering "that's what the AI wrote" ends the review. This is
+what being the author means here: not that you typed every character, but that you
+**own** every line and every design decision.
 
-### Law 3: The "Explain It" Standard
+A special mention for comments: hallucinated or redundant comments ("this returns the
+input tensor", comments explaining code that was deleted) are the fastest tell of an
+unreviewed PR, and they trigger a request for a full manual rewrite.
 
-**Requirement:** If a maintainer or reviewer asks during code review, you must be able to derive the math or explain the logic of any function you submit.
+### Rule 4 — Tell us how it was made
 
-**Failure Condition:** Answering a review question with "That's what the AI outputted" or "I don't know, it works" leads to immediate closure.
+Fill in the AI disclosure in the PR template honestly:
 
-### Law 4: Transparency in AI Usage Disclosure
+- 🟢 **Human-written** — no AI involved.
+- 🟡 **AI-assisted** — AI helped (autocomplete, refactoring, drafts); you reviewed and
+  tested every line.
+- 🔴 **AI-generated** — an agent produced most of the code or the PR.
 
-**Requirement:** All PRs must accurately complete the "AI Usage Disclosure" section in the pull request template. This disclosure is mandatory and must reflect the actual use of AI tools.
+**None of these is a bad answer.** A 🔴 PR with thorough verification and a human who
+can explain every line is welcome here — some of our own most heavily reviewed PRs are
+exactly that. What closes PRs is **mislabeling**, or "verification" that turns out to
+be imaginary. An honest 🔴 beats a dishonest 🟡 every time.
 
-**When to mark as 🔴 AI-generated:**
-- An AI agent (e.g., Cursor, GitHub Copilot, ChatGPT, etc.) generated the code, PR description, or commit messages
-- You cannot explain the logic without referring to the AI's output
-- The PR was created primarily by an agent with minimal human review or modification
+## What we do on our side
 
-**When to mark as 🟡 AI-assisted:**
-- You used AI tools for boilerplate code, refactoring, or suggestions, but you manually reviewed and tested every line
-- You understand and can explain all the code you're submitting
-- You made significant modifications to AI-suggested code
+Policies that only demand things are no fun, so here is our half of the deal:
 
-**When to mark as 🟢 No AI used:**
-- You wrote all code manually without any AI assistance
+- **We gate on evidence, not permission.** Self-verifying contributions (test-first bug
+  fixes, verified docs fixes, `help wanted` issues with acceptance criteria, benchmark
+  results) need no assignment and no waiting — see
+  [CONTRIBUTING.md](CONTRIBUTING.md#which-lane-is-your-contribution).
+- **We verify before we reject.** Review findings — including those from our AI
+  reviewers — are checked by execution, not vibes. Automated closures only ever happen
+  on objective criteria (missing test logs, missing issue link where one is required),
+  never on a bot's opinion of your code quality.
+- **We hold ourselves to the same standard.** Maintainer PRs — agent-built ones
+  included — carry pasted execution logs and go through review like everyone else's.
+  You are welcome to hold us to this.
 
-**Failure Condition:** Incorrectly marking AI-generated code as "AI-assisted" or "No AI used" may result in PR closure, especially if the code contains hallucinations or cannot be explained during review.
+## Instructions for AI Reviewers (Copilot / CodeRabbit)
 
-## 3. Instructions for AI Reviewers (Copilot / CodeRabbit)
+If you are an AI agent (GitHub Copilot, CodeRabbit, etc.) reviewing a PR for Kornia,
+you must follow the repository's dedicated reviewer instructions.
 
-If you are an AI agent (GitHub Copilot, CodeRabbit, etc.) reviewing a PR for Kornia, you must follow the repository's dedicated reviewer instructions.
-
-The **canonical and up-to-date instructions for AI reviewers** are maintained in [`.github/copilot-instructions.md`](.github/copilot-instructions.md). That document defines:
+The **canonical and up-to-date instructions for AI reviewers** are maintained in
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md). That document
+defines:
 
 - The expected reviewer persona and responsibilities
 - The checks to perform on PR descriptions, code, tests, and comments
-- The required enforcement of the laws defined in this `AI_POLICY.md`
+- The required enforcement of the rules defined in this `AI_POLICY.md`
 
-Any other document (including this one) should treat `copilot-instructions.md` as the single source of truth for AI reviewer behaviour. When updating reviewer logic, update `copilot-instructions.md` first and, if needed, adjust references here.
+Any other document (including this one) should treat `copilot-instructions.md` as the
+single source of truth for AI reviewer behaviour. When updating reviewer logic, update
+`copilot-instructions.md` first and, if needed, adjust references here.
 
-This section exists to link AI reviewers to the canonical instructions and to make clear that those instructions must enforce the policies defined in Sections 1 and 2 above.
+## Additional Resources
 
-## 4. Additional Resources
-
-For comprehensive guidance on contributing to Kornia, including development workflows, code quality standards, testing practices, and AI-assisted development best practices, see the [Best Practices section](CONTRIBUTING.md#best-practices) in `CONTRIBUTING.md`.
+For comprehensive guidance on contributing to Kornia, including development workflows,
+code quality standards, testing practices, and AI-assisted development best practices,
+see the [Best Practices section](CONTRIBUTING.md#best-practices) in `CONTRIBUTING.md`.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -26,18 +26,29 @@ Unverified code is a problem. Unexplainable code is a problem. AI is neither.
 
 ## The rules
 
-### Rule 1 — Show us it runs
+### Rule 1 — Show us the evidence
 
-Code that "looks correct" is not enough, no matter who or what wrote it.
+Code that "looks correct" is not enough, no matter who or what wrote it. And one
+honest caveat about our own favorite kind of evidence: **"fails on `main`, passes
+with the fix" proves the behavior *changed* — not that the new behavior is
+*correct*.** A generated test can encode the same wrong assumption as generated
+code, and a pasted log can in principle be fabricated. So evidence is ranked,
+strongest first:
 
-- Every PR with functional changes includes a pasted snippet of your local test run
-  (e.g. `pixi run test tests/...`).
-- Bug fixes should arrive **test-first**: a test that fails on `main` and passes with
-  your fix is the single most convincing thing a PR can contain. It is also your fast
-  lane past most of our process — see the green lane in
-  [CONTRIBUTING.md](CONTRIBUTING.md#which-lane-is-your-contribution).
-- New implementations name their reference (PyTorch, OpenCV, scikit-image, a paper) in
-  the PR description, so reviewers can check the algorithm is real and not hallucinated.
+1. **A test backed by a credible oracle** — a reference implementation (OpenCV,
+   scipy, a paper — embedded as a hardcoded literal with its generation snippet), a
+   documented contract, or a mathematical invariant (`warp(H⁻¹) ∘ warp(H) ≈ id`).
+   For numerical and geometry claims this is the bar.
+2. **A failing-test-first repro** — fails on `main`, passes with the fix. Your fast
+   lane past most of our process — see the green lane in
+   [CONTRIBUTING.md](CONTRIBUTING.md#which-lane-is-your-contribution).
+3. **CI reproduction** — the suite runs your test where everyone can see it.
+4. **Pasted local logs** — required as provenance on every functional change
+   (e.g. `pixi run test tests/...`), but the weakest evidence on its own.
+
+New implementations additionally name their reference (PyTorch, OpenCV,
+scikit-image, a paper) in the PR description, so reviewers can check the algorithm
+is real and not hallucinated.
 
 ### Rule 2 — Don't reinvent kornia
 
@@ -45,12 +56,18 @@ AI tools love writing helpers that already exist. Search `kornia` first and use 
 existing utility; if you genuinely can't, say why in the PR. Writing a new
 `def warp_affine...` when kornia already has one is grounds for immediate rejection.
 
-### Rule 3 — Be able to explain it
+### Rule 3 — Own it, and be able to defend it
 
 If a reviewer asks how a function works, you can walk them through it — the math, the
-shapes, the edge cases. Answering "that's what the AI wrote" ends the review. This is
-what being the author means here: not that you typed every character, but that you
-**own** every line and every design decision.
+shapes, the edge cases, the design decisions. This is what being the author means
+here: not that you typed every character, but that you **own** every line.
+
+Humane interpretation, both directions: written answers are fine, imperfect English
+is fine, "let me check and get back to you" is fine. Reviewers commit to asking
+targeted questions — about algorithms, shapes, edge cases, trade-offs — not to
+running oral exams. What ends a review is disengagement or unresolved substance:
+"that's what the AI wrote" as a final answer, or a correctness concern that never
+gets addressed. The bar is resolved concerns, not eloquence.
 
 A special mention for comments: hallucinated or redundant comments ("this returns the
 input tensor", comments explaining code that was deleted) are the fastest tell of an
@@ -65,10 +82,15 @@ Fill in the AI disclosure in the PR template honestly:
   tested every line.
 - 🔴 **AI-generated** — an agent produced most of the code or the PR.
 
-**None of these is a bad answer.** A 🔴 PR with thorough verification and a human who
-can explain every line is welcome here — some of our own most heavily reviewed PRs are
-exactly that. What closes PRs is **mislabeling**, or "verification" that turns out to
-be imaginary. An honest 🔴 beats a dishonest 🟡 every time.
+**None of these is a bad answer — and the 🟡/🔴 boundary is fuzzy, which is fine.**
+Autocomplete, agent edits, generated tests, and human restructuring form a continuum
+with no objective line; pick the closest label and add a sentence of detail if
+unsure. We will never close a PR over an arguable classification, and we have no
+interest in authorship-taxonomy debates — authorship was never the quality gate.
+What we sanction is **demonstrable deception**: verification that never ran,
+fabricated logs, denying AI use against plain evidence. A 🔴 PR with thorough
+verification is welcome here — some of our own most heavily reviewed PRs are exactly
+that. An honest 🔴 beats a dishonest 🟡 every time.
 
 ## What we do on our side
 
@@ -82,9 +104,22 @@ Policies that only demand things are no fun, so here is our half of the deal:
   reviewers — are checked by execution, not vibes. Automated closures only ever happen
   on objective criteria (missing test logs, missing issue link where one is required),
   never on a bot's opinion of your code quality.
-- **We hold ourselves to the same standard.** Maintainer PRs — agent-built ones
-  included — carry pasted execution logs and go through review like everyone else's.
-  You are welcome to hold us to this.
+- **Maintainers: same evidence bar, different governance authority — stated
+  honestly.** Maintainer PRs — agent-built ones included — carry pasted execution
+  logs, honest disclosure, and review like everyone else's. What maintainers do
+  *not* do is ask themselves for permission: they hold the scope-setting authority
+  the discuss-first gate exists to route to, so the lane/issue guardrails skip them
+  (the validation workflow says so in code). Requiring maintainers to grant
+  themselves an issue would be theater; letting them skip the evidence bar would be
+  corrosion. We do the first openly and refuse the second — hold us to it.
+
+## This policy is an experiment
+
+AI changed the economics of contribution; this policy is our current best response,
+not scripture. We will revisit it after a full contribution season against real
+metrics — green-lane merge rate, disclosure disputes, duplicate work on
+first-PR-wins issues, time to first review, maintainer load — and change what the
+data says is wrong.
 
 ## Instructions for AI Reviewers (Copilot / CodeRabbit)
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -22,7 +22,7 @@ So this policy does not gate on how much AI you used. It gates on two things:
 1. **Verification** — did you actually run it, and can you show us?
 2. **Accountability** — do you understand it, and will you answer for it?
 
-Unverified code is a problem. Unexplainable code is a problem. AI is neither.
+Unverified code is a problem. Code nobody stands behind is a problem. AI is neither.
 
 ## The rules
 
@@ -88,17 +88,19 @@ with no objective line; pick the closest label and add a sentence of detail if
 unsure. We will never close a PR over an arguable classification, and we have no
 interest in authorship-taxonomy debates — authorship was never the quality gate.
 What we sanction is **demonstrable deception**: verification that never ran,
-fabricated logs, denying AI use against plain evidence. A 🔴 PR with thorough
-verification is welcome here — some of our own most heavily reviewed PRs are exactly
-that. An honest 🔴 beats a dishonest 🟡 every time.
+fabricated logs, denying AI use against direct evidence — and AI use is never
+*inferred* from writing or code style; poor code is a quality problem, not a
+disclosure problem. A 🔴 PR with thorough verification is welcome here — some of our
+own most heavily reviewed PRs are exactly that. An honest 🔴 beats a dishonest 🟡
+every time.
 
 ## What we do on our side
 
 Policies that only demand things are no fun, so here is our half of the deal:
 
-- **We gate on evidence, not permission.** Self-verifying contributions (test-first bug
-  fixes, verified docs fixes, `help wanted` issues with acceptance criteria, benchmark
-  results) need no assignment and no waiting — see
+- **We gate on evidence, not permission.** Evidence-bearing contributions (test-first
+  bug fixes, verified docs fixes, `help wanted` issues with acceptance criteria,
+  benchmark results) need no assignment and no waiting — see
   [CONTRIBUTING.md](CONTRIBUTING.md#which-lane-is-your-contribution).
 - **We verify before we reject.** Review findings — including those from our AI
   reviewers — are checked by execution, not vibes. Automated closures only ever happen

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -78,8 +78,8 @@ unreviewed PR, and they trigger a request for a full manual rewrite.
 Fill in the AI disclosure in the PR template honestly:
 
 - 🟢 **Human-written** — no AI involved.
-- 🟡 **AI-assisted** — AI helped (autocomplete, refactoring, drafts); you reviewed and
-  tested every line.
+- 🟡 **AI-assisted** — AI helped (autocomplete, refactoring, drafts); you reviewed the
+  resulting change and ran the relevant tests.
 - 🔴 **AI-generated** — an agent produced most of the code or the PR.
 
 **None of these is a bad answer — and the 🟡/🔴 boundary is fuzzy, which is fine.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,8 @@ When adding a new feature detector or descriptor to `kornia/feature/`:
 ## PR Requirements
 
 All PRs must:
-- Be linked to a previously discussed GitHub issue or Discord discussion (`Fixes #123`)
-- Include pasted local test log output as proof of execution (`pixi run test ...`)
+- Declare a lane (CONTRIBUTING.md "Which lane is your contribution?"): green lane (test-first bug fix, verified docs fix, `help wanted` issue, benchmark results — no prior issue needed) or discuss-first (features/behavior changes — linked issue with maintainer scope confirmation, `Fixes #123`)
+- Include pasted local test log output as proof of execution (`pixi run test ...`); bug fixes include a test that fails on `main`
 - Reference an algorithm source (PyTorch, OpenCV, scikit-image, paper, etc.) for any new implementation
 
 **Comments**: No redundant or ghost comments (e.g., "this returns the input tensor", or comments explaining deleted code). Violation triggers mandatory manual rewrite request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Welcome! This guide will help you contribute to Kornia.
     - **Don't reinvent kornia**: use existing `kornia` utilities instead of writing new ones.
     - **Own it**: you can explain any line during review; disclose AI use honestly in the PR template.
 
-- **15-Day Rule**: PRs waiting on their **author** for 15+ days may be closed to keep the queue readable — reopen anytime when you're back. Time spent waiting on *us* doesn't count against you: if you're blocked on a review, say so and a maintainer will add the `awaiting-review` label, which pauses the timer.
+- **15-Day Rule**: PRs waiting on their **author** for 15+ days may be closed to keep the queue readable — reopen anytime when you're back. Time spent waiting on *us* shouldn't count against you — but honestly, the stale bot can't tell who's waiting on whom, so this runs on a manual mechanism: if you're blocked on a review, say so and a maintainer will add the `awaiting-review` label, which pauses the timer.
 
 - **Transparency**: All discussions must be public.
 
@@ -388,17 +388,22 @@ permission.** Pick your lane:
 
 ### 🟢 Green lane — just send the PR (no issue, no assignment, no waiting)
 
-For contributions that prove themselves:
+For contributions that carry their own evidence:
 
 - **Bug fixes, test-first**: your PR contains a test that **fails on `main`** and passes
   with your fix, plus pasted test logs. That failing test *is* your permission slip —
-  it shows the bug is real and the fix works, and it takes us minutes to verify.
+  it shows the bug is real, and it takes us minutes to verify. One honest caveat: it
+  proves the behavior *changed*, not that the new behavior is *correct* — for
+  numerical/geometry fixes, back the expected values with a reference or invariant
+  (see the evidence ranking in [AI_POLICY.md](AI_POLICY.md)).
 - **Documentation fixes** where the PR description shows the snippet you ran to verify
   the corrected claim.
 - **[`help wanted` issues](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)**:
   these are pre-approved, with acceptance criteria written in the issue. No assignment,
-  no "can I work on this?" — the **first PR that meets the criteria wins**. (Please do
-  check for an already-open PR on the same issue before starting.)
+  no "can I work on this?" — the **first PR that meets the criteria wins**. Please do
+  check for an already-open PR on the same issue before starting; and to be fair about
+  what "wins" means: starting first creates no entitlement — if duplicates land,
+  maintainers merge the best-supported implementation, not the earliest timestamp.
 - **Benchmark results** from your hardware, via the `--contribute` flow in `benchmarks/`.
 
 ### 🟠 Discuss-first lane — open an issue before writing code
@@ -417,6 +422,11 @@ Why discuss first? Because for this kind of work, the design conversation *is* t
 work — and skipping it means we sometimes have to reject finished code, which is
 painful for everyone. A maintainer confirming scope on the issue is your green light;
 formal assignment is optional.
+
+One honest asymmetry, stated openly: **maintainers skip the lane guardrails** — they
+hold the scope-setting authority these gates exist to route to, so making them ask
+themselves for permission would be theater. Their PRs still meet the same evidence,
+disclosure, and review bar (see [AI_POLICY.md](AI_POLICY.md)).
 
 ### Application seasons (GSoC and similar)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -400,7 +400,10 @@ For contributions that carry their own evidence:
   the corrected claim.
 - **[`help wanted` issues](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)**:
   these are pre-approved, with acceptance criteria written in the issue. No assignment,
-  no "can I work on this?" — the **first PR that meets the criteria wins**. Please do
+  no "can I work on this?" — the **first PR that meets the criteria wins**. (Interim
+  honesty note: some older issues inherited this label from our previous templates —
+  while we finish auditing them, check that the issue actually states acceptance
+  criteria or has explicit maintainer confirmation before starting.) Please do
   check for an already-open PR on the same issue before starting; and to be fair about
   what "wins" means: starting first creates no entitlement — if duplicates land,
   maintainers merge the best-supported implementation, not the earliest timestamp.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,7 +300,7 @@ This section provides guidance for contributing to Kornia, with a focus on Pytho
 
 ## Before You Start
 
-1. **Know Your Lane**: Self-verifying fixes (failing test + fix, verified docs corrections, `help wanted` issues) can go straight to a PR. For features and behavior changes, discuss in Discord or a GitHub issue first — see [Which lane is your contribution?](#which-lane-is-your-contribution).
+1. **Know Your Lane**: Self-verifying fixes (failing test + fix, verified docs corrections, `help wanted` issues) can go straight to a PR. For features and behavior changes, discuss first — Discord is a fine place for the conversation, but capture the outcome in a GitHub issue with maintainer scope confirmation, since that issue is what your PR links to. See [Which lane is your contribution?](#which-lane-is-your-contribution).
 
 2. **Start Small**: If you're new to the project, start with small bug fixes or documentation improvements to familiarize yourself with the codebase and contribution process.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! This guide will help you contribute to Kornia.
 
 ## Policies and Guidelines
 
-- **Two lanes**: small self-verifying fixes need no permission — just send the PR. Features and behavior changes need discussion first. See [Which lane is your contribution?](#which-lane-is-your-contribution).
+- **Two lanes**: small evidence-bearing fixes need no permission — just send the PR. Features and behavior changes need discussion first. See [Which lane is your contribution?](#which-lane-is-your-contribution).
 
 - **AI Policy & Authorship**: See [AI_POLICY.md](AI_POLICY.md) for the complete policy. Short version: we don't care how much AI you used (our maintainers use it heavily too) — we care that you **verified** everything and can **explain** everything. That means:
     - **Show us it runs**: PRs include pasted local test logs; bug fixes arrive with a test that fails on `main`.
@@ -300,7 +300,7 @@ This section provides guidance for contributing to Kornia, with a focus on Pytho
 
 ## Before You Start
 
-1. **Know Your Lane**: Self-verifying fixes (failing test + fix, verified docs corrections, `help wanted` issues) can go straight to a PR. For features and behavior changes, discuss first — Discord is a fine place for the conversation, but capture the outcome in a GitHub issue with maintainer scope confirmation, since that issue is what your PR links to. See [Which lane is your contribution?](#which-lane-is-your-contribution).
+1. **Know Your Lane**: Fixes that carry their own evidence (failing test + fix, verified docs corrections, `help wanted` issues) can go straight to a PR. For features and behavior changes, discuss first — Discord is a fine place for the conversation, but capture the outcome in a GitHub issue with maintainer scope confirmation, since that issue is what your PR links to. See [Which lane is your contribution?](#which-lane-is-your-contribution).
 
 2. **Start Small**: If you're new to the project, start with small bug fixes or documentation improvements to familiarize yourself with the codebase and contribution process.
 
@@ -367,7 +367,7 @@ This section provides guidance for contributing to Kornia, with a focus on Pytho
   - Mark as **🟢 Human-written** if you wrote all code manually without AI assistance
   - Mark as **🟡 AI-assisted** if AI tools (Copilot, Cursor, etc.) helped with boilerplate/refactoring/drafts and you manually reviewed and tested every line
   - Mark as **🔴 AI-generated** if an agent produced most of the code or the PR
-  - **None of these is a bad answer** — well-verified 🔴 PRs are welcome (our maintainers ship them too). What gets PRs closed is mislabeling, or verification that turns out to be imaginary. See [AI_POLICY.md](AI_POLICY.md).
+  - **None of these is a bad answer, and the 🟡/🔴 line is fuzzy — pick the closest** — well-verified 🔴 PRs are welcome (our maintainers ship them too). Only demonstrable deception (verification that never ran, fabricated logs) closes PRs; arguable classifications are never litigated. See [AI_POLICY.md](AI_POLICY.md).
 
 ## Communication
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,18 @@ Welcome! This guide will help you contribute to Kornia.
 
 ## Policies and Guidelines
 
-- **AI Policy & Authorship**: See [AI_POLICY.md](AI_POLICY.md) for the complete policy. Summary:
-    - Kornia accepts AI-assisted code but strictly rejects AI-generated contributions where the submitter acts as a proxy.
-    - **Proof of Verification**: PRs must include local test logs proving execution.
-    - **Hallucination & Redundancy Ban**: Use existing `kornia` utilities and never reinvent the wheel, except for when the utility is not available.
-    - **The "Explain It" Standard**: You must be able to explain any code you submit.
-    - Violations result in immediate closure or rejection.
+- **Two lanes**: small self-verifying fixes need no permission — just send the PR. Features and behavior changes need discussion first. See [Which lane is your contribution?](#which-lane-is-your-contribution).
 
-- **15-Day Rule**: PRs with no activity for 15+ days will be automatically closed.
+- **AI Policy & Authorship**: See [AI_POLICY.md](AI_POLICY.md) for the complete policy. Short version: we don't care how much AI you used (our maintainers use it heavily too) — we care that you **verified** everything and can **explain** everything. That means:
+    - **Show us it runs**: PRs include pasted local test logs; bug fixes arrive with a test that fails on `main`.
+    - **Don't reinvent kornia**: use existing `kornia` utilities instead of writing new ones.
+    - **Own it**: you can explain any line during review; disclose AI use honestly in the PR template.
+
+- **15-Day Rule**: PRs waiting on their **author** for 15+ days may be closed to keep the queue readable — reopen anytime when you're back. Time spent waiting on *us* doesn't count against you: if you're blocked on a review, say so and a maintainer will add the `awaiting-review` label, which pauses the timer.
 
 - **Transparency**: All discussions must be public.
 
-We're all volunteers. These policies help us focus on high-impact work.
+We're all volunteers. These policies exist so review time goes to real contributions.
 
 ## Ways to Contribute
 
@@ -300,7 +300,7 @@ This section provides guidance for contributing to Kornia, with a focus on Pytho
 
 ## Before You Start
 
-1. **Discuss First**: Always discuss your proposed changes in Discord or via a GitHub issue before starting implementation. This ensures your work aligns with project goals and avoids duplicate effort.
+1. **Know Your Lane**: Self-verifying fixes (failing test + fix, verified docs corrections, `help wanted` issues) can go straight to a PR. For features and behavior changes, discuss in Discord or a GitHub issue first — see [Which lane is your contribution?](#which-lane-is-your-contribution).
 
 2. **Start Small**: If you're new to the project, start with small bug fixes or documentation improvements to familiarize yourself with the codebase and contribution process.
 
@@ -364,9 +364,10 @@ This section provides guidance for contributing to Kornia, with a focus on Pytho
 - Review AI output thoroughly: check for unnecessary complexity, verify it follows project conventions, ensure it uses existing utilities, and test it
 - Be transparent in PR descriptions about what was AI-assisted and what you manually reviewed (see [Pull Request](#pull-request) for AI Usage Disclosure requirements)
 - **AI Usage Disclosure in PR Template**: When completing the PR template's "AI Usage Disclosure" section:
-  - Mark as **🟢 No AI used** only if you wrote all code manually without any AI assistance
-  - Mark as **🟡 AI-assisted** if you used AI tools (Copilot, Cursor, etc.) for boilerplate/refactoring but manually reviewed and tested every line
-  - Mark as **🔴 AI-generated** if an AI agent generated the code, PR description, or commit messages, or if you cannot explain the logic without referring to the AI's output. **Important**: PRs marked as AI-generated are subject to stricter scrutiny and may be immediately closed if the logic cannot be explained
+  - Mark as **🟢 Human-written** if you wrote all code manually without AI assistance
+  - Mark as **🟡 AI-assisted** if AI tools (Copilot, Cursor, etc.) helped with boilerplate/refactoring/drafts and you manually reviewed and tested every line
+  - Mark as **🔴 AI-generated** if an agent produced most of the code or the PR
+  - **None of these is a bad answer** — well-verified 🔴 PRs are welcome (our maintainers ship them too). What gets PRs closed is mislabeling, or verification that turns out to be imaginary. See [AI_POLICY.md](AI_POLICY.md).
 
 ## Communication
 
@@ -376,35 +377,68 @@ This section provides guidance for contributing to Kornia, with a focus on Pytho
 
 # Pull Request
 
-## Issue Approval and Assignment Workflow
+## Which lane is your contribution?
 
-**Before submitting a PR, you must:**
+First, the honest context: AI has made pull requests cheap to produce and expensive to
+review, and we are a small volunteer team. We used to require maintainer approval and
+assignment before *any* work. That slowed down exactly the people we want most — someone
+who spotted a real bug and has an hour to fix it properly — while barely slowing down
+low-effort submissions at all. So we changed the deal: **we gate on evidence, not
+permission.** Pick your lane:
 
-1. **Open an issue first**: All PRs must be linked to an existing issue. If no issue exists for your work, create one using the appropriate template (bug report or feature request).
+### 🟢 Green lane — just send the PR (no issue, no assignment, no waiting)
 
-2. **Wait for maintainer approval**: A maintainer must review and approve the issue before you start working on it. New issues are automatically labeled with `triage` and will receive a welcome message explaining this process.
+For contributions that prove themselves:
 
-3. **Wait for assignment**: You must be assigned to the issue by a maintainer before submitting a PR. This ensures:
-   - The issue aligns with project goals
-   - No duplicate work is being done
-   - Proper coordination of contributions
+- **Bug fixes, test-first**: your PR contains a test that **fails on `main`** and passes
+  with your fix, plus pasted test logs. That failing test *is* your permission slip —
+  it shows the bug is real and the fix works, and it takes us minutes to verify.
+- **Documentation fixes** where the PR description shows the snippet you ran to verify
+  the corrected claim.
+- **[`help wanted` issues](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)**:
+  these are pre-approved, with acceptance criteria written in the issue. No assignment,
+  no "can I work on this?" — the **first PR that meets the criteria wins**. (Please do
+  check for an already-open PR on the same issue before starting.)
+- **Benchmark results** from your hardware, via the `--contribute` flow in `benchmarks/`.
 
-4. **Do not start work until assigned**: PRs submitted without prior issue approval and assignment may be closed or receive warnings during automated validation.
+### 🟠 Discuss-first lane — open an issue before writing code
 
-This workflow helps maintain quality, avoid conflicts, and ensure contributions align with the project's direction. The automated PR validation workflow will check these requirements and post warnings if they're not met.
+For contributions that change what kornia *means* or where it is going:
 
-**Requirements:**
-- **Issue approval and assignment**: The linked issue must be approved by a maintainer and you must be assigned to it (see workflow above)
-- Link PR to an issue (use "Closes #123" or "Fixes #123")
-- Pass all local tests before submission
-- Provide proof of local test execution in the PR description (this is especially important for first-time contributors)
+- New features and new public APIs
+- **Any change to behavior, defaults, or conventions — even ones that look obviously
+  wrong.** In a geometry library, changing a default silently breaks everyone who
+  adapted to it. We have a specific protocol for fixing shipped conventions; propose
+  the change in an issue and we will route it.
+- New models or integrations (mostly frozen — see the project direction in the README)
+- Large refactors
+
+Why discuss first? Because for this kind of work, the design conversation *is* the
+work — and skipping it means we sometimes have to reject finished code, which is
+painful for everyone. A maintainer confirming scope on the issue is your green light;
+formal assignment is optional.
+
+### Application seasons (GSoC and similar)
+
+Around application deadlines we receive a large wave of first-time PRs. During
+announced application windows, first-time contributions are accepted from the green
+lane only. One well-verified green-lane PR helps your application far more than five
+hasty ones — we read review threads, not PR counts.
+
+## PR requirements
+
+- Pass all local tests before submission, and paste the test log in the PR description
+  (this is how we know it ran — especially important for first-time contributors)
+- Green lane: state which green-lane category applies; for bug fixes, include the
+  failing-test-on-`main` evidence
+- Discuss-first lane: link the issue (use "Closes #123" or "Fixes #123") where a
+  maintainer confirmed the scope
 - Fill the [pull request template](.github/pull_request_template.md)
-- **AI Policy Compliance**: Must comply with [AI_POLICY.md](AI_POLICY.md). This includes:
-  - Using existing `kornia` utilities instead of reinventing
-  - Being able to explain all submitted code
-  - Completing the AI Usage Disclosure in the PR template accurately (see [AI-Assisted Development](#ai-assisted-development) for guidance on when to mark as AI-generated)
-- 15-Day Rule: Inactive PRs (>15 days) will be closed
-- Transparency: Keep discussions public
+- **AI Policy**: comply with [AI_POLICY.md](AI_POLICY.md) — use existing `kornia`
+  utilities, be able to explain all submitted code, and complete the AI disclosure
+  honestly (an honest 🔴 is fine; a dishonest 🟡 is not)
+- 15-Day Rule: PRs waiting on the author for 15+ days may be closed (reopen anytime)
+- Transparency: keep discussions public
 
 **Code review:**
 - By default, GitHub Copilot will check the PR against the AI Policy and the coding standards.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,12 +360,12 @@ This section provides guidance for contributing to Kornia, with a focus on Pytho
 
 ## AI-Assisted Development
 
-- Understand every line of code you submit; you must be able to explain it during review (see [AI Policy](#policies-and-guidelines))
+- Own the code you submit: understand it and be ready to address reviewer questions about it (see [AI Policy](#policies-and-guidelines))
 - Review AI output thoroughly: check for unnecessary complexity, verify it follows project conventions, ensure it uses existing utilities, and test it
 - Be transparent in PR descriptions about what was AI-assisted and what you manually reviewed (see [Pull Request](#pull-request) for AI Usage Disclosure requirements)
 - **AI Usage Disclosure in PR Template**: When completing the PR template's "AI Usage Disclosure" section:
   - Mark as **🟢 Human-written** if you wrote all code manually without AI assistance
-  - Mark as **🟡 AI-assisted** if AI tools (Copilot, Cursor, etc.) helped with boilerplate/refactoring/drafts and you manually reviewed and tested every line
+  - Mark as **🟡 AI-assisted** if AI tools (Copilot, Cursor, etc.) helped with boilerplate/refactoring/drafts and you reviewed the resulting change and ran the relevant tests
   - Mark as **🔴 AI-generated** if an agent produced most of the code or the PR
   - **None of these is a bad answer, and the 🟡/🔴 line is fuzzy — pick the closest** — well-verified 🔴 PRs are welcome (our maintainers ship them too). Only demonstrable deception (verification that never ran, fabricated logs) closes PRs; arguable classifications are never litigated. See [AI_POLICY.md](AI_POLICY.md).
 

--- a/README.md
+++ b/README.md
@@ -272,11 +272,6 @@ Our primary focus is on integrating **Vision Language Models (VLM)** and **Visio
 
 Kornia's foundation lies in its extensive collection of classic computer vision operators, providing robust tools for image processing, feature extraction, and geometric transformations. We continuously seek for contributors to help us improve our documentation and present nice tutorials to our users.
 
-## Contributing
-
-We welcome contributions to Kornia! Whether you are fixing bugs, improving documentation, or adding new computer vision features, please check out our [Contribution Guidelines](CONTRIBUTING.md) to get started with setting up your development environment, running tests, and submitting pull requests.
-
-
 ## Cite
 
 If you are using kornia in your research-related documents, it is recommended that you cite the paper. See more in [CITATION](./CITATION.md).
@@ -293,19 +288,13 @@ If you are using kornia in your research-related documents, it is recommended th
 
 ## Contributing
 
-We appreciate all contributions. If you are planning to contribute back bug-fixes, please do so without any further discussion. If you plan to contribute new features, utility functions or extensions, please first open an issue and discuss the feature with us. Please, consider reading the [CONTRIBUTING](./CONTRIBUTING.md) notes. The participation in this open source project is subject to [Code of Conduct](./CODE_OF_CONDUCT.md).
+We appreciate all contributions, and we are honest about the world we operate in: AI makes code cheap to write, and volunteer review time is our scarcest resource. So our process gates on **evidence, not permission**:
 
-### AI Policy
+- **Small, self-verifying fixes go straight to a PR** — a bug fix with a test that fails on `main`, a docs fix with a verification snippet, or any [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue (pre-approved, no assignment needed — first good PR wins).
+- **Features and behavior changes need a conversation first** — open an issue and get the scope confirmed before writing code. In a geometry library, changed defaults break users silently, so these get extra care.
+- **AI use is fine — including fully agent-written PRs.** Our own maintainers work this way. What we require is that *you* verified everything (pasted test logs), can explain every line during review, and disclose AI use honestly. Unverified or unexplainable code is closed regardless of how it was made.
 
-Kornia accepts AI-assisted code but strictly rejects AI-generated contributions where the submitter acts as a proxy. All contributors must be the **Sole Responsible Author** for every line of code. Please review our [AI Policy](AI_POLICY.md) before submitting pull requests. Key requirements include:
-
-- **Proof of Verification**: PRs must include local test logs proving execution
-- **Pre-Discussion**: All PRs must be discussed in Discord or via a GitHub issue before implementation
-- **Library References**: Implementations must be based on existing library references (PyTorch, OpenCV, etc.)
-- **Use Existing Utilities**: Use existing `kornia` utilities instead of reinventing the wheel
-- **Explain It**: You must be able to explain any code you submit
-
-Automated AI reviewers (e.g., GitHub Copilot) will check PRs against these policies. See [AI_POLICY.md](AI_POLICY.md) for complete details.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the details and [AI_POLICY.md](AI_POLICY.md) for the full policy. Participation is subject to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Community
 - **Discord:** Join our workspace to keep in touch with our core contributors, get latest updates on the industry and  be part of our community. [JOIN HERE](https://discord.gg/HfnywwpBnD)

--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ If you are using kornia in your research-related documents, it is recommended th
 
 We appreciate all contributions, and we are honest about the world we operate in: AI makes code cheap to write, and volunteer review time is our scarcest resource. So our process gates on **evidence, not permission**:
 
-- **Small, self-verifying fixes go straight to a PR** — a bug fix with a test that fails on `main`, a docs fix with a verification snippet, or any [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue (pre-approved, no assignment needed — first good PR wins).
+- **Small, evidence-bearing fixes go straight to a PR** — a bug fix with a test that fails on `main`, a docs fix with a verification snippet, or any [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue (pre-approved, no assignment needed — the best-supported PR wins).
 - **Features and behavior changes need a conversation first** — open an issue and get the scope confirmed before writing code. In a geometry library, changed defaults break users silently, so these get extra care.
-- **AI use is fine — including fully agent-written PRs.** Our own maintainers work this way. What we require is that *you* verified everything (pasted test logs), can explain every line during review, and disclose AI use honestly. Unverified or unexplainable code is closed regardless of how it was made.
+- **AI use is fine — including fully agent-written PRs.** Our own maintainers work this way. What we require is that *you* verified everything (pasted test logs, evidence-backed tests), can answer questions about the code during review, and disclose AI use honestly. What closes PRs is unverified work or unresolved correctness concerns — regardless of how the code was made.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the details and [AI_POLICY.md](AI_POLICY.md) for the full policy. Participation is subject to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
## Which lane? *(check one — see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))*
- [ ] 🟢 **Green lane** — test-first bug fix / verified docs fix / `help wanted` issue / benchmark results. No prior issue needed.
- [x] 🟠 **Discuss-first** — feature or behavior change; scope defined and confirmed by maintainer (@ducha-aiki) in a working session (no separate issue; maintainer-authored).

**Fixes/Relates to:** —

## What does this PR do?

Rebalances the contribution policy: we keep the anti-slop protections but stop making genuine contributors wait for permission. The old rule — *no work without maintainer approval + assignment* — slowed down exactly the people we want most, while barely slowing down low-effort AI-generated PRs (and around GSoC deadlines, collecting assignments was itself the metric being farmed). The new rule: **we gate on evidence, not permission.**

**Two-lane model** (`CONTRIBUTING.md`):
- 🟢 **Green lane — just send the PR** (no issue, no assignment, no waiting): bug fixes that arrive with a test that fails on `main` (the failing test *is* the permission slip), docs fixes with a pasted verification snippet, `help wanted` issues (pre-approved, acceptance criteria in the issue, **first good PR wins** — nothing to squat on), and benchmark results via `--contribute`.
- 🟠 **Discuss-first lane** (unchanged in spirit): features, new APIs, and any behavior/default/convention change need an issue with maintainer scope confirmation before code. Formal assignment becomes optional.
- Application-season note: during announced windows (GSoC etc.), first-time contributions come from the green lane only.

**AI policy reframed** (`AI_POLICY.md`, v2.0): the gate moves from *authorship* to **verification + accountability**. We say openly that maintainers ship agent-written PRs, so banning "AI-generated code" would be hypocritical — what matters is that every claim was executed (pasted test logs, test-first bug fixes, named algorithm references) and a human can explain every line. Honest 🔴 disclosure is welcome; mislabeling and imaginary verification are what close PRs. A new "What we do on our side" section commits us to the same standard: evidence-based review, no closures on subjective bot findings, our own PRs held to the same bar.

**Bureaucracy cut**:
- PR template: 17 checkboxes → 5 (two lane boxes parsed by `pr-validation.yml`, three AI-disclosure options required by policy). The self-review/style/screenshots checklist theater is gone — CI checks style and the diff shows tests.
- Bug report: 3 required fields + 1 optional, zero checkboxes; the wget-`collect_env.py` instructions are replaced by a tested copy-paste one-liner (torch ships `python -m torch.utils.collect_env` built-in for full GPU detail).
- Feature request: 1 required field + 2 optional, zero checkboxes; drops the category dropdown and the VLM/VLA priority signaling.
- Issue templates stop auto-applying `help wanted` — under the new model that label means *pre-approved, first PR wins*, so it must be curated, not automatic. (Follow-up: audit the 23 currently-labeled issues.)

**Automation aligned**:
- `pr-validation.yml`: lane-aware — green-lane PRs are no longer warned about missing issues; discuss-first keeps issue-link checks but drops hard assignment demands; warnings now say exactly what is missing. Embedded JS syntax-checked with `node --check`.
- `issue-triage.yml`: welcome message flips from "wait for assignment" to a friendly explanation of both lanes.
- `stale.yml`: 15-day rule now counts author-side inactivity only — the new `awaiting-review` label (created) pauses the timer for PRs blocked on us; stale/close messages reworded ("bookkeeping, not a rejection").
- `README.md`: the two duplicate Contributing sections are merged into one carrying the evidence-not-permission summary; `CLAUDE.md` and `.github/copilot-instructions.md` updated to match (lane-aware review checks; "never recommend closure based on subjective quality opinions alone").

## Test log

Docs + workflow changes; no library code touched. Verification performed:

```
$ .venv/bin/pre-commit run --files AI_POLICY.md CONTRIBUTING.md README.md CLAUDE.md \
    .github/pull_request_template.md .github/copilot-instructions.md \
    .github/workflows/pr-validation.yml .github/workflows/issue-triage.yml .github/workflows/stale.yml \
    .github/ISSUE_TEMPLATE/bug-report.yml .github/ISSUE_TEMPLATE/feature-request.yml
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check yaml...............................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
mixed line ending........................................................Passed
codespell................................................................Passed

# embedded github-script JS extracted and syntax-checked:
pr-validation.yml JS: OK
issue-triage.yml JS: OK

# env one-liner in the bug template executed:
kornia 0.9.0rc1 | torch 2.9.1 | python 3.11.14 | macOS-26.5.1-arm64-arm-64bit | cuda None (avail=False) | mps=True
```

## AI disclosure *(honest answer required — none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
- [ ] 🟢 **Human-written**
- [ ] 🟡 **AI-assisted** — AI helped; I reviewed and tested every line
- [x] 🔴 **AI-generated** — an agent wrote most of it; I verified it and can explain every line

*(This PR is the new policy demonstrating itself: agent-written, maintainer-directed and reviewed, every mechanical claim verified by execution.)*

Posted on behalf of @ducha-aiki by Claude (Fable 5).
