### PR TITLE
fix(geometry): dtype-aware eps prevents float16 NaN in quaternion log/exp/normalize

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -76,6 +76,17 @@ __all__ = [
 ]
 
 
+def _dtype_safe_eps(eps: float, dtype: torch.dtype) -> float:
+    """Clamp ``eps`` so it does not underflow to zero in the given floating dtype.
+
+    A Python ``float`` default like ``1e-8`` silently rounds to ``0.0`` when cast to
+    float16, which disables the division guard it is meant to provide. Using
+    ``max(eps, torch.finfo(dtype).tiny)`` keeps the guard active in low precision
+    without changing behavior for dtypes where the default is already representable.
+    """
+    return max(eps, torch.finfo(dtype).tiny)
+
+
 def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
     r"""Convert angles from radians to degrees.
 
@@ -652,7 +663,7 @@ def normalize_quaternion(quaternion: torch.Tensor, eps: float = 1.0e-12) -> torc
 
     if not quaternion.shape[-1] == 4:
         raise ValueError(f"Input must be a tensor of shape (*, 4). Got {quaternion.shape}")
-    return F.normalize(quaternion, p=2.0, dim=-1, eps=eps)
+    return F.normalize(quaternion, p=2.0, dim=-1, eps=_dtype_safe_eps(eps, quaternion.dtype))
 
 
 # based on:
@@ -816,7 +827,9 @@ def quaternion_log_to_exp(quaternion: torch.Tensor, eps: float = 1.0e-8) -> torc
         raise ValueError(f"Input must be a tensor of shape (*, 3). Got {quaternion.shape}")
 
     # compute quaternion norm
-    norm_q: torch.Tensor = torch.norm(quaternion, p=2, dim=-1, keepdim=True).clamp(min=eps)
+    norm_q: torch.Tensor = torch.norm(quaternion, p=2, dim=-1, keepdim=True).clamp(
+        min=_dtype_safe_eps(eps, quaternion.dtype)
+    )
 
     # compute scalar and vector
     quaternion_vector: torch.Tensor = quaternion * torch.sin(norm_q) / norm_q
@@ -858,7 +871,9 @@ def quaternion_exp_to_log(quaternion: torch.Tensor, eps: float = 1.0e-8) -> torc
     quaternion_vector = quaternion[..., 1:4]
 
     # compute quaternion norm
-    norm_q: torch.Tensor = torch.norm(quaternion_vector, p=2, dim=-1, keepdim=True).clamp(min=eps)
+    norm_q: torch.Tensor = torch.norm(quaternion_vector, p=2, dim=-1, keepdim=True).clamp(
+        min=_dtype_safe_eps(eps, quaternion_vector.dtype)
+    )
 
     # apply log map
     quaternion_log: torch.Tensor = (


### PR DESCRIPTION
🟢 Green lane (test-first bug fix, verified docs fix, help wanted issue, benchmark results: no issue needed)
- [x] Green lane
- [ ] Discuss-first lane

Fixes #3966

## Description
`quaternion_exp_to_log`, `quaternion_log_to_exp`, and `normalize_quaternion` in
`kornia/geometry/conversions.py` each guard a division by clamping a norm with
a Python `float` default for `eps` (`1e-8` / `1e-12`). In `float16`, these
defaults underflow to exactly `0.0` (float16's smallest subnormal is
~5.96e-08), so the clamp becomes a no-op and the division becomes `0 / 0`,
returning `NaN`.

This reproduces for the identity quaternion — the simplest possible input —
and any quaternion with a zero vector part, in both `quaternion_exp_to_log`
and `quaternion_log_to_exp`, and for near-zero/zero quaternions in
`normalize_quaternion` (which is also the root cause of the NaN reported in
#3952, since `quaternion_to_rotation_matrix` calls it internally).

`float32`, `float64`, and `bfloat16` are unaffected, since `1e-8` is
representable in all three.

## Fix
Added a small helper, `_dtype_safe_eps(eps, dtype)`, which returns
`max(eps, torch.finfo(dtype).tiny)` — i.e. it only raises `eps` when the
requested value isn't representable in the tensor's dtype, and otherwise
leaves it untouched. This follows the same dtype-aware pattern already used
by `safe_zero_division` inside `rotation_matrix_to_quaternion` in this file,
rather than introducing a new approach.

Applied at the three division-guard sites:
- `normalize_quaternion`: `F.normalize(..., eps=_dtype_safe_eps(eps, quaternion.dtype))`
- `quaternion_log_to_exp`: norm clamp uses `_dtype_safe_eps(eps, quaternion.dtype)`
- `quaternion_exp_to_log`: norm clamp uses `_dtype_safe_eps(eps, quaternion_vector.dtype)`

No public API changes — function signatures are unchanged.

## Testing
Verified against every case from #3966 and the linked #3952:

```python
import torch
from kornia.geometry.conversions import (
    quaternion_exp_to_log, quaternion_log_to_exp, normalize_quaternion
)

quaternion_exp_to_log(torch.tensor([1., 0., 0., 0.], dtype=torch.float16))
# now: tensor([0., 0., 0.])  (was: tensor([nan, nan, nan]))

quaternion_exp_to_log(torch.tensor([-1., 0., 0., 0.], dtype=torch.float16))
# now: tensor([0., 0., 0.])  (was: NaN)

quaternion_log_to_exp(torch.zeros(3, dtype=torch.float16))
# now: tensor([1., 0., 0., 0.])  (was: tensor([1., nan, nan, nan]))

normalize_quaternion(torch.zeros(4, dtype=torch.float16))
# now: tensor([0., 0., 0., 0.])  (was: all-NaN)

normalize_quaternion(torch.tensor([1e-13, 0., 0., 0.], dtype=torch.float16))
# now: tensor([0., 0., 0., 0.])  (was: all-NaN)
```

Regression checks — confirmed unchanged:
- Non-zero vector part at float16 (`[-1., 1e-3, 0., 0.]`) still returns the
  correct non-zero log map.
- `float32`, `float64`, `bfloat16` behavior identical to before the change.
- All existing doctests in the three functions pass.

## CI Evidence
All 36 CI checks passed, including the full CPU test matrix across Python
3.11–3.13, PyTorch 2.5.1/2.9.1, float32/float64, on Ubuntu/macOS/Windows —
see the Checks tab on this PR.

## AI Usage Disclosure
🔴 AI-generated — Claude (Anthropic) diagnosed the root cause, proposed the
`_dtype_safe_eps` fix following the existing `safe_zero_division` pattern
already in this file (see `rotation_matrix_to_quaternion`), and drafted the
verification tests. I reviewed the diff and understand the reasoning: eps
defaults are plain Python floats that underflow to `0.0` in float16, silently
disabling the division-by-zero guard; the fix compares eps against
`torch.finfo(dtype).tiny` (the smallest representable value for that dtype)
and only raises it when necessary, leaving float32/float64 behavior
unchanged.