### PR TITLE
docs: remove documented parameters that do not exist in signatures

### DIFF
--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -145,7 +145,6 @@ def adjust_saturation(image: torch.Tensor, factor: Union[float, torch.Tensor]) -
         image: Image/torch.Tensor to be adjusted in the shape of :math:`(*, 3, H, W)`.
         factor: How much to adjust the saturation. 0 will give a black
           and white image, 1 will give the original image while 2 will enhance the saturation by a factor of 2.
-        saturation_mode: The mode to adjust saturation.
 
     Return:
         Adjusted image in the shape of :math:`(*, 3, H, W)`.
@@ -1125,7 +1124,6 @@ class AdjustSaturation(nn.Module):
     Args:
         saturation_factor: How much to adjust the saturation. 0 will give a black
           and white image, 1 will give the original image while 2 will enhance the saturation by a factor of 2.
-        saturation_mode: The mode to adjust saturation.
 
     Shape:
         - Input: Image/torch.Tensor to be adjusted in the shape of :math:`(*, 3, H, W)`.
@@ -1184,7 +1182,6 @@ class AdjustSaturationWithGraySubtraction(nn.Module):
     Args:
         saturation_factor: How much to adjust the saturation. 0 will give a black
           and white image, 1 will give the original image while 2 will enhance the saturation by a factor of 2.
-        saturation_mode: The mode to adjust saturation.
 
     Shape:
         - Input: Image/torch.Tensor to be adjusted in the shape of :math:`(*, 3, H, W)`.

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -349,9 +349,6 @@ class PinholeCamera:
                 world coordinates. The shape of the torch.Tensor can be :math:`(*, 2)`.
             depth: torch.Tensor containing the depth value of each 2d
                 points. The torch.Tensor shape must be equal to point2d :math:`(*, 1)`.
-            normalize: whether to F.normalize the pointcloud. This
-                must be set to `True` when the depth is represented as the Euclidean
-                ray length from the camera position.
 
         Returns:
             torch.Tensor of (x, y, z) world coordinates with shape :math:`(*, 3)`.

--- a/kornia/image/image.py
+++ b/kornia/image/image.py
@@ -282,7 +282,6 @@ class Image:
         Args:
             data: a numpy array containing the image data.
             color_space: the color space of the image.
-            pixel_format: the pixel format of the image.
             channels_order: what dimension the channels are in the image torch.Tensor.
 
         Example:


### PR DESCRIPTION
## Which lane?
- [x] 🟢 **Green lane** — verified docs fix. No prior issue needed.
- [ ] 🟠 **Discuss-first**

**Fixes/Relates to:** _n/a_

## What does this PR do?

Removes five `Args:` entries that document parameters which don't exist in the corresponding signatures. The rendered API docs currently advertise arguments that raise `TypeError` when passed:

| Location | Documented | Actual signature |
|---|---|---|
| `adjust_saturation` | `saturation_mode` | `(image, factor)` |
| `AdjustSaturation` | `saturation_mode` | `(saturation_factor)` |
| `AdjustSaturationWithGraySubtraction` | `saturation_mode` | `(saturation_factor)` |
| `Image.from_numpy` | `pixel_format` | `(data, color_space, channels_order)` |
| `PinholeCamera.unproject` | `normalize` | `(point_2d, depth)` |

`saturation_mode` appears **nowhere** in the codebase outside these three docstrings. The `normalize` description looks like it was copied from `unproject_points` in `kornia/geometry/camera/perspective.py`, which genuinely does take `normalize`.

Verified the parameters are not accepted:

```python
>>> adjust_saturation(torch.ones(1,3,3,3), 2.0, saturation_mode='x')
TypeError: adjust_saturation() got an unexpected keyword argument 'saturation_mode'
>>> AdjustSaturation(2.0, saturation_mode='x')
TypeError: AdjustSaturation.__init__() got an unexpected keyword argument 'saturation_mode'
```

Docstrings only — no behavior change (7 deleted lines, no additions).

## Test log

```
$ pytest --doctest-modules -q kornia/enhance/adjust.py kornia/image/image.py kornia/geometry/camera/pinhole.py

kornia/enhance/adjust.py ..........................                      [ 74%]
kornia/image/image.py ....                                               [ 85%]
kornia/geometry/camera/pinhole.py .....                                  [100%]
======================== 35 passed, 1 warning in 0.10s =========================


$ pytest -q tests/enhance/test_adjust.py tests/image/test_image.py tests/geometry/camera/test_pinhole.py --device cpu --dtype float32

tests/image/test_image.py .........x.....                                [ 88%]
tests/geometry/camera/test_pinhole.py ...........s........               [100%]
============ 160 passed, 8 skipped, 1 xfailed, 3 warnings in 0.43s =============


$ ruff check kornia/enhance/adjust.py kornia/image/image.py kornia/geometry/camera/pinhole.py
All checks passed!

$ ruff format --check kornia/enhance/adjust.py kornia/image/image.py kornia/geometry/camera/pinhole.py
3 files already formatted
```

## AI Usage Disclosure
- [ ] 🟢 **Human-written**
- [x] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests
- [ ] 🔴 **AI-generated**