### PR TITLE
feat: expose separable guided blur

### DIFF
--- a/kornia/filters/guided.py
+++ b/kornia/filters/guided.py
@@ -53,8 +53,8 @@ def _guided_blur_grayscale_guidance(
 ) -> torch.Tensor:
     guidance_sub, input_sub, kernel_size = _preprocess_fast_guided_blur(guidance, input, kernel_size, subsample)
 
-    mean_I = box_blur(guidance_sub, kernel_size, border_type, separable)
-    corr_I = box_blur(guidance_sub.square(), kernel_size, border_type, separable)
+    mean_I = box_blur(guidance_sub, kernel_size, border_type, separable=separable)
+    corr_I = box_blur(guidance_sub.square(), kernel_size, border_type, separable=separable)
     var_I = corr_I - mean_I.square()
 
     if input is guidance:
@@ -62,8 +62,8 @@ def _guided_blur_grayscale_guidance(
         cov_Ip = var_I
 
     else:
-        mean_p = box_blur(input_sub, kernel_size, border_type, separable)
-        corr_Ip = box_blur(guidance_sub * input_sub, kernel_size, border_type, separable)
+        mean_p = box_blur(input_sub, kernel_size, border_type, separable=separable)
+        corr_Ip = box_blur(guidance_sub * input_sub, kernel_size, border_type, separable=separable)
         cov_Ip = corr_Ip - mean_I * mean_p
 
     if isinstance(eps, torch.Tensor):
@@ -72,8 +72,8 @@ def _guided_blur_grayscale_guidance(
     a = cov_Ip / (var_I + eps)
     b = mean_p - a * mean_I
 
-    mean_a = box_blur(a, kernel_size, border_type, separable)
-    mean_b = box_blur(b, kernel_size, border_type, separable)
+    mean_a = box_blur(a, kernel_size, border_type, separable=separable)
+    mean_b = box_blur(b, kernel_size, border_type, separable=separable)
 
     if subsample > 1:
         mean_a = interpolate(mean_a, scale_factor=subsample, mode="bilinear")
@@ -94,9 +94,9 @@ def _guided_blur_multichannel_guidance(
     guidance_sub, input_sub, kernel_size = _preprocess_fast_guided_blur(guidance, input, kernel_size, subsample)
     B, C, H, W = guidance_sub.shape
 
-    mean_I = box_blur(guidance_sub, kernel_size, border_type, separable).permute(0, 2, 3, 1)
+    mean_I = box_blur(guidance_sub, kernel_size, border_type, separable=separable).permute(0, 2, 3, 1)
     II = (guidance_sub.unsqueeze(1) * guidance_sub.unsqueeze(2)).flatten(1, 2)
-    corr_I = box_blur(II, kernel_size, border_type, separable).permute(0, 2, 3, 1)
+    corr_I = box_blur(II, kernel_size, border_type, separable=separable).permute(0, 2, 3, 1)
     var_I = corr_I.reshape(B, H, W, C, C) - mean_I.unsqueeze(-2) * mean_I.unsqueeze(-1)
 
     if guidance is input:
@@ -104,9 +104,9 @@ def _guided_blur_multichannel_guidance(
         cov_Ip = var_I
 
     else:
-        mean_p = box_blur(input_sub, kernel_size, border_type, separable).permute(0, 2, 3, 1)
+        mean_p = box_blur(input_sub, kernel_size, border_type, separable=separable).permute(0, 2, 3, 1)
         Ip = (input_sub.unsqueeze(1) * guidance_sub.unsqueeze(2)).flatten(1, 2)
-        corr_Ip = box_blur(Ip, kernel_size, border_type, separable).permute(0, 2, 3, 1)
+        corr_Ip = box_blur(Ip, kernel_size, border_type, separable=separable).permute(0, 2, 3, 1)
         cov_Ip = corr_Ip.reshape(B, H, W, C, -1) - mean_p.unsqueeze(-2) * mean_I.unsqueeze(-1)
 
     if isinstance(eps, torch.Tensor):
@@ -116,8 +116,8 @@ def _guided_blur_multichannel_guidance(
     a = torch.linalg.solve(var_I + _eps, cov_Ip)  # B, H, W, C_guidance, C_input
     b = mean_p - (mean_I.unsqueeze(-2) @ a).squeeze(-2)  # B, H, W, C_input
 
-    mean_a = box_blur(a.flatten(-2).permute(0, 3, 1, 2), kernel_size, border_type, separable)
-    mean_b = box_blur(b.permute(0, 3, 1, 2), kernel_size, border_type, separable)
+    mean_a = box_blur(a.flatten(-2).permute(0, 3, 1, 2), kernel_size, border_type, separable=separable)
+    mean_b = box_blur(b.permute(0, 3, 1, 2), kernel_size, border_type, separable=separable)
 
     if subsample > 1:
         mean_a = interpolate(mean_a, scale_factor=subsample, mode="bilinear")
@@ -177,9 +177,25 @@ def guided_blur(
         )
 
     if guidance.shape[1] == 1:
-        return _guided_blur_grayscale_guidance(guidance, input, kernel_size, eps, border_type, subsample, separable)
+        return _guided_blur_grayscale_guidance(
+            guidance,
+            input,
+            kernel_size,
+            eps,
+            border_type,
+            subsample,
+            separable=separable,
+        )
     else:
-        return _guided_blur_multichannel_guidance(guidance, input, kernel_size, eps, border_type, subsample, separable)
+        return _guided_blur_multichannel_guidance(
+            guidance,
+            input,
+            kernel_size,
+            eps,
+            border_type,
+            subsample,
+            separable=separable,
+        )
 
 
 class GuidedBlur(nn.Module):

--- a/kornia/filters/guided.py
+++ b/kornia/filters/guided.py
@@ -49,11 +49,12 @@ def _guided_blur_grayscale_guidance(
     eps: float | torch.Tensor,
     border_type: str = "reflect",
     subsample: int = 1,
+    separable: bool = False,
 ) -> torch.Tensor:
     guidance_sub, input_sub, kernel_size = _preprocess_fast_guided_blur(guidance, input, kernel_size, subsample)
 
-    mean_I = box_blur(guidance_sub, kernel_size, border_type)
-    corr_I = box_blur(guidance_sub.square(), kernel_size, border_type)
+    mean_I = box_blur(guidance_sub, kernel_size, border_type, separable)
+    corr_I = box_blur(guidance_sub.square(), kernel_size, border_type, separable)
     var_I = corr_I - mean_I.square()
 
     if input is guidance:
@@ -61,8 +62,8 @@ def _guided_blur_grayscale_guidance(
         cov_Ip = var_I
 
     else:
-        mean_p = box_blur(input_sub, kernel_size, border_type)
-        corr_Ip = box_blur(guidance_sub * input_sub, kernel_size, border_type)
+        mean_p = box_blur(input_sub, kernel_size, border_type, separable)
+        corr_Ip = box_blur(guidance_sub * input_sub, kernel_size, border_type, separable)
         cov_Ip = corr_Ip - mean_I * mean_p
 
     if isinstance(eps, torch.Tensor):
@@ -71,8 +72,8 @@ def _guided_blur_grayscale_guidance(
     a = cov_Ip / (var_I + eps)
     b = mean_p - a * mean_I
 
-    mean_a = box_blur(a, kernel_size, border_type)
-    mean_b = box_blur(b, kernel_size, border_type)
+    mean_a = box_blur(a, kernel_size, border_type, separable)
+    mean_b = box_blur(b, kernel_size, border_type, separable)
 
     if subsample > 1:
         mean_a = interpolate(mean_a, scale_factor=subsample, mode="bilinear")
@@ -88,13 +89,14 @@ def _guided_blur_multichannel_guidance(
     eps: float | torch.Tensor,
     border_type: str = "reflect",
     subsample: int = 1,
+    separable: bool = False,
 ) -> torch.Tensor:
     guidance_sub, input_sub, kernel_size = _preprocess_fast_guided_blur(guidance, input, kernel_size, subsample)
     B, C, H, W = guidance_sub.shape
 
-    mean_I = box_blur(guidance_sub, kernel_size, border_type).permute(0, 2, 3, 1)
+    mean_I = box_blur(guidance_sub, kernel_size, border_type, separable).permute(0, 2, 3, 1)
     II = (guidance_sub.unsqueeze(1) * guidance_sub.unsqueeze(2)).flatten(1, 2)
-    corr_I = box_blur(II, kernel_size, border_type).permute(0, 2, 3, 1)
+    corr_I = box_blur(II, kernel_size, border_type, separable).permute(0, 2, 3, 1)
     var_I = corr_I.reshape(B, H, W, C, C) - mean_I.unsqueeze(-2) * mean_I.unsqueeze(-1)
 
     if guidance is input:
@@ -102,9 +104,9 @@ def _guided_blur_multichannel_guidance(
         cov_Ip = var_I
 
     else:
-        mean_p = box_blur(input_sub, kernel_size, border_type).permute(0, 2, 3, 1)
+        mean_p = box_blur(input_sub, kernel_size, border_type, separable).permute(0, 2, 3, 1)
         Ip = (input_sub.unsqueeze(1) * guidance_sub.unsqueeze(2)).flatten(1, 2)
-        corr_Ip = box_blur(Ip, kernel_size, border_type).permute(0, 2, 3, 1)
+        corr_Ip = box_blur(Ip, kernel_size, border_type, separable).permute(0, 2, 3, 1)
         cov_Ip = corr_Ip.reshape(B, H, W, C, -1) - mean_p.unsqueeze(-2) * mean_I.unsqueeze(-1)
 
     if isinstance(eps, torch.Tensor):
@@ -114,8 +116,8 @@ def _guided_blur_multichannel_guidance(
     a = torch.linalg.solve(var_I + _eps, cov_Ip)  # B, H, W, C_guidance, C_input
     b = mean_p - (mean_I.unsqueeze(-2) @ a).squeeze(-2)  # B, H, W, C_input
 
-    mean_a = box_blur(a.flatten(-2).permute(0, 3, 1, 2), kernel_size, border_type)
-    mean_b = box_blur(b.permute(0, 3, 1, 2), kernel_size, border_type)
+    mean_a = box_blur(a.flatten(-2).permute(0, 3, 1, 2), kernel_size, border_type, separable)
+    mean_b = box_blur(b.permute(0, 3, 1, 2), kernel_size, border_type, separable)
 
     if subsample > 1:
         mean_a = interpolate(mean_a, scale_factor=subsample, mode="bilinear")
@@ -133,6 +135,7 @@ def guided_blur(
     eps: float | torch.Tensor,
     border_type: str = "reflect",
     subsample: int = 1,
+    separable: bool = False,
 ) -> torch.Tensor:
     r"""Blur a torch.Tensor using a Guided filter.
 
@@ -150,6 +153,7 @@ def guided_blur(
           The expected modes are: ``'constant'``, ``'reflect'``,
           ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
         subsample: subsampling factor for Fast Guided filtering. Default: 1 (no subsampling)
+        separable: run as composition of two 1d-convolutions. Default: False
 
     Returns:
         the blurred torch.Tensor with same shape as `input` :math:`(B, C, H, W)`.
@@ -173,9 +177,9 @@ def guided_blur(
         )
 
     if guidance.shape[1] == 1:
-        return _guided_blur_grayscale_guidance(guidance, input, kernel_size, eps, border_type, subsample)
+        return _guided_blur_grayscale_guidance(guidance, input, kernel_size, eps, border_type, subsample, separable)
     else:
-        return _guided_blur_multichannel_guidance(guidance, input, kernel_size, eps, border_type, subsample)
+        return _guided_blur_multichannel_guidance(guidance, input, kernel_size, eps, border_type, subsample, separable)
 
 
 class GuidedBlur(nn.Module):
@@ -191,6 +195,7 @@ class GuidedBlur(nn.Module):
           The expected modes are: ``'constant'``, ``'reflect'``,
           ``'replicate'`` or ``'circular'``. Default: ``'reflect'``.
         subsample: subsampling factor for Fast Guided filtering. Default: 1 (no subsampling)
+        separable: run as composition of two 1d-convolutions. Default: False
 
     Returns:
         the blurred input torch.Tensor.
@@ -210,13 +215,19 @@ class GuidedBlur(nn.Module):
     """
 
     def __init__(
-        self, kernel_size: tuple[int, int] | int, eps: float, border_type: str = "reflect", subsample: int = 1
+        self,
+        kernel_size: tuple[int, int] | int,
+        eps: float,
+        border_type: str = "reflect",
+        subsample: int = 1,
+        separable: bool = False,
     ) -> None:
         super().__init__()
         self.kernel_size = kernel_size
         self.eps = eps
         self.border_type = border_type
         self.subsample = subsample
+        self.separable = separable
 
     def __repr__(self) -> str:
         return (
@@ -224,7 +235,8 @@ class GuidedBlur(nn.Module):
             f"(kernel_size={self.kernel_size}, "
             f"eps={self.eps}, "
             f"border_type={self.border_type}, "
-            f"subsample={self.subsample})"
+            f"subsample={self.subsample}, "
+            f"separable={self.separable})"
         )
 
     def forward(self, guidance: torch.Tensor, input: torch.Tensor) -> torch.Tensor:
@@ -250,4 +262,12 @@ class GuidedBlur(nn.Module):
             Tensor with shape :math:`(B, C_i, H, W)` containing the
             edge-aware filtered version of ``input``.
         """
-        return guided_blur(guidance, input, self.kernel_size, self.eps, self.border_type, self.subsample)
+        return guided_blur(
+            guidance,
+            input,
+            kernel_size=self.kernel_size,
+            eps=self.eps,
+            border_type=self.border_type,
+            subsample=self.subsample,
+            separable=self.separable,
+        )

--- a/tests/filters/test_guided.py
+++ b/tests/filters/test_guided.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from functools import partial
+from unittest.mock import patch
 
 import pytest
 import torch
 
 from kornia.core._compat import torch_version
-from kornia.filters import GuidedBlur, guided_blur
+from kornia.filters import GuidedBlur, box_blur, guided_blur
 
 from testing.base import BaseTester
 
@@ -59,6 +61,80 @@ class TestGuidedBlur(BaseTester):
         assert isinstance(actual_D, torch.Tensor)
         assert actual_D.shape == (batch_size, input_dim, H, W)
 
+    @pytest.mark.parametrize("guide_dim", [1, 3])
+    @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
+    @pytest.mark.parametrize("subsample", [1, 2])
+    def test_separable_matches_nonseparable(
+        self,
+        guide_dim,
+        kernel_size,
+        subsample,
+        device,
+        dtype,
+    ):
+        height, width = 12, 16
+        guide = torch.linspace(
+            0.1,
+            1.0,
+            steps=guide_dim * height * width,
+            device=device,
+            dtype=dtype,
+        ).reshape(1, guide_dim, height, width)
+        inp = torch.linspace(
+            1.0,
+            0.1,
+            steps=2 * height * width,
+            device=device,
+            dtype=dtype,
+        ).reshape(1, 2, height, width)
+
+        expected = guided_blur(
+            guide,
+            inp,
+            kernel_size,
+            eps=0.1,
+            subsample=subsample,
+            separable=False,
+        )
+        actual = guided_blur(
+            guide,
+            inp,
+            kernel_size,
+            eps=0.1,
+            subsample=subsample,
+            separable=True,
+        )
+
+        self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize("guide_dim", [1, 3])
+    def test_module_forwards_separable_to_all_box_blurs(
+        self,
+        guide_dim,
+        device,
+        dtype,
+    ):
+        guide = torch.ones(1, guide_dim, 8, 8, device=device, dtype=dtype)
+        inp = torch.ones(1, 2, 8, 8, device=device, dtype=dtype)
+        received_separable_values = []
+
+        def tracked_box_blur(
+            input_tensor: torch.Tensor,
+            kernel_size: tuple[int, int] | int,
+            border_type: str = "reflect",
+            separable: bool = False,
+        ) -> torch.Tensor:
+            received_separable_values.append(separable)
+            return box_blur(input_tensor, kernel_size, border_type, separable)
+
+        with patch(
+            "kornia.filters.guided.box_blur",
+            side_effect=tracked_box_blur,
+        ):
+            GuidedBlur(3, 0.1, separable=True)(guide, inp)
+
+        assert received_separable_values == [True] * 6
+
     @pytest.mark.parametrize("shape", [(1, 1, 8, 15), (2, 3, 11, 7)])
     @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
     def test_cardinality(self, shape, kernel_size, device, dtype):
@@ -86,25 +162,36 @@ class TestGuidedBlur(BaseTester):
         actual = guided_blur(guide, inp, 3, 0.1)
         assert actual.is_contiguous()
 
-    def test_gradcheck(self, device):
+    @pytest.mark.parametrize("separable", [False, True])
+    def test_gradcheck(self, separable, device):
         guide = torch.rand(1, 2, 5, 4, device=device, dtype=torch.float64)
         img = torch.rand(1, 2, 5, 4, device=device, dtype=torch.float64)
-        self.gradcheck(guided_blur, (guide, img, 3, 0.1), nondet_tol=1e-4)
+        operation = partial(guided_blur, separable=separable)
+        self.gradcheck(operation, (guide, img, 3, 0.1), nondet_tol=1e-4)
 
         eps = torch.rand(1, device=device, dtype=torch.float64)
-        self.gradcheck(guided_blur, (guide, img, 3, eps), nondet_tol=1e-4)
+        self.gradcheck(operation, (guide, img, 3, eps), nondet_tol=1e-4)
 
     @pytest.mark.parametrize("shape", [(1, 1, 8, 16), (2, 3, 12, 8)])
     @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
     @pytest.mark.parametrize("eps", [0.1, 0.01])
     @pytest.mark.parametrize("subsample", [1, 2])
-    def test_module(self, shape, kernel_size, eps, subsample, device, dtype):
+    @pytest.mark.parametrize("separable", [False, True])
+    def test_module(self, shape, kernel_size, eps, subsample, device, dtype, separable):
         guide = torch.rand(shape, device=device, dtype=dtype)
         img = torch.rand(shape, device=device, dtype=dtype)
 
         op = guided_blur
-        op_module = GuidedBlur(kernel_size, eps, subsample=subsample)
-        self.assert_close(op_module(guide, img), op(guide, img, kernel_size, eps, subsample=subsample))
+        op_module = GuidedBlur(
+            kernel_size,
+            eps,
+            subsample=subsample,
+            separable=separable,
+        )
+        self.assert_close(
+            op_module(guide, img),
+            op(guide, img, kernel_size, eps, subsample=subsample, separable=separable),
+        )
 
     @pytest.mark.skipif(
         torch_version() in {"1.9.1", "2.1.0", "2.1.1", "2.1.2"},
@@ -115,15 +202,21 @@ class TestGuidedBlur(BaseTester):
     )
     @pytest.mark.parametrize("kernel_size", [5, (5, 7)])
     @pytest.mark.parametrize("subsample", [1, 2])
-    def test_dynamo(self, kernel_size, subsample, device, dtype, torch_optimizer):
+    @pytest.mark.parametrize("separable", [False, True])
+    def test_dynamo(self, kernel_size, subsample, separable, device, dtype, torch_optimizer):
         guide = torch.ones(2, 3, 8, 8, device=device, dtype=dtype)
         data = torch.ones(2, 3, 8, 8, device=device, dtype=dtype)
-        op = GuidedBlur(kernel_size, 0.1, subsample=subsample)
+        op = GuidedBlur(kernel_size, 0.1, subsample=subsample, separable=separable)
         op_optimized = torch_optimizer(op)
 
         self.assert_close(op(guide, data), op_optimized(guide, data))
 
-        op = GuidedBlur(kernel_size, torch.tensor(0.1, device=device, dtype=dtype), subsample=subsample)
+        op = GuidedBlur(
+            kernel_size,
+            torch.tensor(0.1, device=device, dtype=dtype),
+            subsample=subsample,
+            separable=separable,
+        )
         op_optimized = torch_optimizer(op)
 
         self.assert_close(op(guide, data), op_optimized(guide, data))

--- a/tests/filters/test_guided.py
+++ b/tests/filters/test_guided.py
@@ -107,7 +107,12 @@ class TestGuidedBlur(BaseTester):
             separable=True,
         )
 
-        self.assert_close(actual, expected)
+        if dtype in (torch.float16, torch.bfloat16):
+            # The two convolution decompositions accumulate rounding errors in different orders at half precision.
+            tolerance = 3 * torch.finfo(dtype).eps
+            self.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
+        else:
+            self.assert_close(actual, expected)
 
     @pytest.mark.parametrize("guide_dim", [1, 3])
     def test_module_forwards_separable_to_all_box_blurs(

--- a/tests/filters/test_guided.py
+++ b/tests/filters/test_guided.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
+
 from functools import partial
 from unittest.mock import patch
 
@@ -71,7 +73,7 @@ class TestGuidedBlur(BaseTester):
         subsample,
         device,
         dtype,
-    ):
+    ) -> None:
         height, width = 12, 16
         guide = torch.linspace(
             0.1,
@@ -113,7 +115,7 @@ class TestGuidedBlur(BaseTester):
         guide_dim,
         device,
         dtype,
-    ):
+    ) -> None:
         guide = torch.ones(1, guide_dim, 8, 8, device=device, dtype=dtype)
         inp = torch.ones(1, 2, 8, 8, device=device, dtype=dtype)
         received_separable_values = []
@@ -125,7 +127,7 @@ class TestGuidedBlur(BaseTester):
             separable: bool = False,
         ) -> torch.Tensor:
             received_separable_values.append(separable)
-            return box_blur(input_tensor, kernel_size, border_type, separable)
+            return box_blur(input_tensor, kernel_size, border_type, separable=separable)
 
         with patch(
             "kornia.filters.guided.box_blur",
@@ -133,7 +135,8 @@ class TestGuidedBlur(BaseTester):
         ):
             GuidedBlur(3, 0.1, separable=True)(guide, inp)
 
-        assert received_separable_values == [True] * 6
+        assert received_separable_values
+        assert all(received_separable_values), "Expected all box_blur calls to have separable=True"
 
     @pytest.mark.parametrize("shape", [(1, 1, 8, 15), (2, 3, 11, 7)])
     @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
@@ -163,7 +166,7 @@ class TestGuidedBlur(BaseTester):
         assert actual.is_contiguous()
 
     @pytest.mark.parametrize("separable", [False, True])
-    def test_gradcheck(self, separable, device):
+    def test_gradcheck(self, separable, device) -> None:
         guide = torch.rand(1, 2, 5, 4, device=device, dtype=torch.float64)
         img = torch.rand(1, 2, 5, 4, device=device, dtype=torch.float64)
         operation = partial(guided_blur, separable=separable)
@@ -177,7 +180,7 @@ class TestGuidedBlur(BaseTester):
     @pytest.mark.parametrize("eps", [0.1, 0.01])
     @pytest.mark.parametrize("subsample", [1, 2])
     @pytest.mark.parametrize("separable", [False, True])
-    def test_module(self, shape, kernel_size, eps, subsample, device, dtype, separable):
+    def test_module(self, shape, kernel_size, eps, subsample, device, dtype, separable) -> None:
         guide = torch.rand(shape, device=device, dtype=dtype)
         img = torch.rand(shape, device=device, dtype=dtype)
 
@@ -203,7 +206,7 @@ class TestGuidedBlur(BaseTester):
     @pytest.mark.parametrize("kernel_size", [5, (5, 7)])
     @pytest.mark.parametrize("subsample", [1, 2])
     @pytest.mark.parametrize("separable", [False, True])
-    def test_dynamo(self, kernel_size, subsample, separable, device, dtype, torch_optimizer):
+    def test_dynamo(self, kernel_size, subsample, separable, device, dtype, torch_optimizer) -> None:
         guide = torch.ones(2, 3, 8, 8, device=device, dtype=dtype)
         data = torch.ones(2, 3, 8, 8, device=device, dtype=dtype)
         op = GuidedBlur(kernel_size, 0.1, subsample=subsample, separable=separable)


### PR DESCRIPTION
## Which lane? *(check one — see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))*
- [ ] 🟢 **Green lane** — test-first bug fix / verified docs fix / [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue / benchmark results. No prior issue needed.
- [x] 🟠 **Discuss-first** — feature or behavior change; a maintainer confirmed the scope on the linked issue.

**Fixes/Relates to:** #3662

## What does this PR do?

This PR exposes the existing separable box-filtering option through `guided_blur` and `GuidedBlur`.

When `separable=True`, each internal box blur is computed using two one-dimensional convolutions instead of one two-dimensional convolution. The default
  remains `False`, preserving the existing behavior and public API compatibility.

## Test log
```text
pytest -v tests/filters/test_guided.py --device=cpu --dtype=float32
Setting up torch compile...
===================================================================== test session starts ======================================================================
platform linux -- Python 3.13.11, pytest-9.0.3, pluggy-1.6.0 -- /mnt/devdrive/projects/kornia/.venv/bin/python
cachedir: .pytest_cache

cpu info:
        - Model name: Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz
        - Architecture: x86_64
        - CPU(s): 2
        - Thread(s) per core: 1
gpu info: {}
main deps:
    - kornia-0.9.0rc1
    - torch-2.9.1+cu128
        - commit: 5811a8d7da873dd699ff6687092c225caffcf1bb
        - cuda: 12.8
        - nvidia-driver: None
x deps:
    - `accelerate` not found
dev deps:
    - kornia_rs-0.1.10
    - onnx-1.21.0
gcc info: (Ubuntu 15.2.0-16ubuntu1) 15.2.0
available optimizers: {'', None, 'cudagraphs', 'openxla', 'tvm', 'jit', 'inductor'}
model weights cached: ['checkpoints']

rootdir: /mnt/devdrive/projects/kornia
configfile: pyproject.toml
plugins: cov-7.0.0, anyio-4.12.0, timeout-2.4.0
collected 92 items                                                                                                                                             

tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-1-1-1] PASSED                                                                 [  1%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-1-1-2] PASSED                                                                 [  2%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-1-3-1] PASSED                                                                 [  3%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-1-3-2] PASSED                                                                 [  4%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-3-1-1] PASSED                                                                 [  5%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-3-1-2] PASSED                                                                 [  7%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-3-3-1] PASSED                                                                 [  8%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-5-3-3-2] PASSED                                                                 [  9%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-1-1-1] PASSED                                                      [ 10%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-1-1-2] PASSED                                                      [ 11%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-1-3-1] PASSED                                                      [ 13%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-1-3-2] PASSED                                                      [ 14%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-3-1-1] PASSED                                                      [ 15%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-3-1-2] PASSED                                                      [ 16%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-3-3-1] PASSED                                                      [ 17%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.1-kernel_size1-3-3-2] PASSED                                                      [ 19%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-1-1-1] PASSED                                                                [ 20%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-1-1-2] PASSED                                                                [ 21%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-1-3-1] PASSED                                                                [ 22%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-1-3-2] PASSED                                                                [ 23%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-3-1-1] PASSED                                                                [ 25%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-3-1-2] PASSED                                                                [ 26%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-3-3-1] PASSED                                                                [ 27%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-5-3-3-2] PASSED                                                                [ 28%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-1-1-1] PASSED                                                     [ 29%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-1-1-2] PASSED                                                     [ 30%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-1-3-1] PASSED                                                     [ 32%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-1-3-2] PASSED                                                     [ 33%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-3-1-1] PASSED                                                     [ 34%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-3-1-2] PASSED                                                     [ 35%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-3-3-1] PASSED                                                     [ 36%]
tests/filters/test_guided.py::TestGuidedBlur::test_smoke[cpu-float32-0.01-kernel_size1-3-3-2] PASSED                                                     [ 38%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-1-5-1] PASSED                                              [ 39%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-1-5-3] PASSED                                              [ 40%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-1-kernel_size1-1] PASSED                                   [ 41%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-1-kernel_size1-3] PASSED                                   [ 42%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-2-5-1] PASSED                                              [ 44%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-2-5-3] PASSED                                              [ 45%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-2-kernel_size1-1] PASSED                                   [ 46%]
tests/filters/test_guided.py::TestGuidedBlur::test_separable_matches_nonseparable[cpu-float32-2-kernel_size1-3] PASSED                                   [ 47%]
tests/filters/test_guided.py::TestGuidedBlur::test_module_forwards_separable_to_all_box_blurs[cpu-float32-1] PASSED                                      [ 48%]
tests/filters/test_guided.py::TestGuidedBlur::test_module_forwards_separable_to_all_box_blurs[cpu-float32-3] PASSED                                      [ 50%]
tests/filters/test_guided.py::TestGuidedBlur::test_cardinality[cpu-float32-5-shape0] PASSED                                                              [ 51%]
tests/filters/test_guided.py::TestGuidedBlur::test_cardinality[cpu-float32-5-shape1] PASSED                                                              [ 52%]
tests/filters/test_guided.py::TestGuidedBlur::test_cardinality[cpu-float32-kernel_size1-shape0] PASSED                                                   [ 53%]
tests/filters/test_guided.py::TestGuidedBlur::test_cardinality[cpu-float32-kernel_size1-shape1] PASSED                                                   [ 54%]
tests/filters/test_guided.py::TestGuidedBlur::test_exception PASSED                                                                                      [ 55%]
tests/filters/test_guided.py::TestGuidedBlur::test_noncontiguous[cpu-float32] PASSED                                                                     [ 57%]
tests/filters/test_guided.py::TestGuidedBlur::test_gradcheck[cpu-False] PASSED                                                                           [ 58%]
tests/filters/test_guided.py::TestGuidedBlur::test_gradcheck[cpu-True] PASSED                                                                            [ 59%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.1-5-shape0] PASSED                                                       [ 60%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.1-5-shape1] PASSED                                                       [ 61%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.1-kernel_size1-shape0] PASSED                                            [ 63%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.1-kernel_size1-shape1] PASSED                                            [ 64%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.01-5-shape0] PASSED                                                      [ 65%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.01-5-shape1] PASSED                                                      [ 66%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.01-kernel_size1-shape0] PASSED                                           [ 67%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-1-0.01-kernel_size1-shape1] PASSED                                           [ 69%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.1-5-shape0] PASSED                                                       [ 70%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.1-5-shape1] PASSED                                                       [ 71%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.1-kernel_size1-shape0] PASSED                                            [ 72%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.1-kernel_size1-shape1] PASSED                                            [ 73%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.01-5-shape0] PASSED                                                      [ 75%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.01-5-shape1] PASSED                                                      [ 76%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.01-kernel_size1-shape0] PASSED                                           [ 77%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-False-2-0.01-kernel_size1-shape1] PASSED                                           [ 78%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.1-5-shape0] PASSED                                                        [ 79%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.1-5-shape1] PASSED                                                        [ 80%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.1-kernel_size1-shape0] PASSED                                             [ 82%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.1-kernel_size1-shape1] PASSED                                             [ 83%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.01-5-shape0] PASSED                                                       [ 84%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.01-5-shape1] PASSED                                                       [ 85%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.01-kernel_size1-shape0] PASSED                                            [ 86%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-1-0.01-kernel_size1-shape1] PASSED                                            [ 88%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.1-5-shape0] PASSED                                                        [ 89%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.1-5-shape1] PASSED                                                        [ 90%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.1-kernel_size1-shape0] PASSED                                             [ 91%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.1-kernel_size1-shape1] PASSED                                             [ 92%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.01-5-shape0] PASSED                                                       [ 94%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.01-5-shape1] PASSED                                                       [ 95%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.01-kernel_size1-shape0] PASSED                                            [ 96%]
tests/filters/test_guided.py::TestGuidedBlur::test_module[cpu-float32-True-2-0.01-kernel_size1-shape1] PASSED                                            [ 97%]
tests/filters/test_guided.py::TestGuidedBlur::test_opencv_grayscale[cpu-float32] PASSED                                                                  [ 98%]
tests/filters/test_guided.py::TestGuidedBlur::test_opencv_rgb[cpu-float32] PASSED                                                                        [100%]

====================================================================== 84 passed in 5.43s ======================================================================

KORNIA_TEST_OPTIMIZER=inductor pytest -v \
      tests/filters/test_guided.py::TestGuidedBlur::test_dynamo \
      --device=cpu \
      --dtype=float32 \
      --optimizer=inductor
Setting up torch compile...
===================================================================== test session starts ======================================================================
platform linux -- Python 3.13.11, pytest-9.0.3, pluggy-1.6.0 -- /mnt/devdrive/projects/kornia/.venv/bin/python
cachedir: .pytest_cache

cpu info:
        - Model name: Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz
        - Architecture: x86_64
        - CPU(s): 2
        - Thread(s) per core: 1
gpu info: {}
main deps:
    - kornia-0.9.0rc1
    - torch-2.9.1+cu128
        - commit: 5811a8d7da873dd699ff6687092c225caffcf1bb
        - cuda: 12.8
        - nvidia-driver: None
x deps:
    - `accelerate` not found
dev deps:
    - kornia_rs-0.1.10
    - onnx-1.21.0
gcc info: (Ubuntu 15.2.0-16ubuntu1) 15.2.0
available optimizers: {'', None, 'jit', 'openxla', 'cudagraphs', 'tvm', 'inductor'}
model weights cached: ['checkpoints']

rootdir: /mnt/devdrive/projects/kornia
configfile: pyproject.toml
plugins: cov-7.0.0, anyio-4.12.0, timeout-2.4.0
collected 8 items                                                                                                                                              

tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-False-1-5] PASSED                                                         [ 12%]
tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-False-1-kernel_size1] PASSED                                              [ 25%]
tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-False-2-5] PASSED                                                         [ 37%]
tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-False-2-kernel_size1] PASSED                                              [ 50%]
tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-True-1-5] PASSED                                                          [ 62%]
tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-True-1-kernel_size1] PASSED                                               [ 75%]
tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-True-2-5] PASSED                                                          [ 87%]
tests/filters/test_guided.py::TestGuidedBlur::test_dynamo[cpu-float32-inductor-True-2-kernel_size1] PASSED                                               [100%]

================================================================ 8 passed in 236.33s (0:03:56) =================================================================
```

## AI Usage Disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
- [ ] 🟢 **Human-written**
- [x] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests.
- [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified the result and can address reviewer questions

## 🛠️ Changes Made

  - [x] Added `separable: bool = False` to `guided_blur`.
  - [x] Added `separable: bool = False` to `GuidedBlur`.
  - [x] Propagated the option through the grayscale and multichannel guided filter implementations.
  - [x] Forwarded the option to all internal `box_blur` operations.
  - [x] Updated the public API docstrings.
  - [x] Added tests for output equivalence, parameter forwarding, gradients, module behavior, and Dynamo compatibility.

## 🧪 How Was This Tested?

  - [x] **Unit Tests:** Tested both `separable=False` and `separable=True` with:
    - Grayscale and multichannel guidance.
    - Integer and tuple kernel sizes.
    - Standard and subsampled guided filtering.
    - Functional and module APIs.
    - Gradient checks.
    - Dynamo compilation.

  - [x] **Manual Verification:** Reviewed the implementation to confirm that the new argument reaches every internal `box_blur` call and that the default remains unchanged.

  - [x] **Performance/Edge Cases:** The implementation reuses Kornia's existing separable `box_blur` path. It does not introduce a new filtering algorithm. The separable path changes the kernel cost from approximately `O(kh * kw)` to `O(kh + kw)` per pixel, which is especially useful for larger kernels. No standalone performance benchmark was performed.

## 🚦 Checklist

  - [x] I am assigned to the linked issue.
  - [x] The linked issue has been approved by a maintainer.
  - [x] I have performed a self-review of my code.
  - [x] I have personally type my code with AI help.
  - [x] My code follows the existing style guidelines of this project.
  - [x] No additional comments were necessary because the change delegates to an existing Kornia option without introducing new algorithmic logic.
  - [x] I have added tests that prove the feature works.
  - [ ] Screenshots/recordings are not applicable to this change.