### PR TITLE
docs(geometry): per-op Convention blocks for conversions (batch 3a: scalar, point & pixel-coordinate conversions)

### DIFF
--- a/docs/source/geometry.conversions.rst
+++ b/docs/source/geometry.conversions.rst
@@ -22,6 +22,7 @@ Coordinates
 .. autofunction:: convert_points_from_homogeneous
 .. autofunction:: convert_points_to_homogeneous
 .. autofunction:: convert_affinematrix_to_homography
+.. autofunction:: convert_affinematrix_to_homography3d
 .. autofunction:: denormalize_pixel_coordinates
 .. autofunction:: normalize_pixel_coordinates
 .. autofunction:: denormalize_pixel_coordinates3d

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -48,9 +48,11 @@ Angles and rotations
 --------------------
 
 - Angles are **degrees** in the 2D image APIs (``rotate``,
-  ``get_rotation_matrix2d``, ``RandomRotation``), and **radians** in the
-  3D/conversion APIs (``axis_angle_to_rotation_matrix``, ``So3``;
-  ``rad2deg``/``deg2rad`` exist to convert).
+  ``get_rotation_matrix2d``, ``RandomRotation``,
+  ``angle_to_rotation_matrix``), and **radians** in the 3D
+  rotation-representation APIs (``axis_angle_to_rotation_matrix``, ``So3``;
+  ``rad2deg``/``deg2rad`` exist to convert). Each op's Convention block
+  states its unit.
 - 2D image rotations: positive angle rotates **counter-clockwise as
   displayed** (top-left origin, matching OpenCV):
 

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -50,8 +50,9 @@ Angles and rotations
 - Angles are **degrees** in the 2D image APIs (``rotate``,
   ``get_rotation_matrix2d``, ``RandomRotation``,
   ``angle_to_rotation_matrix``), and **radians** in the 3D
-  rotation-representation APIs (``axis_angle_to_rotation_matrix``, ``So3``;
-  ``rad2deg``/``deg2rad`` exist to convert). Each op's Convention block
+  rotation-representation APIs (``axis_angle_to_rotation_matrix``, ``So3``)
+  and in the polar conversions ``cart2pol``/``pol2cart``
+  (``rad2deg``/``deg2rad`` exist to convert). Each op's Convention block
   states its unit.
 - 2D image rotations: positive angle rotates **counter-clockwise as
   displayed** (top-left origin, matching OpenCV):

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -43,6 +43,9 @@ Coordinates and sizes
   pixel at the image borders, and identically at the image center.
   :func:`kornia.geometry.create_meshgrid` returns a normalized grid by
   default (``normalized_coordinates=True``).
+- 3D grids and 3D pixel coordinates are ``(d, x, y)`` — depth first, not
+  ``(x, y, z)``; :func:`kornia.geometry.grid.create_meshgrid3d` produces this
+  order and the ``*_pixel_coordinates3d`` conversions consume it.
 
 Angles and rotations
 --------------------
@@ -52,8 +55,8 @@ Angles and rotations
   ``angle_to_rotation_matrix``), and **radians** in the 3D
   rotation-representation APIs (``axis_angle_to_rotation_matrix``, ``So3``)
   and in the polar conversions ``cart2pol``/``pol2cart``
-  (``rad2deg``/``deg2rad`` exist to convert). Each op's Convention block
-  states its unit.
+  (``rad2deg``/``deg2rad`` exist to convert). Ops that have a Convention
+  block state their unit there.
 - 2D image rotations: positive angle rotates **counter-clockwise as
   displayed** (top-left origin, matching OpenCV):
 

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -37,7 +37,10 @@ Coordinates and sizes
   points. ``warp_perspective(img, M, dsize=(2, 8))`` produces a 2-row,
   8-column image.
 - Normalized coordinates, where used, are ``[-1, 1]`` in both axes,
-  identical to :func:`torch.nn.functional.grid_sample`.
+  identical to :func:`torch.nn.functional.grid_sample` **called with**
+  ``align_corners=True`` — not to its default, ``align_corners=False``,
+  which places the same values up to half a pixel off — exactly half a
+  pixel at the image borders, and identically at the image center.
   :func:`kornia.geometry.create_meshgrid` returns a normalized grid by
   default (``normalized_coordinates=True``).
 

--- a/docs/source/get-started/conventions.rst
+++ b/docs/source/get-started/conventions.rst
@@ -55,8 +55,7 @@ Angles and rotations
   ``angle_to_rotation_matrix``), and **radians** in the 3D
   rotation-representation APIs (``axis_angle_to_rotation_matrix``, ``So3``)
   and in the polar conversions ``cart2pol``/``pol2cart``
-  (``rad2deg``/``deg2rad`` exist to convert). Ops that have a Convention
-  block state their unit there.
+  (``rad2deg``/``deg2rad`` exist to convert).
 - 2D image rotations: positive angle rotates **counter-clockwise as
   displayed** (top-left origin, matching OpenCV):
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -89,9 +89,9 @@ def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
         input is left with only about seven correct significant digits
         (``rad2deg(torch.tensor(math.pi, dtype=torch.float64)) - 180`` is
         ``-5.0e-06``, not ``0``) because ``kornia.constants.pi`` is a
-        **float32** tensor — a defect in the constant itself, which other
-        kornia modules (augmentation color jitter, feature orientation/MKD,
-        ``enhance.jpeg``) also consume. Separately, ``rad2deg``/``deg2rad``
+        **float32** tensor — a defect in the constant itself, which several
+        other kornia modules also consume (the issue tracks the current
+        inventory). Separately, ``rad2deg``/``deg2rad``
         themselves cast that constant to the input dtype, so an integer input
         truncates ``pi`` to ``3``: ``rad2deg(torch.tensor([1, 2, 3]))`` returns
         ``[60., 120., 180.]`` instead of ``[57.2958, 114.5916, 171.8873]``, and
@@ -119,8 +119,9 @@ def deg2rad(tensor: torch.Tensor) -> torch.Tensor:
     r"""Convert angles from degrees to radians.
 
     Convention:
-        - the input is in **degrees** and the output in **radians**; it is the
-          inverse of :func:`~kornia.geometry.conversions.rad2deg`
+        - the input is in **degrees** and the output in **radians**; it
+          performs the opposite conversion to
+          :func:`~kornia.geometry.conversions.rad2deg`
 
     .. warning::
         Inherits both defects of :func:`~kornia.geometry.conversions.rad2deg`
@@ -1142,8 +1143,9 @@ def normalize_pixel_coordinates3d(
 
     Convention:
         - ``pixel_coordinates`` is :math:`(*, 3)` in ``(d, x, y)`` order —
-          **depth first, then x, then y**, *not* ``(x, y, z)``. The three
-          components are scaled by ``depth - 1``, ``width - 1`` and
+          **depth first, then x, then y**, *not* ``(x, y, z)``. This is the
+          order :func:`~kornia.geometry.grid.create_meshgrid3d` produces. The
+          three components are scaled by ``depth - 1``, ``width - 1`` and
           ``height - 1`` respectively, so with ``depth=3, height=5, width=9``
           the coordinate ``[2., 8., 4.]`` maps to ``[1., 1., 1.]``
         - the positional argument order is
@@ -1200,12 +1202,9 @@ def denormalize_pixel_coordinates3d(
         For a degenerate ``depth``/``height``/``width`` (``1``, ``0`` or
         negative) the clamped denominator scales that component by ``5e-09``
         (``0`` in ``float16``, where ``eps`` underflows) instead of by
-        ``(size - 1) / 2``. That clamp is the exact reciprocal of the one in
-        :func:`~kornia.geometry.conversions.normalize_pixel_coordinates3d`, so a
-        normalize-then-denormalize round trip returns the input as long as the
-        normalized value is finite — in ``float16`` the normalized component is
-        ``inf`` and the round trip returns ``nan``; it is a single call on its
-        own that is wrong. Tracked in
+        ``(size - 1) / 2`` — the same reciprocal-clamp behavior as
+        :func:`~kornia.geometry.conversions.denormalize_pixel_coordinates`,
+        whose warning walks through the round trip. Tracked in
         `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
 
     Args:

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -86,7 +86,7 @@ def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
     .. warning::
         Two distinct defects, tracked in
         `#3937 <https://github.com/kornia/kornia/issues/3937>`_. A ``float64``
-        input loses about seven digits
+        input is left with only about seven correct significant digits
         (``rad2deg(torch.tensor(math.pi, dtype=torch.float64)) - 180`` is
         ``-5.0e-06``, not ``0``) because ``kornia.constants.pi`` is a
         **float32** tensor — a defect in the constant itself, which other
@@ -1244,13 +1244,9 @@ def angle_to_rotation_matrix(angle: torch.Tensor) -> torch.Tensor:
         - applied on the left to a column vector ``(x, y)``, ``angle = 30`` maps
           ``(1., 0.)`` to ``(0.8660, -0.5000)`` — counter-clockwise **as
           displayed** under kornia's y-down image axes. In the raw coordinate
-          plane that is the opposite sense to
-          :func:`~kornia.geometry.conversions.cart2pol`: rotating a nonzero
-          point by ``theta`` degrees this way *decreases* its ``cart2pol``
-          angle ``phi`` by ``theta`` degrees **modulo** :math:`2\pi`, since
-          ``phi`` is re-wrapped into :math:`[-\pi, \pi]` whenever the rotation
-          crosses the ``-x`` branch cut (``phi = -170`` degrees rotated by
-          ``theta = 30`` returns ``phi = +160``, not ``-200``)
+          plane this is the opposite sense to
+          :func:`~kornia.geometry.conversions.cart2pol`, whose Convention block
+          spells out the modulo-:math:`2\pi` relation between the two ops
 
     .. warning::
         The degrees-to-radians step is

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -84,17 +84,18 @@ def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
           conversion is elementwise and preserves shape, device and float dtype
 
     .. warning::
-        The conversion factor is ``kornia.constants.pi``, a **float32**
-        tensor that is cast to the input dtype, so an integer input is divided
-        by ``3`` (``rad2deg(torch.tensor([1, 2, 3]))`` returns
-        ``[60., 120., 180.]`` instead of ``[57.2958, 114.5916, 171.8873]``) and
-        a ``float64`` input loses about seven digits
+        Two distinct defects, tracked in
+        `#3937 <https://github.com/kornia/kornia/issues/3937>`_. A ``float64``
+        input loses about seven digits
         (``rad2deg(torch.tensor(math.pi, dtype=torch.float64)) - 180`` is
-        ``-5.0e-06``, not ``0``). The defect lives in ``kornia.constants.pi``
-        itself, which other kornia modules (augmentation color jitter, feature
-        orientation/MKD, ``enhance.jpeg``) also consume — so a fix limited to
-        ``rad2deg``/``deg2rad`` would not end it. Tracked in
-        `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
+        ``-5.0e-06``, not ``0``) because ``kornia.constants.pi`` is a
+        **float32** tensor — a defect in the constant itself, which other
+        kornia modules (augmentation color jitter, feature orientation/MKD,
+        ``enhance.jpeg``) also consume. Separately, ``rad2deg``/``deg2rad``
+        themselves cast that constant to the input dtype, so an integer input
+        truncates ``pi`` to ``3``: ``rad2deg(torch.tensor([1, 2, 3]))`` returns
+        ``[60., 120., 180.]`` instead of ``[57.2958, 114.5916, 171.8873]``, and
+        a ``float64`` constant alone would not fix it.
 
     Args:
         tensor: torch.Tensor of arbitrary shape.
@@ -122,8 +123,10 @@ def deg2rad(tensor: torch.Tensor) -> torch.Tensor:
           inverse of :func:`~kornia.geometry.conversions.rad2deg`
 
     .. warning::
-        Inherits the float32 ``kornia.constants.pi`` defect — see the warning on
-        :func:`~kornia.geometry.conversions.rad2deg` and
+        Inherits both defects of :func:`~kornia.geometry.conversions.rad2deg`
+        — the float32 ``kornia.constants.pi`` and the cast to the input dtype
+        (``deg2rad(torch.tensor([180, 90]))`` returns ``[3.0000, 1.5000]``).
+        See its warning and
         `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
 
     Args:
@@ -266,7 +269,10 @@ def convert_points_from_homogeneous(points: torch.Tensor, eps: float = 1e-8) -> 
         ``-eps / w``, and there it is usually below the rounding of the working
         dtype — at ``w = 2`` the measured error is ``-5.0e-09`` in ``float64``,
         while in ``float32`` ``2 + eps`` rounds back to ``2`` and the result is
-        exact. Tracked in
+        exact. The numbers above assume ``eps`` is representable: in
+        ``float16`` both the default ``eps`` and ``w = 2e-8`` underflow to
+        ``0``, so ``[[2., 4., 2e-8]]`` takes the ``abs(w) <= eps`` pass-through
+        branch and returns ``[[2., 4.]]``. Tracked in
         `#3938 <https://github.com/kornia/kornia/issues/3938>`_.
 
     Args:
@@ -1094,8 +1100,10 @@ def denormalize_pixel_coordinates(
         ``denormalize_pixel_coordinates(torch.tensor([[0., 0.]], dtype=torch.float64), 4, 1)``
         returns ``[[5e-09, 1.5]]``. This clamp is the exact reciprocal of the one
         in :func:`~kornia.geometry.conversions.normalize_pixel_coordinates`, so a
-        normalize-then-denormalize round trip still returns the input; it is a
-        single call on its own that is wrong. Tracked in
+        normalize-then-denormalize round trip returns the input as long as the
+        normalized value is finite — in ``float16`` ``eps`` underflows, the
+        normalized component is ``inf`` and the round trip returns ``nan``; it
+        is a single call on its own that is wrong. Tracked in
         `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
 
     Args:
@@ -1146,7 +1154,8 @@ def normalize_pixel_coordinates3d(
     .. warning::
         ``depth``, ``height`` and ``width`` are not validated; a degenerate size
         (``1``, ``0`` or negative) clamps that axis' denominator up to ``eps``
-        and blows the corresponding component up by a factor of ``2e8``. Tracked
+        and blows the corresponding component up by a factor of ``2e8``
+        (``inf`` in ``float16``, where ``eps`` underflows). Tracked
         in `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
 
     Args:
@@ -1190,11 +1199,13 @@ def denormalize_pixel_coordinates3d(
     .. warning::
         For a degenerate ``depth``/``height``/``width`` (``1``, ``0`` or
         negative) the clamped denominator scales that component by ``5e-09``
-        instead of by ``(size - 1) / 2``. That clamp is the exact reciprocal of
-        the one in
+        (``0`` in ``float16``, where ``eps`` underflows) instead of by
+        ``(size - 1) / 2``. That clamp is the exact reciprocal of the one in
         :func:`~kornia.geometry.conversions.normalize_pixel_coordinates3d`, so a
-        normalize-then-denormalize round trip still returns the input; it is a
-        single call on its own that is wrong. Tracked in
+        normalize-then-denormalize round trip returns the input as long as the
+        normalized value is finite — in ``float16`` the normalized component is
+        ``inf`` and the round trip returns ``nan``; it is a single call on its
+        own that is wrong. Tracked in
         `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
 
     Args:
@@ -1243,10 +1254,10 @@ def angle_to_rotation_matrix(angle: torch.Tensor) -> torch.Tensor:
 
     .. warning::
         The degrees-to-radians step is
-        :func:`~kornia.geometry.conversions.deg2rad`, so it inherits the float32
-        ``kornia.constants.pi`` defect — see the warning on
-        :func:`~kornia.geometry.conversions.rad2deg` and
-        `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
+        :func:`~kornia.geometry.conversions.deg2rad`, so it inherits both
+        defects of :func:`~kornia.geometry.conversions.rad2deg` — the float32
+        ``kornia.constants.pi`` and the cast to the input dtype. See its
+        warning and `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
 
     Args:
         angle: tensor of angles in degrees, any shape :math:`(*)`.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -192,8 +192,12 @@ def cart2pol(x: torch.Tensor, y: torch.Tensor, eps: float = 1.0e-8) -> tuple[tor
         - kornia's image ``y`` axis points down, so a growing ``phi`` turns
           **clockwise as displayed**. The relation to the other 2-D
           angle op is the opposite sense: applying
-          ``angle_to_rotation_matrix(theta)`` to a point *decreases* that
-          point's ``phi`` by exactly ``theta`` degrees
+          ``angle_to_rotation_matrix(theta)`` to a nonzero point *decreases*
+          that point's ``phi`` by ``theta`` degrees **modulo** :math:`2\pi` —
+          the result is re-wrapped into :math:`[-\pi, \pi]`, so a point at
+          ``phi = -170`` degrees rotated by ``theta = 30`` returns
+          ``phi = +160``, not ``-200``. At the origin ``phi`` carries no
+          direction and the relation does not apply
         - ``rho`` is ``sqrt(x ** 2 + y ** 2 + eps)``, not
           ``sqrt(x ** 2 + y ** 2)`` — see the warning below
 
@@ -213,9 +217,11 @@ def cart2pol(x: torch.Tensor, y: torch.Tensor, eps: float = 1.0e-8) -> tuple[tor
     Args:
         x: torch.Tensor of arbitrary shape.
         y: torch.Tensor of same arbitrary shape.
-        eps: added inside the square root when computing ``rho``; its effect is
-            to keep the gradient of ``rho`` finite at the origin, which is
-            ``nan`` when ``eps=0``.
+        eps: added inside the square root when computing ``rho``. A positive
+            ``eps`` that is representable in the working dtype keeps the
+            gradient of ``rho`` finite at the origin, where it is ``nan`` with
+            ``eps=0``. The default ``1e-8`` underflows in ``float16`` (see the
+            warning above), so there the origin gradient is still ``nan``.
 
     Returns:
         - rho: torch.Tensor with same shape as input.
@@ -1227,9 +1233,12 @@ def angle_to_rotation_matrix(angle: torch.Tensor) -> torch.Tensor:
           ``(1., 0.)`` to ``(0.8660, -0.5000)`` — counter-clockwise **as
           displayed** under kornia's y-down image axes. In the raw coordinate
           plane that is the opposite sense to
-          :func:`~kornia.geometry.conversions.cart2pol`: rotating a point by
-          ``theta`` degrees this way *decreases* its ``cart2pol`` angle ``phi``
-          by exactly ``theta`` degrees
+          :func:`~kornia.geometry.conversions.cart2pol`: rotating a nonzero
+          point by ``theta`` degrees this way *decreases* its ``cart2pol``
+          angle ``phi`` by ``theta`` degrees **modulo** :math:`2\pi`, since
+          ``phi`` is re-wrapped into :math:`[-\pi, \pi]` whenever the rotation
+          crosses the ``-x`` branch cut (``phi = -170`` degrees rotated by
+          ``theta = 30`` returns ``phi = +160``, not ``-200``)
 
     .. warning::
         The degrees-to-radians step is

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -198,10 +198,16 @@ def cart2pol(x: torch.Tensor, y: torch.Tensor, eps: float = 1.0e-8) -> tuple[tor
           ``sqrt(x ** 2 + y ** 2)`` — see the warning below
 
     .. warning::
-        Because ``eps`` is added *inside* the square root, ``rho`` is biased
-        everywhere: ``cart2pol(torch.tensor(0.), torch.tensor(0.))`` returns
-        ``rho = 1e-04`` rather than ``0``, and ``cart2pol(3., 4.)`` in
-        ``float64`` returns ``5.000000001``. Tracked in
+        ``eps`` is added *inside* the square root, so the expression evaluated
+        is ``sqrt(x ** 2 + y ** 2 + eps)`` and ``rho`` is biased high. Whether
+        that bias survives the rounding of the working dtype depends on where
+        it is measured. Away from the origin it is usually invisible:
+        ``cart2pol(3., 4.)`` returns ``5.000000001`` in ``float64`` but rounds
+        back to exactly ``5.`` in ``float32`` and ``float16``. At the origin it
+        is the whole answer: ``cart2pol(torch.tensor(0.), torch.tensor(0.))``
+        returns ``rho = 9.9999997e-05`` in ``float32`` and ``1e-04`` in
+        ``float64`` rather than ``0`` (in ``float16``, ``eps`` underflows the
+        sum and ``rho`` is ``0.``). Tracked in
         `#3939 <https://github.com/kornia/kornia/issues/3939>`_.
 
     Args:
@@ -246,11 +252,17 @@ def convert_points_from_homogeneous(points: torch.Tensor, eps: float = 1e-8) -> 
 
     .. warning::
         The division is by ``w + eps`` rather than by ``w``, and ``eps`` is
-        added without regard to the sign of ``w``: at ``w = 2e-8`` the exact
-        result ``[1e8, 2e8]`` comes out as ``[6.67e7, 1.33e8]`` (33 % low) while
-        at ``w = -2e-8`` it comes out as ``[-2e8, -4e8]`` (100 % high), and even
-        at ``w = 2`` the result carries a relative bias of ``eps / w``. Tracked
-        in `#3938 <https://github.com/kornia/kornia/issues/3938>`_.
+        added without regard to the sign of ``w``, so the **signed** relative
+        error of the result is exactly ``-eps / (w + eps)``. At ``w = 2e-8``
+        that is ``-1/3``: the exact result ``[1e8, 2e8]`` comes out as
+        ``[6.67e7, 1.33e8]`` (33 % low). At ``w = -2e-8`` it is ``+1``:
+        ``[-1e8, -2e8]`` comes out as ``[-2e8, -4e8]`` (100 % high). Only for
+        ``abs(w)`` much larger than ``eps`` does it reduce to the familiar
+        ``-eps / w``, and there it is usually below the rounding of the working
+        dtype — at ``w = 2`` the measured error is ``-5.0e-09`` in ``float64``,
+        while in ``float32`` ``2 + eps`` rounds back to ``2`` and the result is
+        exact. Tracked in
+        `#3938 <https://github.com/kornia/kornia/issues/3938>`_.
 
     Args:
         points: the points to be transformed of shape :math:`(*, N, D)`.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -79,6 +79,20 @@ __all__ = [
 def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
     r"""Convert angles from radians to degrees.
 
+    Convention:
+        - the input is in **radians** and the output in **degrees**; the
+          conversion is elementwise and preserves shape, device and float dtype
+
+    .. warning::
+        The conversion factor is ``kornia.constants.pi``, a **float32**
+        tensor that is cast to the input dtype, so an integer input is divided
+        by ``3`` (``rad2deg(torch.tensor([1, 2, 3]))`` returns
+        ``[60., 120., 180.]`` instead of ``[57.2958, 114.5916, 171.8873]``) and
+        a ``float64`` input loses about seven digits
+        (``rad2deg(torch.tensor(math.pi, dtype=torch.float64)) - 180`` is
+        ``-5.0e-06``, not ``0``). Tracked in
+        `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
+
     Args:
         tensor: torch.Tensor of arbitrary shape.
 
@@ -100,6 +114,19 @@ def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
 def deg2rad(tensor: torch.Tensor) -> torch.Tensor:
     r"""Convert angles from degrees to radians.
 
+    Convention:
+        - the input is in **degrees** and the output in **radians**; it is the
+          inverse of :func:`~kornia.geometry.conversions.rad2deg`
+
+    .. warning::
+        Same float32-``pi`` defect as
+        :func:`~kornia.geometry.conversions.rad2deg`:
+        ``deg2rad(torch.tensor([180, 90]))`` returns ``[3.0000, 1.5000]``
+        instead of ``[3.1416, 1.5708]``, and
+        ``deg2rad(torch.tensor(180., dtype=torch.float64))`` returns
+        ``3.1415927410125732`` instead of ``math.pi``. Tracked in
+        `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
+
     Args:
         tensor: torch.Tensor of arbitrary shape.
 
@@ -120,6 +147,14 @@ def deg2rad(tensor: torch.Tensor) -> torch.Tensor:
 
 def pol2cart(rho: torch.Tensor, phi: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     r"""Convert polar coordinates to cartesian coordinates.
+
+    Convention:
+        - the arguments are ``(rho, phi)`` and the return is the tuple
+          ``(x, y)``, with ``x = rho * cos(phi)`` and ``y = rho * sin(phi)``:
+          ``rho = 5``, ``phi = atan2(4, 3)`` gives ``(3., 4.)``
+        - ``phi`` is in **radians** (``rho = 2``, ``phi = pi / 6`` gives
+          ``(1.7321, 1.)``) and follows the angle convention documented on
+          :func:`~kornia.geometry.conversions.cart2pol`
 
     Args:
         rho: torch.Tensor of arbitrary shape.
@@ -144,12 +179,37 @@ def pol2cart(rho: torch.Tensor, phi: torch.Tensor) -> tuple[torch.Tensor, torch.
 
 
 def cart2pol(x: torch.Tensor, y: torch.Tensor, eps: float = 1.0e-8) -> tuple[torch.Tensor, torch.Tensor]:
-    """Convert cartesian coordinates to polar coordinates.
+    r"""Convert cartesian coordinates to polar coordinates.
+
+    Convention:
+        - the arguments are ``(x, y)`` and the return is the tuple
+          ``(rho, phi)``: ``(3., 4.)`` gives ``(5., 0.9273)``
+        - ``phi`` is ``atan2(y, x)`` in **radians**, so it lies in
+          :math:`[-\pi, \pi]`, is ``0`` on the ``+x`` axis and grows toward
+          ``+y`` (``x = 0``, ``y = 1`` gives ``phi = 1.5708``). Both endpoints
+          are attained on the ``-x`` axis, where the sign of ``y``'s zero
+          decides between ``-pi`` and ``+pi``
+        - kornia's image ``y`` axis points down, so a growing ``phi`` turns
+          **clockwise as displayed**. The relation to the other 2-D
+          angle op is the opposite sense: applying
+          ``angle_to_rotation_matrix(theta)`` to a point *decreases* that
+          point's ``phi`` by exactly ``theta`` degrees
+        - ``rho`` is ``sqrt(x ** 2 + y ** 2 + eps)``, not
+          ``sqrt(x ** 2 + y ** 2)`` — see the warning below
+
+    .. warning::
+        Because ``eps`` is added *inside* the square root, ``rho`` is biased
+        everywhere: ``cart2pol(torch.tensor(0.), torch.tensor(0.))`` returns
+        ``rho = 1e-04`` rather than ``0``, and ``cart2pol(3., 4.)`` in
+        ``float64`` returns ``5.000000001``. Tracked in
+        `#3939 <https://github.com/kornia/kornia/issues/3939>`_.
 
     Args:
         x: torch.Tensor of arbitrary shape.
         y: torch.Tensor of same arbitrary shape.
-        eps: To avoid division by zero.
+        eps: added inside the square root when computing ``rho``; its effect is
+            to keep the gradient of ``rho`` finite at the origin, which is
+            ``nan`` when ``eps=0``.
 
     Returns:
         - rho: torch.Tensor with same shape as input.
@@ -172,12 +232,32 @@ def cart2pol(x: torch.Tensor, y: torch.Tensor, eps: float = 1.0e-8) -> tuple[tor
 def convert_points_from_homogeneous(points: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     r"""Convert points from homogeneous to Euclidean space.
 
+    Convention:
+        - the **last** component of the last dimension is the homogeneous
+          coordinate ``w`` and is dropped from the output
+        - requires rank :math:`\geq 2`: a bare :math:`(D,)` point raises
+          ``ValueError``
+        - when ``abs(w) > eps`` the remaining components are divided by ``w``
+          with its sign kept (``[[2., 4., -2.]]`` gives ``[[-1., -2.]]``), up to
+          the bias described in the warning below
+        - when ``abs(w) <= eps`` (default ``eps = 1e-8``; the test is a strict
+          ``>``) the numerator is instead returned **unchanged**, following
+          OpenCV: ``[[2., 4., 0.]]`` gives ``[[2., 4.]]``
+
+    .. warning::
+        The division is by ``w + eps`` rather than by ``w``, and ``eps`` is
+        added without regard to the sign of ``w``: at ``w = 2e-8`` the exact
+        result ``[1e8, 2e8]`` comes out as ``[6.67e7, 1.33e8]`` (33 % low) while
+        at ``w = -2e-8`` it comes out as ``[-2e8, -4e8]`` (100 % high), and even
+        at ``w = 2`` the result carries a relative bias of ``eps / w``. Tracked
+        in `#3938 <https://github.com/kornia/kornia/issues/3938>`_.
+
     Args:
-        points: the points to be transformed of shape :math:`(B, N, D)`.
+        points: the points to be transformed of shape :math:`(*, N, D)`.
         eps: to avoid division by zero.
 
     Returns:
-        the points in Euclidean space :math:`(B, N, D-1)`.
+        the points in Euclidean space :math:`(*, N, D-1)`.
 
     Examples:
         >>> input = torch.tensor([[0., 0., 1.]])
@@ -205,6 +285,15 @@ def convert_points_from_homogeneous(points: torch.Tensor, eps: float = 1e-8) -> 
 
 def convert_points_to_homogeneous(points: torch.Tensor) -> torch.Tensor:
     r"""Convert points from Euclidean to homogeneous space.
+
+    Convention:
+        - appends the constant ``1`` as the **last** component of the last
+          dimension, which is where
+          :func:`~kornia.geometry.conversions.convert_points_from_homogeneous`
+          expects it
+        - requires rank :math:`\geq 2`: a bare :math:`(D,)` point raises
+          ``ValueError``
+        - the input dtype is preserved, integer dtypes included
 
     Args:
         points: the points to be transformed with shape :math:`(*, N, D)`.
@@ -235,6 +324,12 @@ def _convert_affinematrix_to_homography_impl(A: torch.Tensor) -> torch.Tensor:
 def convert_affinematrix_to_homography(A: torch.Tensor) -> torch.Tensor:
     r"""Convert batch of affine matrices.
 
+    Convention:
+        - appends the row ``[0, 0, 1]`` at the bottom and copies the
+          :math:`2 \times 3` block verbatim; the input tensor is not modified
+        - the rank is enforced to be exactly 3, so batching is **mandatory**: an
+          unbatched :math:`(2, 3)` matrix raises ``ValueError``
+
     Args:
         A: the affine matrix with shape :math:`(B,2,3)`.
 
@@ -261,6 +356,12 @@ def convert_affinematrix_to_homography(A: torch.Tensor) -> torch.Tensor:
 
 def convert_affinematrix_to_homography3d(A: torch.Tensor) -> torch.Tensor:
     r"""Convert batch of 3d affine matrices.
+
+    Convention:
+        - same as
+          :func:`~kornia.geometry.conversions.convert_affinematrix_to_homography`,
+          except that ``A`` is :math:`(B, 3, 4)` and the appended bottom row is
+          ``[0, 0, 0, 1]``
 
     Args:
         A: the affine matrix with shape :math:`(B,3,4)`.
@@ -894,14 +995,37 @@ def quaternion_from_euler(
 def normalize_pixel_coordinates(
     pixel_coordinates: torch.Tensor, height: int, width: int, eps: float = 1e-8
 ) -> torch.Tensor:
-    r"""Normalize pixel coordinates between -1 and 1.
+    r"""Map pixel coordinates so that the first and last pixel of each axis become -1 and 1.
 
-    Normalized, -1 if on extreme left, 1 if on extreme right (x = w-1).
+    Convention:
+        - ``pixel_coordinates`` is :math:`(*, 2)` in ``(x, y)`` order: ``x``
+          indexes columns and is scaled by ``width``, ``y`` indexes rows and is
+          scaled by ``height``. The positional argument order is the other way
+          round — ``(pixel_coordinates, height, width)``
+        - the mapping is **corner-aligned**,
+          ``x_norm = 2 * x / (width - 1) - 1``: for ``width = 4`` the columns
+          ``0``, ``1``, ``3`` map to ``-1``, ``-1/3``, ``+1``. This is the
+          ``align_corners=True`` convention;
+          :func:`torch.nn.functional.grid_sample` at its default
+          ``align_corners=False`` would instead place the first and last of
+          those values at pixels ``-0.5`` and ``3.5`` — half a pixel outside
+          the image on each side — so ``align_corners=True`` must be passed
+          explicitly when feeding this output to it
+        - the output is **not** clamped: coordinates outside the image
+          extrapolate linearly past ``[-1, 1]``, as the example below shows
+
+    .. warning::
+        ``height`` and ``width`` are not validated. For a degenerate size (``1``,
+        ``0`` or negative) the denominator ``size - 1`` is clamped up to ``eps``,
+        so
+        ``normalize_pixel_coordinates(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1)``
+        silently returns ``[[199999999.0, 199999999.0]]`` instead of raising.
+        Tracked in `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
 
     Args:
         pixel_coordinates: the grid with pixel coordinates. Shape can be :math:`(*, 2)`.
-        width: the maximum width in the x-axis.
         height: the maximum height in the y-axis.
+        width: the maximum width in the x-axis.
         eps: safe division by zero.
 
     Return:
@@ -938,10 +1062,27 @@ def denormalize_pixel_coordinates(
 
     The input is assumed to be -1 if on extreme left, 1 if on extreme right (x = w-1).
 
+    Convention:
+        - the inverse of
+          :func:`~kornia.geometry.conversions.normalize_pixel_coordinates`,
+          ``x = (width - 1) * (x_norm + 1) / 2``, with the same ``(x, y)``
+          component order and the same ``(pixel_coordinates, height, width)``
+          positional order
+
+    .. warning::
+        For a degenerate ``height``/``width`` (``1``, ``0`` or negative) the
+        clamped denominator collapses that component instead of exploding it:
+        ``denormalize_pixel_coordinates(torch.tensor([[0., 0.]], dtype=torch.float64), 4, 1)``
+        returns ``[[5e-09, 1.5]]``. This clamp is the exact reciprocal of the one
+        in :func:`~kornia.geometry.conversions.normalize_pixel_coordinates`, so a
+        normalize-then-denormalize round trip still returns the input; it is a
+        single call on its own that is wrong. Tracked in
+        `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
+
     Args:
         pixel_coordinates: the normalized grid coordinates. Shape can be :math:`(*, 2)`.
-        width: the maximum width in the x-axis.
         height: the maximum height in the y-axis.
+        width: the maximum width in the x-axis.
         eps: safe division by zero.
 
     Return:
@@ -970,9 +1111,24 @@ def denormalize_pixel_coordinates(
 def normalize_pixel_coordinates3d(
     pixel_coordinates: torch.Tensor, depth: int, height: int, width: int, eps: float = 1e-8
 ) -> torch.Tensor:
-    r"""Normalize pixel coordinates between -1 and 1.
+    r"""Map 3d pixel coordinates so that the first and last sample of each axis become -1 and 1.
 
-    Normalized, -1 if on extreme left, 1 if on extreme right (x = w-1).
+    Convention:
+        - ``pixel_coordinates`` is :math:`(*, 3)` in ``(d, x, y)`` order —
+          **depth first, then x, then y**, *not* ``(x, y, z)``. The three
+          components are scaled by ``depth - 1``, ``width - 1`` and
+          ``height - 1`` respectively, so with ``depth=3, height=5, width=9``
+          the coordinate ``[2., 8., 4.]`` maps to ``[1., 1., 1.]``
+        - the positional argument order is
+          ``(pixel_coordinates, depth, height, width)``
+        - corner-aligned and unclamped in each axis exactly as in
+          :func:`~kornia.geometry.conversions.normalize_pixel_coordinates`
+
+    .. warning::
+        ``depth``, ``height`` and ``width`` are not validated; a degenerate size
+        (``1``, ``0`` or negative) clamps that axis' denominator up to ``eps``
+        and blows the corresponding component up by a factor of ``2e8``. Tracked
+        in `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
 
     Args:
         pixel_coordinates: the grid with pixel coordinates. Shape can be :math:`(*, 3)`.
@@ -1002,13 +1158,29 @@ def normalize_pixel_coordinates3d(
 def denormalize_pixel_coordinates3d(
     pixel_coordinates: torch.Tensor, depth: int, height: int, width: int, eps: float = 1e-8
 ) -> torch.Tensor:
-    r"""Denormalize pixel coordinates.
+    r"""Denormalize 3d pixel coordinates.
 
-    The input is assumed to be -1 if on extreme left, 1 if on extreme right (x = w-1).
+    Convention:
+        - the inverse of
+          :func:`~kornia.geometry.conversions.normalize_pixel_coordinates3d`,
+          with the same ``(d, x, y)`` component order and the same
+          ``(pixel_coordinates, depth, height, width)`` positional order: with
+          ``depth=3, height=5, width=9`` the input ``[0., 0., 0.]`` maps back to
+          ``[1., 4., 2.]``
+
+    .. warning::
+        For a degenerate ``depth``/``height``/``width`` (``1``, ``0`` or
+        negative) the clamped denominator scales that component by ``5e-09``
+        instead of by ``(size - 1) / 2``. That clamp is the exact reciprocal of
+        the one in
+        :func:`~kornia.geometry.conversions.normalize_pixel_coordinates3d`, so a
+        normalize-then-denormalize round trip still returns the input; it is a
+        single call on its own that is wrong. Tracked in
+        `#3940 <https://github.com/kornia/kornia/issues/3940>`_.
 
     Args:
         pixel_coordinates: the normalized grid coordinates. Shape can be :math:`(*, 3)`.
-        depth: the maximum depth in the x-axis.
+        depth: the maximum depth in the z-axis.
         height: the maximum height in the y-axis.
         width: the maximum width in the x-axis.
         eps: safe division by zero.
@@ -1033,6 +1205,28 @@ def denormalize_pixel_coordinates3d(
 
 def angle_to_rotation_matrix(angle: torch.Tensor) -> torch.Tensor:
     r"""Create a rotation matrix out of angles in degrees.
+
+    Convention:
+        - ``angle`` is in **degrees**, shape :math:`(*)` in and
+          :math:`(*, 2, 2)` out
+        - the matrix is ``[[cos, sin], [-sin, cos]]`` with ``det = +1``; for
+          ``angle = 30`` it is ``[[0.8660, 0.5000], [-0.5000, 0.8660]]``
+        - applied on the left to a column vector ``(x, y)``, ``angle = 30`` maps
+          ``(1., 0.)`` to ``(0.8660, -0.5000)`` — counter-clockwise **as
+          displayed** under kornia's y-down image axes. In the raw coordinate
+          plane that is the opposite sense to
+          :func:`~kornia.geometry.conversions.cart2pol`: rotating a point by
+          ``theta`` degrees this way *decreases* its ``cart2pol`` angle ``phi``
+          by exactly ``theta`` degrees
+
+    .. warning::
+        The degrees-to-radians step is
+        :func:`~kornia.geometry.conversions.deg2rad`, so an integer ``angle``
+        inherits its float32-``pi`` defect:
+        ``angle_to_rotation_matrix(torch.tensor([90]))`` returns
+        ``[[0.0707, 0.9975], [-0.9975, 0.0707]]`` instead of the quarter-turn
+        matrix. Tracked in
+        `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
 
     Args:
         angle: tensor of angles in degrees, any shape :math:`(*)`.
@@ -1241,13 +1435,24 @@ def normalize_homography3d(
 def normalize_points_with_intrinsics(point_2d: torch.Tensor, camera_matrix: torch.Tensor) -> torch.Tensor:
     """Normalize points with intrinsics. Useful for conversion of keypoints to be used with essential matrix.
 
+    Convention:
+        - ``point_2d`` is :math:`(*, 2)` in pixel ``(u, v)`` order and
+          ``camera_matrix`` is a row-major pinhole :math:`(*, 3, 3)` with
+          ``fx = K[0, 0]``, ``fy = K[1, 1]``, ``cx = K[0, 2]``, ``cy = K[1, 2]``
+        - the output is the calibrated camera coordinate
+          ``x = (u - cx) / fx``, ``y = (v - cy) / fy``: with
+          ``K = [[100., 0., 320.], [0., 200., 240.], [0., 0., 1.]]`` the pixel
+          ``(420., 440.)`` maps to ``(1., 1.)``
+        - the skew entry ``K[0, 1]`` is **ignored**; only the two diagonal
+          entries and the ``[:2, 2]`` column are read
+
     Args:
         point_2d: tensor containing the 2d points in the image pixel coordinates. The shape of the tensor can be
                   :math:`(*, 2)`.
         camera_matrix: tensor containing the intrinsics camera matrix. The tensor shape must be :math:`(*, 3, 3)`.
 
     Returns:
-        tensor of (u, v) cam coordinates with shape :math:`(*, 2)`.
+        tensor of normalized camera coordinates :math:`(x, y)` with shape :math:`(*, 2)`.
 
     Example:
         >>> _ = torch.manual_seed(0)
@@ -1273,15 +1478,22 @@ def normalize_points_with_intrinsics(point_2d: torch.Tensor, camera_matrix: torc
 
 
 def denormalize_points_with_intrinsics(point_2d_norm: torch.Tensor, camera_matrix: torch.Tensor) -> torch.Tensor:
-    """Normalize points with intrinsics. Useful for conversion of keypoints to be used with essential matrix.
+    """Denormalize points with intrinsics. Useful for converting normalized camera points back to pixels.
+
+    Convention:
+        - the inverse of
+          :func:`~kornia.geometry.conversions.normalize_points_with_intrinsics`,
+          which documents the ``K`` layout: ``u = x * fx + cx`` and
+          ``v = y * fy + cy``, and the skew entry ``K[0, 1]`` is ignored here
+          too
 
     Args:
-        point_2d_norm: tensor containing the 2d points in the image pixel coordinates. The shape of the tensor can be
-                       :math:`(*, 2)`.
+        point_2d_norm: tensor containing the 2d points in normalized camera coordinates. The shape of the tensor can
+                       be :math:`(*, 2)`.
         camera_matrix: tensor containing the intrinsics camera matrix. The tensor shape must be :math:`(*, 3, 3)`.
 
     Returns:
-        tensor of (u, v) cam coordinates with shape :math:`(*, 2)`.
+        tensor of :math:`(u, v)` pixel coordinates with shape :math:`(*, 2)`.
 
     Example:
         >>> _ = torch.manual_seed(0)
@@ -1578,11 +1790,19 @@ def vector_to_skew_symmetric_matrix(vec: torch.Tensor) -> torch.Tensor:
         v3 & 0 & -v1 \\
         -v2 & v1 & 0\end{bmatrix}
 
+    Convention:
+        - the matrix acts on the left as the first cross-product factor:
+          ``vector_to_skew_symmetric_matrix(v) @ x`` equals ``cross(v, x)``, not
+          its negation — for ``v = (1., 2., 3.)`` and ``x = (4., 5., 6.)`` both
+          are ``(-3., 6., -3.)``
+        - accepts :math:`(3,)` or :math:`(B, 3)` only; any higher rank raises
+          ``ValueError``
+
     Args:
-        vec: tensor of shape :math:`(B, 3)`.
+        vec: tensor of shape :math:`(3,)` or :math:`(B, 3)`.
 
     Returns:
-        tensor of shape :math:`(B, 3, 3)`.
+        tensor of shape :math:`(3, 3)` or :math:`(B, 3, 3)` respectively.
 
     Example:
         >>> vec = torch.tensor([1.0, 2.0, 3.0])

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -90,7 +90,10 @@ def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
         ``[60., 120., 180.]`` instead of ``[57.2958, 114.5916, 171.8873]``) and
         a ``float64`` input loses about seven digits
         (``rad2deg(torch.tensor(math.pi, dtype=torch.float64)) - 180`` is
-        ``-5.0e-06``, not ``0``). Tracked in
+        ``-5.0e-06``, not ``0``). The defect lives in ``kornia.constants.pi``
+        itself, which other kornia modules (augmentation color jitter, feature
+        orientation/MKD, ``enhance.jpeg``) also consume — so a fix limited to
+        ``rad2deg``/``deg2rad`` would not end it. Tracked in
         `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
 
     Args:
@@ -119,12 +122,8 @@ def deg2rad(tensor: torch.Tensor) -> torch.Tensor:
           inverse of :func:`~kornia.geometry.conversions.rad2deg`
 
     .. warning::
-        Same float32-``pi`` defect as
-        :func:`~kornia.geometry.conversions.rad2deg`:
-        ``deg2rad(torch.tensor([180, 90]))`` returns ``[3.0000, 1.5000]``
-        instead of ``[3.1416, 1.5708]``, and
-        ``deg2rad(torch.tensor(180., dtype=torch.float64))`` returns
-        ``3.1415927410125732`` instead of ``math.pi``. Tracked in
+        Inherits the float32 ``kornia.constants.pi`` defect — see the warning on
+        :func:`~kornia.geometry.conversions.rad2deg` and
         `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
 
     Args:
@@ -1028,7 +1027,9 @@ def normalize_pixel_coordinates(
           ``align_corners=False`` would instead place the first and last of
           those values at pixels ``-0.5`` and ``3.5`` — half a pixel outside
           the image on each side — so ``align_corners=True`` must be passed
-          explicitly when feeding this output to it
+          explicitly when feeding this output to it. Note that kornia's own
+          :func:`~kornia.geometry.transform.remap` resolves
+          ``align_corners=None`` to ``False``
         - the output is **not** clamped: coordinates outside the image
           extrapolate linearly past ``[-1, 1]``, as the example below shows
 
@@ -1242,11 +1243,9 @@ def angle_to_rotation_matrix(angle: torch.Tensor) -> torch.Tensor:
 
     .. warning::
         The degrees-to-radians step is
-        :func:`~kornia.geometry.conversions.deg2rad`, so an integer ``angle``
-        inherits its float32-``pi`` defect:
-        ``angle_to_rotation_matrix(torch.tensor([90]))`` returns
-        ``[[0.0707, 0.9975], [-0.9975, 0.0707]]`` instead of the quarter-turn
-        matrix. Tracked in
+        :func:`~kornia.geometry.conversions.deg2rad`, so it inherits the float32
+        ``kornia.constants.pi`` defect — see the warning on
+        :func:`~kornia.geometry.conversions.rad2deg` and
         `#3937 <https://github.com/kornia/kornia/issues/3937>`_.
 
     Args:

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import inspect
 import sys
 from functools import partial
 
@@ -655,7 +656,7 @@ class TestRadDegConversions(BaseTester):
         #                         [-0.49999999999999994, 0.8660254037844387]]
         out = kornia.geometry.conversions.angle_to_rotation_matrix(torch.tensor(30.0, device=device, dtype=dtype))
         expected = torch.tensor([[0.8660254, 0.5], [-0.5, 0.8660254]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
         # A radian-reading implementation would turn pi/2 into the quarter turn [[0, 1], [-1, 0]];
         # this one reads pi/2 as 1.5708 *degrees* and returns a near-identity matrix instead.
@@ -666,7 +667,7 @@ class TestRadDegConversions(BaseTester):
             torch.tensor(torch.pi / 2, device=device, dtype=dtype)
         )
         expected_rad = torch.tensor([[0.99962422, 0.02741213], [-0.02741213, 0.99962422]], device=device, dtype=dtype)
-        self.assert_close(out_rad, expected_rad, atol=1e-2, rtol=1e-2)
+        self.assert_close(out_rad, expected_rad)
 
     @pytest.mark.parametrize(
         ("op_name", "arg", "expected"),
@@ -760,8 +761,8 @@ class TestPolCartConversions(BaseTester):
 
         x, y = kornia.geometry.conversions.pol2cart(rho, phi)
 
-        self.assert_close(x, torch.tensor(3.0, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
-        self.assert_close(y, torch.tensor(4.0, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        self.assert_close(x, torch.tensor(3.0, device=device, dtype=dtype))
+        self.assert_close(y, torch.tensor(4.0, device=device, dtype=dtype))
 
     def test_convention_cart2pol_takes_x_y_and_phi_is_atan2_y_x(self, device, dtype):
         # Convention pin: cart2pol's argument order is (x, y) and its return order is
@@ -774,17 +775,19 @@ class TestPolCartConversions(BaseTester):
         rho, phi = kornia.geometry.conversions.cart2pol(
             torch.tensor(3.0, device=device, dtype=dtype), torch.tensor(4.0, device=device, dtype=dtype)
         )
-        self.assert_close(rho, torch.tensor(5.0, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
-        self.assert_close(phi, torch.tensor(0.9272952180016122, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        self.assert_close(rho, torch.tensor(5.0, device=device, dtype=dtype))
+        self.assert_close(phi, torch.tensor(0.9272952180016122, device=device, dtype=dtype))
 
         phi_y_axis = kornia.geometry.conversions.cart2pol(
             torch.tensor(0.0, device=device, dtype=dtype), torch.tensor(1.0, device=device, dtype=dtype)
         )[1]
-        self.assert_close(
-            phi_y_axis, torch.tensor(1.5707963267948966, device=device, dtype=dtype), atol=1e-2, rtol=1e-2
-        )
+        self.assert_close(phi_y_axis, torch.tensor(1.5707963267948966, device=device, dtype=dtype))
 
-    @pytest.mark.xfail(reason="cart2pol returns sqrt(x**2 + y**2 + eps), biasing rho — kornia#3939", strict=True)
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason="cart2pol returns sqrt(x**2 + y**2 + eps), biasing rho — kornia#3939",
+        strict=True,
+    )
     def test_convention_cart2pol_rho_is_the_exact_radius(self, device, dtype):
         # Intended behavior: rho is the Euclidean radius, so rho(0, 0) == 0. It currently is
         # not: eps is added *inside* the sqrt, so rho = sqrt(x**2 + y**2 + eps) and the origin
@@ -852,7 +855,7 @@ class TestPolCartConversions(BaseTester):
         phi1 = kornia.geometry.conversions.cart2pol(v_rot[0], v_rot[1])[1]
 
         expected_delta = torch.tensor(-0.5235987755982988, device=device, dtype=dtype)
-        self.assert_close(phi1 - phi0, expected_delta, atol=1e-2, rtol=1e-2)
+        self.assert_close(phi1 - phi0, expected_delta)
 
         # Second case: crossing the -x branch cut, where the returned phi is re-wrapped into
         # [-pi, pi] and only the difference modulo 2*pi is -theta (the worked -170 + 30 example
@@ -868,11 +871,18 @@ class TestPolCartConversions(BaseTester):
         w_rot = rot @ w
         phi1_cut = kornia.geometry.conversions.cart2pol(w_rot[0], w_rot[1])[1]
 
-        self.assert_close(phi1_cut, torch.tensor(2.7925268, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        self.assert_close(phi1_cut, torch.tensor(2.7925268, device=device, dtype=dtype))
 
         raw_delta = phi1_cut - phi0_cut
         wrapped_delta = torch.atan2(torch.sin(raw_delta), torch.cos(raw_delta))
-        self.assert_close(wrapped_delta, expected_delta, atol=1e-2, rtol=1e-2)
+        # The re-wrap atan2(sin, cos) adds two more transcendental roundings on top of the two
+        # atan2 outputs it differences, overshooting the central per-dtype tolerances in the half
+        # dtypes: measured |wrapped_delta - expected| is 1.95e-3 in float16 (central allowance
+        # atol 1e-3 + rtol 1e-3 * 0.52 = 1.52e-3) and 1.16e-2 in bfloat16 (allowance 1.19e-2, a
+        # 3 % margin that torch rounding drift could erase). atol 2.4e-2 is ~2x the bfloat16
+        # error; a sign-flipped or unwrapped delta would still be off by >= 1.0.
+        wrap_tol = {"atol": 2.4e-2, "rtol": 0.0} if dtype in (torch.float16, torch.bfloat16) else {}
+        self.assert_close(wrapped_delta, expected_delta, **wrap_tol)
 
 
 class TestConvertPointsToHomogeneous(BaseTester):
@@ -1051,7 +1061,11 @@ class TestConvertPointsFromHomogeneous(BaseTester):
 
         self.assert_close(actual, expected)
 
-    @pytest.mark.xfail(reason="convert_points_from_homogeneous divides by w + eps — kornia#3938", strict=True)
+    @pytest.mark.xfail(
+        raises=AssertionError,
+        reason="convert_points_from_homogeneous divides by w + eps — kornia#3938",
+        strict=True,
+    )
     def test_convention_divides_by_exactly_w(self, device, dtype):
         # Intended behavior: for |w| > eps the point is divided by exactly w. It currently is
         # divided by w + eps with no regard for sign, so the signed relative error is exactly
@@ -1069,7 +1083,7 @@ class TestConvertPointsFromHomogeneous(BaseTester):
         out = kornia.geometry.conversions.convert_points_from_homogeneous(points)
 
         expected = torch.tensor([[1e8, 2e8]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
     def test_wart_division_is_by_w_plus_eps_for_both_signs_3938(self, device, dtype):
         # Wart pin for kornia#3938, companion to the strict xfail above: assert the CURRENT
@@ -1103,22 +1117,30 @@ class TestConvertPointsFromHomogeneous(BaseTester):
         self.assert_close(out_neg, expected_neg, atol=0.0, rtol=1e-2)
 
 
+def _skip_if_mps_clamp_caching(device):
+    # Runtime probe instead of a torch-version pin, so the skip retires itself on any torch
+    # build where the two clamps below return different values.
+    if device.type == "mps" and torch.equal(
+        torch.zeros(2, device=device).clamp(1e-8), torch.zeros(2, device=device).clamp(1e-7)
+    ):
+        pytest.skip(
+            "this torch build caches clamp's scalar min per shape/dtype on MPS -- first value wins "
+            "(seen on torch 2.9.1): z = torch.zeros(2, device='mps'); z.clamp(1e-8) then z.clamp(1e-7) "
+            "both return 9.99999993922529e-09, while the same pair on cpu returns 1e-08 then "
+            "1.0000000116860974e-07. The clamped eps this pin measures is therefore set by whichever "
+            "earlier test clamped first, which is a torch defect, not a kornia one"
+        )
+
+
 def _assert_degenerate_size_cell(
     func_2d, func_3d, fill, ndim, arg_name, degenerate_size, expected, tols, device, dtype
 ):
     # Shared driver for the two kornia#3940 wart matrices below -- the normalize and
     # denormalize halves differ only in function pair, fill value, tolerances and expected
-    # table -- so the eventual #3940 cleanup edits one body and one MPS-skip site. eps=1e-8 is
+    # table -- so the eventual #3940 cleanup edits one body and one MPS-skip helper. eps=1e-8 is
     # passed explicitly so the pinned literals do not silently track a later change to the default eps
     # while the clamp bug itself is still present.
-    if device.type == "mps":
-        pytest.skip(
-            "torch 2.9.1 caches clamp's scalar min per shape/dtype on MPS -- first value wins: "
-            "z = torch.zeros(2, device='mps'); z.clamp(1e-8) then z.clamp(1e-7) both return "
-            "9.99999993922529e-09, while the same pair on cpu returns 1e-08 then 1.0000000116860974e-07. "
-            "The clamped eps this pin measures is therefore set by whichever earlier test clamped "
-            "first, which is a torch defect, not a kornia one"
-        )
+    _skip_if_mps_clamp_caching(device)
 
     if ndim == "2d":
         sizes = {"height": 5, "width": 7}
@@ -1131,8 +1153,12 @@ def _assert_degenerate_size_cell(
 
     out = func(pts, *sizes.values(), eps=1e-8)
 
-    atol, rtol = tols
-    assert_close(out, torch.tensor([expected], device=device, dtype=dtype), atol=atol, rtol=rtol)
+    expected_t = torch.tensor([expected], device=device, dtype=dtype)
+    if tols is None:
+        assert_close(out, expected_t)
+    else:
+        atol, rtol = tols
+        assert_close(out, expected_t, atol=atol, rtol=rtol)
 
 
 class TestNormalizePixelCoordinates(BaseTester):
@@ -1196,7 +1222,7 @@ class TestNormalizePixelCoordinates(BaseTester):
         out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 4)
 
         expected = torch.tensor([[-1.0, -1.0], [-0.33333333, -0.33333333], [1.0, 1.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
     def test_convention_positional_order_is_height_then_width(self, device, dtype):
         # Convention pin: the positional signature is (pixel_coordinates, height, width), which is
@@ -1209,7 +1235,7 @@ class TestNormalizePixelCoordinates(BaseTester):
         out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 2, 4)
 
         expected = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
     def test_convention_output_is_not_clamped(self, device, dtype):
         # Convention pin: nothing is clamped to [-1, 1] -- out-of-image coordinates extrapolate
@@ -1221,7 +1247,7 @@ class TestNormalizePixelCoordinates(BaseTester):
         out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 4)
 
         expected = torch.tensor([[5.6666667, -1.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
     def test_convention_grid_sample_needs_align_corners_true(self, device, dtype):
         # Convention pin: feeding normalized coordinates to torch.nn.functional.grid_sample
@@ -1238,9 +1264,7 @@ class TestNormalizePixelCoordinates(BaseTester):
 
         sampled_aligned = torch.nn.functional.grid_sample(img, grid, align_corners=True).flatten()
 
-        self.assert_close(
-            sampled_aligned, torch.tensor([0.0, 5.0, 15.0], device=device, dtype=dtype), atol=1e-2, rtol=1e-2
-        )
+        self.assert_close(sampled_aligned, torch.tensor([0.0, 5.0, 15.0], device=device, dtype=dtype))
 
     def test_convention_3d_component_order_is_depth_x_y(self, device, dtype):
         # Convention pin (normalize_pixel_coordinates3d has no test class of its own): the
@@ -1253,13 +1277,11 @@ class TestNormalizePixelCoordinates(BaseTester):
         #                                      -> (1.0, 0.0, 3.0)
         far_corner = torch.tensor([[2.0, 8.0, 4.0]], device=device, dtype=dtype)
         out = kornia.geometry.conversions.normalize_pixel_coordinates3d(far_corner, 3, 5, 9)
-        self.assert_close(out, torch.tensor([[1.0, 1.0, 1.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        self.assert_close(out, torch.tensor([[1.0, 1.0, 1.0]], device=device, dtype=dtype))
 
         swapped = torch.tensor([[2.0, 4.0, 8.0]], device=device, dtype=dtype)
         out_swapped = kornia.geometry.conversions.normalize_pixel_coordinates3d(swapped, 3, 5, 9)
-        self.assert_close(
-            out_swapped, torch.tensor([[1.0, 0.0, 3.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2
-        )
+        self.assert_close(out_swapped, torch.tensor([[1.0, 0.0, 3.0]], device=device, dtype=dtype))
 
     # Wart-pin matrix for kornia#3940, normalizing half: one cell per (size argument x
     # degenerate class) of normalize_pixel_coordinates and normalize_pixel_coordinates3d,
@@ -1314,7 +1336,7 @@ class TestNormalizePixelCoordinates(BaseTester):
             arg_name,
             degenerate_size,
             expected,
-            (1e-2, 1e-2),
+            None,
             device,
             dtype,
         )
@@ -1327,15 +1349,76 @@ class TestNormalizePixelCoordinates(BaseTester):
         #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
         #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1, eps=1e-8)
         #     -> [[199999999.0, 199999999.0]]
-        if device.type == "mps":
-            pytest.skip("same torch 2.9.1 MPS clamp-min caching as _assert_degenerate_size_cell above")
+        _skip_if_mps_clamp_caching(device)
 
         pts = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
 
         out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 1, 1, eps=1e-8)
 
         expected = torch.tensor([[199999999.0, 199999999.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
+
+
+def test_wart_default_eps_1e_8_backs_the_quoted_warning_numbers():
+    # The wart pins in this file pass eps=1e-8 explicitly so their literals do not track the
+    # default, which leaves the default itself pinned by nothing while six docstring warnings
+    # quote numbers that hold only for eps=1e-8: cart2pol (rho = 1e-04 at the origin),
+    # convert_points_from_homogeneous (the -1/3 and +1 relative errors at w = +/-2e-8),
+    # normalize_pixel_coordinates and normalize_pixel_coordinates3d (the 199999999.0 / 2e8
+    # blow-up factor) and denormalize_pixel_coordinates / denormalize_pixel_coordinates3d (the
+    # 5e-09 collapse factor). If this fails, the default moved -- rework those warnings'
+    # numbers together with this list.
+    for op_name in (
+        "cart2pol",
+        "convert_points_from_homogeneous",
+        "normalize_pixel_coordinates",
+        "denormalize_pixel_coordinates",
+        "normalize_pixel_coordinates3d",
+        "denormalize_pixel_coordinates3d",
+    ):
+        op = getattr(kornia.geometry.conversions, op_name)
+        assert inspect.signature(op).parameters["eps"].default == 1e-8, op_name
+
+
+def test_wart_float16_underflowed_default_eps_flips_branches(device):
+    # Wart pins for the float16 sentences of the #3939 and #3938 warnings. float16 is
+    # hardcoded (no dtype fixture) so the pins run in every test configuration: the float16
+    # legs of the wart pins above are skipped because the default eps=1e-8 underflows to 0
+    # there, which is exactly the behavior pinned here. eps is left at its default on purpose
+    # -- the underflow of the *default* is the claim. atol=rtol=0.0 because both claims are
+    # exactness claims: with the float16 default tolerance (1e-3) the eps-biased
+    # rho = 1e-4 of the other branch would still compare equal to 0.
+    # Snippet used to generate expected (torch only, executed on cpu float16):
+    #   cart2pol(torch.tensor(0., dtype=torch.float16), torch.tensor(0., dtype=torch.float16))[0]
+    #     -> 0.0  (not sqrt(eps) = 1e-4: eps underflows the sum inside the sqrt)
+    #   convert_points_from_homogeneous(torch.tensor([[2., 4., 2e-8]], dtype=torch.float16))
+    #     -> [[2., 4.]]  (w underflows to 0 and takes the abs(w) <= eps passthrough branch)
+    zero = torch.tensor(0.0, device=device, dtype=torch.float16)
+    rho = kornia.geometry.conversions.cart2pol(zero, zero)[0]
+    assert_close(rho, zero, atol=0.0, rtol=0.0)
+
+    out = kornia.geometry.conversions.convert_points_from_homogeneous(
+        torch.tensor([[2.0, 4.0, 2e-8]], device=device, dtype=torch.float16)
+    )
+    assert_close(out, torch.tensor([[2.0, 4.0]], device=device, dtype=torch.float16), atol=0.0, rtol=0.0)
+
+
+def test_wart_float16_degenerate_roundtrip_is_inf_then_nan(device):
+    # Wart pin for the float16 sentence of the #3940 warnings, float16-hardcoded like the test
+    # above: with the default eps underflowed to 0, the clamp keeps the degenerate denominator
+    # at 0, the normalized component is inf (not the 2e8 the other dtypes pin) and the
+    # denormalize round trip of that is nan, not the input.
+    # Snippet used to generate expected (torch only, executed on cpu float16):
+    #   normalize_pixel_coordinates(torch.ones(1, 2, dtype=torch.float16), 1, 1) -> [[inf, inf]]
+    #   denormalize_pixel_coordinates(<that>, 1, 1) -> [[nan, nan]]
+    _skip_if_mps_clamp_caching(device)
+
+    ones = torch.ones(1, 2, device=device, dtype=torch.float16)
+    norm = kornia.geometry.conversions.normalize_pixel_coordinates(ones, 1, 1)
+    assert (norm == torch.inf).all()
+
+    denorm = kornia.geometry.conversions.denormalize_pixel_coordinates(norm, 1, 1)
+    assert torch.isnan(denorm).all()
 
 
 class TestDenormalizePixelCoordinates(BaseTester):
@@ -1398,7 +1481,7 @@ class TestDenormalizePixelCoordinates(BaseTester):
         out = kornia.geometry.conversions.denormalize_pixel_coordinates(pts_norm, 2, 4)
 
         expected = torch.tensor([[3.0, 0.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
     def test_convention_roundtrip_denormalize_of_normalize(self, device, dtype):
         # Convention pin: denormalize(normalize(p)) == p on a non-degenerate, non-square,
@@ -1409,7 +1492,7 @@ class TestDenormalizePixelCoordinates(BaseTester):
         norm = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 5, 7)
         out = kornia.geometry.conversions.denormalize_pixel_coordinates(norm, 5, 7)
 
-        self.assert_close(out, pts, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, pts)
 
     def test_convention_3d_component_order_and_roundtrip(self, device, dtype):
         # Convention pin (denormalize_pixel_coordinates3d has no test class of its own): same
@@ -1420,12 +1503,12 @@ class TestDenormalizePixelCoordinates(BaseTester):
         centre = kornia.geometry.conversions.denormalize_pixel_coordinates3d(
             torch.tensor([[0.0, 0.0, 0.0]], device=device, dtype=dtype), 3, 5, 9
         )
-        self.assert_close(centre, torch.tensor([[1.0, 4.0, 2.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        self.assert_close(centre, torch.tensor([[1.0, 4.0, 2.0]], device=device, dtype=dtype))
 
         pts = torch.tensor([[1.0, 2.0, 3.0]], device=device, dtype=dtype)
         norm = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 3, 5, 9)
         out = kornia.geometry.conversions.denormalize_pixel_coordinates3d(norm, 3, 5, 9)
-        self.assert_close(out, pts, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, pts)
 
     # Wart-pin matrix for kornia#3940, denormalizing half: one cell per (size argument x
     # degenerate class) of denormalize_pixel_coordinates and denormalize_pixel_coordinates3d,
@@ -1590,7 +1673,7 @@ class TestDenormalizePointsWithIntrinsics(BaseTester):
         out = kornia.geometry.conversions.denormalize_points_with_intrinsics(points_norm, camera_matrix)
 
         expected = torch.tensor([[420.0, 440.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
 
 class TestNormalizePointsWithIntrinsics(BaseTester):
@@ -1666,7 +1749,7 @@ class TestNormalizePointsWithIntrinsics(BaseTester):
         out = kornia.geometry.conversions.normalize_points_with_intrinsics(points_2d, camera_matrix)
 
         expected = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
     def test_convention_skew_term_is_ignored(self, device, dtype):
         # Convention pin: only the diagonal fx, fy and the [:2, 2] column of K are read -- the
@@ -1682,7 +1765,7 @@ class TestNormalizePointsWithIntrinsics(BaseTester):
         out = kornia.geometry.conversions.normalize_points_with_intrinsics(points_2d, camera_matrix)
 
         expected = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        self.assert_close(out, expected)
 
 
 class TestRt2Extrinsics(BaseTester):

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -837,8 +837,9 @@ class TestPolCartConversions(BaseTester):
     def test_convention_positive_rotation_decreases_cart2pol_phi(self, device, dtype):
         # Cross-symbol convention pin: angle_to_rotation_matrix and cart2pol use *opposite*
         # angle senses in the same (x, y) plane. Applying angle_to_rotation_matrix(+theta) to a
-        # point decreases that point's cart2pol phi by exactly theta, so neither symbol may be
-        # documented with a bare "positive angle = counter-clockwise".
+        # nonzero point decreases that point's cart2pol phi by theta modulo 2*pi, so neither
+        # symbol may be documented with a bare "positive angle = counter-clockwise".
+        # First case: no branch-cut crossing, so the raw difference is -theta itself.
         # Snippet used to generate expected (stdlib only):
         #   import math
         #   -math.radians(30.0) -> -0.5235987755982988
@@ -851,6 +852,27 @@ class TestPolCartConversions(BaseTester):
 
         expected_delta = torch.tensor(-0.5235987755982988, device=device, dtype=dtype)
         self.assert_close(phi1 - phi0, expected_delta, atol=1e-2, rtol=1e-2)
+
+        # Second case: crossing the -x branch cut. A point at phi = -170 deg rotated by
+        # theta = +30 deg comes back with phi re-wrapped into [-pi, pi]: the returned phi is
+        # +160 deg, not -200 deg, so the raw difference is +330 deg and only the difference
+        # modulo 2*pi is -theta.
+        # Snippet used to generate expected (stdlib only):
+        #   import math
+        #   5 * math.cos(math.radians(-170.0)), 5 * math.sin(math.radians(-170.0))
+        #     -> (-4.92403876506104, -0.8682408883346514)
+        #   math.radians(160.0) -> 2.792526803190927
+        w = torch.tensor([-4.9240388, -0.8682409], device=device, dtype=dtype)
+        phi0_cut = kornia.geometry.conversions.cart2pol(w[0], w[1])[1]
+
+        w_rot = rot @ w
+        phi1_cut = kornia.geometry.conversions.cart2pol(w_rot[0], w_rot[1])[1]
+
+        self.assert_close(phi1_cut, torch.tensor(2.7925268, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+
+        raw_delta = phi1_cut - phi0_cut
+        wrapped_delta = torch.atan2(torch.sin(raw_delta), torch.cos(raw_delta))
+        self.assert_close(wrapped_delta, expected_delta, atol=1e-2, rtol=1e-2)
 
 
 class TestConvertPointsToHomogeneous(BaseTester):
@@ -1214,30 +1236,48 @@ class TestNormalizePixelCoordinates(BaseTester):
             out_swapped, torch.tensor([[1.0, 0.0, 3.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2
         )
 
-    def test_wart_degenerate_size_is_accepted_and_explodes(self, device, dtype):
-        # Wart pin for #3940: asserts the CURRENT broken output that the docstring warnings
-        # document. If this test fails, #3940 was (partly) fixed -- update or remove the four
-        # warnings in normalize_pixel_coordinates, denormalize_pixel_coordinates,
-        # normalize_pixel_coordinates3d and denormalize_pixel_coordinates3d. This is NOT a
-        # contract that degenerate sizes must keep returning these values.
-        # It is a regular test rather than a strict xfail on purpose: the intended behavior
-        # (raise ValueError, or clamp the *output*, or keep the current pass-through) is a
-        # maintainer decision, and a strict xfail asserting one of those answers would stay
-        # silently XFAIL forever if a different one were chosen. A wart pin flips loudly under
-        # every polarity, because any validation fix stops returning 199999999.0.
-        # Snippet used to generate expected (torch only):
-        #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
-        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1) -> [[199999999.0, 199999999.0]]
-        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 4, -3) -> [[199999999.0, -0.3333333333333334]]
-        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 4, 0) -> [[199999999.0, -0.3333333333333334]]
-        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 0, 4) -> [[-0.3333333333333334, 199999999.0]]
-        # The mechanism is `(hw - 1).clamp(eps)`: size 1 gives 0, size 0 gives -1 and a negative
-        # size gives a more negative denominator, all clamped up to eps = 1e-8, so the factor
-        # becomes 2e8. All three of the sizes the #3940 warnings name (1, 0, negative) are pinned
-        # literally, so a fix that special-cases only one of them still flips this test. The
-        # height=0 leg is pinned too, so a fix that validates only `width` also flips it.
-        # At float16 2e8 overflows to inf and the same literal overflows identically, so the
-        # comparison stays meaningful at every dtype.
+    # Wart-pin matrix for kornia#3940, normalizing half: one cell per (size argument x
+    # degenerate class) of normalize_pixel_coordinates and normalize_pixel_coordinates3d,
+    # asserting the CURRENT broken output that the docstring warnings document. If any cell
+    # fails, #3940 was (partly) fixed -- update or remove the degenerate-size warnings in
+    # normalize_pixel_coordinates, denormalize_pixel_coordinates, normalize_pixel_coordinates3d
+    # and denormalize_pixel_coordinates3d. The cells are NOT a contract that degenerate sizes
+    # must keep returning these values.
+    # They are regular tests rather than strict xfails on purpose: the intended behavior
+    # (raise ValueError, or clamp the *output*, or keep the current pass-through) is a
+    # maintainer decision, and a strict xfail asserting one of those answers would stay
+    # silently XFAIL forever if a different one were chosen. A wart pin flips loudly under
+    # every polarity, and covering the full matrix means any partial fix -- one function, one
+    # argument, or one degenerate class -- flips at least one cell.
+    # Exactly one size argument is degenerate per cell (the others stay at 5/7 in 2-D and
+    # 5/7/9 in 3-D), so the finite components pin which argument was degenerated. All three
+    # classes give the same output because the mechanism is `(size - 1).clamp(eps)`: size 1
+    # gives 0, size 0 gives -1 and size -3 gives -4, all clamped up to eps = 1e-8, so the
+    # factor becomes 2e8.
+    # Snippet used to generate expected (torch only; same output for bad in (1, 0, -3)):
+    #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
+    #   npc3 = kornia.geometry.conversions.normalize_pixel_coordinates3d
+    #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), bad, 7) -> [[-0.6666666666666667, 199999999.0]]
+    #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 5, bad) -> [[199999999.0, -0.5]]
+    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), bad, 7, 9)
+    #     -> [[199999999.0, -0.75, -0.6666666666666667]]
+    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 5, bad, 9) -> [[-0.5, -0.75, 199999999.0]]
+    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 5, 7, bad) -> [[-0.5, 199999999.0, -0.6666666666666667]]
+    # At float16 2e8 overflows to inf and the literal overflows identically; at bfloat16 both
+    # sides round to 200278016.0, so the comparison stays meaningful at every dtype.
+    @pytest.mark.parametrize("degenerate_size", [1, 0, -3], ids=["one", "zero", "negative"])
+    @pytest.mark.parametrize(
+        ("ndim", "arg_name", "expected"),
+        [
+            ("2d", "height", [-0.6666667, 199999999.0]),
+            ("2d", "width", [199999999.0, -0.5]),
+            ("3d", "depth", [199999999.0, -0.75, -0.6666667]),
+            ("3d", "height", [-0.5, -0.75, 199999999.0]),
+            ("3d", "width", [-0.5, 199999999.0, -0.6666667]),
+        ],
+        ids=["2d-height", "2d-width", "3d-depth", "3d-height", "3d-width"],
+    )
+    def test_wart_degenerate_size_matrix(self, ndim, arg_name, degenerate_size, expected, device, dtype):
         if device.type == "mps":
             pytest.skip(
                 "torch 2.9.1 caches clamp's scalar min per shape/dtype on MPS -- first value wins: "
@@ -1247,48 +1287,34 @@ class TestNormalizePixelCoordinates(BaseTester):
                 "first, which is a torch defect, not a kornia one"
             )
 
+        if ndim == "2d":
+            sizes = {"height": 5, "width": 7}
+            func = kornia.geometry.conversions.normalize_pixel_coordinates
+        else:
+            sizes = {"depth": 5, "height": 7, "width": 9}
+            func = kornia.geometry.conversions.normalize_pixel_coordinates3d
+        sizes[arg_name] = degenerate_size
+        pts = torch.ones(1, len(sizes), device=device, dtype=dtype)
+
+        out = func(pts, *sizes.values())
+
+        self.assert_close(out, torch.tensor([expected], device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+
+    def test_wart_all_size_arguments_degenerate_together(self, device, dtype):
+        # Wart pin for kornia#3940, companion to the matrix above: both sizes degenerate at
+        # once also passes silently, exploding every component. Flips together with the matrix
+        # when #3940 is fixed -- see the cleanup note above the matrix.
+        # Snippet used to generate expected (torch only):
+        #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
+        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1) -> [[199999999.0, 199999999.0]]
+        if device.type == "mps":
+            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the wart matrix above")
+
         pts = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
 
-        degenerate = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 1, 1)
+        out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 1, 1)
+
         expected = torch.tensor([[199999999.0, 199999999.0]], device=device, dtype=dtype)
-        self.assert_close(degenerate, expected, atol=1e-2, rtol=1e-2)
-
-        negative_width = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, -3)
-        expected_negative = torch.tensor([[199999999.0, -0.33333333]], device=device, dtype=dtype)
-        self.assert_close(negative_width, expected_negative, atol=1e-2, rtol=1e-2)
-
-        zero_width = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 0)
-        self.assert_close(zero_width, expected_negative, atol=1e-2, rtol=1e-2)
-
-        zero_height = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 0, 4)
-        expected_zero_height = torch.tensor([[-0.33333333, 199999999.0]], device=device, dtype=dtype)
-        self.assert_close(zero_height, expected_zero_height, atol=1e-2, rtol=1e-2)
-
-    def test_wart_degenerate_size_3d_is_accepted_and_explodes(self, device, dtype):
-        # Wart pin for #3940, 3-D sibling: asserts the CURRENT broken output that the docstring
-        # warnings document. If this test fails, #3940 was (partly) fixed -- update or remove the
-        # four warnings in normalize_pixel_coordinates, denormalize_pixel_coordinates,
-        # normalize_pixel_coordinates3d and denormalize_pixel_coordinates3d. This is NOT a
-        # contract that degenerate sizes must keep returning these values; see the polarity note
-        # on the 2-D wart pin above.
-        # Snippet used to generate expected (torch only):
-        #   npc3 = kornia.geometry.conversions.normalize_pixel_coordinates3d
-        #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 1, 5, 9)
-        #     -> [[199999999.0, -0.75, -0.5]]
-        #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 0, 5, 9)
-        #     -> [[199999999.0, -0.75, -0.5]]   (depth 0 is pinned literally as well as depth 1)
-        # Only the depth axis is degenerate here: x and y still use width 9 and height 5, so
-        # 2 * 1 / 8 - 1 = -0.75 and 2 * 1 / 4 - 1 = -0.5 stay finite next to the exploded depth.
-        if device.type == "mps":
-            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the 2-D wart pin above")
-
-        pts = torch.tensor([[1.0, 1.0, 1.0]], device=device, dtype=dtype)
-
-        out = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 1, 5, 9)
-        zero_depth = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 0, 5, 9)
-
-        expected = torch.tensor([[199999999.0, -0.75, -0.5]], device=device, dtype=dtype)
-        self.assert_close(zero_depth, expected, atol=1e-2, rtol=1e-2)
         self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
 
@@ -1381,56 +1407,58 @@ class TestDenormalizePixelCoordinates(BaseTester):
         out = kornia.geometry.conversions.denormalize_pixel_coordinates3d(norm, 3, 5, 9)
         self.assert_close(out, pts, atol=1e-2, rtol=1e-2)
 
-    def test_wart_degenerate_size_collapses_instead_of_exploding(self, device, dtype):
-        # Wart pin for #3940, denormalizing half: asserts the CURRENT broken output that the
-        # docstring warnings document. If this test fails, #3940 was (partly) fixed -- update or
-        # remove the four warnings in normalize_pixel_coordinates,
-        # denormalize_pixel_coordinates, normalize_pixel_coordinates3d and
-        # denormalize_pixel_coordinates3d. This is NOT a contract that degenerate sizes must keep
-        # returning these values.
-        # It is a regular test rather than a strict xfail on purpose: the intended behavior
-        # (raise ValueError, or clamp, or keep the current pass-through) is a maintainer
-        # decision, and a strict xfail asserting one of those answers would stay silently XFAIL
-        # forever if a different one were chosen. A wart pin flips loudly under every polarity.
-        # Snippet used to generate expected (torch only):
-        #   dpc = kornia.geometry.conversions.denormalize_pixel_coordinates
-        #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 4, 1) -> [[5e-09, 1.5]]
-        #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 4, 0) -> [[5e-09, 1.5]]
-        #   dpc3 = kornia.geometry.conversions.denormalize_pixel_coordinates3d
-        #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 1, 5, 9) -> [[5e-09, 4.0, 2.0]]
-        #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 0, 5, 9) -> [[5e-09, 4.0, 2.0]]
-        # Both size 1 and a literal size 0 are pinned, so a fix that special-cases only one of the
-        # sizes the #3940 warnings name still flips this test.
-        # Here the clamped denominator multiplies instead of divides, so the degenerate axis
-        # collapses to eps / 2 = 5e-09 rather than exploding to 2e8. The tolerance is tight
-        # (rtol 1e-6, atol 0) on purpose: at atol 1e-2 the collapsed component would compare
-        # equal to any small number, including the 0.0 a "clamp the output" fix might return.
-        # It still holds at every dtype -- at float16 5e-09 underflows to 0.0 on both the
-        # measured and the literal side, and at bfloat16 both round to 5.005858838558197e-09.
+    # Wart-pin matrix for kornia#3940, denormalizing half: one cell per (size argument x
+    # degenerate class) of denormalize_pixel_coordinates and denormalize_pixel_coordinates3d,
+    # asserting the CURRENT broken output that the docstring warnings document. If any cell
+    # fails, #3940 was (partly) fixed -- update or remove the degenerate-size warnings in
+    # normalize_pixel_coordinates, denormalize_pixel_coordinates, normalize_pixel_coordinates3d
+    # and denormalize_pixel_coordinates3d. The cells are NOT a contract that degenerate sizes
+    # must keep returning these values; see the polarity note on the normalize wart matrix,
+    # which also explains why exactly one argument is degenerate per cell and why all three
+    # classes (1, 0, -3) give the same output.
+    # Here the clamped denominator multiplies instead of divides, so the degenerate axis
+    # collapses to eps / 2 = 5e-09 rather than exploding to 2e8. The tolerance is tight
+    # (rtol 1e-6, atol 0) on purpose: at atol 1e-2 the collapsed component would compare
+    # equal to any small number, including the 0.0 a "clamp the output" fix might return.
+    # It still holds at every dtype -- at float16 5e-09 underflows to 0.0 on both the
+    # measured and the literal side, at bfloat16 both round to 5.005858838558197e-09, and the
+    # finite components 2.0/3.0/4.0 are exact in every dtype.
+    # Snippet used to generate expected (torch only; same output for bad in (1, 0, -3)):
+    #   dpc = kornia.geometry.conversions.denormalize_pixel_coordinates
+    #   dpc3 = kornia.geometry.conversions.denormalize_pixel_coordinates3d
+    #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), bad, 7) -> [[3.0, 5e-09]]
+    #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 5, bad) -> [[5e-09, 2.0]]
+    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), bad, 7, 9) -> [[5e-09, 4.0, 3.0]]
+    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 5, bad, 9) -> [[2.0, 4.0, 5e-09]]
+    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 5, 7, bad) -> [[2.0, 5e-09, 3.0]]
+    @pytest.mark.parametrize("degenerate_size", [1, 0, -3], ids=["one", "zero", "negative"])
+    @pytest.mark.parametrize(
+        ("ndim", "arg_name", "expected"),
+        [
+            ("2d", "height", [3.0, 5e-09]),
+            ("2d", "width", [5e-09, 2.0]),
+            ("3d", "depth", [5e-09, 4.0, 3.0]),
+            ("3d", "height", [2.0, 4.0, 5e-09]),
+            ("3d", "width", [2.0, 5e-09, 3.0]),
+        ],
+        ids=["2d-height", "2d-width", "3d-depth", "3d-height", "3d-width"],
+    )
+    def test_wart_degenerate_size_matrix(self, ndim, arg_name, degenerate_size, expected, device, dtype):
         if device.type == "mps":
-            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the normalize wart pins")
+            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the normalize wart matrix")
 
-        out = kornia.geometry.conversions.denormalize_pixel_coordinates(
-            torch.tensor([[0.0, 0.0]], device=device, dtype=dtype), 4, 1
-        )
-        self.assert_close(out, torch.tensor([[5e-09, 1.5]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
+        if ndim == "2d":
+            sizes = {"height": 5, "width": 7}
+            func = kornia.geometry.conversions.denormalize_pixel_coordinates
+        else:
+            sizes = {"depth": 5, "height": 7, "width": 9}
+            func = kornia.geometry.conversions.denormalize_pixel_coordinates3d
+        sizes[arg_name] = degenerate_size
+        pts = torch.zeros(1, len(sizes), device=device, dtype=dtype)
 
-        out_zero = kornia.geometry.conversions.denormalize_pixel_coordinates(
-            torch.tensor([[0.0, 0.0]], device=device, dtype=dtype), 4, 0
-        )
-        self.assert_close(out_zero, torch.tensor([[5e-09, 1.5]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
+        out = func(pts, *sizes.values())
 
-        out3d = kornia.geometry.conversions.denormalize_pixel_coordinates3d(
-            torch.tensor([[0.0, 0.0, 0.0]], device=device, dtype=dtype), 1, 5, 9
-        )
-        self.assert_close(out3d, torch.tensor([[5e-09, 4.0, 2.0]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
-
-        out3d_zero = kornia.geometry.conversions.denormalize_pixel_coordinates3d(
-            torch.tensor([[0.0, 0.0, 0.0]], device=device, dtype=dtype), 0, 5, 9
-        )
-        self.assert_close(
-            out3d_zero, torch.tensor([[5e-09, 4.0, 2.0]], device=device, dtype=dtype), atol=0.0, rtol=1e-6
-        )
+        self.assert_close(out, torch.tensor([expected], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
 
 
 class TestProjectPoints(BaseTester):

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -643,6 +643,99 @@ class TestRadDegConversions(BaseTester):
         expected_rad = torch.tensor([[0.99962422, 0.02741213], [-0.02741213, 0.99962422]], device=device, dtype=dtype)
         self.assert_close(out_rad, expected_rad, atol=1e-2, rtol=1e-2)
 
+    @pytest.mark.xfail(reason="kornia.constants.pi is float32, so f64 loses ~7 digits — kornia#3937", strict=True)
+    def test_convention_deg2rad_of_180_is_exactly_pi_in_float64(self, device, dtype):
+        # Intended behavior, second half of the #3937 pair: deg2rad is exact to the precision of
+        # its input dtype, like torch.deg2rad. It is not: deg2rad multiplies by
+        # kornia.constants.pi / 180, and that constant is a *float32* tensor merely cast to the
+        # input dtype, so a float64 input carries a systematic ~2.8e-8 relative error.
+        # Marked xfail(strict=True) so fixing #3937 makes this XPASS and forces the mark out.
+        # Snippet used to generate expected (stdlib + torch):
+        #   (180.0 * math.pi) / 180.0 == math.pi  -> True, so an unbiased impl is exact
+        #   kornia deg2rad(tensor(180., f64)).item() -> 3.1415927410125732
+        #   that value - math.pi -> 8.742278012618954e-08
+        if dtype != torch.float64:
+            pytest.skip("float64-only claim: at float32 the float32 pi *is* the correctly rounded constant")
+
+        out = kornia.geometry.conversions.deg2rad(torch.tensor(180.0, device=device, dtype=dtype))
+        expected = torch.tensor(torch.pi, device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-12, rtol=1e-12)
+
+    @pytest.mark.xfail(reason="angle_to_rotation_matrix inherits the float32-pi defect — kornia#3937", strict=True)
+    def test_convention_angle_to_rotation_matrix_90_is_the_exact_quarter_turn_in_float64(self, device, dtype):
+        # Intended behavior, downstream half of the #3937 pair: angle_to_rotation_matrix(90) is
+        # the exact quarter turn [[0, 1], [-1, 0]] to the precision of its input dtype. It is not:
+        # the degrees-to-radians step is deg2rad, so the float32 pi leaks into the angle and the
+        # cosine comes out as -4.371139e-08 instead of ~6.1e-17.
+        # Marked xfail(strict=True) so fixing #3937 makes this XPASS and forces the mark out.
+        # Snippet used to generate expected (stdlib + torch):
+        #   torch.cos(torch.tensor(math.pi / 2, dtype=torch.float64)) -> 6.123233995736766e-17
+        #   kornia angle_to_rotation_matrix(tensor(90., f64)).flatten().tolist() ->
+        #     [-4.371139000186241e-08, 0.999999999999999, -0.999999999999999, -4.371139000186241e-08]
+        # atol/rtol 1e-12 sits between the two: it rejects the current 4.4e-8 cosine and accepts
+        # the 6.1e-17 an unbiased constant would give.
+        if dtype != torch.float64:
+            pytest.skip("float64-only claim: at float32 the float32 pi *is* the correctly rounded constant")
+
+        out = kornia.geometry.conversions.angle_to_rotation_matrix(torch.tensor(90.0, device=device, dtype=dtype))
+        expected = torch.tensor([[0.0, 1.0], [-1.0, 0.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-12, rtol=1e-12)
+
+    def test_wart_rad2deg_of_integer_input_divides_by_three(self, device):
+        # Wart pin for #3937: asserts the CURRENT broken output that the docstring warning
+        # documents. If this test fails, #3937 was (partly) fixed -- update or remove the warnings
+        # in rad2deg, deg2rad and angle_to_rotation_matrix and flip/remove the three
+        # test_convention_* xfails above. This is NOT a contract that int inputs must keep
+        # returning these values.
+        # It is a regular test rather than a strict xfail on purpose: what an integer input
+        # *should* do (promote to float like torch.rad2deg, or raise) is a maintainer decision,
+        # and a strict xfail asserting the promoted-float answer would stay silently XFAIL forever
+        # if the fix chose to raise. A wart pin flips loudly under either polarity.
+        # Snippet used to generate expected (torch only):
+        #   kornia rad2deg(torch.tensor([1, 2, 3])) -> tensor([ 60., 120., 180.]), dtype float32
+        #   torch.rad2deg(torch.tensor([1, 2, 3]))  -> tensor([ 57.2958, 114.5916, 171.8873])
+        # kornia.constants.pi is cast to the *integer* input dtype and truncates to 3.
+        out = kornia.geometry.conversions.rad2deg(torch.tensor([1, 2, 3], device=device))
+
+        assert out.dtype == torch.float32
+        expected = torch.tensor([60.0, 120.0, 180.0], device=device, dtype=torch.float32)
+        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
+    def test_wart_deg2rad_of_integer_input_multiplies_by_three(self, device):
+        # Wart pin for #3937: asserts the CURRENT broken output that the docstring warning
+        # documents. If this test fails, #3937 was (partly) fixed -- update or remove the warnings
+        # in rad2deg, deg2rad and angle_to_rotation_matrix and flip/remove the three
+        # test_convention_* xfails above. This is NOT a contract that int inputs must keep
+        # returning these values; see the polarity note on the rad2deg wart pin above.
+        # Snippet used to generate expected (torch only):
+        #   kornia deg2rad(torch.tensor([180, 90])) -> tensor([3.0000, 1.5000]), dtype float32
+        #   torch.deg2rad(torch.tensor([180, 90]))  -> tensor([3.1416, 1.5708])
+        out = kornia.geometry.conversions.deg2rad(torch.tensor([180, 90], device=device))
+
+        assert out.dtype == torch.float32
+        expected = torch.tensor([3.0, 1.5], device=device, dtype=torch.float32)
+        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
+    def test_wart_angle_to_rotation_matrix_of_integer_angle(self, device):
+        # Wart pin for #3937: asserts the CURRENT broken output that the docstring warning
+        # documents. If this test fails, #3937 was (partly) fixed -- update or remove the warnings
+        # in rad2deg, deg2rad and angle_to_rotation_matrix and flip/remove the three
+        # test_convention_* xfails above. This is NOT a contract that int inputs must keep
+        # returning these values; see the polarity note on the rad2deg wart pin above.
+        # This is the downstream case: an integer angle reaches deg2rad, which turns 90 degrees
+        # into 90 * 3 / 180 = 1.5 radians, so the matrix is nowhere near the quarter turn.
+        # Snippet used to generate expected (torch only):
+        #   kornia angle_to_rotation_matrix(torch.tensor([90])).flatten().tolist() ->
+        #     [0.07073719799518585, 0.9974949955940247, -0.9974949955940247, 0.07073719799518585]
+        #   math.cos(1.5), math.sin(1.5) -> (0.0707372016677029, 0.9974949866040544)
+        out = kornia.geometry.conversions.angle_to_rotation_matrix(torch.tensor([90], device=device))
+
+        assert out.dtype == torch.float32
+        expected = torch.tensor(
+            [[[0.07073720, 0.99749500], [-0.99749500, 0.07073720]]], device=device, dtype=torch.float32
+        )
+        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
 
 class TestPolCartConversions(BaseTester):
     def test_smoke(self, device, dtype):
@@ -971,11 +1064,13 @@ class TestConvertPointsFromHomogeneous(BaseTester):
     @pytest.mark.xfail(reason="convert_points_from_homogeneous divides by w + eps — kornia#3938", strict=True)
     def test_convention_divides_by_exactly_w(self, device, dtype):
         # Intended behavior: for |w| > eps the point is divided by exactly w. It currently is
-        # divided by w + eps with no regard for sign, which is 33 % low at w = +2e-8 and 100 %
-        # high at w = -2e-8, and leaves a permanent ~eps/w relative bias everywhere (#3938).
+        # divided by w + eps with no regard for sign, so the signed relative error is exactly
+        # -eps / (w + eps): -1/3 at w = +2e-8 (33 % low) and +1 at w = -2e-8 (100 % high) (#3938).
         # Marked xfail(strict=True) so fixing #3938 makes this XPASS and forces the mark out.
         # Snippet used to generate expected (by hand):
         #   2 / 2e-8, 4 / 2e-8 -> [1e8, 2e8]  (kornia returns [6.6666667e7, 1.3333333e8])
+        #   measured signed relative error in float64: -0.3333333333333334, and
+        #   -eps / (w + eps) = -1e-8 / 3e-8 = -0.3333333333333333
         if dtype == torch.float16:
             pytest.skip("float16 underflows w=2e-8 to 0, which is the |w| <= eps passthrough branch, not the eps bias")
 
@@ -1119,6 +1214,67 @@ class TestNormalizePixelCoordinates(BaseTester):
             out_swapped, torch.tensor([[1.0, 0.0, 3.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2
         )
 
+    def test_wart_degenerate_size_is_accepted_and_explodes(self, device, dtype):
+        # Wart pin for #3940: asserts the CURRENT broken output that the docstring warnings
+        # document. If this test fails, #3940 was (partly) fixed -- update or remove the four
+        # warnings in normalize_pixel_coordinates, denormalize_pixel_coordinates,
+        # normalize_pixel_coordinates3d and denormalize_pixel_coordinates3d. This is NOT a
+        # contract that degenerate sizes must keep returning these values.
+        # It is a regular test rather than a strict xfail on purpose: the intended behavior
+        # (raise ValueError, or clamp the *output*, or keep the current pass-through) is a
+        # maintainer decision, and a strict xfail asserting one of those answers would stay
+        # silently XFAIL forever if a different one were chosen. A wart pin flips loudly under
+        # every polarity, because any validation fix stops returning 199999999.0.
+        # Snippet used to generate expected (torch only):
+        #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
+        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1) -> [[199999999.0, 199999999.0]]
+        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 4, -3) -> [[199999999.0, -0.3333333333333334]]
+        # The mechanism is `(hw - 1).clamp(eps)`: size 1 gives 0 and a negative size gives a
+        # negative denominator, both clamped up to eps = 1e-8, so the factor becomes 2e8.
+        # At float16 2e8 overflows to inf and the same literal overflows identically, so the
+        # comparison stays meaningful at every dtype.
+        if device.type == "mps":
+            pytest.skip(
+                "torch 2.9.1 caches clamp's scalar min per shape/dtype on MPS -- first value wins: "
+                "z = torch.zeros(2, device='mps'); z.clamp(1e-8) then z.clamp(1e-7) both return "
+                "9.99999993922529e-09, while the same pair on cpu returns 1e-08 then 1.0000000116860974e-07. "
+                "The clamped eps this pin measures is therefore set by whichever earlier test clamped "
+                "first, which is a torch defect, not a kornia one"
+            )
+
+        pts = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
+
+        degenerate = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 1, 1)
+        expected = torch.tensor([[199999999.0, 199999999.0]], device=device, dtype=dtype)
+        self.assert_close(degenerate, expected, atol=1e-2, rtol=1e-2)
+
+        negative_width = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, -3)
+        expected_negative = torch.tensor([[199999999.0, -0.33333333]], device=device, dtype=dtype)
+        self.assert_close(negative_width, expected_negative, atol=1e-2, rtol=1e-2)
+
+    def test_wart_degenerate_size_3d_is_accepted_and_explodes(self, device, dtype):
+        # Wart pin for #3940, 3-D sibling: asserts the CURRENT broken output that the docstring
+        # warnings document. If this test fails, #3940 was (partly) fixed -- update or remove the
+        # four warnings in normalize_pixel_coordinates, denormalize_pixel_coordinates,
+        # normalize_pixel_coordinates3d and denormalize_pixel_coordinates3d. This is NOT a
+        # contract that degenerate sizes must keep returning these values; see the polarity note
+        # on the 2-D wart pin above.
+        # Snippet used to generate expected (torch only):
+        #   npc3 = kornia.geometry.conversions.normalize_pixel_coordinates3d
+        #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 1, 5, 9)
+        #     -> [[199999999.0, -0.75, -0.5]]
+        # Only the depth axis is degenerate here: x and y still use width 9 and height 5, so
+        # 2 * 1 / 8 - 1 = -0.75 and 2 * 1 / 4 - 1 = -0.5 stay finite next to the exploded depth.
+        if device.type == "mps":
+            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the 2-D wart pin above")
+
+        pts = torch.tensor([[1.0, 1.0, 1.0]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 1, 5, 9)
+
+        expected = torch.tensor([[199999999.0, -0.75, -0.5]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
 
 class TestDenormalizePixelCoordinates(BaseTester):
     def test_tensor_bhw2(self, device, dtype):
@@ -1208,6 +1364,41 @@ class TestDenormalizePixelCoordinates(BaseTester):
         norm = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 3, 5, 9)
         out = kornia.geometry.conversions.denormalize_pixel_coordinates3d(norm, 3, 5, 9)
         self.assert_close(out, pts, atol=1e-2, rtol=1e-2)
+
+    def test_wart_degenerate_size_collapses_instead_of_exploding(self, device, dtype):
+        # Wart pin for #3940, denormalizing half: asserts the CURRENT broken output that the
+        # docstring warnings document. If this test fails, #3940 was (partly) fixed -- update or
+        # remove the four warnings in normalize_pixel_coordinates,
+        # denormalize_pixel_coordinates, normalize_pixel_coordinates3d and
+        # denormalize_pixel_coordinates3d. This is NOT a contract that degenerate sizes must keep
+        # returning these values.
+        # It is a regular test rather than a strict xfail on purpose: the intended behavior
+        # (raise ValueError, or clamp, or keep the current pass-through) is a maintainer
+        # decision, and a strict xfail asserting one of those answers would stay silently XFAIL
+        # forever if a different one were chosen. A wart pin flips loudly under every polarity.
+        # Snippet used to generate expected (torch only):
+        #   dpc = kornia.geometry.conversions.denormalize_pixel_coordinates
+        #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 4, 1) -> [[5e-09, 1.5]]
+        #   dpc3 = kornia.geometry.conversions.denormalize_pixel_coordinates3d
+        #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 1, 5, 9) -> [[5e-09, 4.0, 2.0]]
+        # Here the clamped denominator multiplies instead of divides, so the degenerate axis
+        # collapses to eps / 2 = 5e-09 rather than exploding to 2e8. The tolerance is tight
+        # (rtol 1e-6, atol 0) on purpose: at atol 1e-2 the collapsed component would compare
+        # equal to any small number, including the 0.0 a "clamp the output" fix might return.
+        # It still holds at every dtype -- at float16 5e-09 underflows to 0.0 on both the
+        # measured and the literal side, and at bfloat16 both round to 5.005858838558197e-09.
+        if device.type == "mps":
+            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the normalize wart pins")
+
+        out = kornia.geometry.conversions.denormalize_pixel_coordinates(
+            torch.tensor([[0.0, 0.0]], device=device, dtype=dtype), 4, 1
+        )
+        self.assert_close(out, torch.tensor([[5e-09, 1.5]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
+
+        out3d = kornia.geometry.conversions.denormalize_pixel_coordinates3d(
+            torch.tensor([[0.0, 0.0, 0.0]], device=device, dtype=dtype), 1, 5, 9
+        )
+        self.assert_close(out3d, torch.tensor([[5e-09, 4.0, 2.0]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
 
 
 class TestProjectPoints(BaseTester):

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -1229,8 +1229,13 @@ class TestNormalizePixelCoordinates(BaseTester):
         #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
         #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1) -> [[199999999.0, 199999999.0]]
         #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 4, -3) -> [[199999999.0, -0.3333333333333334]]
-        # The mechanism is `(hw - 1).clamp(eps)`: size 1 gives 0 and a negative size gives a
-        # negative denominator, both clamped up to eps = 1e-8, so the factor becomes 2e8.
+        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 4, 0) -> [[199999999.0, -0.3333333333333334]]
+        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 0, 4) -> [[-0.3333333333333334, 199999999.0]]
+        # The mechanism is `(hw - 1).clamp(eps)`: size 1 gives 0, size 0 gives -1 and a negative
+        # size gives a more negative denominator, all clamped up to eps = 1e-8, so the factor
+        # becomes 2e8. All three of the sizes the #3940 warnings name (1, 0, negative) are pinned
+        # literally, so a fix that special-cases only one of them still flips this test. The
+        # height=0 leg is pinned too, so a fix that validates only `width` also flips it.
         # At float16 2e8 overflows to inf and the same literal overflows identically, so the
         # comparison stays meaningful at every dtype.
         if device.type == "mps":
@@ -1252,6 +1257,13 @@ class TestNormalizePixelCoordinates(BaseTester):
         expected_negative = torch.tensor([[199999999.0, -0.33333333]], device=device, dtype=dtype)
         self.assert_close(negative_width, expected_negative, atol=1e-2, rtol=1e-2)
 
+        zero_width = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 0)
+        self.assert_close(zero_width, expected_negative, atol=1e-2, rtol=1e-2)
+
+        zero_height = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 0, 4)
+        expected_zero_height = torch.tensor([[-0.33333333, 199999999.0]], device=device, dtype=dtype)
+        self.assert_close(zero_height, expected_zero_height, atol=1e-2, rtol=1e-2)
+
     def test_wart_degenerate_size_3d_is_accepted_and_explodes(self, device, dtype):
         # Wart pin for #3940, 3-D sibling: asserts the CURRENT broken output that the docstring
         # warnings document. If this test fails, #3940 was (partly) fixed -- update or remove the
@@ -1263,6 +1275,8 @@ class TestNormalizePixelCoordinates(BaseTester):
         #   npc3 = kornia.geometry.conversions.normalize_pixel_coordinates3d
         #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 1, 5, 9)
         #     -> [[199999999.0, -0.75, -0.5]]
+        #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 0, 5, 9)
+        #     -> [[199999999.0, -0.75, -0.5]]   (depth 0 is pinned literally as well as depth 1)
         # Only the depth axis is degenerate here: x and y still use width 9 and height 5, so
         # 2 * 1 / 8 - 1 = -0.75 and 2 * 1 / 4 - 1 = -0.5 stay finite next to the exploded depth.
         if device.type == "mps":
@@ -1271,8 +1285,10 @@ class TestNormalizePixelCoordinates(BaseTester):
         pts = torch.tensor([[1.0, 1.0, 1.0]], device=device, dtype=dtype)
 
         out = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 1, 5, 9)
+        zero_depth = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 0, 5, 9)
 
         expected = torch.tensor([[199999999.0, -0.75, -0.5]], device=device, dtype=dtype)
+        self.assert_close(zero_depth, expected, atol=1e-2, rtol=1e-2)
         self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
 
@@ -1379,8 +1395,12 @@ class TestDenormalizePixelCoordinates(BaseTester):
         # Snippet used to generate expected (torch only):
         #   dpc = kornia.geometry.conversions.denormalize_pixel_coordinates
         #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 4, 1) -> [[5e-09, 1.5]]
+        #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 4, 0) -> [[5e-09, 1.5]]
         #   dpc3 = kornia.geometry.conversions.denormalize_pixel_coordinates3d
         #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 1, 5, 9) -> [[5e-09, 4.0, 2.0]]
+        #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 0, 5, 9) -> [[5e-09, 4.0, 2.0]]
+        # Both size 1 and a literal size 0 are pinned, so a fix that special-cases only one of the
+        # sizes the #3940 warnings name still flips this test.
         # Here the clamped denominator multiplies instead of divides, so the degenerate axis
         # collapses to eps / 2 = 5e-09 rather than exploding to 2e8. The tolerance is tight
         # (rtol 1e-6, atol 0) on purpose: at atol 1e-2 the collapsed component would compare
@@ -1395,10 +1415,22 @@ class TestDenormalizePixelCoordinates(BaseTester):
         )
         self.assert_close(out, torch.tensor([[5e-09, 1.5]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
 
+        out_zero = kornia.geometry.conversions.denormalize_pixel_coordinates(
+            torch.tensor([[0.0, 0.0]], device=device, dtype=dtype), 4, 0
+        )
+        self.assert_close(out_zero, torch.tensor([[5e-09, 1.5]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
+
         out3d = kornia.geometry.conversions.denormalize_pixel_coordinates3d(
             torch.tensor([[0.0, 0.0, 0.0]], device=device, dtype=dtype), 1, 5, 9
         )
         self.assert_close(out3d, torch.tensor([[5e-09, 4.0, 2.0]], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
+
+        out3d_zero = kornia.geometry.conversions.denormalize_pixel_coordinates3d(
+            torch.tensor([[0.0, 0.0, 0.0]], device=device, dtype=dtype), 0, 5, 9
+        )
+        self.assert_close(
+            out3d_zero, torch.tensor([[5e-09, 4.0, 2.0]], device=device, dtype=dtype), atol=0.0, rtol=1e-6
+        )
 
 
 class TestProjectPoints(BaseTester):

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -602,6 +602,7 @@ class TestRadDegConversions(BaseTester):
         self.gradcheck(kornia.geometry.conversions.deg2rad, (x_deg,))
 
     @pytest.mark.xfail(
+        raises=AssertionError,
         reason="kornia.constants.pi is float32, so f64 loses ~7 digits (angle_to_rotation_matrix "
         "inherits it via deg2rad) — kornia#3937",
         strict=True,
@@ -620,8 +621,11 @@ class TestRadDegConversions(BaseTester):
         # turn. It is not: all three multiply by kornia.constants.pi, a *float32* tensor merely
         # cast to the input dtype, so a float64 input carries a systematic ~2.8e-8 relative
         # error (#3937). float64 is hardcoded (like test_rad2deg_gradcheck above) because at
-        # float32 the biased constant *is* the correctly rounded pi. Marked xfail(strict=True)
-        # so fixing #3937 makes every case XPASS and forces this mark out — a one-place edit.
+        # float32 the biased constant *is* the correctly rounded pi; MPS is skipped visibly
+        # below because it has no float64 at all, so without the skip the xfail would be
+        # satisfied by a TypeError instead of the precision assert it documents (hence also
+        # raises=AssertionError on the mark). Marked xfail(strict=True) so fixing #3937 makes
+        # every case XPASS and forces this mark out — a one-place edit.
         # Snippet used to generate expected (stdlib + torch):
         #   math.degrees(math.pi) == 180.0 and (180.0 * math.pi) / 180.0 == math.pi exactly
         #   kornia rad2deg(tensor(pi, f64)).item()   -> 179.99999499104382
@@ -630,6 +634,9 @@ class TestRadDegConversions(BaseTester):
         #     [-4.371139000186241e-08, 0.999999999999999, -0.999999999999999, -4.371139e-08]
         # atol/rtol 1e-12 sits between the current ~4.4e-8 cosine error and the 6.123234e-17
         # an unbiased constant would give.
+        if device.type == "mps":
+            pytest.skip("MPS has no float64, and this pin is float64-only by construction")
+
         op = getattr(kornia.geometry.conversions, op_name)
 
         out = op(torch.tensor(arg, device=device, dtype=torch.float64))
@@ -793,11 +800,46 @@ class TestPolCartConversions(BaseTester):
         )[0]
         self.assert_close(rho, torch.tensor(0.0, device=device, dtype=dtype), atol=1e-6, rtol=0.0)
 
+    def test_wart_rho_is_biased_by_eps_inside_the_sqrt_3939(self, device, dtype):
+        # Wart pin for kornia#3939, companion to the strict xfail above: assert the CURRENT
+        # biased rho. The xfail pins the intended rho(0, 0) == 0 but cannot flip under every fix
+        # polarity -- the equally standard sqrt(clamp(x**2 + y**2, min=eps)) (the shape
+        # normalize_pixel_coordinates already uses) also returns 1e-4 at the origin, leaving the
+        # mark silently XFAIL with a stale reason string. So two cells are pinned: the origin,
+        # rho = sqrt(eps) = 1e-4, which flips under a grad-only eps (rho 0) and under eps**2
+        # inside the sqrt (rho 1e-8); and a sub-eps point x = 5e-5, whose x**2 = 2.5e-9 < eps
+        # gives rho = sqrt(1.25e-8) ~ 1.118e-4, which additionally flips under the clamp shape
+        # (rho 1e-4, 10.6 % below, outside rtol 1e-2). If either assert fails, #3939 was
+        # (partly) fixed -- update or remove the warning in cart2pol and flip/remove the strict
+        # xfail above. eps=1e-8 is passed explicitly so the pinned literals do not silently
+        # track a later change to the default.
+        # Snippet used to generate expected (torch only, executed at each pinned dtype):
+        #   c2p = kornia.geometry.conversions.cart2pol
+        #   c2p(torch.tensor(0., dtype=torch.float64), torch.tensor(0., dtype=torch.float64),
+        #       eps=1e-8)[0] -> 0.0001                    (f32: 9.999999747378752e-05)
+        #   c2p(torch.tensor(5e-5, dtype=torch.float64), torch.tensor(0., dtype=torch.float64),
+        #       eps=1e-8)[0] -> 0.00011180339887498949    (f32: 0.00011180339788552374)
+        # At bfloat16 the outputs land within 0.3 % of the literals (1.00136e-4, 1.12057e-4),
+        # inside rtol 1e-2, so the pin holds there too.
+        if dtype == torch.float16:
+            pytest.skip("float16 cannot represent eps=1e-8, so rho is 0 at both pinned points and the bias invisible")
+
+        zero = torch.tensor(0.0, device=device, dtype=dtype)
+
+        rho_origin = kornia.geometry.conversions.cart2pol(zero, zero, eps=1e-8)[0]
+        rho_sub_eps = kornia.geometry.conversions.cart2pol(
+            torch.tensor(5e-5, device=device, dtype=dtype), zero, eps=1e-8
+        )[0]
+
+        self.assert_close(rho_origin, torch.tensor(1e-4, device=device, dtype=dtype), atol=0.0, rtol=1e-2)
+        self.assert_close(
+            rho_sub_eps, torch.tensor(1.1180339887498949e-4, device=device, dtype=dtype), atol=0.0, rtol=1e-2
+        )
+
     def test_convention_positive_rotation_decreases_cart2pol_phi(self, device, dtype):
-        # Cross-symbol convention pin: angle_to_rotation_matrix and cart2pol use *opposite*
-        # angle senses in the same (x, y) plane. Applying angle_to_rotation_matrix(+theta) to a
-        # nonzero point decreases that point's cart2pol phi by theta modulo 2*pi, so neither
-        # symbol may be documented with a bare "positive angle = counter-clockwise".
+        # Cross-symbol convention pin: enforces the opposite-sense relation between
+        # angle_to_rotation_matrix and cart2pol stated canonically in cart2pol's Convention
+        # block (phi decreases by theta modulo 2*pi).
         # First case: no branch-cut crossing, so the raw difference is -theta itself.
         # Snippet used to generate expected (stdlib only):
         #   import math
@@ -812,10 +854,9 @@ class TestPolCartConversions(BaseTester):
         expected_delta = torch.tensor(-0.5235987755982988, device=device, dtype=dtype)
         self.assert_close(phi1 - phi0, expected_delta, atol=1e-2, rtol=1e-2)
 
-        # Second case: crossing the -x branch cut. A point at phi = -170 deg rotated by
-        # theta = +30 deg comes back with phi re-wrapped into [-pi, pi]: the returned phi is
-        # +160 deg, not -200 deg, so the raw difference is +330 deg and only the difference
-        # modulo 2*pi is -theta.
+        # Second case: crossing the -x branch cut, where the returned phi is re-wrapped into
+        # [-pi, pi] and only the difference modulo 2*pi is -theta (the worked -170 + 30 example
+        # lives in cart2pol's Convention block).
         # Snippet used to generate expected (stdlib only):
         #   import math
         #   5 * math.cos(math.radians(-170.0)), 5 * math.sin(math.radians(-170.0))
@@ -893,14 +934,17 @@ class TestConvertPointsToHomogeneous(BaseTester):
 
 class TestConvertAtoH(BaseTester):
     def test_convert_points(self, device, dtype):
-        # generate input data
-        A = torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], device=device, dtype=dtype).view(1, 2, 3)
+        # Convention pin and its enforcement point: the (B, 2, 3) affine block is copied
+        # verbatim into the top of the (B, 3, 3) result (no transpose, no reordering) and the
+        # row [0, 0, 1] is appended at the *bottom*. The literal is non-symmetric so a
+        # transpose is caught.
+        # Snippet used to generate expected (torch only):
+        #   convert_affinematrix_to_homography(torch.tensor([[[1., 2., 3.], [4., 5., 6.]]]))
+        #     -> [[[1., 2., 3.], [4., 5., 6.], [0., 0., 1.]]]
+        A = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]], device=device, dtype=dtype)
 
-        expected = torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device=device, dtype=dtype).view(
-            1, 3, 3
-        )
+        expected = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
 
-        # to euclidean
         H = kornia.geometry.conversions.convert_affinematrix_to_homography(A)
         self.assert_close(H, expected)
 
@@ -921,18 +965,6 @@ class TestConvertAtoH(BaseTester):
         expected = op(points_h)
 
         self.assert_close(actual, expected)
-
-    def test_convention_appends_bottom_row_0_0_1(self, device, dtype):
-        # Convention pin: the (B, 2, 3) affine block is copied verbatim into the top of the
-        # (B, 3, 3) result (no transpose, no reordering) and the row [0, 0, 1] is appended at
-        # the *bottom*. The literal is non-symmetric so a transpose is caught.
-        # Snippet used to generate expected (by hand): [[1, 2, 3], [4, 5, 6]] gains [0, 0, 1]
-        A = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]], device=device, dtype=dtype)
-
-        out = kornia.geometry.conversions.convert_affinematrix_to_homography(A)
-
-        expected = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
-        self.assert_close(out, expected)
 
     def test_convention_homography3d_appends_bottom_row_0_0_0_1(self, device, dtype):
         # Convention pin (3-D sibling, which has no test class of its own): the (B, 3, 4) affine
@@ -1038,6 +1070,69 @@ class TestConvertPointsFromHomogeneous(BaseTester):
 
         expected = torch.tensor([[1e8, 2e8]], device=device, dtype=dtype)
         self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_wart_division_is_by_w_plus_eps_for_both_signs_3938(self, device, dtype):
+        # Wart pin for kornia#3938, companion to the strict xfail above: assert the CURRENT
+        # biased outputs for both signs of w. The xfail pins the intended behavior but cannot
+        # flip under every fix polarity -- a sign-aware eps (w + sign(w) * eps) leaves the
+        # positive-w case failing the intended [1e8, 2e8] and the mark silently XFAIL; here the
+        # NEGATIVE-w cell (divided by -2e-8 + 1e-8 = -1e-8, doubling the point) flips under that
+        # fix too, and both cells flip under an exact division or a grad-only eps. If either
+        # assert fails, #3938 was (partly) fixed -- update or remove the warning in
+        # convert_points_from_homogeneous and flip/remove the strict xfail above. eps=1e-8 is
+        # passed explicitly so the pinned literals do not silently track a later change to the default.
+        # Snippet used to generate expected (torch only, executed at each pinned dtype):
+        #   cpfh = kornia.geometry.conversions.convert_points_from_homogeneous
+        #   cpfh(torch.tensor([[2., 4., 2e-8]], dtype=torch.float64), eps=1e-8)
+        #     -> [[66666666.66666666, 133333333.33333331]]   (f32: [[66666668.0, 133333336.0]])
+        #   cpfh(torch.tensor([[2., 4., -2e-8]], dtype=torch.float64), eps=1e-8)
+        #     -> [[-200000000.0, -400000000.0]]               (f32: identical)
+        # At bfloat16 the outputs land within 0.15 % of the literals (66584576, -200278016),
+        # inside rtol 1e-2, so the pin holds there too.
+        if dtype == torch.float16:
+            pytest.skip("float16 underflows w=2e-8 to 0, which is the |w| <= eps passthrough branch, not the eps bias")
+
+        cpfh = kornia.geometry.conversions.convert_points_from_homogeneous
+
+        out_pos = cpfh(torch.tensor([[2.0, 4.0, 2e-8]], device=device, dtype=dtype), eps=1e-8)
+        out_neg = cpfh(torch.tensor([[2.0, 4.0, -2e-8]], device=device, dtype=dtype), eps=1e-8)
+
+        expected_pos = torch.tensor([[6.6666668e7, 1.33333336e8]], device=device, dtype=dtype)
+        expected_neg = torch.tensor([[-2e8, -4e8]], device=device, dtype=dtype)
+        self.assert_close(out_pos, expected_pos, atol=0.0, rtol=1e-2)
+        self.assert_close(out_neg, expected_neg, atol=0.0, rtol=1e-2)
+
+
+def _assert_degenerate_size_cell(
+    func_2d, func_3d, fill, ndim, arg_name, degenerate_size, expected, tols, device, dtype
+):
+    # Shared driver for the two kornia#3940 wart matrices below -- the normalize and
+    # denormalize halves differ only in function pair, fill value, tolerances and expected
+    # table -- so the eventual #3940 cleanup edits one body and one MPS-skip site. eps=1e-8 is
+    # passed explicitly so the pinned literals do not silently track a later change to the default eps
+    # while the clamp bug itself is still present.
+    if device.type == "mps":
+        pytest.skip(
+            "torch 2.9.1 caches clamp's scalar min per shape/dtype on MPS -- first value wins: "
+            "z = torch.zeros(2, device='mps'); z.clamp(1e-8) then z.clamp(1e-7) both return "
+            "9.99999993922529e-09, while the same pair on cpu returns 1e-08 then 1.0000000116860974e-07. "
+            "The clamped eps this pin measures is therefore set by whichever earlier test clamped "
+            "first, which is a torch defect, not a kornia one"
+        )
+
+    if ndim == "2d":
+        sizes = {"height": 5, "width": 7}
+        func = func_2d
+    else:
+        sizes = {"depth": 5, "height": 7, "width": 9}
+        func = func_3d
+    sizes[arg_name] = degenerate_size
+    pts = torch.full((1, len(sizes)), fill, device=device, dtype=dtype)
+
+    out = func(pts, *sizes.values(), eps=1e-8)
+
+    atol, rtol = tols
+    assert_close(out, torch.tensor([expected], device=device, dtype=dtype), atol=atol, rtol=rtol)
 
 
 class TestNormalizePixelCoordinates(BaseTester):
@@ -1187,12 +1282,15 @@ class TestNormalizePixelCoordinates(BaseTester):
     # Snippet used to generate expected (torch only; same output for bad in (1, 0, -3)):
     #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
     #   npc3 = kornia.geometry.conversions.normalize_pixel_coordinates3d
-    #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), bad, 7) -> [[-0.6666666666666667, 199999999.0]]
-    #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 5, bad) -> [[199999999.0, -0.5]]
-    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), bad, 7, 9)
+    #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), bad, 7, eps=1e-8)
+    #     -> [[-0.6666666666666667, 199999999.0]]
+    #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 5, bad, eps=1e-8) -> [[199999999.0, -0.5]]
+    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), bad, 7, 9, eps=1e-8)
     #     -> [[199999999.0, -0.75, -0.6666666666666667]]
-    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 5, bad, 9) -> [[-0.5, -0.75, 199999999.0]]
-    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 5, 7, bad) -> [[-0.5, 199999999.0, -0.6666666666666667]]
+    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 5, bad, 9, eps=1e-8)
+    #     -> [[-0.5, -0.75, 199999999.0]]
+    #   npc3(torch.tensor([[1., 1., 1.]], dtype=torch.float64), 5, 7, bad, eps=1e-8)
+    #     -> [[-0.5, 199999999.0, -0.6666666666666667]]
     # At float16 2e8 overflows to inf and the literal overflows identically; at bfloat16 both
     # sides round to 200278016.0, so the comparison stays meaningful at every dtype.
     @pytest.mark.parametrize("degenerate_size", [1, 0, -3], ids=["one", "zero", "negative"])
@@ -1208,27 +1306,18 @@ class TestNormalizePixelCoordinates(BaseTester):
         ids=["2d-height", "2d-width", "3d-depth", "3d-height", "3d-width"],
     )
     def test_wart_degenerate_size_matrix(self, ndim, arg_name, degenerate_size, expected, device, dtype):
-        if device.type == "mps":
-            pytest.skip(
-                "torch 2.9.1 caches clamp's scalar min per shape/dtype on MPS -- first value wins: "
-                "z = torch.zeros(2, device='mps'); z.clamp(1e-8) then z.clamp(1e-7) both return "
-                "9.99999993922529e-09, while the same pair on cpu returns 1e-08 then 1.0000000116860974e-07. "
-                "The clamped eps this pin measures is therefore set by whichever earlier test clamped "
-                "first, which is a torch defect, not a kornia one"
-            )
-
-        if ndim == "2d":
-            sizes = {"height": 5, "width": 7}
-            func = kornia.geometry.conversions.normalize_pixel_coordinates
-        else:
-            sizes = {"depth": 5, "height": 7, "width": 9}
-            func = kornia.geometry.conversions.normalize_pixel_coordinates3d
-        sizes[arg_name] = degenerate_size
-        pts = torch.ones(1, len(sizes), device=device, dtype=dtype)
-
-        out = func(pts, *sizes.values())
-
-        self.assert_close(out, torch.tensor([expected], device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        _assert_degenerate_size_cell(
+            kornia.geometry.conversions.normalize_pixel_coordinates,
+            kornia.geometry.conversions.normalize_pixel_coordinates3d,
+            1.0,
+            ndim,
+            arg_name,
+            degenerate_size,
+            expected,
+            (1e-2, 1e-2),
+            device,
+            dtype,
+        )
 
     def test_wart_all_size_arguments_degenerate_together(self, device, dtype):
         # Wart pin for kornia#3940, companion to the matrix above: both sizes degenerate at
@@ -1236,13 +1325,14 @@ class TestNormalizePixelCoordinates(BaseTester):
         # when #3940 is fixed -- see the cleanup note above the matrix.
         # Snippet used to generate expected (torch only):
         #   npc = kornia.geometry.conversions.normalize_pixel_coordinates
-        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1) -> [[199999999.0, 199999999.0]]
+        #   npc(torch.tensor([[1., 1.]], dtype=torch.float64), 1, 1, eps=1e-8)
+        #     -> [[199999999.0, 199999999.0]]
         if device.type == "mps":
-            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the wart matrix above")
+            pytest.skip("same torch 2.9.1 MPS clamp-min caching as _assert_degenerate_size_cell above")
 
         pts = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
 
-        out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 1, 1)
+        out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 1, 1, eps=1e-8)
 
         expected = torch.tensor([[199999999.0, 199999999.0]], device=device, dtype=dtype)
         self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
@@ -1356,11 +1446,14 @@ class TestDenormalizePixelCoordinates(BaseTester):
     # Snippet used to generate expected (torch only; same output for bad in (1, 0, -3)):
     #   dpc = kornia.geometry.conversions.denormalize_pixel_coordinates
     #   dpc3 = kornia.geometry.conversions.denormalize_pixel_coordinates3d
-    #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), bad, 7) -> [[3.0, 5e-09]]
-    #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 5, bad) -> [[5e-09, 2.0]]
-    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), bad, 7, 9) -> [[5e-09, 4.0, 3.0]]
-    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 5, bad, 9) -> [[2.0, 4.0, 5e-09]]
-    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 5, 7, bad) -> [[2.0, 5e-09, 3.0]]
+    #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), bad, 7, eps=1e-8) -> [[3.0, 5e-09]]
+    #   dpc(torch.tensor([[0., 0.]], dtype=torch.float64), 5, bad, eps=1e-8) -> [[5e-09, 2.0]]
+    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), bad, 7, 9, eps=1e-8)
+    #     -> [[5e-09, 4.0, 3.0]]
+    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 5, bad, 9, eps=1e-8)
+    #     -> [[2.0, 4.0, 5e-09]]
+    #   dpc3(torch.tensor([[0., 0., 0.]], dtype=torch.float64), 5, 7, bad, eps=1e-8)
+    #     -> [[2.0, 5e-09, 3.0]]
     @pytest.mark.parametrize("degenerate_size", [1, 0, -3], ids=["one", "zero", "negative"])
     @pytest.mark.parametrize(
         ("ndim", "arg_name", "expected"),
@@ -1374,21 +1467,18 @@ class TestDenormalizePixelCoordinates(BaseTester):
         ids=["2d-height", "2d-width", "3d-depth", "3d-height", "3d-width"],
     )
     def test_wart_degenerate_size_matrix(self, ndim, arg_name, degenerate_size, expected, device, dtype):
-        if device.type == "mps":
-            pytest.skip("same torch 2.9.1 MPS clamp-min caching as the normalize wart matrix")
-
-        if ndim == "2d":
-            sizes = {"height": 5, "width": 7}
-            func = kornia.geometry.conversions.denormalize_pixel_coordinates
-        else:
-            sizes = {"depth": 5, "height": 7, "width": 9}
-            func = kornia.geometry.conversions.denormalize_pixel_coordinates3d
-        sizes[arg_name] = degenerate_size
-        pts = torch.zeros(1, len(sizes), device=device, dtype=dtype)
-
-        out = func(pts, *sizes.values())
-
-        self.assert_close(out, torch.tensor([expected], device=device, dtype=dtype), atol=0.0, rtol=1e-6)
+        _assert_degenerate_size_cell(
+            kornia.geometry.conversions.denormalize_pixel_coordinates,
+            kornia.geometry.conversions.denormalize_pixel_coordinates3d,
+            0.0,
+            ndim,
+            arg_name,
+            degenerate_size,
+            expected,
+            (0.0, 1e-6),
+            device,
+            dtype,
+        )
 
 
 class TestProjectPoints(BaseTester):
@@ -1870,20 +1960,14 @@ def test_vector_to_skew_symmetric_matrix(batch_size, device, dtype):
     assert_close(skew_symmetric_matrix[..., 1, 2], -vector[..., 0])
     assert_close(skew_symmetric_matrix[..., 2, 1], vector[..., 0])
 
-
-def test_convention_skew_symmetric_matrix_is_cross_product_from_the_left(device, dtype):
-    # Convention pin (vector_to_skew_symmetric_matrix has no test class in this file, so this
-    # sits next to the existing module-level test, which already pins all nine entries):
-    # [v]x @ x == cross(v, x) -- the vector is the LEFT factor of the cross product, NOT
-    # cross(x, v), which is the negation.
+    # Convention's enforcement point: [v]x @ x == cross(v, x) -- the vector is the LEFT factor
+    # of the cross product, NOT cross(x, v), which is the negation.
     # Snippet used to generate expected (stdlib only):
     #   v, x = (1, 2, 3), (4, 5, 6)
     #   cross(v, x) = (2*6 - 3*5, 3*4 - 1*6, 1*5 - 2*4) -> (-3, 6, -3)
     v = torch.tensor([1.0, 2.0, 3.0], device=device, dtype=dtype)
     x = torch.tensor([4.0, 5.0, 6.0], device=device, dtype=dtype)
-
     skew = kornia.geometry.conversions.vector_to_skew_symmetric_matrix(v)
-
     expected_cross = torch.tensor([-3.0, 6.0, -3.0], device=device, dtype=dtype)
     assert_close(skew @ x, expected_cross)
 

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -601,22 +601,40 @@ class TestRadDegConversions(BaseTester):
         x_deg = 180.0 * torch.rand(batch_shape, device=device, dtype=torch.float64)
         self.gradcheck(kornia.geometry.conversions.deg2rad, (x_deg,))
 
-    @pytest.mark.xfail(reason="kornia.constants.pi is float32, so f64 loses ~7 digits — kornia#3937", strict=True)
-    def test_convention_rad2deg_of_pi_is_exactly_180_in_float64(self, device, dtype):
-        # Intended behavior: rad2deg is exact to the precision of its input dtype, like
-        # torch.rad2deg. It is not: rad2deg multiplies by 180 / kornia.constants.pi, and that
-        # constant is a *float32* tensor merely cast to the input dtype, so a float64 input
-        # carries a systematic ~2.8e-8 relative error (see #3937). Marked xfail(strict=True) so
-        # that fixing #3937 makes this XPASS and forces the mark to be removed.
-        # Snippet used to generate expected (numpy/torch not needed):
-        #   math.degrees(math.pi) == 180.0 exactly; torch.rad2deg(tensor(pi, f64)) - 180.0 == 0.0
-        #   kornia rad2deg(tensor(pi, f64)).item() -> 179.99999499104382
-        if dtype != torch.float64:
-            pytest.skip("float64-only claim: at float32 the biased constant rounds back to 180.0 exactly")
+    @pytest.mark.xfail(
+        reason="kornia.constants.pi is float32, so f64 loses ~7 digits (angle_to_rotation_matrix "
+        "inherits it via deg2rad) — kornia#3937",
+        strict=True,
+    )
+    @pytest.mark.parametrize(
+        ("op_name", "arg", "expected"),
+        [
+            ("rad2deg", torch.pi, 180.0),
+            ("deg2rad", 180.0, torch.pi),
+            ("angle_to_rotation_matrix", 90.0, [[0.0, 1.0], [-1.0, 0.0]]),
+        ],
+    )
+    def test_convention_float64_results_are_exact_3937(self, device, op_name, arg, expected):
+        # Intended behavior: each op is exact to the precision of its input dtype, like
+        # torch.rad2deg / torch.deg2rad; angle_to_rotation_matrix(90) is then the exact quarter
+        # turn. It is not: all three multiply by kornia.constants.pi, a *float32* tensor merely
+        # cast to the input dtype, so a float64 input carries a systematic ~2.8e-8 relative
+        # error (#3937). float64 is hardcoded (like test_rad2deg_gradcheck above) because at
+        # float32 the biased constant *is* the correctly rounded pi. Marked xfail(strict=True)
+        # so fixing #3937 makes every case XPASS and forces this mark out — a one-place edit.
+        # Snippet used to generate expected (stdlib + torch):
+        #   math.degrees(math.pi) == 180.0 and (180.0 * math.pi) / 180.0 == math.pi exactly
+        #   kornia rad2deg(tensor(pi, f64)).item()   -> 179.99999499104382
+        #   kornia deg2rad(tensor(180., f64)).item() -> 3.1415927410125732 (math.pi + 8.7e-08)
+        #   kornia angle_to_rotation_matrix(tensor(90., f64)).flatten().tolist() ->
+        #     [-4.371139000186241e-08, 0.999999999999999, -0.999999999999999, -4.371139e-08]
+        # atol/rtol 1e-12 sits between the current ~4.4e-8 cosine error and the 6.123234e-17
+        # an unbiased constant would give.
+        op = getattr(kornia.geometry.conversions, op_name)
 
-        out = kornia.geometry.conversions.rad2deg(torch.tensor(torch.pi, device=device, dtype=dtype))
-        expected = torch.tensor(180.0, device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-12, rtol=1e-12)
+        out = op(torch.tensor(arg, device=device, dtype=torch.float64))
+
+        self.assert_close(out, torch.tensor(expected, device=device, dtype=torch.float64), atol=1e-12, rtol=1e-12)
 
     def test_convention_angle_to_rotation_matrix_takes_degrees(self, device, dtype):
         # Convention pin: angle_to_rotation_matrix reads its argument in DEGREES (not radians)
@@ -643,98 +661,39 @@ class TestRadDegConversions(BaseTester):
         expected_rad = torch.tensor([[0.99962422, 0.02741213], [-0.02741213, 0.99962422]], device=device, dtype=dtype)
         self.assert_close(out_rad, expected_rad, atol=1e-2, rtol=1e-2)
 
-    @pytest.mark.xfail(reason="kornia.constants.pi is float32, so f64 loses ~7 digits — kornia#3937", strict=True)
-    def test_convention_deg2rad_of_180_is_exactly_pi_in_float64(self, device, dtype):
-        # Intended behavior, second half of the #3937 pair: deg2rad is exact to the precision of
-        # its input dtype, like torch.deg2rad. It is not: deg2rad multiplies by
-        # kornia.constants.pi / 180, and that constant is a *float32* tensor merely cast to the
-        # input dtype, so a float64 input carries a systematic ~2.8e-8 relative error.
-        # Marked xfail(strict=True) so fixing #3937 makes this XPASS and forces the mark out.
-        # Snippet used to generate expected (stdlib + torch):
-        #   (180.0 * math.pi) / 180.0 == math.pi  -> True, so an unbiased impl is exact
-        #   kornia deg2rad(tensor(180., f64)).item() -> 3.1415927410125732
-        #   that value - math.pi -> 8.742278012618954e-08
-        if dtype != torch.float64:
-            pytest.skip("float64-only claim: at float32 the float32 pi *is* the correctly rounded constant")
-
-        out = kornia.geometry.conversions.deg2rad(torch.tensor(180.0, device=device, dtype=dtype))
-        expected = torch.tensor(torch.pi, device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-12, rtol=1e-12)
-
-    @pytest.mark.xfail(reason="angle_to_rotation_matrix inherits the float32-pi defect — kornia#3937", strict=True)
-    def test_convention_angle_to_rotation_matrix_90_is_the_exact_quarter_turn_in_float64(self, device, dtype):
-        # Intended behavior, downstream half of the #3937 pair: angle_to_rotation_matrix(90) is
-        # the exact quarter turn [[0, 1], [-1, 0]] to the precision of its input dtype. It is not:
-        # the degrees-to-radians step is deg2rad, so the float32 pi leaks into the angle and the
-        # cosine comes out as -4.371139e-08 instead of ~6.1e-17.
-        # Marked xfail(strict=True) so fixing #3937 makes this XPASS and forces the mark out.
-        # Snippet used to generate expected (stdlib + torch):
-        #   torch.cos(torch.tensor(math.pi / 2, dtype=torch.float64)) -> 6.123233995736766e-17
-        #   kornia angle_to_rotation_matrix(tensor(90., f64)).flatten().tolist() ->
-        #     [-4.371139000186241e-08, 0.999999999999999, -0.999999999999999, -4.371139000186241e-08]
-        # atol/rtol 1e-12 sits between the two: it rejects the current 4.4e-8 cosine and accepts
-        # the 6.1e-17 an unbiased constant would give.
-        if dtype != torch.float64:
-            pytest.skip("float64-only claim: at float32 the float32 pi *is* the correctly rounded constant")
-
-        out = kornia.geometry.conversions.angle_to_rotation_matrix(torch.tensor(90.0, device=device, dtype=dtype))
-        expected = torch.tensor([[0.0, 1.0], [-1.0, 0.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-12, rtol=1e-12)
-
-    def test_wart_rad2deg_of_integer_input_divides_by_three(self, device):
-        # Wart pin for #3937: asserts the CURRENT broken output that the docstring warning
-        # documents. If this test fails, #3937 was (partly) fixed -- update or remove the warnings
-        # in rad2deg, deg2rad and angle_to_rotation_matrix and flip/remove the three
-        # test_convention_* xfails above. This is NOT a contract that int inputs must keep
-        # returning these values.
-        # It is a regular test rather than a strict xfail on purpose: what an integer input
-        # *should* do (promote to float like torch.rad2deg, or raise) is a maintainer decision,
-        # and a strict xfail asserting the promoted-float answer would stay silently XFAIL forever
-        # if the fix chose to raise. A wart pin flips loudly under either polarity.
+    @pytest.mark.parametrize(
+        ("op_name", "arg", "expected"),
+        [
+            ("rad2deg", [1, 2, 3], [60.0, 120.0, 180.0]),
+            ("deg2rad", [180, 90], [3.0, 1.5]),
+            ("angle_to_rotation_matrix", [90], [[[0.07073720, 0.99749500], [-0.99749500, 0.07073720]]]),
+        ],
+    )
+    def test_wart_integer_input_truncates_pi_to_3_3937(self, device, op_name, arg, expected):
+        # Wart pins for #3937: assert the CURRENT broken outputs the docstring warnings document.
+        # kornia.constants.pi is cast to the *integer* input dtype and truncates to 3, so rad2deg
+        # divides by 3, deg2rad multiplies by 3 (90 degrees -> 1.5 radians), and the downstream
+        # angle_to_rotation_matrix([90]) is nowhere near the quarter turn. If a case fails, #3937
+        # was (partly) fixed -- update or remove the warnings in rad2deg, deg2rad and
+        # angle_to_rotation_matrix and flip/remove the strict xfail above. NOT a contract that
+        # int inputs must keep these values: what they *should* do (promote to float like
+        # torch.rad2deg, or raise) is a maintainer decision, and a strict xfail asserting the
+        # promoted-float answer would stay silently XFAIL forever if the fix chose to raise;
+        # a wart pin flips loudly under either polarity.
         # Snippet used to generate expected (torch only):
         #   kornia rad2deg(torch.tensor([1, 2, 3])) -> tensor([ 60., 120., 180.]), dtype float32
-        #   torch.rad2deg(torch.tensor([1, 2, 3]))  -> tensor([ 57.2958, 114.5916, 171.8873])
-        # kornia.constants.pi is cast to the *integer* input dtype and truncates to 3.
-        out = kornia.geometry.conversions.rad2deg(torch.tensor([1, 2, 3], device=device))
-
-        assert out.dtype == torch.float32
-        expected = torch.tensor([60.0, 120.0, 180.0], device=device, dtype=torch.float32)
-        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
-
-    def test_wart_deg2rad_of_integer_input_multiplies_by_three(self, device):
-        # Wart pin for #3937: asserts the CURRENT broken output that the docstring warning
-        # documents. If this test fails, #3937 was (partly) fixed -- update or remove the warnings
-        # in rad2deg, deg2rad and angle_to_rotation_matrix and flip/remove the three
-        # test_convention_* xfails above. This is NOT a contract that int inputs must keep
-        # returning these values; see the polarity note on the rad2deg wart pin above.
-        # Snippet used to generate expected (torch only):
+        #     (torch.rad2deg gives [ 57.2958, 114.5916, 171.8873])
         #   kornia deg2rad(torch.tensor([180, 90])) -> tensor([3.0000, 1.5000]), dtype float32
-        #   torch.deg2rad(torch.tensor([180, 90]))  -> tensor([3.1416, 1.5708])
-        out = kornia.geometry.conversions.deg2rad(torch.tensor([180, 90], device=device))
-
-        assert out.dtype == torch.float32
-        expected = torch.tensor([3.0, 1.5], device=device, dtype=torch.float32)
-        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
-
-    def test_wart_angle_to_rotation_matrix_of_integer_angle(self, device):
-        # Wart pin for #3937: asserts the CURRENT broken output that the docstring warning
-        # documents. If this test fails, #3937 was (partly) fixed -- update or remove the warnings
-        # in rad2deg, deg2rad and angle_to_rotation_matrix and flip/remove the three
-        # test_convention_* xfails above. This is NOT a contract that int inputs must keep
-        # returning these values; see the polarity note on the rad2deg wart pin above.
-        # This is the downstream case: an integer angle reaches deg2rad, which turns 90 degrees
-        # into 90 * 3 / 180 = 1.5 radians, so the matrix is nowhere near the quarter turn.
-        # Snippet used to generate expected (torch only):
+        #     (torch.deg2rad gives [3.1416, 1.5708])
         #   kornia angle_to_rotation_matrix(torch.tensor([90])).flatten().tolist() ->
         #     [0.07073719799518585, 0.9974949955940247, -0.9974949955940247, 0.07073719799518585]
-        #   math.cos(1.5), math.sin(1.5) -> (0.0707372016677029, 0.9974949866040544)
-        out = kornia.geometry.conversions.angle_to_rotation_matrix(torch.tensor([90], device=device))
+        #     (math.cos(1.5), math.sin(1.5) -> (0.0707372016677029, 0.9974949866040544))
+        op = getattr(kornia.geometry.conversions, op_name)
+
+        out = op(torch.tensor(arg, device=device))
 
         assert out.dtype == torch.float32
-        expected = torch.tensor(
-            [[[0.07073720, 0.99749500], [-0.99749500, 0.07073720]]], device=device, dtype=torch.float32
-        )
-        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+        self.assert_close(out, torch.tensor(expected, device=device, dtype=torch.float32), atol=1e-4, rtol=1e-4)
 
 
 class TestPolCartConversions(BaseTester):
@@ -877,7 +836,8 @@ class TestPolCartConversions(BaseTester):
 
 class TestConvertPointsToHomogeneous(BaseTester):
     def test_convert_points(self, device, dtype):
-        # generate input data
+        # Convention pin: the homogeneous 1.0 is appended as the *last* component (the
+        # non-symmetric rows catch a prepend or a component reversal).
         points_h = torch.tensor(
             [[1.0, 2.0, 1.0], [0.0, 1.0, 2.0], [2.0, 1.0, 0.0], [-1.0, -2.0, -1.0], [0.0, 1.0, -2.0]],
             device=device,
@@ -929,18 +889,6 @@ class TestConvertPointsToHomogeneous(BaseTester):
         expected = op(points_h)
 
         self.assert_close(actual, expected)
-
-    def test_convention_appends_one_as_the_last_component(self, device, dtype):
-        # Convention pin: the homogeneous 1.0 is appended as the *last* component of each point,
-        # (*, D) -> (*, D + 1); it is not prepended, and the existing components keep their
-        # order. The literal is non-symmetric so a prepend or a reversal is caught.
-        # Snippet used to generate expected (by hand): [1, 2, 3] -> [1, 2, 3, 1]
-        points = torch.tensor([[1.0, 2.0, 3.0]], device=device, dtype=dtype)
-
-        out = kornia.geometry.conversions.convert_points_to_homogeneous(points)
-
-        expected = torch.tensor([[1.0, 2.0, 3.0, 1.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected)
 
 
 class TestConvertAtoH(BaseTester):
@@ -1020,7 +968,9 @@ class TestConvertPointsFromHomogeneous(BaseTester):
         assert points.shape == points.shape[:-1] + (2,)
 
     def test_points(self, device, dtype):
-        # generate input data
+        # Convention pins: the [2., 1., 0.] row is the |w| <= eps case (default eps 1e-8) --
+        # returned *unchanged*, not zeros, not inf, no exception. The negative-w rows pin that
+        # the sign of w is preserved (no abs): [0., 1., -2.] -> [0., -0.5].
         points_h = torch.tensor(
             [[1.0, 2.0, 1.0], [0.0, 1.0, 2.0], [2.0, 1.0, 0.0], [-1.0, -2.0, -1.0], [0.0, 1.0, -2.0]],
             device=device,
@@ -1068,20 +1018,6 @@ class TestConvertPointsFromHomogeneous(BaseTester):
         expected = op(points_h)
 
         self.assert_close(actual, expected)
-
-    def test_convention_small_w_returns_the_numerator_unchanged(self, device, dtype):
-        # Convention pin: when |w| <= eps (default 1e-8, tested strictly with >) the point is
-        # returned *unchanged* -- not zeros, not inf, and no exception. For |w| > eps the sign
-        # of w is preserved (no abs, no sign flip).
-        # Snippet used to generate expected (by hand):
-        #   w = 0   -> passthrough        -> [2, 4]
-        #   w = -2  -> divide by w        -> [2 / -2, 4 / -2] = [-1, -2]
-        points = torch.tensor([[2.0, 4.0, 0.0], [2.0, 4.0, -2.0]], device=device, dtype=dtype)
-
-        out = kornia.geometry.conversions.convert_points_from_homogeneous(points)
-
-        expected = torch.tensor([[2.0, 4.0], [-1.0, -2.0]], device=device, dtype=dtype)
-        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
 
     @pytest.mark.xfail(reason="convert_points_from_homogeneous divides by w + eps — kornia#3938", strict=True)
     def test_convention_divides_by_exactly_w(self, device, dtype):
@@ -1195,26 +1131,20 @@ class TestNormalizePixelCoordinates(BaseTester):
     def test_convention_grid_sample_needs_align_corners_true(self, device, dtype):
         # Convention pin: feeding normalized coordinates to torch.nn.functional.grid_sample
         # requires align_corners=True to be passed explicitly. With it, the three normalized
-        # pixel centres sample back the exact pixel values; with grid_sample's own default
-        # (align_corners=None -> False, passed explicitly here to keep the run warning-free)
-        # every value is wrong, including the corner pixel 15.0 -> 3.75.
+        # pixel centres sample back the exact pixel values; grid_sample's own default
+        # (align_corners=None -> False) instead places u = -1, -1/3, 1 at pixels
+        # ((u + 1) * 4 - 1) / 2 = -0.5, 0.8333, 3.5, i.e. half a pixel outside the image at
+        # both ends, so every sampled value would be wrong.
         # Snippet used to generate expected (stdlib only, W = 4, img = arange(16).view(4, 4)):
         #   img[0, 0], img[1, 1], img[3, 3] -> 0.0, 5.0, 15.0
-        #   align_corners=False places u = -1, -1/3, 1 at pixels ((u + 1) * 4 - 1) / 2 =
-        #   -0.5, 0.8333, 3.5, i.e. half a pixel outside the image at both ends, so bilinear
-        #   sampling with zero padding gives 0.0, 25/6, 3.75
         img = torch.arange(16.0, device=device, dtype=dtype).view(1, 1, 4, 4)
         pts = torch.tensor([[0.0, 0.0], [1.0, 1.0], [3.0, 3.0]], device=device, dtype=dtype)
         grid = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 4).view(1, 1, 3, 2)
 
         sampled_aligned = torch.nn.functional.grid_sample(img, grid, align_corners=True).flatten()
-        sampled_default = torch.nn.functional.grid_sample(img, grid, align_corners=False).flatten()
 
         self.assert_close(
             sampled_aligned, torch.tensor([0.0, 5.0, 15.0], device=device, dtype=dtype), atol=1e-2, rtol=1e-2
-        )
-        self.assert_close(
-            sampled_default, torch.tensor([0.0, 4.1666667, 3.75], device=device, dtype=dtype), atol=5e-2, rtol=5e-2
         )
 
     def test_convention_3d_component_order_is_depth_x_y(self, device, dtype):
@@ -1664,20 +1594,6 @@ class TestNormalizePointsWithIntrinsics(BaseTester):
         expected = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
         self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
 
-    def test_convention_roundtrip_denormalize_of_normalize(self, device, dtype):
-        # Convention pin: denormalize(normalize(p, K), K) == p for a non-identity K with
-        # fx != fy and cx != cy, so the two are exact mutual inverses.
-        # Snippet used to generate expected (by hand): the input itself.
-        points_2d = torch.tensor([[420.0, 440.0]], device=device, dtype=dtype)
-        camera_matrix = torch.tensor(
-            [[[100.0, 0.0, 320.0], [0.0, 200.0, 240.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
-        )
-
-        norm = kornia.geometry.conversions.normalize_points_with_intrinsics(points_2d, camera_matrix)
-        out = kornia.geometry.conversions.denormalize_points_with_intrinsics(norm, camera_matrix)
-
-        self.assert_close(out, points_2d, atol=1e-2, rtol=1e-2)
-
 
 class TestRt2Extrinsics(BaseTester):
     @pytest.mark.parametrize("batch_size", [1, 2, 3])
@@ -1957,9 +1873,9 @@ def test_vector_to_skew_symmetric_matrix(batch_size, device, dtype):
 
 def test_convention_skew_symmetric_matrix_is_cross_product_from_the_left(device, dtype):
     # Convention pin (vector_to_skew_symmetric_matrix has no test class in this file, so this
-    # sits next to the existing module-level test): the returned matrix is [[0, -v3, v2],
-    # [v3, 0, -v1], [-v2, v1, 0]], i.e. [v]x @ x == cross(v, x) -- NOT cross(x, v), which is
-    # the negation.
+    # sits next to the existing module-level test, which already pins all nine entries):
+    # [v]x @ x == cross(v, x) -- the vector is the LEFT factor of the cross product, NOT
+    # cross(x, v), which is the negation.
     # Snippet used to generate expected (stdlib only):
     #   v, x = (1, 2, 3), (4, 5, 6)
     #   cross(v, x) = (2*6 - 3*5, 3*4 - 1*6, 1*5 - 2*4) -> (-3, 6, -3)
@@ -1967,9 +1883,6 @@ def test_convention_skew_symmetric_matrix_is_cross_product_from_the_left(device,
     x = torch.tensor([4.0, 5.0, 6.0], device=device, dtype=dtype)
 
     skew = kornia.geometry.conversions.vector_to_skew_symmetric_matrix(v)
-
-    expected_matrix = torch.tensor([[0.0, -3.0, 2.0], [3.0, 0.0, -1.0], [-2.0, 1.0, 0.0]], device=device, dtype=dtype)
-    assert_close(skew, expected_matrix)
 
     expected_cross = torch.tensor([-3.0, 6.0, -3.0], device=device, dtype=dtype)
     assert_close(skew @ x, expected_cross)

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -877,10 +877,12 @@ class TestPolCartConversions(BaseTester):
         wrapped_delta = torch.atan2(torch.sin(raw_delta), torch.cos(raw_delta))
         # The re-wrap atan2(sin, cos) adds two more transcendental roundings on top of the two
         # atan2 outputs it differences, overshooting the central per-dtype tolerances in the half
-        # dtypes: measured |wrapped_delta - expected| is 1.95e-3 in float16 (central allowance
-        # atol 1e-3 + rtol 1e-3 * 0.52 = 1.52e-3) and 1.16e-2 in bfloat16 (allowance 1.19e-2, a
-        # 3 % margin that torch rounding drift could erase). atol 2.4e-2 is ~2x the bfloat16
-        # error; a sign-flipped or unwrapped delta would still be off by >= 1.0.
+        # dtypes. Measured against the dtype-cast expected tensor the assert compares with
+        # (-0.5234375 in both halves): |err| is 1.953125e-3 in float16 (wrapped -0.525390625;
+        # central allowance atol 1e-3 + rtol 1e-3 * 0.52 = 1.52e-3) and 1.171875e-2 in bfloat16
+        # (wrapped -0.53515625; allowance 1.19e-2 -- a 1.4 % margin that torch rounding drift
+        # could erase). atol 2.4e-2 is ~2x the bfloat16 error; a sign-flipped or unwrapped delta
+        # would still be off by >= 1.0.
         wrap_tol = {"atol": 2.4e-2, "rtol": 0.0} if dtype in (torch.float16, torch.bfloat16) else {}
         self.assert_close(wrapped_delta, expected_delta, **wrap_tol)
 

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -601,6 +601,48 @@ class TestRadDegConversions(BaseTester):
         x_deg = 180.0 * torch.rand(batch_shape, device=device, dtype=torch.float64)
         self.gradcheck(kornia.geometry.conversions.deg2rad, (x_deg,))
 
+    @pytest.mark.xfail(reason="kornia.constants.pi is float32, so f64 loses ~7 digits — kornia#3937", strict=True)
+    def test_convention_rad2deg_of_pi_is_exactly_180_in_float64(self, device, dtype):
+        # Intended behavior: rad2deg is exact to the precision of its input dtype, like
+        # torch.rad2deg. It is not: rad2deg multiplies by 180 / kornia.constants.pi, and that
+        # constant is a *float32* tensor merely cast to the input dtype, so a float64 input
+        # carries a systematic ~2.8e-8 relative error (see #3937). Marked xfail(strict=True) so
+        # that fixing #3937 makes this XPASS and forces the mark to be removed.
+        # Snippet used to generate expected (numpy/torch not needed):
+        #   math.degrees(math.pi) == 180.0 exactly; torch.rad2deg(tensor(pi, f64)) - 180.0 == 0.0
+        #   kornia rad2deg(tensor(pi, f64)).item() -> 179.99999499104382
+        if dtype != torch.float64:
+            pytest.skip("float64-only claim: at float32 the biased constant rounds back to 180.0 exactly")
+
+        out = kornia.geometry.conversions.rad2deg(torch.tensor(torch.pi, device=device, dtype=dtype))
+        expected = torch.tensor(180.0, device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-12, rtol=1e-12)
+
+    def test_convention_angle_to_rotation_matrix_takes_degrees(self, device, dtype):
+        # Convention pin: angle_to_rotation_matrix reads its argument in DEGREES (not radians)
+        # and returns [[cos, sin], [-sin, cos]] -- the transpose of the textbook math-frame CCW
+        # matrix. Pinned on a small non-symmetric angle so a sign flip on the off-diagonal is
+        # caught.
+        # Snippet used to generate expected (stdlib only):
+        #   import math
+        #   c, s = math.cos(math.radians(30.0)), math.sin(math.radians(30.0))
+        #   [[c, s], [-s, c]] -> [[0.8660254037844387, 0.49999999999999994],
+        #                         [-0.49999999999999994, 0.8660254037844387]]
+        out = kornia.geometry.conversions.angle_to_rotation_matrix(torch.tensor(30.0, device=device, dtype=dtype))
+        expected = torch.tensor([[0.8660254, 0.5], [-0.5, 0.8660254]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+        # A radian-reading implementation would turn pi/2 into the quarter turn [[0, 1], [-1, 0]];
+        # this one reads pi/2 as 1.5708 *degrees* and returns a near-identity matrix instead.
+        # Snippet used to generate expected:
+        #   c, s = math.cos(math.radians(math.pi / 2)), math.sin(math.radians(math.pi / 2))
+        #   [[c, s], [-s, c]] -> [[0.9996242168385687, 0.027412134354665284], ...]
+        out_rad = kornia.geometry.conversions.angle_to_rotation_matrix(
+            torch.tensor(torch.pi / 2, device=device, dtype=dtype)
+        )
+        expected_rad = torch.tensor([[0.99962422, 0.02741213], [-0.02741213, 0.99962422]], device=device, dtype=dtype)
+        self.assert_close(out_rad, expected_rad, atol=1e-2, rtol=1e-2)
+
 
 class TestPolCartConversions(BaseTester):
     def test_smoke(self, device, dtype):
@@ -644,6 +686,78 @@ class TestPolCartConversions(BaseTester):
 
         self.assert_close(x, x_cart2pol)
         self.assert_close(y, y_cart2pol)
+
+    def test_convention_pol2cart_takes_rho_phi_returns_x_y(self, device, dtype):
+        # Convention pin: pol2cart's argument order is (rho, phi) and its return order is
+        # (x, y), with phi in RADIANS measured from the +x axis: x = rho*cos(phi),
+        # y = rho*sin(phi). The literal is deliberately off-axis (3 != 4) so that swapping
+        # either the arguments or the returns is caught.
+        # Snippet used to generate expected (stdlib only):
+        #   import math
+        #   phi = math.atan2(4.0, 3.0)  # 0.9272952180016122 rad
+        #   5.0 * math.cos(phi), 5.0 * math.sin(phi) -> (3.0000000000000004, 4.0)
+        rho = torch.tensor(5.0, device=device, dtype=dtype)
+        phi = torch.tensor(0.9272952180016122, device=device, dtype=dtype)
+
+        x, y = kornia.geometry.conversions.pol2cart(rho, phi)
+
+        self.assert_close(x, torch.tensor(3.0, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        self.assert_close(y, torch.tensor(4.0, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+
+    def test_convention_cart2pol_takes_x_y_and_phi_is_atan2_y_x(self, device, dtype):
+        # Convention pin: cart2pol's argument order is (x, y) and its return order is
+        # (rho, phi), with phi = atan2(y, x) in radians -- zero on the +x axis and increasing
+        # toward +y (which is clockwise *as displayed* under kornia's y-down image axes).
+        # Snippet used to generate expected (stdlib only):
+        #   import math
+        #   math.hypot(3.0, 4.0), math.atan2(4.0, 3.0) -> (5.0, 0.9272952180016122)
+        #   math.atan2(1.0, 0.0) -> 1.5707963267948966  (atan2(x, y) would give 0.0 here)
+        rho, phi = kornia.geometry.conversions.cart2pol(
+            torch.tensor(3.0, device=device, dtype=dtype), torch.tensor(4.0, device=device, dtype=dtype)
+        )
+        self.assert_close(rho, torch.tensor(5.0, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+        self.assert_close(phi, torch.tensor(0.9272952180016122, device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+
+        phi_y_axis = kornia.geometry.conversions.cart2pol(
+            torch.tensor(0.0, device=device, dtype=dtype), torch.tensor(1.0, device=device, dtype=dtype)
+        )[1]
+        self.assert_close(
+            phi_y_axis, torch.tensor(1.5707963267948966, device=device, dtype=dtype), atol=1e-2, rtol=1e-2
+        )
+
+    @pytest.mark.xfail(reason="cart2pol returns sqrt(x**2 + y**2 + eps), biasing rho — kornia#3939", strict=True)
+    def test_convention_cart2pol_rho_is_the_exact_radius(self, device, dtype):
+        # Intended behavior: rho is the Euclidean radius, so rho(0, 0) == 0. It currently is
+        # not: eps is added *inside* the sqrt, so rho = sqrt(x**2 + y**2 + eps) and the origin
+        # maps to sqrt(1e-8) = 1e-4 (see #3939; eps belongs in the gradient path, not the
+        # value). Marked xfail(strict=True) so fixing #3939 makes this XPASS loudly.
+        # Snippet used to generate expected (stdlib only):
+        #   math.hypot(0.0, 0.0) -> 0.0 ; kornia cart2pol(0., 0.)[0].item() -> 0.0001
+        if dtype == torch.float16:
+            pytest.skip("float16 cannot represent the default eps=1e-8, so the bias is invisible there")
+
+        rho = kornia.geometry.conversions.cart2pol(
+            torch.tensor(0.0, device=device, dtype=dtype), torch.tensor(0.0, device=device, dtype=dtype)
+        )[0]
+        self.assert_close(rho, torch.tensor(0.0, device=device, dtype=dtype), atol=1e-6, rtol=0.0)
+
+    def test_convention_positive_rotation_decreases_cart2pol_phi(self, device, dtype):
+        # Cross-symbol convention pin: angle_to_rotation_matrix and cart2pol use *opposite*
+        # angle senses in the same (x, y) plane. Applying angle_to_rotation_matrix(+theta) to a
+        # point decreases that point's cart2pol phi by exactly theta, so neither symbol may be
+        # documented with a bare "positive angle = counter-clockwise".
+        # Snippet used to generate expected (stdlib only):
+        #   import math
+        #   -math.radians(30.0) -> -0.5235987755982988
+        v = torch.tensor([3.0, 4.0], device=device, dtype=dtype)
+        phi0 = kornia.geometry.conversions.cart2pol(v[0], v[1])[1]
+
+        rot = kornia.geometry.conversions.angle_to_rotation_matrix(torch.tensor(30.0, device=device, dtype=dtype))
+        v_rot = rot @ v
+        phi1 = kornia.geometry.conversions.cart2pol(v_rot[0], v_rot[1])[1]
+
+        expected_delta = torch.tensor(-0.5235987755982988, device=device, dtype=dtype)
+        self.assert_close(phi1 - phi0, expected_delta, atol=1e-2, rtol=1e-2)
 
 
 class TestConvertPointsToHomogeneous(BaseTester):
@@ -701,6 +815,18 @@ class TestConvertPointsToHomogeneous(BaseTester):
 
         self.assert_close(actual, expected)
 
+    def test_convention_appends_one_as_the_last_component(self, device, dtype):
+        # Convention pin: the homogeneous 1.0 is appended as the *last* component of each point,
+        # (*, D) -> (*, D + 1); it is not prepended, and the existing components keep their
+        # order. The literal is non-symmetric so a prepend or a reversal is caught.
+        # Snippet used to generate expected (by hand): [1, 2, 3] -> [1, 2, 3, 1]
+        points = torch.tensor([[1.0, 2.0, 3.0]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.convert_points_to_homogeneous(points)
+
+        expected = torch.tensor([[1.0, 2.0, 3.0, 1.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected)
+
 
 class TestConvertAtoH(BaseTester):
     def test_convert_points(self, device, dtype):
@@ -732,6 +858,43 @@ class TestConvertAtoH(BaseTester):
         expected = op(points_h)
 
         self.assert_close(actual, expected)
+
+    def test_convention_appends_bottom_row_0_0_1(self, device, dtype):
+        # Convention pin: the (B, 2, 3) affine block is copied verbatim into the top of the
+        # (B, 3, 3) result (no transpose, no reordering) and the row [0, 0, 1] is appended at
+        # the *bottom*. The literal is non-symmetric so a transpose is caught.
+        # Snippet used to generate expected (by hand): [[1, 2, 3], [4, 5, 6]] gains [0, 0, 1]
+        A = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.convert_affinematrix_to_homography(A)
+
+        expected = torch.tensor([[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
+        self.assert_close(out, expected)
+
+    def test_convention_homography3d_appends_bottom_row_0_0_0_1(self, device, dtype):
+        # Convention pin (3-D sibling, which has no test class of its own): the (B, 3, 4) affine
+        # block is copied verbatim and the row [0, 0, 0, 1] is appended at the bottom.
+        # Snippet used to generate expected (by hand):
+        #   [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]] gains [0, 0, 0, 1]
+        A = torch.tensor(
+            [[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]]], device=device, dtype=dtype
+        )
+
+        out = kornia.geometry.conversions.convert_affinematrix_to_homography3d(A)
+
+        expected = torch.tensor(
+            [
+                [
+                    [1.0, 2.0, 3.0, 4.0],
+                    [5.0, 6.0, 7.0, 8.0],
+                    [9.0, 10.0, 11.0, 12.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        self.assert_close(out, expected)
 
 
 class TestConvertPointsFromHomogeneous(BaseTester):
@@ -791,6 +954,38 @@ class TestConvertPointsFromHomogeneous(BaseTester):
 
         self.assert_close(actual, expected)
 
+    def test_convention_small_w_returns_the_numerator_unchanged(self, device, dtype):
+        # Convention pin: when |w| <= eps (default 1e-8, tested strictly with >) the point is
+        # returned *unchanged* -- not zeros, not inf, and no exception. For |w| > eps the sign
+        # of w is preserved (no abs, no sign flip).
+        # Snippet used to generate expected (by hand):
+        #   w = 0   -> passthrough        -> [2, 4]
+        #   w = -2  -> divide by w        -> [2 / -2, 4 / -2] = [-1, -2]
+        points = torch.tensor([[2.0, 4.0, 0.0], [2.0, 4.0, -2.0]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.convert_points_from_homogeneous(points)
+
+        expected = torch.tensor([[2.0, 4.0], [-1.0, -2.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.xfail(reason="convert_points_from_homogeneous divides by w + eps — kornia#3938", strict=True)
+    def test_convention_divides_by_exactly_w(self, device, dtype):
+        # Intended behavior: for |w| > eps the point is divided by exactly w. It currently is
+        # divided by w + eps with no regard for sign, which is 33 % low at w = +2e-8 and 100 %
+        # high at w = -2e-8, and leaves a permanent ~eps/w relative bias everywhere (#3938).
+        # Marked xfail(strict=True) so fixing #3938 makes this XPASS and forces the mark out.
+        # Snippet used to generate expected (by hand):
+        #   2 / 2e-8, 4 / 2e-8 -> [1e8, 2e8]  (kornia returns [6.6666667e7, 1.3333333e8])
+        if dtype == torch.float16:
+            pytest.skip("float16 underflows w=2e-8 to 0, which is the |w| <= eps passthrough branch, not the eps bias")
+
+        points = torch.tensor([[2.0, 4.0, 2e-8]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.convert_points_from_homogeneous(points)
+
+        expected = torch.tensor([[1e8, 2e8]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
 
 class TestNormalizePixelCoordinates(BaseTester):
     def test_tensor_bhw2(self, device, dtype, atol, rtol):
@@ -842,6 +1037,88 @@ class TestNormalizePixelCoordinates(BaseTester):
 
         self.assert_close(actual, expected)
 
+    def test_convention_corner_aligned_formula(self, device, dtype):
+        # Convention pin: normalize_pixel_coordinates maps x -> 2*x/(W - 1) - 1 (corner-aligned,
+        # i.e. the align_corners=True convention). grid_sample's *default* align_corners=False
+        # convention, (2*x + 1)/W - 1, would give [-0.75, -0.25, 0.75] for the same input.
+        # Snippet used to generate expected (stdlib only, W = 4):
+        #   [2 * x / (4 - 1) - 1 for x in (0.0, 1.0, 3.0)] -> [-1.0, -0.3333333333333333, 1.0]
+        pts = torch.tensor([[0.0, 0.0], [1.0, 1.0], [3.0, 3.0]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 4)
+
+        expected = torch.tensor([[-1.0, -1.0], [-0.33333333, -0.33333333], [1.0, 1.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_convention_positional_order_is_height_then_width(self, device, dtype):
+        # Convention pin: the positional signature is (pixel_coordinates, height, width), which is
+        # the reverse of the per-point (x, y) -> (width, height) scaling order: slot 0 is scaled by
+        # width and slot 1 by height. Calling with H and W swapped would give [[5.0, -0.3333]].
+        # Snippet used to generate expected (stdlib only, H = 2, W = 4):
+        #   2 * 3.0 / (4 - 1) - 1, 2 * 1.0 / (2 - 1) - 1 -> (1.0, 1.0)
+        pts = torch.tensor([[3.0, 1.0]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 2, 4)
+
+        expected = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_convention_output_is_not_clamped(self, device, dtype):
+        # Convention pin: nothing is clamped to [-1, 1] -- out-of-image coordinates extrapolate
+        # linearly past it.
+        # Snippet used to generate expected (stdlib only, H = W = 4):
+        #   2 * 10.0 / (4 - 1) - 1, 2 * 0.0 / (4 - 1) - 1 -> (5.666666666666666, -1.0)
+        pts = torch.tensor([[10.0, 0.0]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 4)
+
+        expected = torch.tensor([[5.6666667, -1.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_convention_grid_sample_needs_align_corners_true(self, device, dtype):
+        # Convention pin: feeding normalized coordinates to torch.nn.functional.grid_sample
+        # requires align_corners=True to be passed explicitly. With it, the three normalized
+        # pixel centres sample back the exact pixel values; with grid_sample's own default
+        # (align_corners=None -> False, passed explicitly here to keep the run warning-free)
+        # every value is wrong, including the corner pixel 15.0 -> 3.75.
+        # Snippet used to generate expected (stdlib only, W = 4, img = arange(16).view(4, 4)):
+        #   img[0, 0], img[1, 1], img[3, 3] -> 0.0, 5.0, 15.0
+        #   align_corners=False places u = -1, -1/3, 1 at pixels ((u + 1) * 4 - 1) / 2 =
+        #   -0.5, 0.8333, 3.5, i.e. half a pixel outside the image at both ends, so bilinear
+        #   sampling with zero padding gives 0.0, 25/6, 3.75
+        img = torch.arange(16.0, device=device, dtype=dtype).view(1, 1, 4, 4)
+        pts = torch.tensor([[0.0, 0.0], [1.0, 1.0], [3.0, 3.0]], device=device, dtype=dtype)
+        grid = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 4, 4).view(1, 1, 3, 2)
+
+        sampled_aligned = torch.nn.functional.grid_sample(img, grid, align_corners=True).flatten()
+        sampled_default = torch.nn.functional.grid_sample(img, grid, align_corners=False).flatten()
+
+        self.assert_close(
+            sampled_aligned, torch.tensor([0.0, 5.0, 15.0], device=device, dtype=dtype), atol=1e-2, rtol=1e-2
+        )
+        self.assert_close(
+            sampled_default, torch.tensor([0.0, 4.1666667, 3.75], device=device, dtype=dtype), atol=5e-2, rtol=5e-2
+        )
+
+    def test_convention_3d_component_order_is_depth_x_y(self, device, dtype):
+        # Convention pin (normalize_pixel_coordinates3d has no test class of its own): the
+        # component order is (d, x, y) -- depth first, then x scaled by width, then y scaled by
+        # height. It is NOT (x, y, z): reading the same three numbers that way sends the point
+        # out of range instead of to the far corner.
+        # Snippet used to generate expected (stdlib only, D = 3, H = 5, W = 9):
+        #   2 * 2 / (3 - 1) - 1, 2 * 8 / (9 - 1) - 1, 2 * 4 / (5 - 1) - 1 -> (1.0, 1.0, 1.0)
+        #   the (x, y, z) reading [2, 4, 8] gives 2 * 2 / 2 - 1, 2 * 4 / 8 - 1, 2 * 8 / 4 - 1
+        #                                      -> (1.0, 0.0, 3.0)
+        far_corner = torch.tensor([[2.0, 8.0, 4.0]], device=device, dtype=dtype)
+        out = kornia.geometry.conversions.normalize_pixel_coordinates3d(far_corner, 3, 5, 9)
+        self.assert_close(out, torch.tensor([[1.0, 1.0, 1.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+
+        swapped = torch.tensor([[2.0, 4.0, 8.0]], device=device, dtype=dtype)
+        out_swapped = kornia.geometry.conversions.normalize_pixel_coordinates3d(swapped, 3, 5, 9)
+        self.assert_close(
+            out_swapped, torch.tensor([[1.0, 0.0, 3.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2
+        )
+
 
 class TestDenormalizePixelCoordinates(BaseTester):
     def test_tensor_bhw2(self, device, dtype):
@@ -890,6 +1167,47 @@ class TestDenormalizePixelCoordinates(BaseTester):
         expected = op(grid, height, width)
 
         self.assert_close(actual, expected)
+
+    def test_convention_corner_aligned_inverse(self, device, dtype):
+        # Convention pin: denormalize_pixel_coordinates is the corner-aligned inverse,
+        # x = (W - 1) * (x_norm + 1) / 2, taken positionally as (coords, height, width) with
+        # (x, y) points. grid_sample's align_corners=False convention, ((x_norm + 1) * W - 1)/2,
+        # would give [[3.5, -0.5]] for the same input.
+        # Snippet used to generate expected (stdlib only, H = 2, W = 4):
+        #   (4 - 1) * (1.0 + 1) / 2, (2 - 1) * (-1.0 + 1) / 2 -> (3.0, 0.0)
+        pts_norm = torch.tensor([[1.0, -1.0]], device=device, dtype=dtype)
+
+        out = kornia.geometry.conversions.denormalize_pixel_coordinates(pts_norm, 2, 4)
+
+        expected = torch.tensor([[3.0, 0.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_convention_roundtrip_denormalize_of_normalize(self, device, dtype):
+        # Convention pin: denormalize(normalize(p)) == p on a non-degenerate, non-square,
+        # non-identity image size, so the two formulas are exact mutual inverses.
+        # Snippet used to generate expected (by hand): the input itself.
+        pts = torch.tensor([[1.0, 2.0], [3.0, 0.0]], device=device, dtype=dtype)
+
+        norm = kornia.geometry.conversions.normalize_pixel_coordinates(pts, 5, 7)
+        out = kornia.geometry.conversions.denormalize_pixel_coordinates(norm, 5, 7)
+
+        self.assert_close(out, pts, atol=1e-2, rtol=1e-2)
+
+    def test_convention_3d_component_order_and_roundtrip(self, device, dtype):
+        # Convention pin (denormalize_pixel_coordinates3d has no test class of its own): same
+        # (d, x, y) order as the 3-D normalizer, so the normalized origin maps to the per-axis
+        # centres ((D - 1)/2, (W - 1)/2, (H - 1)/2), and the pair round-trips exactly.
+        # Snippet used to generate expected (stdlib only, D = 3, H = 5, W = 9):
+        #   (3 - 1) / 2, (9 - 1) / 2, (5 - 1) / 2 -> (1.0, 4.0, 2.0)
+        centre = kornia.geometry.conversions.denormalize_pixel_coordinates3d(
+            torch.tensor([[0.0, 0.0, 0.0]], device=device, dtype=dtype), 3, 5, 9
+        )
+        self.assert_close(centre, torch.tensor([[1.0, 4.0, 2.0]], device=device, dtype=dtype), atol=1e-2, rtol=1e-2)
+
+        pts = torch.tensor([[1.0, 2.0, 3.0]], device=device, dtype=dtype)
+        norm = kornia.geometry.conversions.normalize_pixel_coordinates3d(pts, 3, 5, 9)
+        out = kornia.geometry.conversions.denormalize_pixel_coordinates3d(norm, 3, 5, 9)
+        self.assert_close(out, pts, atol=1e-2, rtol=1e-2)
 
 
 class TestProjectPoints(BaseTester):
@@ -987,6 +1305,22 @@ class TestDenormalizePointsWithIntrinsics(BaseTester):
 
         self.assert_close(actual, expected)
 
+    def test_convention_maps_normalized_camera_points_to_pixels(self, device, dtype):
+        # Convention pin: the input is in *normalized camera* coordinates and the output is in
+        # *pixel* coordinates, using the pinhole layout u = x * fx + cx, v = y * fy + cy.
+        # fx != fy and cx != cy so a transposed or swapped read of K is caught.
+        # Snippet used to generate expected (stdlib only, fx=100, fy=200, cx=320, cy=240):
+        #   1.0 * 100 + 320, 1.0 * 200 + 240 -> (420.0, 440.0)
+        points_norm = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
+        camera_matrix = torch.tensor(
+            [[[100.0, 0.0, 320.0], [0.0, 200.0, 240.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+        )
+
+        out = kornia.geometry.conversions.denormalize_points_with_intrinsics(points_norm, camera_matrix)
+
+        expected = torch.tensor([[420.0, 440.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
 
 class TestNormalizePointsWithIntrinsics(BaseTester):
     def test_smoke(self, device, dtype):
@@ -1045,6 +1379,53 @@ class TestNormalizePointsWithIntrinsics(BaseTester):
         expected = op(points_2d, camera_matrix)
 
         self.assert_close(actual, expected)
+
+    def test_convention_intrinsics_layout_fx_fy_cx_cy(self, device, dtype):
+        # Convention pin: K is the standard row-major pinhole matrix, fx = K[..., 0, 0],
+        # fy = K[..., 1, 1], cx = K[..., 0, 2], cy = K[..., 1, 2], and the point is (u, v) in
+        # pixels, so x = (u - cx)/fx, y = (v - cy)/fy. fx != fy and cx != cy, so swapping the
+        # two focal lengths would give [[0.5, 2.0]] and a transposed K would not divide at all.
+        # Snippet used to generate expected (stdlib only, fx=100, fy=200, cx=320, cy=240):
+        #   (420.0 - 320) / 100, (440.0 - 240) / 200 -> (1.0, 1.0)
+        points_2d = torch.tensor([[420.0, 440.0]], device=device, dtype=dtype)
+        camera_matrix = torch.tensor(
+            [[[100.0, 0.0, 320.0], [0.0, 200.0, 240.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+        )
+
+        out = kornia.geometry.conversions.normalize_points_with_intrinsics(points_2d, camera_matrix)
+
+        expected = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_convention_skew_term_is_ignored(self, device, dtype):
+        # Convention pin: only the diagonal fx, fy and the [:2, 2] column of K are read -- the
+        # skew entry K[..., 0, 1] is silently ignored, so a skewed K gives the same answer as
+        # the skew-free one. A skew-aware implementation would return (1.0 - 7/100, 1.0).
+        # Snippet used to generate expected (stdlib only): identical to the skew-free result,
+        #   (420.0 - 320) / 100, (440.0 - 240) / 200 -> (1.0, 1.0)
+        points_2d = torch.tensor([[420.0, 440.0]], device=device, dtype=dtype)
+        camera_matrix = torch.tensor(
+            [[[100.0, 7.0, 320.0], [0.0, 200.0, 240.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+        )
+
+        out = kornia.geometry.conversions.normalize_points_with_intrinsics(points_2d, camera_matrix)
+
+        expected = torch.tensor([[1.0, 1.0]], device=device, dtype=dtype)
+        self.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+
+    def test_convention_roundtrip_denormalize_of_normalize(self, device, dtype):
+        # Convention pin: denormalize(normalize(p, K), K) == p for a non-identity K with
+        # fx != fy and cx != cy, so the two are exact mutual inverses.
+        # Snippet used to generate expected (by hand): the input itself.
+        points_2d = torch.tensor([[420.0, 440.0]], device=device, dtype=dtype)
+        camera_matrix = torch.tensor(
+            [[[100.0, 0.0, 320.0], [0.0, 200.0, 240.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+        )
+
+        norm = kornia.geometry.conversions.normalize_points_with_intrinsics(points_2d, camera_matrix)
+        out = kornia.geometry.conversions.denormalize_points_with_intrinsics(norm, camera_matrix)
+
+        self.assert_close(out, points_2d, atol=1e-2, rtol=1e-2)
 
 
 class TestRt2Extrinsics(BaseTester):
@@ -1321,6 +1702,26 @@ def test_vector_to_skew_symmetric_matrix(batch_size, device, dtype):
     assert_close(skew_symmetric_matrix[..., 2, 0], -vector[..., 1])
     assert_close(skew_symmetric_matrix[..., 1, 2], -vector[..., 0])
     assert_close(skew_symmetric_matrix[..., 2, 1], vector[..., 0])
+
+
+def test_convention_skew_symmetric_matrix_is_cross_product_from_the_left(device, dtype):
+    # Convention pin (vector_to_skew_symmetric_matrix has no test class in this file, so this
+    # sits next to the existing module-level test): the returned matrix is [[0, -v3, v2],
+    # [v3, 0, -v1], [-v2, v1, 0]], i.e. [v]x @ x == cross(v, x) -- NOT cross(x, v), which is
+    # the negation.
+    # Snippet used to generate expected (stdlib only):
+    #   v, x = (1, 2, 3), (4, 5, 6)
+    #   cross(v, x) = (2*6 - 3*5, 3*4 - 1*6, 1*5 - 2*4) -> (-3, 6, -3)
+    v = torch.tensor([1.0, 2.0, 3.0], device=device, dtype=dtype)
+    x = torch.tensor([4.0, 5.0, 6.0], device=device, dtype=dtype)
+
+    skew = kornia.geometry.conversions.vector_to_skew_symmetric_matrix(v)
+
+    expected_matrix = torch.tensor([[0.0, -3.0, 2.0], [3.0, 0.0, -1.0], [-2.0, 1.0, 0.0]], device=device, dtype=dtype)
+    assert_close(skew, expected_matrix)
+
+    expected_cross = torch.tensor([-3.0, 6.0, -3.0], device=device, dtype=dtype)
+    assert_close(skew @ x, expected_cross)
 
 
 class TestAxisAngleToRotationMatrix:


### PR DESCRIPTION
## What

Adds a short, execution-verified `Convention:` block to the docstring of the 16 scalar / point / pixel-coordinate symbols of `kornia/geometry/conversions.py`, plus `test_convention_*` pins that fail if any documented convention changes silently. This is sub-batch **3a** of the tracking issue #3941, and continues the same programme as #3924 (batch 1, `geometry.transform` warps) and #3926 (batch 2, crops/flips/pyramid/TPS/elastic). Sub-batches 3b (15 rotation-representation symbols) and 3c (14 homography-normalization & camera-frame symbols) follow as separate PRs.

**No behavior change.** Docstrings, tests and `.rst` only — verified by tokenizing `kornia/geometry/conversions.py` before and after: the two token streams are identical once docstring tokens are excluded.

## Lane

🟢 **Green lane** — documentation fixes plus tests, no issue or assignment needed. Per CONTRIBUTING's green-lane requirement for documentation fixes, every corrected claim below was verified by running it, and the verification snippets live in the test file as pins (each with a generation-snippet comment, per CLAUDE.md's hardcoded-reference-values pattern). Nothing here changes behavior, defaults or conventions: the behavior defects the audit turned up were routed to dedicated issues (#3937–#3940) rather than fixed here, which keeps this PR in the green lane and leaves the repair conversation where it belongs.

## Scope — 16 symbols

| Symbol | Convention block | `.. warning::` | pins |
|---|---|---|---|
| `rad2deg` | ✅ | #3937 | 2 (1 xfail, 1 wart) |
| `deg2rad` | ✅ | #3937 | 2 (1 xfail, 1 wart) |
| `pol2cart` | ✅ | — | 1 |
| `cart2pol` | ✅ | #3939 | 3 (1 xfail) + 1 wart |
| `angle_to_rotation_matrix` | ✅ | #3937 | 3 (1 xfail, 1 wart) |
| `convert_points_from_homogeneous` | ✅ | #3938 | 1 (1 xfail) + 1 wart + annotated pre-existing `test_points` |
| `convert_points_to_homogeneous` | ✅ | — | annotated pre-existing `test_convert_points` |
| `convert_affinematrix_to_homography` | ✅ | — | strengthened pre-existing `test_convert_points` |
| `convert_affinematrix_to_homography3d` | ✅ | — | 1 |
| `normalize_pixel_coordinates` | ✅ | #3940 | 4 + 7 wart legs |
| `denormalize_pixel_coordinates` | ✅ | #3940 | 2 + 6 wart legs |
| `normalize_pixel_coordinates3d` | ✅ | #3940 | 1 + 9 wart legs |
| `denormalize_pixel_coordinates3d` | ✅ | #3940 | 1 + 9 wart legs |
| `normalize_points_with_intrinsics` | ✅ | — | 2 |
| `denormalize_points_with_intrinsics` | ✅ | — | 1 |
| `vector_to_skew_symmetric_matrix` | ✅ | — | folded into pre-existing entry-wise test |

Totals (grep-verified at HEAD): **16** `Convention:` blocks, **9** `.. warning::` directives, **19** `test_convention_*` functions of which **3** carry `xfail(strict=True, raises=AssertionError)` marks (5 parametrized legs), plus **9** `test_wart_*` functions (39 legs per configuration) — two of them 15-leg parametrized matrices sharing one driver, one asserting the six ops' `eps` default is the `1e-8` the warnings quote, and two float16-hardcoded pins backing the docstrings' float16-underflow claims with executed values covering every (function, size argument, degenerate class) cell of #3940. The pins column above counts parametrized legs per symbol; a test exercising two symbols (e.g. the `cart2pol`/`angle_to_rotation_matrix` relation pin) is counted once, under the symbol whose convention it states. Review waves 3–6 deduplicated pins whose facts were already enforced by pre-existing tests in the same class (26→19 convention definitions) — the surviving pre-existing tests are annotated as the convention's enforcement point. `docs/source/geometry.conversions.rst` also gains the missing `convert_affinematrix_to_homography3d` autofunction entry.

The blocks state the facts that are easy to get wrong and were previously undocumented: `(x, y)` component order against `(pixel_coordinates, height, width)` positional order; the `(d, x, y)` component order of the 3-D variants; corner-aligned `2x/(W-1) - 1` normalization and its relationship to `grid_sample`'s `align_corners`; that `angle_to_rotation_matrix` takes **degrees** and rotates in the opposite sense to `cart2pol`'s `phi` in the raw coordinate plane; `[v]_x @ x == cross(v, x)`; and the `fx, fy, cx, cy` intrinsics layout with the skew entry `K[0, 1]` ignored.

## Behavior findings → dedicated issues

- **#3937** — `kornia.constants.pi` is a float32 constant, so `rad2deg`/`deg2rad` (and `angle_to_rotation_matrix` through `deg2rad`) lose ~7 digits on float64 input and divide integer input by 3.
- **#3938** — `convert_points_from_homogeneous` divides by `w + eps` rather than `w`.
- **#3939** — `cart2pol` returns `sqrt(x**2 + y**2 + eps)`, so `rho` is biased high; the bias survives rounding in float64 (`cart2pol(3., 4.)` is `5.000000001`) and dominates at the origin in float32 and float64, though away from the origin float32 and float16 round back to the exact radius. The `eps` docstring also described a division the function does not perform.
- **#3940** — degenerate `height`/`width`/`depth` (`1`, `0` or negative) are not validated in the pixel-coordinate normalizers; the clamped denominator produces a `2e8` blow-up instead of an error.

All 9 warnings link an **open, dedicated** issue, so each disappears with its fix instead of going stale. Two pin polarities keep them from going stale silently:

- The 3 `xfail(strict=True)` marks (5 legs) assert the *intended* behavior: one parametrized float64 test covering exact `180.0` from `rad2deg(pi)`, exact `pi` from `deg2rad(180.)` and the exact quarter turn from `angle_to_rotation_matrix(90.)` (float64 hardcoded in the body, so the legs execute — and XPASS loudly on a #3937 fix — in every run configuration, including the default float32 one; on MPS they skip visibly, float64 not existing there, and `raises=AssertionError` keeps an environment error from satisfying any mark), plus `rho(0, 0) == 0` (the origin, where the eps bias is the whole answer) and division by exactly `w`. Because a strict xfail can also be stranded by a fix the mark's author did not anticipate, the two single-value xfails have wart companions pinning the current `rho` at and below `eps`, and the current signed errors at `w = ±2e-8` — cells chosen so that grad-only-eps, `eps**2`, clamp-shaped and sign-aware-eps fixes each flip at least one pin of the pair. The clamp and sign-aware shapes — the two that would strand the strict xfail alone — were simulated and observed to fail the companion wart; the other two shapes XPASS the strict marks by construction.
- The 9 `test_wart_*` tests (39 legs per configuration) assert the **current broken output** for the cases where the intended behavior is a maintainer decision rather than an obvious value: integer input to `rad2deg`/`deg2rad`/`angle_to_rotation_matrix` (promote like `torch.rad2deg`, or raise?) and degenerate sizes in the four pixel-coordinate normalizers (raise, clamp, or keep the pass-through?) — the latter as two parametrized matrices covering all 30 (function, size argument, class ∈ {1, 0, negative}) cells with exactly one argument degenerate per cell, so **any** partial #3940 fix flips at least one named leg. Every eps-dependent wart call passes `eps=1e-8` explicitly, so retuning the *default* eps cannot fail these pins while the degenerate-size handling they actually pin is unchanged. A strict xfail asserting one of those answers would stay silently `XFAIL` forever if the other were chosen — a raising implementation keeps a raising xfail red. A wart pin flips loudly under **either** polarity, and its comment block says so, naming the issue and the exact docstring warnings to update when it fires.

## Documentation-fact fixes (11)

The audit found 11 documented claims contradicted by execution; all are corrected here (10 in docstrings, 1 on the Conventions page):

- **`normalize_pixel_coordinates` / `denormalize_pixel_coordinates`**: the `Args:` block listed `width:` before `height:` while the signature is `(pixel_coordinates, height, width, ...)` — a reader following doc order and calling positionally swapped H and W. Both blocks reordered.
- **`normalize_pixel_coordinates3d`**: the summary line "-1 if on extreme left, 1 if on extreme right (x = w-1)" was copied verbatim from the 2-D function and implies `x` is the first component; it is actually the **second** — the order is `(d, x, y)`.
- **`denormalize_points_with_intrinsics`**: its summary said "**Normalize** points with intrinsics", its `Args` described the input as "in the image pixel coordinates" and its `Returns` said "`(u, v)` cam coordinates" — a sibling copy-paste with input and output descriptions swapped relative to reality.
- **`docs/source/get-started/conventions.rst`**: the page claimed normalized coordinates are "identical to `torch.nn.functional.grid_sample`". They are identical only with `align_corners=True` passed explicitly; under `grid_sample`'s own default the same grid samples different values, and with `mode='nearest'` it samples the corner out of bounds.
- **Review wave 2** corrected two claims in the batch's own warnings that were wider than what executes: `cart2pol`'s "`rho` is biased **everywhere**" (float32 and float16 round `cart2pol(3., 4.)` back to exactly `5.`; the surviving cases are float64, and the origin in float32/float64), and `convert_points_from_homogeneous`' relative bias of "`eps / w`" (the signed relative error is exactly `-eps / (w + eps)` — wrong sign, and 50 % vs the actual 33 % at `w = 2 * eps`; `-eps / w` is only the large-`|w|` approximation, and at `w = 2` it is visible in float64 but vanishes in float32).
- Also: `cart2pol`'s "`eps`: To avoid division by zero" (there is no division); `normalize_pixel_coordinates`' "between -1 and 1" (nothing is clamped — its own example returns `1.0408`); `denormalize_pixel_coordinates3d`'s "`depth`: the maximum depth in the x-axis" (it is the z axis); `normalize_points_with_intrinsics`' `Returns: (u, v) cam coordinates` (it returns calibrated coordinates, not pixels); `convert_points_from_homogeneous`' `(B, N, D)`-only shape claim (its own example passes a 2-D tensor); `vector_to_skew_symmetric_matrix`' `(B, 3)`-only claim (unbatched `(3,)` is accepted, and is what its example uses).

## Verification

Convention pins, both float dtypes:

```
$ pixi run -e default uv run pytest tests/geometry/test_conversions.py -q -k "test_convention or test_wart" --dtype=float32,float64 --color=no
collected 448 items / 309 deselected / 139 selected

tests/geometry/test_conversions.py xxx.........xx......xx............... [ 33%]
........................................................................ [ 98%]
..                                                                       [100%]

================ 104 passed, 309 deselected, 7 xfailed in 0.89s ================
```

No `XPASS` and no SKIP at any CPU float dtype. The 7 XFAILs are the 3 float64-hardcoded #3937 legs (dtype-fixture-free, so they run — and stay armed — in every configuration) plus the `rho` and divide-by-`w` strict xfails at each of the two dtypes. At `--dtype=all` the same selection is 200 passed, 4 skipped, 9 xfailed, 0 failed, 0 XPASS; the 4 skips are the float16 legs of the `rho`/`w` claims and of their wart companions, each carrying the numeric underflow reason.

- Every pin was **mutation-checked when introduced**: the claim it asserts was temporarily broken, the pin was observed to fail, and the mutation was reverted by targeted edit. Review waves 3–4 then removed pins whose facts were provably enforced by pre-existing tests (the specific covering literals are named in the review threads) and verified per-cell isolation of the #3940 matrices against four simulated partial fixes.
- Full-file baseline recorded before any edit and re-checked after: at `--dtype=all` on CPU every failure is bfloat16/float16 (zero at float32/float64), and the post-change failure set is a subset of that baseline. MPS (`float32,float16`) likewise unchanged. Caveat, stated because it makes baseline diffs noisy: `tests/geometry/test_conversions.py` contains pre-existing unseeded `torch.rand` calls, so the float16 failure count moves by ±2 between identical runs of the *unmodified* file — a separate seeding issue, not introduced here.
- Convention pins assert through `BaseTester.assert_close`'s central per-dtype tolerance table (f32 1e-4, f64 1e-5); the few explicit tolerances that remain each carry an in-comment measurement justifying them.
- `pixi run lint` clean.
- MPS (`--device=mps --dtype=float32,float16`): pin selection 39 passed / 70 skipped / 2 xfailed / 0 failed (the wart-matrix skips come from a single runtime probe of the torch clamp-caching defect, so they self-retire when torch fixes it; the float64-only #3937 legs also skip there rather than xfailing on an unrelated `TypeError`), and the full-file failure set (29) is a subset of the recorded MPS baseline (30). The wart-matrix legs and the both-degenerate pin carry a visible `pytest.skip` on MPS: torch 2.9.1 caches `clamp`'s scalar `min` per shape/dtype there, so `z = torch.zeros(2, device="mps"); z.clamp(1e-8); z.clamp(1e-7)` returns `9.99999993922529e-09` both times, while the same pair on cpu returns `1e-08` then `1.0000000116860974e-07`. The clamped `eps` those pins measure is therefore set by test order on MPS — a torch defect, not a kornia one.
- `pixi run build-docs` succeeds with `-W` (warnings-as-errors), so the new `:func:`/`:math:` markup and the added autofunction entry all resolve.
- `kornia/geometry/conversions.py` tokenized before and after: identical except for docstring tokens.

## Algorithm source

N/A — this PR implements no algorithm. It documents the behavior kornia already has. The audit methodology was: for each symbol, execute the base checklist (accepted shapes including unbatched, dtype handling, raise-vs-pass-through on bad rank, broadcasting, device) plus a conversions-specific trap list, and record snippet + observed output; a claim was written down only if a run produced it. Sentences that were merely inferred from reading source were removed or corrected. Every number quoted in a block or warning is reproducible from the snippet next to it.

Posted on behalf of @ducha-aiki by Claude (Fable 5).


