### PR TITLE
bugfix(geometry): support non-contiguous DSNT inputs

### DIFF
--- a/kornia/geometry/subpix/dsnt.py
+++ b/kornia/geometry/subpix/dsnt.py
@@ -66,7 +66,7 @@ def spatial_softmax2d(input: torch.Tensor, temperature: Optional[torch.Tensor] =
     if temperature is None:
         temperature = torch.tensor(1.0)
     temperature = temperature.to(device=input.device, dtype=input.dtype)
-    x = input.view(batch_size, channels, -1)
+    x = input.reshape(batch_size, channels, -1)
 
     x_soft = F.softmax(x * temperature, dim=-1)
 
@@ -107,7 +107,7 @@ def spatial_expectation2d(input: torch.Tensor, normalized_coordinates: bool = Tr
     pos_x = grid[..., 0].reshape(-1)
     pos_y = grid[..., 1].reshape(-1)
 
-    input_flat = input.view(batch_size, channels, -1)
+    input_flat = input.reshape(batch_size, channels, -1)
 
     # Compute the expectation of the coordinates.
     expected_y = torch.sum(pos_y * input_flat, -1, keepdim=True)

--- a/tests/geometry/subpix/test_dsnt.py
+++ b/tests/geometry/subpix/test_dsnt.py
@@ -80,6 +80,15 @@ class TestSpatialSoftmax2d(BaseTester):
         sums = actual.sum(-1).sum(-1)
         self.assert_close(sums, torch.ones_like(sums))
 
+    def test_non_contiguous(self, device, dtype):
+        input = torch.randn(2, 3, 4, 6, device=device, dtype=dtype).transpose(-2, -1)
+        assert not input.is_contiguous()
+
+        expected = kornia.geometry.subpix.spatial_softmax2d(input.contiguous())
+        actual = kornia.geometry.subpix.spatial_softmax2d(input)
+
+        self.assert_close(actual, expected)
+
     def test_dynamo(self, input, torch_optimizer):
         op = kornia.geometry.subpix.spatial_softmax2d
         op_optimized = torch_optimizer(op)
@@ -107,6 +116,17 @@ class TestSpatialExpectation2d(BaseTester):
         self.assert_close(actual_norm, expected_norm)
         actual_px = kornia.geometry.subpix.spatial_expectation2d(input, False)
         self.assert_close(actual_px, expected_px)
+
+    def test_non_contiguous(self, device, dtype):
+        input = torch.rand(2, 3, 4, 6, device=device, dtype=dtype)
+        input = input / input.sum(dim=(-2, -1), keepdim=True)
+        input = input.transpose(-2, -1)
+        assert not input.is_contiguous()
+
+        expected = kornia.geometry.subpix.spatial_expectation2d(input.contiguous())
+        actual = kornia.geometry.subpix.spatial_expectation2d(input)
+
+        self.assert_close(actual, expected)
 
     @pytest.mark.skip("After the op be optimized the results are not the same")
     def test_dynamo(self, dtype, device, torch_optimizer):


### PR DESCRIPTION
## Which lane? 

- [x] 🟢 **Green lane** — test-first bug fix / verified docs fix / [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue / benchmark results. No prior issue needed.
- [ ] 🟠 **Discuss-first** — feature or behavior change; a maintainer confirmed the scope on the linked issue.

**Fixes/Relates to:** n/a: green-lane bug fix with no prior issue

## What does this PR do?

Fixes `spatial_softmax2d` and `spatial_expectation2d` failing on valid non-contiguous input tensors.

The added `test_non_contiguous` tests fail on `main` with:

`RuntimeError: view size is not compatible with input tensor's size and stride`

The implementation uses `reshape` instead of `view` when flattening the spatial dimensions. This preserves existing behavior for contiguous inputs while supporting tensors with non-contiguous layouts, such as transposed tensors.

## Test log

```shell
$ uv run --extra dev pytest -v \
  tests/geometry/subpix/test_dsnt.py::TestSpatialSoftmax2d::test_non_contiguous \
  tests/geometry/subpix/test_dsnt.py::TestSpatialExpectation2d::test_non_contiguous \
  --device=cpu --dtype=all

collected 8 items

TestSpatialSoftmax2d::test_non_contiguous[cpu-bfloat16] PASSED
TestSpatialSoftmax2d::test_non_contiguous[cpu-float16] PASSED
TestSpatialSoftmax2d::test_non_contiguous[cpu-float32] PASSED
TestSpatialSoftmax2d::test_non_contiguous[cpu-float64] PASSED
TestSpatialExpectation2d::test_non_contiguous[cpu-bfloat16] PASSED
TestSpatialExpectation2d::test_non_contiguous[cpu-float16] PASSED
TestSpatialExpectation2d::test_non_contiguous[cpu-float32] PASSED
TestSpatialExpectation2d::test_non_contiguous[cpu-float64] PASSED

============================= 8 passed in 1.55s =============================
```

## AI Usage Disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*

- [ ] 🟢 **Human-written**
- [x] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests
- [ ] 🔴 **AI-generated** — an agent wrote most of it; I verified the result and can address reviewer questions