### PR TITLE
fix(geometry): accept arbitrary batch ranks in axis_angle_to_rotation_matrix

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -292,10 +292,9 @@ def axis_angle_to_rotation_matrix(axis_angle: torch.Tensor) -> torch.Tensor:
     r"""Convert 3d vector of axis-angle rotation to 3x3 rotation matrix.
 
     Args:
-        axis_angle: tensor of 3d vector of axis-angle rotations in radians with shape :math:`(N, 3)`.
-
+        axis_angle: tensor of 3d vector of axis-angle rotations in radians with shape :math:`(*, 3)`.
     Returns:
-        tensor of rotation matrices of shape :math:`(N, 3, 3)`.
+        tensor of rotation matrices of shape :math:`(*, 3, 3)`.
 
     Example:
         >>> input = torch.tensor([[0., 0., 0.]])
@@ -319,8 +318,8 @@ def axis_angle_to_rotation_matrix(axis_angle: torch.Tensor) -> torch.Tensor:
 
     def _compute_rotation_matrix(axis_angle: torch.Tensor, theta2: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
         theta = torch.sqrt(theta2.clamp(min=1e-12))  # clamping to ensure no nan gradients
-        wxyz = axis_angle / (theta.unsqueeze(-1) + eps)  # (B, 3)
-        wx, wy, wz = wxyz.unbind(dim=1)  # (B,)
+        wxyz = axis_angle / (theta.unsqueeze(-1) + eps)
+        wx, wy, wz = wxyz.unbind(dim=-1)
 
         cos_theta = torch.cos(theta)
         sin_theta = torch.sin(theta)
@@ -348,12 +347,13 @@ def axis_angle_to_rotation_matrix(axis_angle: torch.Tensor) -> torch.Tensor:
                 torch.stack([r10, r11, r12], dim=-1),
                 torch.stack([r20, r21, r22], dim=-1),
             ],
-            dim=1,
+            dim=-2,
         )
 
         return rot
 
     def _compute_rotation_matrix_taylor(axis_angle: torch.Tensor) -> torch.Tensor:
+        batch_shape = axis_angle.shape[:-1]
         rx, ry, rz = axis_angle.unbind(-1)
         k_one = torch.ones_like(rx)
 
@@ -370,16 +370,17 @@ def axis_angle_to_rotation_matrix(axis_angle: torch.Tensor) -> torch.Tensor:
                 k_one,
             ],
             dim=-1,
-        ).view(-1, 3, 3)
+        ).reshape(*batch_shape, 3, 3)
 
         return rot
 
     theta2 = (axis_angle * axis_angle).sum(dim=-1)
 
-    rot_normal = _compute_rotation_matrix(axis_angle, theta2)  # (N,3,3)
-    rot_taylor = _compute_rotation_matrix_taylor(axis_angle)  # (N,3,3)
+    rot_normal = _compute_rotation_matrix(axis_angle, theta2)
+    rot_taylor = _compute_rotation_matrix_taylor(axis_angle)
 
-    mask = (theta2 > 1e-6).view(-1, 1, 1)  # shape (N,1,1)
+    batch_shape = axis_angle.shape[:-1]
+    mask = (theta2 > 1e-6).reshape(*batch_shape, 1, 1)
 
     rotation_matrix = torch.where(mask, rot_normal, rot_taylor)
 

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -293,6 +293,7 @@ def axis_angle_to_rotation_matrix(axis_angle: torch.Tensor) -> torch.Tensor:
 
     Args:
         axis_angle: tensor of 3d vector of axis-angle rotations in radians with shape :math:`(*, 3)`.
+
     Returns:
         tensor of rotation matrices of shape :math:`(*, 3, 3)`.
 


### PR DESCRIPTION
## Summary

Fixes `axis_angle_to_rotation_matrix` to accept arbitrary batch ranks `(*, 3)` instead of only rank-2 `(N, 3)`, matching the documented guard and sibling functions.

### Problem

The function's shape guard checks `axis_angle.shape[-1] == 3` and raises `ValueError("Input size must be a (*, 3)")`, but the body uses `unbind(dim=1)`, `stack(dim=1)`, and `.view(-1, 3, 3)` — all of which assume exactly one batch dimension. Inputs of any other rank fail with `IndexError`/`ValueError` from deep inside the computation.

This also breaks composition: `axis_angle_to_rotation_matrix(rotation_matrix_to_axis_angle(R))` fails for every rank except 3, including for shapes produced by `rotation_matrix_to_axis_angle`'s own doctest.

### Fix

1. `unbind(dim=1)` → `unbind(dim=-1)` — split along the last axis (rank-agnostic)
2. `stack(dim=1)` → `stack(dim=-2)` — stack matrix rows before the last dim
3. `.view(-1, 3, 3)` → `.reshape(*batch_shape, 3, 3)` — preserve batch shape in Taylor fallback
4. `mask.view(-1, 1, 1)` → `.reshape(*batch_shape, 1, 1)` — preserve batch shape for broadcasting

### Test results

```python
>>> aa2R(torch.zeros(3,)).shape
torch.Size([3, 3])
>>> aa2R(torch.zeros(2, 3)).shape
torch.Size([2, 3, 3])
>>> aa2R(torch.zeros(0, 3)).shape
torch.Size([0, 3, 3])
>>> aa2R(torch.zeros(2, 5, 3)).shape
torch.Size([2, 5, 3, 3])
>>> aa2R(torch.zeros(1, 1, 3)).shape
torch.Size([1, 1, 3, 3])
```

Identity correctness verified: `aa2R(zeros(*shape))` produces identity matrices for all ranks.

Closes #3955
