### PR TITLE
fix(color): validate input range in rgb_to_hsv

### DIFF
--- a/kornia/color/hsv.py
+++ b/kornia/color/hsv.py
@@ -53,6 +53,12 @@ def rgb_to_hsv(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     if len(image.shape) < 3 or image.shape[-3] != 3:
         raise ValueError(f"Input size must have a shape of (*, 3, H, W). Got {image.shape}")
 
+    if image.min() < 0.0 or image.max() > 1.0:
+        raise ValueError(
+            f"Input image values must be in the range [0, 1]. "
+            f"Got min {image.min().item()} and max {image.max().item()}."
+        )
+
     max_rgb = image.amax(-3)
     min_rgb = image.amin(-3)
     deltac = max_rgb - min_rgb

--- a/tests/color/test_hsv.py
+++ b/tests/color/test_hsv.py
@@ -49,6 +49,10 @@ class TestRgbToHsv(BaseTester):
             img = torch.ones(2, 1, 1, device=device, dtype=dtype)
             assert kornia.color.rgb_to_hsv(img)
 
+        with pytest.raises(ValueError, match="range"):
+            img = torch.tensor([[[[1.5]], [[0.0]], [[0.0]]]], device=device, dtype=dtype)
+            assert kornia.color.rgb_to_hsv(img)
+
     def test_unit(self, device, dtype):
         data = torch.tensor(
             [


### PR DESCRIPTION
Fixes #3997

rgb_to_hsv assumed input in [0, 1] but silently produced invalid HSV output for out-of-range values. This adds a clear ValueError for out-of-range inputs.

## Test log

```
$ uv run pytest tests/color/test_hsv.py -q --device=cpu --dtype=float32
23 passed
```

## AI Usage Disclosure

- [x] 🔴 AI-generated — an agent wrote most of it; I verified the result and can address reviewer questions