### PR TITLE
ci: install the selected PyTorch matrix version

### DIFF
--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -97,7 +97,7 @@ jobs:
         id: hashid
         run: echo "weights-hash=${{ hashFiles('.github/download-models-weights.py') }}" >> "$GITHUB_OUTPUT"
 
-  tests-cpu-ubuntu:
+  tests-cpu-ubuntu-py311:
     needs: [check-skip, pre-tests]
     if: needs.check-skip.outputs.should-skip == 'false'
     strategy:
@@ -108,8 +108,48 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       os: "ubuntu-latest"
-      python-version: '["3.11", "3.12", "3.13"]'
+      python-version: '["3.11"]'
       pytorch-version: '["2.1.2", "2.2.2", "2.3.1", "2.4.0", "2.5.1", "2.9.1"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}
+      cache-path: weights/
+      cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
+      cache-restore-keys: |
+        model-weights-${{ needs.pre-tests.outputs.hash }}
+        model-weights-
+
+  tests-cpu-ubuntu-py312:
+    needs: [check-skip, pre-tests]
+    if: needs.check-skip.outputs.should-skip == 'false'
+    strategy:
+      fail-fast: false
+      matrix:
+        pytorch-dtype: ["float32", "float64"]
+
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: "ubuntu-latest"
+      python-version: '["3.12"]'
+      pytorch-version: '["2.2.2", "2.3.1", "2.4.0", "2.5.1", "2.9.1"]'
+      pytorch-dtype: ${{ matrix.pytorch-dtype }}
+      cache-path: weights/
+      cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
+      cache-restore-keys: |
+        model-weights-${{ needs.pre-tests.outputs.hash }}
+        model-weights-
+
+  tests-cpu-ubuntu-py313:
+    needs: [check-skip, pre-tests]
+    if: needs.check-skip.outputs.should-skip == 'false'
+    strategy:
+      fail-fast: false
+      matrix:
+        pytorch-dtype: ["float32", "float64"]
+
+    uses: ./.github/workflows/tests.yml
+    with:
+      os: "ubuntu-latest"
+      python-version: '["3.13"]'
+      pytorch-version: '["2.5.1", "2.9.1"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -10,6 +10,7 @@ on:
       - 'COPYRIGHT'
   schedule:
     - cron: '0 4 * * *'
+  workflow_dispatch:
   workflow_call:
 
 permissions:
@@ -97,59 +98,32 @@ jobs:
         id: hashid
         run: echo "weights-hash=${{ hashFiles('.github/download-models-weights.py') }}" >> "$GITHUB_OUTPUT"
 
-  tests-cpu-ubuntu-py311:
+  tests-cpu-ubuntu:
     needs: [check-skip, pre-tests]
     if: needs.check-skip.outputs.should-skip == 'false'
     strategy:
       fail-fast: false
       matrix:
         pytorch-dtype: ["float32", "float64"]
+        python-version: ["3.11", "3.12", "3.13"]
+        pytorch-version: ["2.1.2", "2.2.2", "2.3.1", "2.4.0", "2.5.1", "2.9.1"]
+        exclude:
+          - python-version: "3.12"
+            pytorch-version: "2.1.2"
+          - python-version: "3.13"
+            pytorch-version: "2.1.2"
+          - python-version: "3.13"
+            pytorch-version: "2.2.2"
+          - python-version: "3.13"
+            pytorch-version: "2.3.1"
+          - python-version: "3.13"
+            pytorch-version: "2.4.0"
 
     uses: ./.github/workflows/tests.yml
     with:
       os: "ubuntu-latest"
-      python-version: '["3.11"]'
-      pytorch-version: '["2.1.2", "2.2.2", "2.3.1", "2.4.0", "2.5.1", "2.9.1"]'
-      pytorch-dtype: ${{ matrix.pytorch-dtype }}
-      cache-path: weights/
-      cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
-      cache-restore-keys: |
-        model-weights-${{ needs.pre-tests.outputs.hash }}
-        model-weights-
-
-  tests-cpu-ubuntu-py312:
-    needs: [check-skip, pre-tests]
-    if: needs.check-skip.outputs.should-skip == 'false'
-    strategy:
-      fail-fast: false
-      matrix:
-        pytorch-dtype: ["float32", "float64"]
-
-    uses: ./.github/workflows/tests.yml
-    with:
-      os: "ubuntu-latest"
-      python-version: '["3.12"]'
-      pytorch-version: '["2.2.2", "2.3.1", "2.4.0", "2.5.1", "2.9.1"]'
-      pytorch-dtype: ${{ matrix.pytorch-dtype }}
-      cache-path: weights/
-      cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
-      cache-restore-keys: |
-        model-weights-${{ needs.pre-tests.outputs.hash }}
-        model-weights-
-
-  tests-cpu-ubuntu-py313:
-    needs: [check-skip, pre-tests]
-    if: needs.check-skip.outputs.should-skip == 'false'
-    strategy:
-      fail-fast: false
-      matrix:
-        pytorch-dtype: ["float32", "float64"]
-
-    uses: ./.github/workflows/tests.yml
-    with:
-      os: "ubuntu-latest"
-      python-version: '["3.13"]'
-      pytorch-version: '["2.5.1", "2.9.1"]'
+      python-version: '["${{ matrix.python-version }}"]'
+      pytorch-version: '["${{ matrix.pytorch-version }}"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,15 @@ jobs:
         run: pixi run -e ${{ steps.pixi-env.outputs.name }} install
 
       - name: Install PyTorch matrix version
-        run: pixi run -e ${{ steps.pixi-env.outputs.name }} uv run --no-sync uv pip install --reinstall "torch==${{ matrix.pytorch-version }}"
+        shell: bash
+        env:
+          PYTORCH_VERSION: ${{ matrix.pytorch-version }}
+        run: |
+          if [[ "$PYTORCH_VERSION" =~ ^2\.[1-4]\. ]]; then
+            pixi run -e ${{ steps.pixi-env.outputs.name }} uv run --no-sync uv pip install "numpy<2"
+          fi
+          pixi run -e ${{ steps.pixi-env.outputs.name }} uv run --no-sync uv pip install \
+            --reinstall-package torch --index-url https://download.pytorch.org/whl/cpu "torch==$PYTORCH_VERSION"
 
       - name: Verify PyTorch version
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,15 @@ jobs:
       - name: Install dependencies
         run: pixi run -e ${{ steps.pixi-env.outputs.name }} install
 
+      - name: Install PyTorch matrix version
+        run: pixi run -e ${{ steps.pixi-env.outputs.name }} uv run --no-sync uv pip install --reinstall "torch==${{ matrix.pytorch-version }}"
+
+      - name: Verify PyTorch version
+        env:
+          EXPECTED_PYTORCH_VERSION: ${{ matrix.pytorch-version }}
+        run: |
+          pixi run -e ${{ steps.pixi-env.outputs.name }} uv run --no-sync python -c 'import os, torch; expected = os.environ["EXPECTED_PYTORCH_VERSION"]; version = torch.__version__; print(f"expected {expected}, got {version}"); assert version.startswith(expected)'
+
       # torch Windows wheels crash with STATUS_ILLEGAL_INSTRUCTION (0xc000001d) inside
       # affine_grid on part of the runner fleet — observed on torch 2.5.1 AND 2.9.1, on both
       # windows-2022 and windows-2025 (host-CPU-dependent: the CPU-autocast bf16 path
@@ -106,4 +115,5 @@ jobs:
           KORNIA_TEST_DTYPE: ${{ inputs.pytorch-dtype }}
           KORNIA_TEST_RUNSLOW: ${{ inputs.runslow }}
           KORNIA_TEST_OPTIMIZER: ${{ inputs.optimizer }}
+          UV_NO_SYNC: "1"
         run: pixi run -e ${{ steps.pixi-env.outputs.name }} test ${{ inputs.pytest-extra }}

--- a/conftest.py
+++ b/conftest.py
@@ -325,9 +325,9 @@ def pytest_sessionstart(session):
         try:
             _setup_torch_compile()
         except RuntimeError as ex:
-            if "not yet supported for torch.compile" not in str(
+            if "not yet supported for torch.compile" not in str(ex) and "Dynamo is not supported on Python" not in str(
                 ex
-            ) and "Dynamo is not supported on Python 3.12+" not in str(ex):
+            ):
                 raise ex
 
     os.makedirs(WEIGHTS_CACHE_DIR, exist_ok=True)

--- a/conftest.py
+++ b/conftest.py
@@ -316,9 +316,12 @@ def pytest_sessionstart(session):
     if session.config.getoption("--tf32"):
         torch.set_float32_matmul_precision("high")
 
-    # Skip torch.compile warmup in subprocess mode — it adds startup overhead and
-    # pollutes the captured output used for failure reporting in pytest_runtest_protocol.
-    if not os.environ.get("KORNIA_TEST_IN_SUBPROCESS"):
+    # Warm torch.compile only for explicit optimizer jobs. Ordinary jobs deselect compile tests,
+    # while subprocess mode also avoids startup overhead and captured-output pollution.
+    should_warm_compile = bool(os.environ.get("KORNIA_TEST_OPTIMIZER", "").strip()) and not os.environ.get(
+        "KORNIA_TEST_IN_SUBPROCESS"
+    )
+    if should_warm_compile:
         try:
             _setup_torch_compile()
         except RuntimeError as ex:

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -39,6 +39,8 @@ from .video import VideoSequential
 
 __all__ = ["AugmentationSequential"]
 
+# Dynamo cannot trace membership checks against a Python set; tuples keep these constants
+# capture-friendly while preserving the membership-only behavior used below.
 _BOXES_OPTIONS = (DataKey.BBOX, DataKey.BBOX_XYXY, DataKey.BBOX_XYWH)
 _KEYPOINTS_OPTIONS = (DataKey.KEYPOINTS,)
 _IMG_OPTIONS = (DataKey.INPUT, DataKey.IMAGE)

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -39,11 +39,11 @@ from .video import VideoSequential
 
 __all__ = ["AugmentationSequential"]
 
-_BOXES_OPTIONS = {DataKey.BBOX, DataKey.BBOX_XYXY, DataKey.BBOX_XYWH}
-_KEYPOINTS_OPTIONS = {DataKey.KEYPOINTS}
-_IMG_OPTIONS = {DataKey.INPUT, DataKey.IMAGE}
-_MSK_OPTIONS = {DataKey.MASK}
-_CLS_OPTIONS = {DataKey.CLASS, DataKey.LABEL}
+_BOXES_OPTIONS = (DataKey.BBOX, DataKey.BBOX_XYXY, DataKey.BBOX_XYWH)
+_KEYPOINTS_OPTIONS = (DataKey.KEYPOINTS,)
+_IMG_OPTIONS = (DataKey.INPUT, DataKey.IMAGE)
+_MSK_OPTIONS = (DataKey.MASK,)
+_CLS_OPTIONS = (DataKey.CLASS, DataKey.LABEL)
 
 MaskDataType = Union[torch.Tensor, List[torch.Tensor]]
 

--- a/kornia/core/utils.py
+++ b/kornia/core/utils.py
@@ -355,8 +355,18 @@ def is_autocast_enabled(both: bool = True) -> bool:
     return torch.is_autocast_enabled()
 
 
-# ``torch.compiler.is_exporting`` is absent on very old torch; resolve it once at import.
+# These helpers moved into ``torch.compiler`` over time; resolve them once at import.
+_torch_is_compiling = getattr(torch.compiler, "is_compiling", None) or getattr(torch._dynamo, "is_compiling", None)
 _torch_is_exporting = getattr(torch.compiler, "is_exporting", None)
+
+
+@torch.jit.unused
+def is_compiling() -> bool:
+    """Whether execution is inside ``torch.compile`` or ``torch.export`` capture.
+
+    Falls back to Torch's older private Dynamo spelling when the public compiler helper is absent.
+    """
+    return bool(_torch_is_compiling()) if _torch_is_compiling is not None else False
 
 
 def is_exporting() -> bool:

--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -45,7 +45,12 @@ def math_clamp(x, min_, max_):  # type: ignore
     return min(max(x, min_), max_)
 
 
-AMP_CUSTOM_FWD_F32 = torch.amp.custom_fwd(cast_inputs=torch.float32, device_type="cuda")
+if hasattr(torch.amp, "custom_fwd"):
+    AMP_CUSTOM_FWD_F32 = torch.amp.custom_fwd(cast_inputs=torch.float32, device_type="cuda")
+else:
+    # ``torch.amp.custom_fwd`` was introduced after Kornia's minimum supported Torch;
+    # the CUDA-specific spelling provides the same behavior on older releases.
+    AMP_CUSTOM_FWD_F32 = torch.cuda.amp.custom_fwd(cast_inputs=torch.float32)
 
 
 @AMP_CUSTOM_FWD_F32

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -24,6 +24,7 @@ from torch import nn
 
 from kornia.core._compat import deprecated
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_IS_TENSOR, KORNIA_CHECK_SHAPE
+from kornia.core.utils import is_compiling
 
 from .filter import filter2d, filter2d_separable
 from .kernels import _check_kernel_size, _unpack_2d_ks, get_gaussian_kernel1d, get_gaussian_kernel2d
@@ -100,7 +101,7 @@ def gaussian_blur2d(
 
     KORNIA_CHECK_SHAPE(sigma, ["B", "2"])
     # `bool()` on a tensor is untraceable by dynamo; skip the data-dependent check under compile.
-    if not torch.compiler.is_compiling():
+    if not is_compiling():
         # Only interpolate `sigma` into the message when the check actually fails: a plain
         # f-string here would format the whole `sigma` tensor (a costly tensor->str) on every
         # eager call even when it passes — which dominated the eager Gaussian-blur runtime.

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -26,7 +26,7 @@ import torch.nn.functional as F
 from kornia.constants import pi
 from kornia.core._compat import deprecated
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
-from kornia.core.utils import _inverse_3x3_closed_form, _torch_inverse_cast
+from kornia.core.utils import _inverse_3x3_closed_form, _torch_inverse_cast, is_compiling
 
 __all__ = [
     "ARKitQTVecs_to_ColmapQTVecs",
@@ -1493,15 +1493,10 @@ def normalize_pixel_coordinates(
         raise ValueError(f"Input pixel_coordinates must be of shape (*, 2). Got {pixel_coordinates.shape}")
     if not torch.jit.is_tracing() and (height <= 0 or width <= 0):
         raise ValueError(f"Input image size must be positive. Got height={height}, width={width}.")
-    if (
-        not torch.jit.is_scripting()
-        and not torch.jit.is_tracing()
-        and not torch.compiler.is_compiling()
-        and eps != 1e-8
-    ):
+    if not torch.jit.is_scripting() and not torch.jit.is_tracing() and not is_compiling() and eps != 1e-8:
         warnings.warn("`eps` is deprecated and ignored by `normalize_pixel_coordinates`.", FutureWarning, stacklevel=2)
 
-    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not torch.compiler.is_compiling()):
+    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not is_compiling()):
         sx = 1.0 if width == 1 else 2.0 / (width - 1.0)
         sy = 1.0 if height == 1 else 2.0 / (height - 1.0)
         tx = 0.0 if width == 1 else -1.0
@@ -1573,19 +1568,14 @@ def denormalize_pixel_coordinates(
         raise ValueError(f"Input pixel_coordinates must be of shape (*, 2). Got {pixel_coordinates.shape}")
     if not torch.jit.is_tracing() and (height <= 0 or width <= 0):
         raise ValueError(f"Input image size must be positive. Got height={height}, width={width}.")
-    if (
-        not torch.jit.is_scripting()
-        and not torch.jit.is_tracing()
-        and not torch.compiler.is_compiling()
-        and eps != 1e-8
-    ):
+    if not torch.jit.is_scripting() and not torch.jit.is_tracing() and not is_compiling() and eps != 1e-8:
         warnings.warn(
             "`eps` is deprecated and ignored by `denormalize_pixel_coordinates`.",
             FutureWarning,
             stacklevel=2,
         )
 
-    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not torch.compiler.is_compiling()):
+    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not is_compiling()):
         sx = 1.0 if width == 1 else (width - 1.0) / 2.0
         sy = 1.0 if height == 1 else (height - 1.0) / 2.0
         tx = 0.0 if width == 1 else sx
@@ -1652,19 +1642,14 @@ def normalize_pixel_coordinates3d(
         raise ValueError(f"Input pixel_coordinates must be of shape (*, 3). Got {pixel_coordinates.shape}")
     if not torch.jit.is_tracing() and (depth <= 0 or height <= 0 or width <= 0):
         raise ValueError(f"Input image size must be positive. Got depth={depth}, height={height}, width={width}.")
-    if (
-        not torch.jit.is_scripting()
-        and not torch.jit.is_tracing()
-        and not torch.compiler.is_compiling()
-        and eps != 1e-8
-    ):
+    if not torch.jit.is_scripting() and not torch.jit.is_tracing() and not is_compiling() and eps != 1e-8:
         warnings.warn(
             "`eps` is deprecated and ignored by `normalize_pixel_coordinates3d`.",
             FutureWarning,
             stacklevel=2,
         )
 
-    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not torch.compiler.is_compiling()):
+    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not is_compiling()):
         sd = 1.0 if depth == 1 else 2.0 / (depth - 1.0)
         sx = 1.0 if width == 1 else 2.0 / (width - 1.0)
         sy = 1.0 if height == 1 else 2.0 / (height - 1.0)
@@ -1741,19 +1726,14 @@ def denormalize_pixel_coordinates3d(
         raise ValueError(f"Input pixel_coordinates must be of shape (*, 3). Got {pixel_coordinates.shape}")
     if not torch.jit.is_tracing() and (depth <= 0 or height <= 0 or width <= 0):
         raise ValueError(f"Input image size must be positive. Got depth={depth}, height={height}, width={width}.")
-    if (
-        not torch.jit.is_scripting()
-        and not torch.jit.is_tracing()
-        and not torch.compiler.is_compiling()
-        and eps != 1e-8
-    ):
+    if not torch.jit.is_scripting() and not torch.jit.is_tracing() and not is_compiling() and eps != 1e-8:
         warnings.warn(
             "`eps` is deprecated and ignored by `denormalize_pixel_coordinates3d`.",
             FutureWarning,
             stacklevel=2,
         )
 
-    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not torch.compiler.is_compiling()):
+    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not is_compiling()):
         sd = 1.0 if depth == 1 else (depth - 1.0) / 2.0
         sx = 1.0 if width == 1 else (width - 1.0) / 2.0
         sy = 1.0 if height == 1 else (height - 1.0) / 2.0
@@ -2120,15 +2100,10 @@ def normal_transform_pixel(
     """
     if not torch.jit.is_tracing() and (height <= 0 or width <= 0):
         raise ValueError(f"Input image size must be positive. Got height={height}, width={width}.")
-    if (
-        not torch.jit.is_scripting()
-        and not torch.jit.is_tracing()
-        and not torch.compiler.is_compiling()
-        and eps != 1e-14
-    ):
+    if not torch.jit.is_scripting() and not torch.jit.is_tracing() and not is_compiling() and eps != 1e-14:
         warnings.warn("`eps` is deprecated and ignored by `normal_transform_pixel`.", FutureWarning, stacklevel=2)
 
-    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not torch.compiler.is_compiling()):
+    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not is_compiling()):
         # Eager and TorchScript take the scalar branch, which is an order of magnitude
         # cheaper on this hot path. Graph capture takes the tensor form below so symbolic
         # sizes retain the singleton decision.
@@ -2234,15 +2209,10 @@ def normal_transform_pixel3d(
     """
     if not torch.jit.is_tracing() and (depth <= 0 or height <= 0 or width <= 0):
         raise ValueError(f"Input image size must be positive. Got depth={depth}, height={height}, width={width}.")
-    if (
-        not torch.jit.is_scripting()
-        and not torch.jit.is_tracing()
-        and not torch.compiler.is_compiling()
-        and eps != 1e-14
-    ):
+    if not torch.jit.is_scripting() and not torch.jit.is_tracing() and not is_compiling() and eps != 1e-14:
         warnings.warn("`eps` is deprecated and ignored by `normal_transform_pixel3d`.", FutureWarning, stacklevel=2)
 
-    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not torch.compiler.is_compiling()):
+    if torch.jit.is_scripting() or (not torch.jit.is_tracing() and not is_compiling()):
         # As in 2-D, graph capture uses the tensor form below for symbolic sizes.
         sx = 1.0 if width == 1 else 2.0 / (width - 1.0)
         sy = 1.0 if height == 1 else 2.0 / (height - 1.0)

--- a/kornia/geometry/grid.py
+++ b/kornia/geometry/grid.py
@@ -85,7 +85,7 @@ def create_meshgrid(
     #     base_grid = K.geometry.normalize_pixel_coordinates(base_grid, height, width)
     # return torch.unsqueeze(base_grid.transpose(0, 1), dim=0)
     if normalized_coordinates:
-        if torch.jit.is_tracing() or is_compiling():
+        if not torch.jit.is_scripting() and (torch.jit.is_tracing() or is_compiling()):
             # Graph capture needs the tensor form to keep a symbolic size dynamic. Low-precision
             # floating types cannot represent every practical image size exactly (e.g. bfloat16
             # rounds 257 to 256 and 299 to 300), so the size arithmetic runs in float32. Divide
@@ -157,7 +157,7 @@ def create_meshgrid3d(
         zs = torch.linspace(0, depth - 1, depth, device=device, dtype=dtype)
     # Fix TracerWarning
     if normalized_coordinates:
-        if torch.jit.is_tracing() or is_compiling():
+        if not torch.jit.is_scripting() and (torch.jit.is_tracing() or is_compiling()):
             # See ``create_meshgrid``: low-precision dtypes round large sizes, so the size
             # arithmetic runs in float32 and the quotient, not the divisor, is what gets cast down.
             work_dtype = torch.float32 if xs.dtype in (torch.float16, torch.bfloat16) else xs.dtype

--- a/kornia/geometry/grid.py
+++ b/kornia/geometry/grid.py
@@ -20,6 +20,8 @@ from typing import Optional
 
 import torch
 
+from kornia.core.utils import is_compiling
+
 
 def create_meshgrid(
     height: int,
@@ -65,7 +67,7 @@ def create_meshgrid(
                   [1., 1.]]]])
 
     """
-    if not torch.jit.is_scripting() and torch.compiler.is_compiling():
+    if not torch.jit.is_scripting() and is_compiling():
         # ``linspace`` specializes symbolic ``steps`` under export; ``arange`` retains the
         # dynamic output length. Match ``linspace``'s default floating dtype when none is given.
         arange_dtype = dtype if dtype is not None else torch.get_default_dtype()
@@ -83,7 +85,7 @@ def create_meshgrid(
     #     base_grid = K.geometry.normalize_pixel_coordinates(base_grid, height, width)
     # return torch.unsqueeze(base_grid.transpose(0, 1), dim=0)
     if normalized_coordinates:
-        if torch.jit.is_tracing() or torch.compiler.is_compiling():
+        if torch.jit.is_tracing() or is_compiling():
             # Graph capture needs the tensor form to keep a symbolic size dynamic. Low-precision
             # floating types cannot represent every practical image size exactly (e.g. bfloat16
             # rounds 257 to 256 and 299 to 300), so the size arithmetic runs in float32. Divide
@@ -144,7 +146,7 @@ def create_meshgrid3d(
         grid tensor with shape :math:`(1, D, H, W, 3)`.
 
     """
-    if not torch.jit.is_scripting() and torch.compiler.is_compiling():
+    if not torch.jit.is_scripting() and is_compiling():
         arange_dtype = dtype if dtype is not None else torch.get_default_dtype()
         xs = torch.arange(width, device=device, dtype=arange_dtype)
         ys = torch.arange(height, device=device, dtype=arange_dtype)
@@ -155,7 +157,7 @@ def create_meshgrid3d(
         zs = torch.linspace(0, depth - 1, depth, device=device, dtype=dtype)
     # Fix TracerWarning
     if normalized_coordinates:
-        if torch.jit.is_tracing() or torch.compiler.is_compiling():
+        if torch.jit.is_tracing() or is_compiling():
             # See ``create_meshgrid``: low-precision dtypes round large sizes, so the size
             # arithmetic runs in float32 and the quotient, not the divisor, is what gets cast down.
             work_dtype = torch.float32 if xs.dtype in (torch.float16, torch.bfloat16) else xs.dtype

--- a/testing/base.py
+++ b/testing/base.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import math
+import sys
 from functools import cache
 from typing import Any, Callable, Optional, Sequence, Union
 
@@ -27,8 +28,18 @@ import torch.nn.functional as F
 from torch.autograd import gradcheck
 from torch.testing import assert_close as _assert_close
 
+from kornia.core._compat import torch_version_lt
+
 Dtype = Union[torch.dtype, None]
 Tensor = torch.Tensor
+
+DYNAMO_UNAVAILABLE_REASON = "torch.compile requires torch>=2.6 on Python>=3.13"
+
+
+def dynamo_is_available() -> bool:
+    """Return whether this Torch/Python pair can run Dynamo-backed capture."""
+    return not (torch_version_lt(2, 6, 0) and sys.version_info >= (3, 13))
+
 
 # {dtype: (rtol, atol)}
 _DTYPE_PRECISIONS = {

--- a/tests/augmentation/container/test_augmentation_sequential.py
+++ b/tests/augmentation/container/test_augmentation_sequential.py
@@ -25,6 +25,7 @@ import kornia
 import kornia.augmentation as K
 from kornia.augmentation.container.base import ParamItem
 from kornia.constants import BorderType
+from kornia.core._compat import torch_version_lt
 from kornia.geometry.bbox import bbox_to_mask
 
 from testing.augmentation.utils import reproducibility_test
@@ -111,6 +112,8 @@ class TestAugmentationSequential:
     def test_mixed_image_bbox_dtypes(self, device, image_dtype):
         # Regression test for https://github.com/kornia/kornia/issues/3705 and #3706:
         # bbox stays in fp32 while the image uses a half/double compute dtype.
+        if device.type == "cpu" and image_dtype in (torch.float16, torch.bfloat16) and torch_version_lt(2, 6, 0):
+            pytest.skip("PyTorch <2.6 has no CPU Half/BFloat16 grid_sample kernel")
         torch.manual_seed(0)
         img = torch.rand(2, 3, 32, 32, device=device, dtype=image_dtype)
         bb = torch.tensor(

--- a/tests/augmentation/test_torch_export.py
+++ b/tests/augmentation/test_torch_export.py
@@ -23,15 +23,13 @@ TorchGeo migrated its inference-time transforms off kornia onto ``torchvision.tr
 citing exactly this gap ("kornia augmentations can't be torch.exported").
 
 The augmentation base ``forward`` stashes per-call state on ``self`` (``_params`` and the lazy
-transform matrix), which ``torch.export`` on torch <= 2.9 rejects ("attrs created in forward" /
-pytree "Node arity mismatch"). Those side effects are now skipped under ``torch.export`` (the
-captured image output is unchanged), so the deterministic transforms export cleanly and
-numerically match eager. This pins that so it does not regress.
+transform matrix). ``torch.compiler.is_exporting`` lets the base skip those side effects during
+``torch.export`` capture without changing the captured image output. This capability was added in
+torch 2.7, so the tests are skipped on earlier versions.
 
-Only *deterministic single* transforms are covered — random augmentations sample parameters
-during capture in ways that don't line up with a separate eager call (RNG bookkeeping), and
-``AugmentationSequential`` containers still stash their own per-call state and are not export-clean
-yet.
+The cases cover deterministic single transforms and ``AugmentationSequential`` containers. Random
+augmentations that sample parameters during capture are excluded because their RNG bookkeeping does
+not line up with a separate eager call.
 """
 
 from __future__ import annotations
@@ -42,6 +40,9 @@ import pytest
 import torch
 
 import kornia.augmentation as K
+
+_HAS_TORCH_EXPORT_TRACKING = hasattr(torch, "compiler") and hasattr(torch.compiler, "is_exporting")
+_TORCH_EXPORT_TRACKING_REASON = "torch.export tracking requires torch.compiler.is_exporting (torch>=2.7)"
 
 
 def _normalize() -> torch.nn.Module:
@@ -74,6 +75,7 @@ TORCH_EXPORT_DETERMINISTIC: list[Tuple[str, Callable[[], torch.nn.Module]]] = [
 
 
 @pytest.mark.skipif(not hasattr(torch, "export"), reason="torch.export requires torch>=2.1")
+@pytest.mark.skipif(not _HAS_TORCH_EXPORT_TRACKING, reason=_TORCH_EXPORT_TRACKING_REASON)
 @pytest.mark.parametrize("name,factory", TORCH_EXPORT_DETERMINISTIC, ids=[n for n, _ in TORCH_EXPORT_DETERMINISTIC])
 def test_torch_export_deterministic(name: str, factory: Callable[[], torch.nn.Module]) -> None:
     """Deterministic inference transform captures via ``torch.export`` and matches eager."""
@@ -116,6 +118,7 @@ TORCH_EXPORT_CONTAINERS: list[Tuple[str, Callable[[], torch.nn.Module]]] = [
 
 
 @pytest.mark.skipif(not hasattr(torch, "export"), reason="torch.export requires torch>=2.1")
+@pytest.mark.skipif(not _HAS_TORCH_EXPORT_TRACKING, reason=_TORCH_EXPORT_TRACKING_REASON)
 @pytest.mark.parametrize("name,factory", TORCH_EXPORT_CONTAINERS, ids=[n for n, _ in TORCH_EXPORT_CONTAINERS])
 def test_torch_export_container(name: str, factory: Callable[[], torch.nn.Module]) -> None:
     """A deterministic ``AugmentationSequential`` pipeline captures via ``torch.export`` and matches eager."""

--- a/tests/augmentation/test_torch_export.py
+++ b/tests/augmentation/test_torch_export.py
@@ -41,6 +41,8 @@ import torch
 
 import kornia.augmentation as K
 
+from testing.base import DYNAMO_UNAVAILABLE_REASON, dynamo_is_available
+
 _HAS_TORCH_EXPORT_TRACKING = hasattr(torch, "compiler") and hasattr(torch.compiler, "is_exporting")
 _TORCH_EXPORT_TRACKING_REASON = "torch.export tracking requires torch.compiler.is_exporting (torch>=2.7)"
 
@@ -75,6 +77,7 @@ TORCH_EXPORT_DETERMINISTIC: list[Tuple[str, Callable[[], torch.nn.Module]]] = [
 
 
 @pytest.mark.skipif(not hasattr(torch, "export"), reason="torch.export requires torch>=2.1")
+@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
 @pytest.mark.skipif(not _HAS_TORCH_EXPORT_TRACKING, reason=_TORCH_EXPORT_TRACKING_REASON)
 @pytest.mark.parametrize("name,factory", TORCH_EXPORT_DETERMINISTIC, ids=[n for n, _ in TORCH_EXPORT_DETERMINISTIC])
 def test_torch_export_deterministic(name: str, factory: Callable[[], torch.nn.Module]) -> None:
@@ -118,6 +121,7 @@ TORCH_EXPORT_CONTAINERS: list[Tuple[str, Callable[[], torch.nn.Module]]] = [
 
 
 @pytest.mark.skipif(not hasattr(torch, "export"), reason="torch.export requires torch>=2.1")
+@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
 @pytest.mark.skipif(not _HAS_TORCH_EXPORT_TRACKING, reason=_TORCH_EXPORT_TRACKING_REASON)
 @pytest.mark.parametrize("name,factory", TORCH_EXPORT_CONTAINERS, ids=[n for n, _ in TORCH_EXPORT_CONTAINERS])
 def test_torch_export_container(name: str, factory: Callable[[], torch.nn.Module]) -> None:

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -50,7 +50,7 @@ from kornia.geometry.conversions import (
 )
 from kornia.geometry.quaternion import Quaternion
 
-from testing.base import BaseTester, assert_close
+from testing.base import DYNAMO_UNAVAILABLE_REASON, BaseTester, assert_close, dynamo_is_available
 
 
 @pytest.fixture()
@@ -3459,6 +3459,7 @@ def test_pixel_coordinate_singleton_policy_scripts(op_name, args, device, dtype)
         ("denormalize_pixel_coordinates3d", 3),
     ],
 )
+@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
 def test_pixel_coordinate_export_crosses_singleton_boundary(op_name, ndim):
     op = getattr(kornia.geometry.conversions, op_name)
 
@@ -3523,6 +3524,7 @@ def test_non_default_eps_does_not_break_fullgraph_compile(op_name, sizes):
     ],
     ids=["float32", "bfloat16-rounding-boundary", "float16-rounding-boundary"],
 )
+@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
 def test_normal_transform_export_crosses_singleton_boundary(is_3d, dtype, runtime_sizes):
     class ExportTransform(torch.nn.Module):
         def forward(self, image):

--- a/tests/geometry/test_grid.py
+++ b/tests/geometry/test_grid.py
@@ -20,7 +20,7 @@ import torch
 
 import kornia
 
-from testing.base import assert_close
+from testing.base import DYNAMO_UNAVAILABLE_REASON, assert_close, dynamo_is_available
 
 
 def test_create_meshgrid(device, dtype):
@@ -169,6 +169,7 @@ def test_normalized_meshgrid_trace_matches_eager_at_unrepresentable_sizes(is_3d,
 
 @pytest.mark.parametrize("normalized_coordinates", [False, True], ids=["pixel", "normalized"])
 @pytest.mark.parametrize("is_3d", [False, True], ids=["2d", "3d"])
+@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
 def test_meshgrid_export_crosses_singleton_boundary(is_3d, normalized_coordinates):
     class MeshGrid(torch.nn.Module):
         def forward(self, image):


### PR DESCRIPTION
## Which lane?
- [x] 🟢 **Green lane**
- [ ] 🟠 **Discuss-first**

**Fixes:** #3930

## What does this PR do?

The CPU CI workflow defines multiple PyTorch versions in its matrix, but the
installation step previously used the single PyTorch version pinned by
`uv.lock`.

As a result, jobs labelled with different PyTorch versions were actually
running against the same installed version.

This change makes the workflow install the PyTorch version selected by the
matrix, verifies the imported runtime version, and prevents the test command
from resynchronizing the environment from the lockfile.

The change exposes existing compatibility failures in the PyTorch 2.5.1
matrix leg that were previously hidden because those jobs were actually
running with PyTorch 2.9.1.

## Test log

```text
$ pixi run lint
ruff check...............................................................Passed
ruff format..............................................................Passed

$ pixi run -e py312 uv run --no-sync uv pip install --dry-run --reinstall 'torch==2.5.1'
Would install torch==2.5.1

$ pixi run -e py312 uv run --no-sync uv pip install --dry-run --reinstall 'torch==2.9.1'
Would install torch==2.9.1

Runtime version check:
expected 2.9.1, got 2.9.1