### PR TITLE
feat(geometry): add missing reverse conversions

### DIFF
--- a/docs/source/geometry.conversions.rst
+++ b/docs/source/geometry.conversions.rst
@@ -37,6 +37,7 @@ Homography
 .. autofunction:: normalize_homography
 .. autofunction:: denormalize_homography
 .. autofunction:: normalize_homography3d
+.. autofunction:: denormalize_homography3d
 
 Quaternion
 ----------
@@ -82,3 +83,4 @@ Pose
 .. autofunction:: camtoworld_graphics_to_vision_Rt
 .. autofunction:: camtoworld_vision_to_graphics_Rt
 .. autofunction:: ARKitQTVecs_to_ColmapQTVecs
+.. autofunction:: ColmapQTVecs_to_ARKitQTVecs

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -29,6 +29,7 @@ from kornia.core.utils import _inverse_3x3_closed_form, _torch_inverse_cast
 
 __all__ = [
     "ARKitQTVecs_to_ColmapQTVecs",
+    "ColmapQTVecs_to_ARKitQTVecs",
     "Rt_to_matrix4x4",
     "angle_axis_to_quaternion",
     "angle_axis_to_rotation_matrix",
@@ -47,6 +48,7 @@ __all__ = [
     "convert_points_to_homogeneous",
     "deg2rad",
     "denormalize_homography",
+    "denormalize_homography3d",
     "denormalize_pixel_coordinates",
     "denormalize_pixel_coordinates3d",
     "denormalize_points_with_intrinsics",
@@ -1875,6 +1877,41 @@ def normalize_homography3d(
     return dst_norm_trans_src_norm
 
 
+def denormalize_homography3d(
+    dst_pix_trans_src_pix: torch.Tensor, dsize_src: tuple[int, int, int], dsize_dst: tuple[int, int, int]
+) -> torch.Tensor:
+    r"""De-normalize a given 3D homography from [-1, 1] to actual depth, height and width.
+
+    Args:
+        dst_pix_trans_src_pix: homography/ies from source to destination to be
+          denormalized. :math:`(B, 4, 4)`
+        dsize_src: size of the source image (depth, height, width).
+        dsize_dst: size of the destination image (depth, height, width).
+
+    Returns:
+        the denormalized homography of shape :math:`(B, 4, 4)`.
+
+    """
+    if not isinstance(dst_pix_trans_src_pix, torch.Tensor):
+        raise TypeError(f"Input type is not a torch.Tensor. Got {type(dst_pix_trans_src_pix)}")
+
+    if not (len(dst_pix_trans_src_pix.shape) == 3 or dst_pix_trans_src_pix.shape[-2:] == (4, 4)):
+        raise ValueError(f"Input dst_pix_trans_src_pix must be a Bx4x4 tensor. Got {dst_pix_trans_src_pix.shape}")
+
+    # source and destination sizes
+    src_d, src_h, src_w = dsize_src
+    dst_d, dst_h, dst_w = dsize_dst
+
+    # compute the transformation pixel/norm for src/dst
+    src_norm_trans_src_pix: torch.Tensor = normal_transform_pixel3d(src_d, src_h, src_w).to(dst_pix_trans_src_pix)
+    dst_norm_trans_dst_pix: torch.Tensor = normal_transform_pixel3d(dst_d, dst_h, dst_w).to(dst_pix_trans_src_pix)
+    dst_pix_trans_dst_norm = _torch_inverse_cast(dst_norm_trans_dst_pix)
+
+    # compute chain transformations
+    dst_pix_trans_src_pix = dst_pix_trans_dst_norm @ (dst_pix_trans_src_pix @ src_norm_trans_src_pix)
+    return dst_pix_trans_src_pix
+
+
 def normalize_points_with_intrinsics(point_2d: torch.Tensor, camera_matrix: torch.Tensor) -> torch.Tensor:
     """Normalize points with intrinsics. Useful for conversion of keypoints to be used with essential matrix.
 
@@ -2221,6 +2258,28 @@ def ARKitQTVecs_to_ColmapQTVecs(qvec: torch.Tensor, tvec: torch.Tensor) -> tuple
     t_colmap = t_colmap.reshape(-1, 3, 1)
     q_colmap = rotation_matrix_to_quaternion(R_colmap.contiguous())
     return q_colmap, t_colmap
+
+
+def ColmapQTVecs_to_ARKitQTVecs(qvec: torch.Tensor, tvec: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Convert Colmap world-to-camera pose to the Apple ARKit screen pose.
+
+    Both poses are in quaternion representation.
+
+    Args:
+        qvec: Colmap rotation quaternion :math:`(B, 4)`, [w, x, y, z] format.
+        tvec: translation vector :math:`(B, 3, 1)`, [x, y, z]
+
+    Returns:
+        qvec: ARKit rotation quaternion :math:`(B, 4)`, [w, x, y, z] format.
+        tvec: translation vector :math:`(B, 3, 1)`, [x, y, z]
+
+    """
+    R_colmap = quaternion_to_rotation_matrix(qvec)
+    Rcv, Tcv = worldtocam_to_camtoworld_Rt(R_colmap, tvec)
+    Rcg, Tcg = camtoworld_vision_to_graphics_Rt(Rcv, Tcv)
+    t_arkit = Tcg.reshape(-1, 3, 1)
+    q_arkit = rotation_matrix_to_quaternion(Rcg.contiguous())
+    return q_arkit, t_arkit
 
 
 def vector_to_skew_symmetric_matrix(vec: torch.Tensor) -> torch.Tensor:

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -29,6 +29,7 @@ from kornia.core._compat import torch_version
 from kornia.core.ops import eye_like
 from kornia.geometry.conversions import (
     ARKitQTVecs_to_ColmapQTVecs,
+    ColmapQTVecs_to_ARKitQTVecs,
     Rt_to_matrix4x4,
     axis_angle_to_rotation_matrix,
     camtoworld_graphics_to_vision_4x4,
@@ -3490,6 +3491,44 @@ class TestCARKitToColmap(BaseTester):
 
         self.assert_close(angles_colmap, expected_angles, rtol=1e-4, atol=1e-5)
         self.assert_close(t_colmap, expected_t, rtol=1e-4, atol=1e-5)
+
+    @pytest.mark.parametrize("batch_size", [1, 3])
+    def test_round_trip(self, batch_size, device, dtype):
+        q_arkit = kornia.geometry.axis_angle_to_quaternion(
+            torch.tensor([[0.4, -0.6, 0.8]], device=device, dtype=dtype).repeat(batch_size, 1)
+        )
+        t_arkit = torch.tensor([[[1.0], [-2.0], [3.0]]], device=device, dtype=dtype).repeat(batch_size, 1, 1)
+
+        q_colmap, t_colmap = ARKitQTVecs_to_ColmapQTVecs(q_arkit, t_arkit)
+        q_arkit_back, t_arkit_back = ColmapQTVecs_to_ARKitQTVecs(q_colmap, t_colmap)
+
+        assert q_arkit_back.shape == (batch_size, 4)
+        assert t_arkit_back.shape == (batch_size, 3, 1)
+        self.assert_close(
+            kornia.geometry.quaternion_to_rotation_matrix(q_arkit_back),
+            kornia.geometry.quaternion_to_rotation_matrix(q_arkit),
+        )
+        self.assert_close(t_arkit_back, t_arkit)
+
+        q_colmap_back, t_colmap_back = ARKitQTVecs_to_ColmapQTVecs(q_arkit_back, t_arkit_back)
+        self.assert_close(
+            kornia.geometry.quaternion_to_rotation_matrix(q_colmap_back),
+            kornia.geometry.quaternion_to_rotation_matrix(q_colmap),
+        )
+        self.assert_close(t_colmap_back, t_colmap)
+
+    def test_reverse_shape_errors(self, device):
+        from kornia.core.exceptions import ShapeError
+
+        quaternion = torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=device)
+        translation = torch.ones(1, 3, 1, device=device)
+
+        with pytest.raises(ShapeError):
+            ColmapQTVecs_to_ARKitQTVecs(quaternion[0], translation)
+        with pytest.raises(ShapeError):
+            ColmapQTVecs_to_ARKitQTVecs(quaternion, translation[..., 0])
+        with pytest.raises(ValueError, match=r"shape \(\*, 4\)"):
+            ColmapQTVecs_to_ARKitQTVecs(quaternion[:, :3], translation)
 
 
 class TestEulerFromQuaternion(BaseTester):

--- a/tests/geometry/transform/test_homography_warper.py
+++ b/tests/geometry/transform/test_homography_warper.py
@@ -485,6 +485,42 @@ class TestHomographyWarper3D(BaseTester):
         ).expand(batch_size, -1, -1)
         self.assert_close(norm_homo, res)
 
+    @pytest.mark.parametrize("batch_size", [1, 3])
+    def test_normalize_denormalize_homography_round_trip(self, batch_size, device, dtype):
+        dsize_src = (3, 5, 7)
+        dsize_dst = (6, 8, 11)
+        dst_pix_trans_src_pix = torch.tensor(
+            [[1.2, 0.1, 0.0, 1.0], [0.0, 0.8, 0.2, -2.0], [0.0, 0.0, 1.1, 0.5], [0.0, 0.0, 0.0, 1.0]],
+            device=device,
+            dtype=dtype,
+        ).expand(batch_size, -1, -1)
+
+        normalized = kornia.geometry.conversions.normalize_homography3d(dst_pix_trans_src_pix, dsize_src, dsize_dst)
+        denormalized = kornia.geometry.conversions.denormalize_homography3d(normalized, dsize_src, dsize_dst)
+
+        assert denormalized.shape == (batch_size, 4, 4)
+        if dtype == torch.float16:
+            self.assert_close(denormalized, dst_pix_trans_src_pix, rtol=0.0, atol=5e-3)
+        else:
+            self.assert_close(denormalized, dst_pix_trans_src_pix)
+
+        renormalized = kornia.geometry.conversions.normalize_homography3d(
+            kornia.geometry.conversions.denormalize_homography3d(normalized, dsize_src, dsize_dst),
+            dsize_src,
+            dsize_dst,
+        )
+        if dtype == torch.float16:
+            self.assert_close(renormalized, normalized, rtol=0.0, atol=5e-3)
+        else:
+            self.assert_close(renormalized, normalized)
+
+    def test_denormalize_homography_invalid_input(self):
+        with pytest.raises(TypeError, match=r"Input type is not a torch.Tensor"):
+            kornia.geometry.conversions.denormalize_homography3d([[1.0]], (3, 5, 7), (6, 8, 11))
+
+        with pytest.raises(ValueError, match="must be a Bx4x4 tensor"):
+            kornia.geometry.conversions.denormalize_homography3d(torch.ones(2, 2), (3, 5, 7), (6, 8, 11))
+
     @pytest.mark.parametrize("offset", [1, 3, 7])
     @pytest.mark.parametrize("shape", [(4, 5, 6), (2, 4, 6), (4, 3, 9), (5, 7, 8)])
     def test_warp_grid_translation(self, shape, offset, device, dtype):


### PR DESCRIPTION
## Which lane?

- [ ] 🟢 **Green lane**
- [x] 🟠 **Discuss-first** — maintainer scope was confirmed on #3962.

**Fixes:** #3962

## What does this PR do?

Adds the two reverse conversions discussed in #3962:

- `denormalize_homography3d`, the inverse of `normalize_homography3d`.
- `ColmapQTVecs_to_ARKitQTVecs`, the reverse of `ARKitQTVecs_to_ColmapQTVecs`.

The implementation reuses the existing conversion utilities and follows the
conventions already used in `kornia.geometry.conversions`.

The tests cover round-trip behavior, asymmetric 3D source and destination
sizes, batching, output shapes, validation cases, dtype/device combinations,
and quaternion rotation equivalence without relying on a particular
quaternion sign.

The public API exports and geometry conversion documentation were updated for
both functions.

## Test log

```text
$ pixi run lint
ruff check...............................................................Passed
ruff format..............................................................Passed

$ pixi run typecheck
All checks passed!

Focused homography tests:
9 passed

Focused ARKit/Colmap tests:
9 passed

$ tests/test_api_surface.py
12 passed

$ tests/geometry/transform/test_homography_warper.py
101 passed

$ tests/geometry/test_conversions.py
286 passed, 22 xfailed

$ doctest kornia/geometry/conversions.py
32 passed

$ git diff --check
Passed
```

## AI Usage Disclosure

- [ ] 🟢 **Human-written**
- [x] 🟡 **AI-assisted**
- [ ] 🔴 **AI-generated** 