### PR TITLE
fix(core): stop @deprecated from rewriting the global warning filters

### DIFF
--- a/kornia/core/_compat.py
+++ b/kornia/core/_compat.py
@@ -135,19 +135,15 @@ def _emit_deprecation_warning(
     beginning = f"Since kornia {version} the " if version is not None else ""
     extra = f" {extra_reason}" if extra_reason else ""
 
-    warnings.simplefilter("always", DeprecationWarning)
-    try:
-        if replace_with is not None:
-            msg = f"{beginning}`{name}` is deprecated in favor of `{replace_with}`.{extra}"
-        else:
-            msg = f"{beginning}`{name}` is deprecated and will be removed in the future versions.{extra}"
-        warnings.warn(
-            msg,
-            category=DeprecationWarning,
-            stacklevel=3,
-        )
-    finally:
-        warnings.simplefilter("default", DeprecationWarning)
+    if replace_with is not None:
+        msg = f"{beginning}`{name}` is deprecated in favor of `{replace_with}`.{extra}"
+    else:
+        msg = f"{beginning}`{name}` is deprecated and will be removed in the future versions.{extra}"
+    warnings.warn(
+        msg,
+        category=DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 def deprecated(

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -6445,15 +6445,17 @@ class TestAxisAngleToRotationMatrix:
 
 # Module-level pins for kornia#3956: the four deprecated aliases of this module
 # (angle_axis_to_rotation_matrix, rotation_matrix_to_angle_axis, quaternion_to_angle_axis,
-# angle_axis_to_quaternion) are not the site of the defect -- the root cause is
-# _emit_deprecation_warning in kornia/core/_compat.py, which wraps its warnings.warn call in
+# angle_axis_to_quaternion) were never the site of the defect -- the root cause was
+# _emit_deprecation_warning in kornia/core/_compat.py, which wrapped its warnings.warn call in
 # warnings.simplefilter("always", DeprecationWarning) / simplefilter("default", DeprecationWarning)
-# and so rewrites the PROCESS-GLOBAL filter list on every call. Every deprecated symbol in kornia
-# is therefore affected, which is why these live at module level rather than in one symbol's class,
-# following the module-level wart precedent above. Both pins run inside warnings.catch_warnings()
-# so that the filter mutation they provoke cannot leak into the rest of the suite: this bug is
-# contagious across tests, and an unisolated pin would silently disarm every other test's warning
-# discipline.
+# and so rewrote the PROCESS-GLOBAL filter list on every call. Every deprecated symbol in kornia
+# was therefore affected, which is why these live at module level rather than in one symbol's
+# class, following the module-level wart precedent above; the emitter itself is pinned in
+# tests/utils/test_deprecated.py, and these four cells are what keeps the convention attached to
+# the aliases rather than to one caller of the decorator. Both pins run inside
+# warnings.catch_warnings() so that a regression's filter mutation cannot leak into the rest of the
+# suite: that bug was contagious across tests, and an unisolated pin would silently disarm every
+# other test's warning discipline.
 # Both pins parametrize over _DEPRECATED_ALIAS_NAMES_AND_ARGS, the projection of the module-level
 # _DEPRECATED_ALIASES table down to the two columns they use -- neither is about what the alias
 # forwards TO, only about the warning it emits on the way -- so both the list of aliases and the
@@ -6461,29 +6463,24 @@ class TestAxisAngleToRotationMatrix:
 # it never reads.
 
 
-@pytest.mark.xfail(
-    raises=AssertionError,
-    reason="_emit_deprecation_warning forces the DeprecationWarning filter to 'always', so "
-    "-W error::DeprecationWarning cannot escalate it — kornia#3956",
-    strict=True,
-)
 @pytest.mark.parametrize(("alias_name", "arg"), _DEPRECATED_ALIAS_NAMES_AND_ARGS, ids=_DEPRECATED_ALIAS_IDS)
 def test_convention_deprecated_alias_warning_can_be_escalated_to_an_error_3956(alias_name, arg):
-    # Intended behavior: a DeprecationWarning emitted by kornia obeys the caller's warning filters,
-    # so a project that runs under -W error::DeprecationWarning (or pytest's filterwarnings =
-    # error) sees the call fail and can find its deprecated usages. It does not:
-    # _emit_deprecation_warning installs simplefilter("always", DeprecationWarning) immediately
-    # before warnings.warn, which overrides the caller's "error" entry, so the warning is printed
-    # and execution continues. The escalated DeprecationWarning is caught by type rather than
-    # through the shared _runs_without_raising helper: that helper treats *any* exception as the
-    # awaited raise, so an unrelated TypeError from the alias would set escalated=True, pass the
-    # body, and -- under xfail(strict=True) -- be reported as XPASS(strict) on a test named
-    # ..._can_be_escalated_to_an_error_3956, which reads as "#3956 is fixed, drop the mark".
-    # Catching DeprecationWarning specifically lets any other exception propagate and be reported
-    # as an error instead. (The #3955 call sites keep the broad helper on purpose: there an
-    # unrelated exception makes the assertion *fail*, which is already the correct report.)
-    # Marked xfail(strict=True) so fixing #3956 makes all four cases XPASS and forces the mark out.
-    # Companion wart: test_wart_deprecated_alias_rewrites_the_global_warning_filters_3956.
+    # Convention: a DeprecationWarning emitted by kornia obeys the caller's warning filters, so a
+    # project running under -W error::DeprecationWarning (or pytest's filterwarnings = error) sees
+    # the call fail and can find its deprecated usages. Until kornia#3956 was fixed it did not:
+    # _emit_deprecation_warning installed simplefilter("always", DeprecationWarning) immediately
+    # before warnings.warn, which overrode the caller's "error" entry, so the warning was printed
+    # and execution continued.
+    # The escalated DeprecationWarning is caught by type rather than through the shared
+    # _runs_without_raising helper: that helper treats *any* exception as the awaited raise, so an
+    # unrelated TypeError from the alias would set escalated=True and pass the body under a name
+    # that reads as "escalation works". Catching DeprecationWarning specifically lets any other
+    # exception propagate and be reported as an error instead. (The #3955 call sites keep the broad
+    # helper on purpose: there an unrelated exception makes the assertion *fail*, which is already
+    # the correct report.)
+    # Four cells, one per alias, because all four are separate @deprecated call sites: the fix is
+    # in _emit_deprecation_warning, but a future decorator that emits its own warning would have to
+    # honor this too.
     alias = getattr(kornia.geometry.conversions, alias_name)
     tensor = torch.tensor(arg)
 
@@ -6500,23 +6497,16 @@ def test_convention_deprecated_alias_warning_can_be_escalated_to_an_error_3956(a
 
 
 @pytest.mark.parametrize(("alias_name", "arg"), _DEPRECATED_ALIAS_NAMES_AND_ARGS, ids=_DEPRECATED_ALIAS_IDS)
-def test_wart_deprecated_alias_rewrites_the_global_warning_filters_3956(alias_name, arg):
-    # Wart pin for kornia#3956, companion to the strict xfail above: assert that a single alias
-    # call CURRENTLY leaves two entries of its own at the head of the process-global filter list,
-    # starting from an empty one. Four cells, one per alias, because all four are separate
-    # @deprecated call sites and a fix could plausibly be applied per decorator rather than in
-    # _emit_deprecation_warning; the 'default' entry (pushed by the finally clause) and the
-    # 'always' entry (pushed before the warn) are both asserted, since a half fix that drops only
-    # the "always" would leave the caller's filters just as clobbered.
-    # If any cell fails, #3956 was (partly) fixed in kornia/core/_compat.py -- flip/remove the
-    # strict xfail above. NOT a contract that calling a deprecated alias must mutate global state.
-    # Snippet used to generate expected (stdlib + torch, executed on cpu):
-    #   with warnings.catch_warnings():
-    #       warnings.resetwarnings()
-    #       kornia.geometry.conversions.angle_axis_to_quaternion(torch.tensor([0.1, 0.2, 0.3]))
-    #       warnings.filters[:2]
-    #   -> [('default', None, <class 'DeprecationWarning'>, None, 0),
-    #       ('always',  None, <class 'DeprecationWarning'>, None, 0)]
+def test_convention_deprecated_alias_leaves_the_global_warning_filters_alone_3956(alias_name, arg):
+    # The other half of kornia#3956, and the half the escalation pin above cannot see: a call must
+    # leave warnings.filters exactly as it found it. Before the fix a single alias call pushed two
+    # entries of its own -- 'always' before the warn and 'default' from the finally clause -- so
+    # even a caller that never escalated had its process-global warning config rewritten, and the
+    # 'default' entry outlived the call. Pinned separately because a half fix that dropped only the
+    # "always" would restore escalation while still clobbering the caller's filters.
+    # Starts from an EMPTY filter list rather than the ambient one so the assertion is exact rather
+    # than a length comparison, and runs inside warnings.catch_warnings() so neither the reset nor
+    # any mutation a regression reintroduces can leak into the rest of the suite.
     alias = getattr(kornia.geometry.conversions, alias_name)
     tensor = torch.tensor(arg)
 
@@ -6526,9 +6516,6 @@ def test_wart_deprecated_alias_rewrites_the_global_warning_filters_3956(alias_na
 
         alias(tensor)
 
-        head = warnings.filters[:2]
+        after = list(warnings.filters)
 
-    assert head == [
-        ("default", None, DeprecationWarning, None, 0),
-        ("always", None, DeprecationWarning, None, 0),
-    ], f"kornia#3956: {alias_name} no longer rewrites the global DeprecationWarning filters; got {head}"
+    assert after == [], f"kornia#3956: {alias_name} mutated the global DeprecationWarning filters; got {after}"

--- a/tests/utils/test_deprecated.py
+++ b/tests/utils/test_deprecated.py
@@ -116,6 +116,30 @@ class TestDeprecatedWrappers:
         dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert len(dep_warnings) == 2
 
+    def test_warning_can_be_escalated_to_an_error(self):
+        """`-W error::DeprecationWarning` must turn the warning into an error.
+
+        See https://github.com/kornia/kornia/issues/3956: the emitter used to prepend its
+        own "always" filter, which shadowed the caller's "error" filter and exempted kornia
+        from a documented CPython mechanism.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            with pytest.raises(DeprecationWarning):
+                utils.create_meshgrid(2, 2)
+
+    def test_warning_does_not_mutate_the_global_filters(self):
+        """Emitting the warning must leave `warnings.filters` exactly as it found it.
+
+        The two `simplefilter` calls used to prepend a global entry each, so a single call
+        to any deprecated symbol permanently rewrote the process-wide warning config.
+        """
+        with warnings.catch_warnings():
+            warnings.resetwarnings()
+            assert warnings.filters == []
+            utils.create_meshgrid(2, 2)
+            assert warnings.filters == []
+
 
 class TestRestoredWrappers:
     """Names removed in 0.8.3 without a deprecation window, restored as warning shims.


### PR DESCRIPTION
## Which lane? *(check one â€” see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))*
- [x] ðŸŸ¢ **Green lane** â€” test-first bug fix / verified docs fix / [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue / benchmark results. No prior issue needed.
- [ ] ðŸŸ  **Discuss-first** â€” feature or behavior change; a maintainer confirmed the scope on the linked issue.

**Fixes/Relates to:** #3956

## What does this PR do?

`_emit_deprecation_warning` in `kornia/core/_compat.py` wrapped its `warnings.warn` call in `warnings.simplefilter("always", DeprecationWarning)`, with a `finally` that called `warnings.simplefilter("default", DeprecationWarning)`. `simplefilter` prepends an entry to the process-global `warnings.filters` list, so neither call was scoped to the function. The first one sat in front of whatever filter the caller had set, and the `finally` did not undo it, it prepended a second entry that then stayed for the rest of the process.

Two things followed from that. Running under `-W error::DeprecationWarning` did not turn kornia's own deprecation warning into an error, so downstream projects had no way to fail their CI on deprecated kornia API usage. Every later `DeprecationWarning` in the same process, from any library, was also downgraded, because the leaked `default` entry kept shadowing the user's `error` filter. Calling any one of the 63 `@deprecated` symbols was enough to trigger it.

This PR deletes both `simplefilter` calls and the `try/finally`, and warns directly, so the caller's filters decide. Two new tests in `tests/utils/test_deprecated.py` fail on `main`: `test_warning_can_be_escalated_to_an_error`, where `main` does not raise, and `test_warning_does_not_mutate_the_global_filters`, where `main` leaves two extra entries in `warnings.filters`. Both run inside `catch_warnings()` so the mutation cannot leak into the rest of the suite.

One deliberate behavior change to flag, since it is easy to miss in the diff. Under Python's default filters a `DeprecationWarning` is only shown when it comes from `__main__`, so dropping the forced "always" makes these warnings less visible in library-internal call chains. That is the normal tradeoff, it is what other libraries do, and it is the side the issue argues for, because a warning that cannot be escalated to an error is of little use to the people who most need it.

## Test log

`pixi` is not installed on this machine, so these ran on the repo `.venv` interpreter directly, which is the same environment `pixi run test-module` shells out to via `uv run pytest`.

```
$ python -m pytest tests/utils/test_deprecated.py
======================== 30 passed, 1 warning in 1.76s ========================

$ python -m pytest tests/geometry/test_conversions.py --dtype=float32,float64
======================= 413 passed, 7 xfailed in 2.86s ========================

$ python -m pytest tests/test_import.py tests/test_api_surface.py
============================= 14 passed in 5.45s ==============================
```

The same two new tests with `main`'s `kornia/core/_compat.py` restored, to show they fail without the fix:

```
$ git checkout upstream/main -- kornia/core/_compat.py
$ python -m pytest tests/utils/test_deprecated.py -k "escalated or mutate"
tests/utils/test_deprecated.py FF                                        [100%]
=========================== short test summary info ===========================
FAILED tests/utils/test_deprecated.py::TestDeprecatedWrappers::test_warning_can_be_escalated_to_an_error
FAILED tests/utils/test_deprecated.py::TestDeprecatedWrappers::test_warning_does_not_mutate_the_global_filters
================ 2 failed, 28 deselected, 2 warnings in 1.82s =================
```

The first fails with `Failed: DID NOT RAISE DeprecationWarning`, the second with `warnings.filters` holding `[('default', DeprecationWarning), ('always', DeprecationWarning)]` where it should hold `[]`.

`ruff check` and `ruff format --check` are both clean on the two changed files.

## AI Usage Disclosure *(pick the closest â€” the ðŸŸ¡/ðŸ”´ line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
- [ ] ðŸŸ¢ **Human-written**
- [ ] ðŸŸ¡ **AI-assisted** â€” AI helped; I reviewed the resulting change and ran the relevant tests
- [x] ðŸ”´ **AI-generated** â€” an agent wrote most of it; I verified the result and can address reviewer questions

An agent wrote the fix, the tests and this description; I reviewed the change, reproduced the bug and ran the tests above myself, and I can answer questions on it.