### PR TITLE
fix(geometry): pad mixed-size laplacian pyramids

### DIFF
--- a/kornia/geometry/transform/pyramid.py
+++ b/kornia/geometry/transform/pyramid.py
@@ -591,23 +591,17 @@ def build_laplacian_pyramid(
           level — level 0 is **not** the unchanged original image whenever
           ``max_level > 1``
         - the input is reflect-padded up to the next power of two (per
-          dimension) only when **neither** the height **nor** the width is
-          already a power of two; when it is applied, every returned level
+          dimension) when padding is required to keep adjacent Gaussian levels
+          aligned for subtraction; when it is applied, every returned level
           — including level 0 — is shaped from the padded size
         - border_type: ``'reflect'`` by default
         - align_corners: ``False`` by default
 
     .. warning::
-        For a mixed odd/power-of-two input size (one dimension a power of two,
-        the other not), no padding is applied and the level-to-level
-        subtraction can raise ``RuntimeError`` from a shape mismatch when
-        ``max_level > 1`` (e.g. a :math:`(1, 1, 5, 8)` input with
-        ``max_level=2``). This is likely unintended and tracked in
-        `#3927 <https://github.com/kornia/kornia/issues/3927>`_. Separately, the
-        ``max_level`` bounds check does not currently reject non-positive
+        The ``max_level`` bounds check does not currently reject non-positive
         **integer** values: passing an integer ``max_level <= 0`` returns the
-        same single-element list as ``max_level=1`` instead of raising — also
-        tracked in `#3927 <https://github.com/kornia/kornia/issues/3927>`_.
+        same single-element list as ``max_level=1`` instead of raising. Tracked
+        in `#3927 <https://github.com/kornia/kornia/issues/3927>`_.
 
     Args:
         input : the torch.Tensor to be used to construct the pyramid with shape :math:`(B, C, H, W)`.
@@ -632,7 +626,11 @@ def build_laplacian_pyramid(
 
     h = input.size()[2]
     w = input.size()[3]
-    require_padding = not (is_powerof_two(w) or is_powerof_two(h))
+    width_is_powerof_two = is_powerof_two(w)
+    height_is_powerof_two = is_powerof_two(h)
+    require_padding = not (width_is_powerof_two or height_is_powerof_two)
+    if max_level > 1:
+        require_padding = not (width_is_powerof_two and height_is_powerof_two)
 
     if require_padding:
         # in case of arbitrary shape torch.Tensor image need to be padded.

--- a/tests/geometry/transform/test_pyramid.py
+++ b/tests/geometry/transform/test_pyramid.py
@@ -224,6 +224,12 @@ class TestBuildLaplacianPyramid(BaseTester):
         assert len(pyramid) == 1
         assert pyramid[0].shape == (1, 2, 4, 5)
 
+    @pytest.mark.parametrize("height,width", ((5, 8), (8, 5)))
+    def test_mixed_power_of_two_size_padding(self, height, width, device, dtype):
+        sample = torch.rand(1, 2, height, width, device=device, dtype=dtype)
+        pyramid = kornia.geometry.transform.build_laplacian_pyramid(sample, max_level=2)
+        assert [img.shape for img in pyramid] == [torch.Size((1, 2, 8, 8)), torch.Size((1, 2, 4, 4))]
+
     @pytest.mark.parametrize("batch_size", (1, 2, 3))
     @pytest.mark.parametrize("channels", (1, 3))
     @pytest.mark.parametrize("max_level", (2, 3, 4))


### PR DESCRIPTION
## Which lane? *(check one — see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))*
- [x] 🟢 **Green lane** — test-first bug fix / verified docs fix / [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue / benchmark results. No prior issue needed.
- [ ] 🟠 **Discuss-first** — feature or behavior change; a maintainer confirmed the scope on the linked issue.

**Fixes/Relates to:** Fixes #3927

## What does this PR do?

This fixes the Laplacian pyramid padding predicate for mixed power-of-two input sizes, such as `5x8` and `8x5`.

On `main`, `build_laplacian_pyramid(torch.rand(1, 1, 5, 8), 2)` raises during the residual subtraction because no padding is applied when only one dimension is already a power of two. The fix pads mixed-size inputs when `max_level > 1`, while preserving the existing `max_level=1` behavior that does not need adjacent-level subtraction.

I also updated the docstring to remove the now-fixed mixed-size warning, while leaving the separate `max_level <= 0` validation note unchanged.

## Test log

```
$ pytest tests\geometry\transform\test_pyramid.py::TestBuildLaplacianPyramid::test_mixed_power_of_two_size_padding -q
2 passed in 3.67s

$ pytest tests\geometry\transform\test_pyramid.py -q
61 passed in 3.75s

$ ruff check kornia\geometry\transform\pyramid.py tests\geometry\transform\test_pyramid.py
All checks passed!
```

## AI Usage Disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
- [ ] 🟢 **Human-written**
- [x] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests
- [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified the result and can address reviewer questions
