### PR TITLE
docs: realign ROADMAP with the reference-core direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Kornia's differentiated value is its geometry core: warping and sampling, homogr
 
 ### AI Models
 
-The model zoo is currently **frozen for expansion** while maintainer bandwidth concentrates on the core. Shipped models (LoFTR, LightGlue, DISK, DeDoDe, SAM, and friends) stay available and maintained; new integrations — including VLM/VLA models — land only with a contributor committed to their long-term maintenance (say so explicitly on the issue). See the [Roadmap](ROADMAP.md#guiding-themes) for the reasoning and the reopen conditions.
+The model zoo is currently **frozen for expansion** while maintainer bandwidth concentrates on the core. Shipped models (LoFTR, LightGlue, DISK, DeDoDe, SAM, and friends) stay available and maintained, and model work approved before the freeze (Efficient LoFTR, SANDesc) will be completed under its existing scope. New integrations — including VLM/VLA models — require a named maintainer sponsor who accepts ongoing ownership of the integration; a contributor implementation alone cannot reopen the surface. See the [Roadmap](ROADMAP.md#guiding-themes) for the reasoning and the reopen condition.
 
 ### Documentation And Tutorial Optimization
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ English | [简体中文](README_zh-CN.md)
 
 **Kornia** is a differentiable computer vision library that provides a rich set of differentiable image processing and geometric vision algorithms. Built on top of [PyTorch](https://pytorch.org), Kornia integrates seamlessly into existing AI workflows, allowing you to leverage powerful [batch transformations](), [auto-differentiation]() and [GPU acceleration](). Whether you're working on image transformations, augmentations, or AI-driven image processing, Kornia equips you with the tools you need to bring your ideas to life.
 
-> **📢 Announcement**: Kornia is shifting towards end-to-end vision models. We are focusing on integrating state-of-the-art Vision Language Models (VLM) and Vision Language Agents (VLA) to provide comprehensive end-to-end vision solutions.
+> **📢 Direction**: Kornia is becoming the **reference implementation and executable specification** for differentiable computer vision and geometry in the PyTorch ecosystem — explicit conventions, conformance tests, and honest benchmarks over API growth. Read the [Roadmap](ROADMAP.md).
 
 ## Key Components
 1. **Differentiable Image Processing**<br>
@@ -252,21 +252,20 @@ tf_kornia = kornia.to_tensorflow()
 
 ## Call For Contributors
 
-Are you passionate about computer vision, AI, and open-source development? Join us in shaping the future of Kornia! We are actively seeking contributors to help expand and enhance our library, making it even more powerful, accessible, and versatile. Whether you're an experienced developer or just starting, there's a place for you in our community.
+Are you passionate about computer vision, AI, and open-source development? Join us in shaping the future of Kornia! We are actively seeking contributors to help strengthen the library — making it more correct, faster, and better specified. Whether you're an experienced developer or just starting, there's a place for you in our community.
 
-### Accessible AI Models
+### Strengthen the Core (Priority)
 
-We are excited to announce our latest advancement: a new initiative designed to seamlessly integrate lightweight AI models into Kornia.
-We aim to run any models as smooth as big models such as StableDiffusion, to support them well in many perspectives.
+Kornia's differentiated value is its geometry core: warping and sampling, homographies, cameras, epipolar geometry, rotations and Lie groups, and geometry-consistent augmentation. The highest-impact contributions make that core more trustworthy — see the [Roadmap](ROADMAP.md) for the full picture. Great entry points:
 
-**Priority Focus: VLM/VLA Models**
+- **Benchmark results from your hardware**: run the benchmark suite with `--contribute` and send the JSON — CUDA numbers from diverse GPUs are especially wanted.
+- **Convention pinning tests and conformance vectors** for core geometry ops.
+- **Corrective error messages**: upgrade bare shape asserts into errors that state what was wrong, what was expected, and which convention applies.
+- **Classical vision in the core domain**: camera intrinsic calibration, fiducial markers (ArUco/ChArUco), classical tracking, dense stereo, Hough transforms.
 
-Our primary focus is on integrating **Vision Language Models (VLM)** and **Vision Language Agents (VLA)** to enable end-to-end vision solutions. We're actively seeking contributors to help us:
+### AI Models
 
-- **VLM/VLA Integration (Priority)**: Implement and integrate state-of-the-art Vision Language Models and Vision Language Agents. This includes models like Qwen2.5-VL, SAM-3, and other cutting-edge VLM/VLA architectures. If you are a researcher working on VLM/VLA models, Kornia is an excellent place for you to promote your model!
-- Expand the Model Selection: Import decent models into our library. If you are a researcher, Kornia is an excellent place for you to promote your model!
-- Model Optimization: Work on optimizing models to reduce their computational footprint while maintaining accuracy and performance. You may start from offering ONNX support!
-- Model Documentation: Create detailed guides and examples to help users get the most out of these models in their projects.
+The model zoo is currently **frozen for expansion** while maintainer bandwidth concentrates on the core. Shipped models (LoFTR, LightGlue, DISK, DeDoDe, SAM, and friends) stay available and maintained; new integrations — including VLM/VLA models — land only with a contributor committed to their long-term maintenance (say so explicitly on the issue). See the [Roadmap](ROADMAP.md#guiding-themes) for the reasoning and the reopen conditions.
 
 ### Documentation And Tutorial Optimization
 

--- a/README.md
+++ b/README.md
@@ -258,10 +258,12 @@ Are you passionate about computer vision, AI, and open-source development? Join 
 
 Kornia's differentiated value is its geometry core: warping and sampling, homographies, cameras, epipolar geometry, rotations and Lie groups, and geometry-consistent augmentation. The highest-impact contributions make that core more trustworthy — see the [Roadmap](ROADMAP.md) for the full picture. Great entry points:
 
-- **Benchmark results from your hardware**: run the benchmark suite with `--contribute` and send the JSON — CUDA numbers from diverse GPUs are especially wanted.
-- **Convention pinning tests and conformance vectors** for core geometry ops.
-- **Corrective error messages**: upgrade bare shape asserts into errors that state what was wrong, what was expected, and which convention applies.
-- **Classical vision in the core domain**: camera intrinsic calibration, fiducial markers (ArUco/ChArUco), classical tracking, dense stereo, Hough transforms.
+- **Benchmark results from your hardware** *(green lane — just send the PR)*: run the benchmark suite with `--contribute` and send the JSON — CUDA numbers from diverse GPUs are especially wanted.
+- **Convention pinning tests and conformance vectors** for core geometry ops *(green lane once curated into a `help wanted` issue with acceptance criteria)*.
+- **Corrective error messages** *(same curation rule)*: upgrade bare shape asserts into errors that state what was wrong, what was expected, and which convention applies.
+- **Classical vision in the core domain** *(discuss-first — open an issue)*: camera intrinsic calibration, fiducial markers (ArUco/ChArUco), classical tracking, dense stereo, Hough transforms.
+
+See the [Roadmap's contributor areas](ROADMAP.md#areas-seeking-contributors) for how each of these routes through the contribution lanes.
 
 ### AI Models
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,7 +93,7 @@ wrappers (LoFTR, LightGlue, DISK, DeDoDe, SAM, XFeat, ALIKED, Kimi-VL, …) rema
 available and maintained under a *usable-or-deleted* rule. The freeze partially
 reopens if a maintainer with model-work capacity joins the project.
 
-## Short term — next release (v0.8.4)
+## Short term — next release
 
 - **Stabilize CI and the augmentation core.** Recent fixes repaired regressions from the
   ONNX-exportability refactor and healed the scheduled test matrix. Ship these in a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,163 +5,245 @@ high-impact work, to show users the direction of the project, and to make our
 priorities legible to the wider community.
 
 It is a living document. Dates are intentions, not commitments, and priorities shift
-as the ecosystem does. If you want to work on something here, open or comment on the
-linked issue first so we can coordinate (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+as the ecosystem does. If you want to work on something here, check which
+contribution lane it falls into first (see
+[CONTRIBUTING.md](CONTRIBUTING.md)): small evidence-bearing fixes can go straight to
+a PR; features and behavior changes need a discussion on an issue first.
+
+**Where Kornia is going.** Kornia is becoming the **reference implementation and
+executable specification** for differentiable computer vision and geometry in the
+PyTorch ecosystem. At ~3M downloads/month the highest-leverage work is not growing
+the API — it is making the differentiated core (warping and sampling, homographies,
+cameras, epipolar geometry, rotations and Lie groups, geometry-consistent
+augmentation) unusually trustworthy: conventions explicit and pinned by tests,
+behavior validated by conformance vectors, guarantees enforced by CI. Progress is
+measured in confidence, not API count — a strong release can contain zero new public
+APIs and still deliver better `torch.compile` coverage, fixed convention ambiguity,
+improved numerical stability, and stronger dtype/device behavior.
 
 ## Guiding themes
 
-Three engineering north stars shape most of the roadmap below. The important insight
-is that the first two are largely **the same body of work**:
+Four engineering north stars shape the roadmap below.
 
-1. **Compile-first (`torch.compile` / dynamo).** The numeric core (filters, color,
+1. **The reference core: conventions, conformance, tiers.** Geometric code has a
+   uniquely dangerous failure mode: small convention mistakes (`align_corners`,
+   pixel-center vs corner, (x,y) vs (row,col), normalized vs pixel coordinates,
+   rotation direction, homography normalization) produce code that *runs correctly
+   while being mathematically wrong* — and this is exactly the error class LLMs
+   reproduce. The program, in order, per API surface:
+
+   1. **Document** — every core op gets a Convention block in its docs plus
+      `test_convention_*` pinning tests, describing actual behavior including known
+      warts. The first batches have landed
+      ([#3924](https://github.com/kornia/kornia/pull/3924),
+      [#3926](https://github.com/kornia/kornia/pull/3926)); the canonical
+      [Conventions & Pitfalls](https://kornia.readthedocs.io/en/latest/get-started/conventions.html)
+      page is live. Behavior bugs found by the audit get dedicated issues.
+   2. **Repair & deprecate** — one coordinated window fixes accumulated semantic and
+      default-value bugs, so downstream users face a single loud migration instead of
+      a drizzle of breaking changes. Clearly-broken-output bugs (NaN, crashes) land
+      early as ordinary bugfixes.
+   3. **Freeze** — after the window, a **Tier A ("Kornia Core")** set is declared:
+      symbols with the strongest guarantees (autograd, gradcheck, compile, dtype/
+      device correctness, explicit conventions, semantic stability). Tier A starts
+      brutally small and a guarantee is only claimed where CI enforces it. See the
+      [stability policy](https://kornia.readthedocs.io/en/latest/get-started/stability.html).
+
+   Alongside this grows a **conformance corpus**: framework-neutral golden vectors
+   (inputs, expected outputs, tolerances, convention metadata) that external
+   implementations — JAX ports, Rust/Triton kernels, vendored copies, and
+   LLM-generated code — can validate against. Long-term, Kornia defining the
+   conformance tests for differentiable geometric vision may matter more than owning
+   every implementation.
+
+2. **Compile-first (`torch.compile` / dynamo).** The numeric core (filters, color,
    geometry, enhance, losses) is already largely compile-clean. The remaining work is
    concentrated in the stochastic augmentation pipeline and the dynamic-shape feature
-   detectors, which branch on tensor values and break the graph.
+   detectors, which branch on tensor values and break the graph — the augmentation
+   classes fail structurally in data-dependent parameter generation
+   ([#3913](https://github.com/kornia/kornia/issues/3913)). Compile support is
+   claimed **per evidenced surface**: today that means the functional core, not the
+   augmentation classes, and docs state the scope explicitly.
 
-2. **Export-first (ONNX).** ONNX export fails on the *same* patterns that break
+3. **Export-first (ONNX).** ONNX export fails on the *same* patterns that break
    `torch.compile`: data-dependent control flow, `.item()` calls, and dynamic shapes.
    [#3722](https://github.com/kornia/kornia/pull/3722) demonstrated the fix — replacing
    the stochastic apply path with `torch.where` blends and gating linear-algebra
    fallbacks on `is_tracing()` — which advanced both goals in a single change. The
    remaining spine work pays out to compile and export together.
 
-3. **Performance.** A static-shape, data-independent augmentation graph — the same one
-   the compile/export work produces — is what fuses under `inductor` and what a native
-   `kornia-rs` kernel can accelerate. Our differentiator is GPU-batched, on-device,
-   differentiable augmentation; our goal is to make that regime dramatically faster and
-   to measure it honestly against alternatives. For the non-differentiable CPU/`uint8`
-   regime — where users today reach for albumentations — an opt-in `kornia-rs` backend is
-   the path to a step-change: local benchmarks already show `kornia-rs` beating
-   albumentations by 1.3–2.5x on common ops, so the moonshot there is an API-integration
-   problem, not a kernel-performance one.
+4. **Performance, honestly measured.** The benchmark harness is now first-class:
+   `benchmarks/` measures kornia (eager + compiled) against OpenCV, torchvision v2,
+   albumentations, and PIL with median+IQR timings, hardware metadata, and an
+   auto-published results page — and it publishes where Kornia *loses* (CPU,
+   batch=1) alongside where it wins (large-batch GPU, differentiability, compiled
+   paths), so the page is citable by skeptics. Measurement drives the fix order:
+   the systemic finding is that the augmentation pipeline is **launch-bound, not
+   kernel-bound** (per-call wrapper orchestration can make throughput *fall* as
+   batch grows), so orchestration overhead is fixed first; then the measured kernel
+   outliers (`median_blur`, `canny`, `rotate`). For the non-differentiable
+   CPU/`uint8` regime an opt-in `kornia-rs` backend is the path to a step-change,
+   and hand-written Triton kernels are reserved for the small set of ops `inductor`
+   structurally cannot fuse.
 
-A fourth theme, **breadth**, runs in parallel and is largely community-driven: closing
-classical-CV gaps and hardening the model zoo.
+A fifth theme, **breadth**, is community-driven and runs through the discuss-first
+lane. One boundary is stated openly: **model-zoo expansion is frozen.** No new model
+or VLM/VLA integrations while maintainer bandwidth concentrates on the core; shipped
+wrappers (LoFTR, LightGlue, DISK, DeDoDe, SAM, XFeat, ALIKED, Kimi-VL, …) remain
+available and maintained under a *usable-or-deleted* rule. The freeze partially
+reopens if a maintainer with model-work capacity joins the project.
 
 ## Short term — next release (v0.8.4)
 
 - **Stabilize CI and the augmentation core.** Recent fixes repaired regressions from the
   ONNX-exportability refactor and healed the scheduled test matrix. Ship these in a
   release so users get the fixes.
+- **Convention-block batches.** Continue the per-op audit:
+  `geometry.conversions` → bounding boxes
+  ([#1142](https://github.com/kornia/kornia/issues/1142)) → camera → augmentation
+  classes. Each batch delivers Convention blocks, pinning tests, and dedicated
+  issues for any behavior bug found.
+- **Broken-output bugfixes** from the audit, landing ahead of the repair window:
+  pyramid bounds check ([#3927](https://github.com/kornia/kornia/issues/3927)),
+  1-pixel crop NaN ([#3929](https://github.com/kornia/kornia/issues/3929)).
+- **CI truthfulness.** Every advertised CI matrix axis must actually reach the code
+  under test; first repair is the unused pytorch-version axis
+  ([#3930](https://github.com/kornia/kornia/issues/3930)).
+- **Contribution policy v2** ([#3932](https://github.com/kornia/kornia/pull/3932)):
+  the two-lane model (green lane / discuss-first), verification-based AI policy, and
+  minimized templates.
 - **Progressively enable more `ruff` rule sets** to raise code health
   ([#2445](https://github.com/kornia/kornia/issues/2445)).
 - **Docs modernization** — evaluate the migration to MkDocs
   ([#3454](https://github.com/kornia/kornia/issues/3454)).
-- **Harden the recently-landed model zoo.** Several VLM/model integrations shipped without
-  full test coverage; add tests before building further on them
+- **Model-zoo maintenance (Tier C).** Shipped integrations must be usable or
+  deleted: add the missing test coverage for what already landed
   ([#3554](https://github.com/kornia/kornia/issues/3554),
   [#3555](https://github.com/kornia/kornia/issues/3555),
   [#3556](https://github.com/kornia/kornia/issues/3556),
-  [#3481](https://github.com/kornia/kornia/issues/3481)).
+  [#3481](https://github.com/kornia/kornia/issues/3481)) — no new integrations.
 
 ## Medium term — ~6 months
 
+- **The Repair & Deprecation window → Tier A v1.** Execute the one coordinated
+  release motion for the semantic and default-value repairs accumulated by the
+  audit (e.g. `warp_image_tps` `align_corners` default
+  [#3928](https://github.com/kornia/kornia/issues/3928), `pyrdown` output rounding,
+  inconsistent 3D-crop defaults, bbox width arithmetic
+  [#1142](https://github.com/kornia/kornia/issues/1142)) — each with an old-vs-new
+  conformance vector pair and one migration note. Afterwards, publish the support-tier
+  policy and declare Tier A v1: small, explicit, CI-enforced.
+- **The conformance corpus.** Define the framework-neutral format (per-dtype/device
+  tolerances, convention metadata), migrate the existing convention-pinning tests
+  into it, add semantic invariant tests
+  (`warp(inv(H), warp(H, img)) ≈ img`, `project(unproject(d, K), K) ≈ uv`,
+  `R @ R.T ≈ I`), and publish a docs page: *validate your (hand-written or
+  LLM-generated) geometry code against Kornia*.
+- **The agent knowledge layer.** `llms.txt` / `llms-full.txt` are live and
+  benchmark-fed; after the final convention batch, ship `AGENTS.md` and a small set
+  of validated skills (image warping & homographies, batched differentiable
+  augmentation with transform tracking, camera/epipolar conventions, feature
+  matching) — all derived from the canonical docs, never duplicating them.
 - **The compile / export spine.** *In progress — much of the augmentation surface now
   compiles fullgraph.* The stochastic-apply path, the `_extract_device_dtype`/version-check
   helpers, the transform-matrix blend, and the shape-changing crops (`Resize`, `CenterCrop`)
   have all landed as genuine single-path fixes; common intensity ops (color jitter, solarize,
   brightness/contrast, erasing, flips) are fullgraph on the CI torch. Remaining: the
   data-dependent tail — random-coordinate `RandomCrop`/`crop_by_indices`, histogram-based
-  `equalize`, and random-permutation dispatch — which need redesign, not guards. On the export
+  `equalize`, and random-permutation dispatch — which need redesign, not guards
+  ([#3913](https://github.com/kornia/kornia/issues/3913)). On the export
   side: solve multi-output ONNX export generically so tuple-returning modules (e.g. `Canny`,
   YUV conversions) are no longer blocked, and converge on a single modern ONNX opset.
 - **Dynamo tests in CI — landed for the compile-clean core.** A PR-time `dynamo` job now runs
   the compile-clean augmentation/enhance/filter/color/loss/morphology tests under `inductor` on
-  the CI torch version, so a fullgraph regression is caught at PR time (it immediately caught a
-  version-dependent flip break that local-only testing had masked). Still to do: publish an ONNX
-  export conformance matrix (exportable / numerically-verified / blocked-with-reason) for the
-  public API, and widen the dynamo job beyond the core once model/feature paths are vetted.
-- **Augmentation performance.** Introduce a `uint8` fast path and begin moving the hottest
-  ops (warps, blurs, color conversions) toward native `kornia-rs` kernels. *The cross-library
-  benchmark harness has landed* — `benchmarks/augmentation/{flagship,cross_library,pipeline}.py`
-  plus a documented `README.md` measure kornia (eager + compiled) against torchvision v2,
-  albumentations, OpenCV, and PIL on CPU and GPU, with an honest per-regime reading
-  and a standing improvement list. Early findings: `torch.compile` gives kornia 2–4× on pointwise
-  ops and a compiled pipeline already beats torchvision v2 / reaches albumentations parity on CPU;
-  kornia-rs is the fastest CPU/`uint8` backend on most ops (motivating the backend item below).
-  *GPU headline (measured on a Jetson Orin, `pipeline.py`, batch 32, 224², a 6-op pipeline
-  including `ColorJitter`): the compiled kornia pipeline runs at **2669 img/s vs torchvision
-  v2's 1536 (~1.7× faster) — while staying end-to-end differentiable**, the regime no other
-  library competes in.* This depended on a device-propagation fix: `nn.Module.to()/.cuda()`
-  move children through `_apply`, bypassing the augmentation's `to()` override, so building a
-  pipeline the recommended way left random-parameter sampling on the CPU (host-bound, ~171
-  img/s eager, and `torch.compile` could not fuse across the per-forward host work). Moving
-  parameter generation onto the module's device (~903 img/s eager) is what lets `inductor`
-  fuse the whole pipeline.
+  the CI torch version, so a fullgraph regression is caught at PR time. Still to do: publish an
+  ONNX export conformance matrix (exportable / numerically-verified / blocked-with-reason) for
+  the public API, and widen the dynamo job beyond the core once model/feature paths are vetted.
+- **Augmentation performance — orchestration first.** GPU profiling shows the deficit
+  vs torchvision on cheap augmentations is *not* the kernels: for
+  `RandomHorizontalFlip` the raw flip is ~22% of the module forward and the other
+  ~78% is per-call orchestration in the augmentation base (transform-matrix build,
+  the `where`-blend, dtype/shape bookkeeping). The highest-leverage work is a leaner,
+  fully-compilable base `forward` (a fast path that skips `compute_transformation`
+  for non-affine ops) plus CUDA-graph capture — one fix that lifts every
+  augmentation. Compiled kornia pipelines already beat torchvision v2 on GPU while
+  staying end-to-end differentiable (see the published benchmark page); killing
+  wrapper overhead extends that lead to the eager path everyone runs by default.
 - **A `kornia-rs` augmentation backend (opt-in).** Add a backend selector (e.g.
   `backend="rust"`) that routes non-differentiable, CPU, `uint8` augmentation through
-  `kornia-rs` (`kornia_rs.imgproc` / `kornia_rs.augmentations`), while the PyTorch path
-  stays the default for GPU-batched, differentiable, and float workloads. This is the
-  concrete route to a 10x-vs-albumentations target on CPU: local benchmarks at 256² show
-  `kornia-rs` already ahead of albumentations (e.g. HFlip 13.4k vs 10.5k, ColorJitter
-  1.56k vs 0.62k, Rotation 4.6k vs 2.2k img/s) and 2–28x faster than the equivalent
-  PyTorch path, so the remaining work is API surface (dispatch, dtype/layout bridging,
-  parity tests), not raw speed. Prototyping the dispatch hook is the first step.
-- **GPU augmentation leadership — kill wrapper overhead, then Triton the kernel-bound
-  minority.** GPU profiling shows kornia's deficit vs torchvision on cheap augmentations is
-  *not* the kernels: for `RandomHorizontalFlip` the raw flip is ~22% of the module forward and
-  the other ~78% is per-call orchestration in the augmentation base (transform-matrix build,
-  the `where`-blend, dtype/shape bookkeeping) that torchvision skips. The highest-leverage work
-  is therefore a leaner, fully-compilable base `forward` (a fast path that skips
-  `compute_transformation` for non-affine ops) plus CUDA-graph capture — one fix that lifts
-  every augmentation. `torch.compile` alone helps (ColorJitter's fused pointwise chain already
-  beats torchvision v2 at 1.86×) but cannot erase overhead that lives outside the graph.
-  Hand-written **Triton** kernels are reserved for the genuinely kernel-bound ops `inductor`
-  cannot fuse or beat: the fused warp sampler (`warp_affine`/`warp_perspective`/`grid_sample`/
-  `remap` — highest fan-out, all geometric augs route through it), `median_blur`,
-  `equalize`/histogram, bilateral/guided filters, and morphology. Pointwise ops stay on
-  `inductor` — a Triton rewrite there only re-derives what the compiler already emits.
-- **VLM / VLA focus.** Complete and test the native-PyTorch model integrations that are the
-  project's current priority: e.g. SmolVLM2
-  ([#3455](https://github.com/kornia/kornia/issues/3455),
-  [#3770](https://github.com/kornia/kornia/issues/3770)),
-  PaliGemma ([#3471](https://github.com/kornia/kornia/issues/3471)),
-  Qwen2.5-VL ([#3410](https://github.com/kornia/kornia/issues/3410)),
-  and SAM-3 ([#3406](https://github.com/kornia/kornia/issues/3406)).
+  `kornia-rs`, while the PyTorch path stays the default for GPU-batched,
+  differentiable, and float workloads. Upstream kernels are already fast (recent
+  `kornia-rs` releases beat OpenCV raw on warps); the current bottleneck is the
+  tensor↔image interop cost, and the dispatch only ships for ops where it wins
+  ≥5× including conversion. Sequencing is conformance-first: `kornia-rs` outputs are
+  validated against Kornia's golden vectors before any dispatch, making it the
+  conformance corpus's first external consumer.
+- **Triton for the kernel-bound minority.** Hand-written kernels only where
+  `inductor` structurally cannot help and the benchmark data shows a real gap:
+  `median_blur` (selection networks), `canny` (data-dependent NMS + hysteresis),
+  possibly large-kernel morphology. Capped ambition (2–3 kernels), each with a
+  registered custom op, backward, and conformance vectors; opt-in experimental until
+  GPU CI can verify them.
+- **Batched RANSAC.** Restructure the RANSAC hot loop to not need a compiler:
+  vectorize over hypotheses (sample K minimal sets, solve batched, score batched)
+  with chunked execution and confidence-based stopping. GPU-batched robust geometry
+  is core mission; the variants (eager, lazy-scripted, compiled-chunked, batched)
+  are benchmark-arbitrated.
 
 ## Long term — vision
 
+- **The reference implementation for differentiable CV.** External implementations —
+  JAX ports, native kernels, vendored code, and code written by LLMs — validate
+  against Kornia's conformance data, and humans and coding agents consistently
+  produce *correct* geometry code from Kornia's documentation. Success is fewer
+  convention bugs in the wild, not more modules in the package.
 - **A fully compilable, fully exportable library.** Every public operator runs under
   `torch.compile` without graph breaks and exports to ONNX with verified numerical
   equivalence — including the stochastic augmentation and dynamic-shape feature paths.
 - **The fastest differentiable, GPU-batched augmentation stack**, with a published,
   reproducible benchmark that states precisely the regime in which we lead.
-- **End-to-end spatial-AI and VLM/VLA workflows** — pairing Kornia's deep geometry and
-  feature-matching foundations with modern learned models, usable from classical
-  calibration through to vision-language reasoning.
-- **Breadth toward feature-completeness** for a differentiable CV library — closing the
-  notable gaps below.
 
 ## Areas seeking contributors
 
-We especially welcome help in these areas. Comment on the linked issue (or open one) to
-get started. Issues labelled [`help wanted`](https://github.com/kornia/kornia/labels/help%20wanted)
-and [`good first issue`](https://github.com/kornia/kornia/labels/good%20first%20issue)
-are good entry points.
+We especially welcome help in these areas. Issues labelled
+[`help wanted`](https://github.com/kornia/kornia/labels/help%20wanted) are
+pre-approved green-lane work — first good PR wins. For anything feature-shaped,
+open or comment on an issue first (discuss-first lane, see
+[CONTRIBUTING.md](CONTRIBUTING.md)).
 
-**Modern deep-learning CV (largest gaps):**
+**Classical vision in the core domain (highest priority):** these strengthen exactly
+the geometry/camera surface the project is built around.
 
-- **Learned optical flow** (RAFT / SEA-RAFT). A significant gap — the endpoint-error
-  metric (AEPE) already exists, but there is no flow model.
-- **Pose estimation** models (human / hand keypoints).
-- **Object-detection breadth** beyond RT-DETR and YuNet (e.g. YOLO, open-vocabulary
-  detection).
-- **Feature-matching extensions** — Efficient LoFTR
-  ([#3282](https://github.com/kornia/kornia/issues/3282)),
-  SANDesc ([#3752](https://github.com/kornia/kornia/issues/3752)).
-
-**Classical computer vision:**
-
-- **Camera intrinsic calibration** (Zhang's method, checkerboard / ChArUco detection).
-  Kornia can undistort and solve PnP but cannot yet calibrate a camera from scratch.
-- **Fiducial markers** (ArUco / ChArUco).
+- **Camera intrinsic calibration** (Zhang's method, checkerboard / ChArUco
+  detection). Kornia can undistort and solve PnP but cannot yet calibrate a camera
+  from scratch — the largest gap in the camera core.
+- **Fiducial markers** (ArUco / ChArUco) — detection feeding directly into the
+  calibration and pose pipelines.
 - **Classical tracking** — Lucas-Kanade, KCF
   ([#1381](https://github.com/kornia/kornia/issues/1381)).
-- Dense stereo matching, Hough transforms, contour/shape analysis, template matching.
+- Dense stereo matching, Hough transforms and Hough voting, contour/shape analysis,
+  template matching.
+
+**Reference-core contributions (green lane, great first PRs):**
+
+- **Benchmark results from your hardware** — run the suite with `--contribute` and
+  send the JSON; CUDA numbers from diverse GPUs are especially wanted.
+- **Convention pinning tests and conformance vectors** for core geometry ops.
+- **Corrective error messages** — upgrading bare shape asserts into errors that state
+  what was wrong, what was expected, which convention applies, and the likely fix.
 
 **Augmentation parity** (vs. common augmentation libraries): dropout-family transforms
 (CoarseDropout, GridDropout), grid/optical distortion, weather effects (fog, sun-flare),
 noise variants (ISO noise), and additional compression transforms.
+
+**Learned models (maintainer-required):** the model-zoo freeze means these land only
+with a contributor committed to long-term maintenance of the integration — comment on
+the issue and say so explicitly. Closest to core are the feature-matching
+extensions — Efficient LoFTR
+([#3282](https://github.com/kornia/kornia/issues/3282)), SANDesc
+([#3752](https://github.com/kornia/kornia/issues/3752)). Larger gaps (learned
+optical flow such as RAFT / SEA-RAFT, pose estimation, object-detection breadth
+beyond RT-DETR and YuNet) are acknowledged but are not maintainer priorities.
 
 **Code health & infrastructure:**
 
@@ -172,7 +254,9 @@ noise variants (ISO noise), and additional compression transforms.
 
 ## How to contribute
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and guidelines. In short: link your PR to
-an approved issue, include local test output, and cite a reference (paper, OpenCV,
-PyTorch, etc.) for any new algorithm. For larger roadmap items, start a discussion on the
-issue first so we can align on design before you write code.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, guidelines, and the two-lane
+model: **green lane** (test-first bug fixes, verified docs fixes, `help wanted`
+issues, benchmark results — just send the PR) and **discuss-first** (features and
+behavior changes — align on scope in an issue before writing code). Include local
+test output in your PR and cite a reference (paper, OpenCV, PyTorch, etc.) for any
+new algorithm.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -72,7 +72,10 @@ Four engineering north stars shape the roadmap below.
    classes fail structurally in data-dependent parameter generation
    ([#3913](https://github.com/kornia/kornia/issues/3913)). Compile support is
    claimed **per evidenced surface**: today that means the functional core, not the
-   augmentation classes, and docs state the scope explicitly.
+   augmentation classes as a class-level guarantee — many individual augmentations
+   already run fullgraph in the PR-time dynamo job (see the compile/export spine
+   below), but the data-dependent parameter generators keep the class-level claim
+   off the table — and docs state the scope explicitly.
 
 3. **Export-first (ONNX).** ONNX export fails on the *same* patterns that break
    `torch.compile`: data-dependent control flow, `.item()` calls, and dynamic shapes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -227,10 +227,11 @@ and finish under the rules they started under.
 
 ## Areas seeking contributors
 
-We especially welcome help in these areas. Issues labelled
-[`help wanted`](https://github.com/kornia/kornia/labels/help%20wanted) are
-green-lane entry points: pre-approved, with acceptance criteria in the issue (a
-label audit to make this uniformly true is listed under short-term work). No
+We especially welcome help in these areas. Curated
+[`help wanted`](https://github.com/kornia/kornia/labels/help%20wanted) issues with
+explicit acceptance criteria are green-lane entry points. While the legacy-label
+audit (short-term work above) is pending, check that the issue actually contains
+those criteria or an explicit maintainer confirmation before starting. No
 assignment needed — and if duplicate PRs land, maintainers merge the
 best-supported implementation, not the earliest. For anything feature-shaped,
 open or comment on an issue first (discuss-first lane, see

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,13 +41,22 @@ Four engineering north stars shape the roadmap below.
       page is live. Behavior bugs found by the audit get dedicated issues.
    2. **Repair & deprecate** — one coordinated window fixes accumulated semantic and
       default-value bugs, so downstream users face a single loud migration instead of
-      a drizzle of breaking changes. Clearly-broken-output bugs (NaN, crashes) land
-      early as ordinary bugfixes.
+      a drizzle of breaking changes. The window runs *under* the
+      [stability policy](https://kornia.readthedocs.io/en/latest/get-started/stability.html),
+      not around it: every semantic or default change gets the policy's deprecation
+      treatment (at least one minor release of warnings, landing at a 0.x minor
+      boundary) — "coordinated" means the changes are batched into one migration,
+      not that the deprecation rules are waived. Only clearly-broken-output bugs
+      (NaN, crashes) use the policy's correctness escape hatch and land early as
+      ordinary bugfixes.
    3. **Freeze** — after the window, a **Tier A ("Kornia Core")** set is declared:
       symbols with the strongest guarantees (autograd, gradcheck, compile, dtype/
       device correctness, explicit conventions, semantic stability). Tier A starts
-      brutally small and a guarantee is only claimed where CI enforces it. See the
-      [stability policy](https://kornia.readthedocs.io/en/latest/get-started/stability.html).
+      brutally small and a guarantee is only claimed where CI enforces it.
+      **These tiers are proposed, not yet in force**: until the tier policy is
+      published after the window, the current
+      [stability policy](https://kornia.readthedocs.io/en/latest/get-started/stability.html)
+      (stable core / best-effort / experimental) remains the authoritative contract.
 
    Alongside this grows a **conformance corpus**: framework-neutral golden vectors
    (inputs, expected outputs, tolerances, convention metadata) that external
@@ -90,8 +99,13 @@ A fifth theme, **breadth**, is community-driven and runs through the discuss-fir
 lane. One boundary is stated openly: **model-zoo expansion is frozen.** No new model
 or VLM/VLA integrations while maintainer bandwidth concentrates on the core; shipped
 wrappers (LoFTR, LightGlue, DISK, DeDoDe, SAM, XFeat, ALIKED, Kimi-VL, …) remain
-available and maintained under a *usable-or-deleted* rule. The freeze partially
-reopens if a maintainer with model-work capacity joins the project.
+available and maintained under a *usable-or-deleted* rule. The single exception
+rule, applied everywhere in this document: **a new integration requires a named
+maintainer sponsor who accepts ongoing ownership — a contributor's implementation
+alone, however good, does not reopen the surface.** The freeze lifts when a
+maintainer with model-work capacity joins the project. Contributions already in
+flight before the freeze (an open issue plus a PR under review) are grandfathered
+and finish under the rules they started under.
 
 ## Short term — next release
 
@@ -100,7 +114,7 @@ reopens if a maintainer with model-work capacity joins the project.
   release so users get the fixes.
 - **Convention-block batches.** Continue the per-op audit:
   `geometry.conversions` → bounding boxes
-  ([#1142](https://github.com/kornia/kornia/issues/1142)) → camera → augmentation
+  ([#3934](https://github.com/kornia/kornia/issues/3934)) → camera → augmentation
   classes. Each batch delivers Convention blocks, pinning tests, and dedicated
   issues for any behavior bug found.
 - **Broken-output bugfixes** from the audit, landing ahead of the repair window:
@@ -116,12 +130,14 @@ reopens if a maintainer with model-work capacity joins the project.
   ([#2445](https://github.com/kornia/kornia/issues/2445)).
 - **Docs modernization** — evaluate the migration to MkDocs
   ([#3454](https://github.com/kornia/kornia/issues/3454)).
-- **Model-zoo maintenance (Tier C).** Shipped integrations must be usable or
-  deleted: add the missing test coverage for what already landed
-  ([#3554](https://github.com/kornia/kornia/issues/3554),
-  [#3555](https://github.com/kornia/kornia/issues/3555),
-  [#3556](https://github.com/kornia/kornia/issues/3556),
-  [#3481](https://github.com/kornia/kornia/issues/3481)) — no new integrations.
+- **Model-zoo maintenance (best-effort tier; future Tier C).** Shipped integrations
+  must be usable or deleted — kept loading, tested, and honest (recent example:
+  repointing Kimi-VL to working weights). The 2025-era coverage-gap issues are
+  resolved; newly found maintenance work gets a current tracking issue with
+  acceptance criteria — no new integrations.
+- **`help wanted` label audit.** Older issue templates auto-applied the label;
+  re-triage the open `help wanted` issues so the label only marks genuinely
+  pre-approved work with acceptance criteria, as the green lane requires.
 
 ## Medium term — ~6 months
 
@@ -130,9 +146,12 @@ reopens if a maintainer with model-work capacity joins the project.
   audit (e.g. `warp_image_tps` `align_corners` default
   [#3928](https://github.com/kornia/kornia/issues/3928), `pyrdown` output rounding,
   inconsistent 3D-crop defaults, bbox width arithmetic
-  [#1142](https://github.com/kornia/kornia/issues/1142)) — each with an old-vs-new
-  conformance vector pair and one migration note. Afterwards, publish the support-tier
-  policy and declare Tier A v1: small, explicit, CI-enforced.
+  [#3934](https://github.com/kornia/kornia/issues/3934)) — each change with an
+  old-vs-new conformance vector pair, the stability policy's deprecation treatment
+  (at least one minor release of warnings before landing at a 0.x minor boundary),
+  and one collective migration note. Afterwards, publish the support-tier policy and
+  declare Tier A v1: small, explicit, CI-enforced. Until that publication the
+  current stability policy remains the authoritative contract.
 - **The conformance corpus.** Define the framework-neutral format (per-dtype/device
   tolerances, convention metadata), migrate the existing convention-pinning tests
   into it, add semantic invariant tests
@@ -197,9 +216,12 @@ reopens if a maintainer with model-work capacity joins the project.
   against Kornia's conformance data, and humans and coding agents consistently
   produce *correct* geometry code from Kornia's documentation. Success is fewer
   convention bugs in the wild, not more modules in the package.
-- **A fully compilable, fully exportable library.** Every public operator runs under
-  `torch.compile` without graph breaks and exports to ONNX with verified numerical
-  equivalence — including the stochastic augmentation and dynamic-shape feature paths.
+- **A fully compilable, fully exportable core.** Every applicable Tier A tensor
+  operator runs under `torch.compile` without unnecessary graph breaks and exports
+  to ONNX where ONNX can represent its semantics, with verified numerical
+  equivalence — including the stochastic augmentation and dynamic-shape feature
+  paths that break today. Best-effort and experimental surfaces are covered as
+  evidence allows, never by blanket claim.
 - **The fastest differentiable, GPU-batched augmentation stack**, with a published,
   reproducible benchmark that states precisely the regime in which we lead.
 
@@ -207,7 +229,10 @@ reopens if a maintainer with model-work capacity joins the project.
 
 We especially welcome help in these areas. Issues labelled
 [`help wanted`](https://github.com/kornia/kornia/labels/help%20wanted) are
-pre-approved green-lane work — first good PR wins. For anything feature-shaped,
+green-lane entry points: pre-approved, with acceptance criteria in the issue (a
+label audit to make this uniformly true is listed under short-term work). No
+assignment needed — and if duplicate PRs land, maintainers merge the
+best-supported implementation, not the earliest. For anything feature-shaped,
 open or comment on an issue first (discuss-first lane, see
 [CONTRIBUTING.md](CONTRIBUTING.md)).
 
@@ -224,26 +249,39 @@ the geometry/camera surface the project is built around.
 - Dense stereo matching, Hough transforms and Hough voting, contour/shape analysis,
   template matching.
 
-**Reference-core contributions (green lane, great first PRs):**
+**Reference-core contributions:**
 
-- **Benchmark results from your hardware** — run the suite with `--contribute` and
-  send the JSON; CUDA numbers from diverse GPUs are especially wanted.
-- **Convention pinning tests and conformance vectors** for core geometry ops.
-- **Corrective error messages** — upgrading bare shape asserts into errors that state
-  what was wrong, what was expected, which convention applies, and the likely fix.
+- **Benchmark results from your hardware** (unconditionally green lane) — run the
+  suite with `--contribute` and send the JSON; CUDA numbers from diverse GPUs are
+  especially wanted.
+- **Good candidates for curated `help wanted` issues** — convention pinning tests
+  and conformance vectors for core geometry ops; corrective error messages
+  (upgrading bare shape asserts into errors that state what was wrong, what was
+  expected, which convention applies, and the likely fix). These become green-lane
+  once a maintainer has written acceptance criteria into a `help wanted` issue —
+  pinning behavior and changing raised errors are contract-adjacent edits, so they
+  need that curation step first.
 
-**Augmentation parity** (vs. common augmentation libraries): dropout-family transforms
+**Augmentation parity** — low-priority, community-driven, discuss-first: Kornia does
+not compete on generic augmentation breadth (the differentiated value is
+differentiability, GPU batching, and transform tracking), but well-motivated parity
+transforms are accepted through the discuss-first lane: dropout-family transforms
 (CoarseDropout, GridDropout), grid/optical distortion, weather effects (fog, sun-flare),
 noise variants (ISO noise), and additional compression transforms.
 
-**Learned models (maintainer-required):** the model-zoo freeze means these land only
-with a contributor committed to long-term maintenance of the integration — comment on
-the issue and say so explicitly. Closest to core are the feature-matching
-extensions — Efficient LoFTR
-([#3282](https://github.com/kornia/kornia/issues/3282)), SANDesc
-([#3752](https://github.com/kornia/kornia/issues/3752)). Larger gaps (learned
-optical flow such as RAFT / SEA-RAFT, pose estimation, object-detection breadth
-beyond RT-DETR and YuNet) are acknowledged but are not maintainer priorities.
+**Learned models — frozen (see the guiding themes):**
+
+- **Grandfathered model work.** Efficient LoFTR
+  ([#3282](https://github.com/kornia/kornia/issues/3282), PR
+  [#3621](https://github.com/kornia/kornia/pull/3621) under review) and SANDesc
+  ([#3752](https://github.com/kornia/kornia/issues/3752), pre-freeze maintainer
+  approval on the issue) were approved and started before the model-zoo freeze and
+  may continue under their existing scopes. They are exceptions honoring prior
+  commitments, not invitations for new model integrations.
+- **Acknowledged gaps — not currently soliciting contributions.** Learned optical
+  flow (RAFT / SEA-RAFT), pose estimation, and object-detection breadth beyond
+  RT-DETR and YuNet are real gaps, listed for honesty. New model work remains
+  frozen until a maintainer accepts ongoing ownership of the integration.
 
 **Code health & infrastructure:**
 

--- a/docs/source/get-started/stability.rst
+++ b/docs/source/get-started/stability.rst
@@ -28,6 +28,26 @@ rather than grown.
 **Experimental** — ``kornia.contrib`` and anything underscore-prefixed or
 absent from the rendered documentation. No stability promise.
 
+Planned evolution: support tiers
+--------------------------------
+
+The `roadmap <https://github.com/kornia/kornia/blob/main/ROADMAP.md>`_ describes
+a future, finer-grained tier structure ("Tier A / B / C") in which a deliberately
+small Tier A core carries per-symbol, CI-enforced guarantees. **That structure is
+not in force yet.** It will be published only after the coordinated
+repair-and-deprecation window described in the roadmap has resolved the
+convention bugs surfaced by the ongoing per-operator audit — targeted within the
+roadmap's ~6-month medium-term horizon (dates are intentions, not commitments).
+Until the tier policy is published, this page is the authoritative stability
+contract and the tiers above (stable core / best-effort / experimental) are what
+you may rely on.
+
+The repair window itself runs under the promises on this page, not around them:
+every semantic or default change it ships gets the promise-2 deprecation
+treatment — at least one minor release of warnings, landing at a 0.x minor
+boundary, with old-vs-new reference vectors — and only clearly-broken-output
+bugs (NaN, crashes) use the correctness escape hatch below.
+
 What counts as public API
 -------------------------
 


### PR DESCRIPTION
## Which lane? *(check one — see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))*
- [ ] 🟢 **Green lane** — test-first bug fix / verified docs fix / `help wanted` issue / benchmark results. No prior issue needed.
- [x] 🟠 **Discuss-first** — feature or behavior change; a maintainer confirmed the scope on the linked issue.

**Fixes/Relates to:** relates to #3932 (policy this PR is filed under). Scope set directly by @ducha-aiki (maintainer-initiated — maintainers carry the discuss-first burden themselves per the v2 policy).

## What does this PR do?

> **Merge order:** merge #3932 first. This PR's roadmap references the two-lane contribution model that #3932 introduces into CONTRIBUTING.md; merging in that order means the two docs are never contradictory on `main` (raised by qodo, answer on the thread).

Rewrites `ROADMAP.md` (and the matching `README.md` signaling) to match the project's actual direction — the reference-implementation/executable-specification program — instead of the model-zoo-expansion era it still described:

- **New leading guiding theme**: conventions → one coordinated Repair & Deprecation window → Tier A ("Kornia Core") with CI-enforced guarantees, plus the framework-neutral conformance corpus. Links the live Conventions & Pitfalls page and stability policy.
- **Compile theme** now states the honest scoping: claims per evidenced surface; augmentation param generation is the structural gap (#3913).
- **Performance theme** refreshed with the measured reality: launch-bound orchestration overhead first, then kernel outliers (`median_blur`, `canny`, `rotate`); benchmark page publishes losses alongside wins.
- **Model-zoo freeze stated openly**, with its reopen trigger (a maintainer with model-work capacity). The "VLM/VLA focus" medium-term priority section is removed; shipped wrappers stay maintained under usable-or-deleted (Tier C).
- **Short/medium term** now name the convention batches, broken-output fixes (#3927/#3929), CI truthfulness (#3930), repair window → Tier A v1, conformance corpus, knowledge layer, and batched RANSAC.
- **Contributor areas re-accented, not trimmed**: camera calibration + fiducial markers *promoted* (core-domain gaps), Hough transforms/voting, stereo, tracking, template matching all kept; new green-lane asks added (benchmark JSONs, convention pins, corrective error messages); learned-model gaps (RAFT, pose, detection, ELoFTR, SANDesc) kept with an explicit maintainer-required caveat.

`README.md` (second commit) retires the remaining VLM/VLA priority signaling, complementing — not touching — the Contributing/AI-policy sections that #3932 rewrites:

- The 📢 announcement banner ("shifting towards end-to-end vision models… VLM/VLA") now states the reference-core direction and links the roadmap.
- "Accessible AI Models / **Priority Focus: VLM/VLA Models**" becomes "**Strengthen the Core (Priority)**" (green-lane asks + core-domain classical CV) plus an honest "AI Models" freeze note with the maintainer-required condition and reopen pointer.

**Third commit — Sol's review round (all five points verified, then adopted):**

- `docs/source/get-started/stability.rst` gains a **"Planned evolution: support tiers"** section: Tier A/B/C is *not in force* until published after the repair window (targeted within the roadmap's ~6-month medium-term horizon); until then the current policy is the authoritative contract. It also pins the repair window to the existing rules — promise-2 deprecation treatment (≥1 minor release of warnings, 0.x minor boundary) for semantic changes, escape hatch only for broken-output bugs. The roadmap cross-references this instead of inventing parallel rules.
- **One model-freeze exception rule, stated once and applied everywhere**: a new integration requires a named maintainer sponsor accepting ongoing ownership; a contributor implementation alone does not reopen the surface. Efficient LoFTR (#3282, PR #3621) and SANDesc (#3752, pre-freeze maintainer approval) are named as *grandfathered pre-freeze commitments*; RAFT/pose/detection breadth reframed as "acknowledged gaps — not currently soliciting contributions". README aligned to the same finite grandfathering rule.
- **Green lane un-broadened**: benchmark JSONs stay unconditionally green; convention pins and corrective error messages become "good candidates for curated `help wanted` issues" (contract-adjacent edits need maintainer-written acceptance criteria first). "First good PR wins" → best-supported-implementation wording, matching #3932. The `help wanted` label audit is now an explicit short-term item.
- **Stale references cleaned**: #3554/#3555/#3556/#3481 (all closed-completed) removed from next-release work; the bbox inclusive-width repair now has its own dedicated open issue **#3934** (verified live in `kornia/geometry/bbox.py`), replacing the closed #1142 per the one-issue-per-repair doctrine.
- **Long-term ambition rescoped**: compile/export promised for applicable Tier A tensor operators with per-surface evidence, not "every public operator"; augmentation parity marked low-priority/community/discuss-first.

**Bot review handling:** Copilot's stale-`v0.8.4` finding confirmed against the repo (`0.9.0rc1`) and fixed by unpinning the heading; qodo's CONTRIBUTING-contradiction finding answered via the merge-order note above.

## Test log

Docs-only change (`ROADMAP.md`, `README.md`, `docs/source/get-started/stability.rst`); no functional code touched.

```
$ pixi run lint
ruff check...............................................................Passed
ruff format..............................................................Passed
```

## AI disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
- [ ] 🟢 **Human-written**
- [ ] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests
- [x] 🔴 **AI-generated** — an agent wrote most of it; structure and all contentious calls (VLM/VLA removal, freeze disclosure, learned-model demotion) were decided by @ducha-aiki in session; the maintainer will address reviewer questions

Posted on behalf of @ducha-aiki by Claude (Fable 5).
