### PR TITLE
test(geometry): make conversion tests deterministic

### DIFF
--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -46,6 +46,11 @@ from kornia.geometry.quaternion import Quaternion
 from testing.base import BaseTester, assert_close
 
 
+@pytest.fixture(autouse=True)
+def seed_rng() -> None:
+    torch.manual_seed(0)
+
+
 @pytest.fixture()
 def atol(device, dtype):
     """Lower tolerance for cuda-float16 only."""


### PR DESCRIPTION
## Which lane? *(check one — see [Contributing Guide](https://github.com/kornia/kornia/blob/main/CONTRIBUTING.md#which-lane-is-your-contribution))*
- [x] 🟢 **Green lane** — test-first bug fix / verified docs fix / [`help wanted`](https://github.com/kornia/kornia/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22) issue / benchmark results. No prior issue needed.
- [ ] 🟠 **Discuss-first** — feature or behavior change; a maintainer confirmed the scope on the linked issue.

**Fixes/Relates to:** Fixes #3943

## What does this PR do?

Add a function-scoped autouse fixture that calls `torch.manual_seed(0)` before every parametrized case in `test_conversions.py`. This makes every executable Torch RNG consumer in the file, including `Quaternion.random`, reproducible and keeps individual tests independent of collection order or selection.

This changes no library behavior, tolerance, expected value, skip, or xfail. The 61 reduced-precision failures below are pre-existing issues; this PR stabilizes that baseline rather than making those cases pass.

On unmodified `main`, five consecutive all-dtype runs produced 62, 60, 63, 60, and 63 failures. With this fixture, five consecutive runs produced the same count and the same set of failure IDs every time.

## Test log

```
$ for i in 1 2 3 4 5; do
    .pixi/envs/default/bin/uv run pytest tests/geometry/test_conversions.py -q --dtype=all
  done

run 1: 61 failed, 863 passed, 10 skipped, 37 xfailed, 8 warnings
run 2: 61 failed, 863 passed, 10 skipped, 37 xfailed, 8 warnings
run 3: 61 failed, 863 passed, 10 skipped, 37 xfailed, 8 warnings
run 4: 61 failed, 863 passed, 10 skipped, 37 xfailed, 8 warnings
run 5: 61 failed, 863 passed, 10 skipped, 37 xfailed, 8 warnings
failure-ID sets differing across runs: 0

$ .pixi/envs/default/bin/uv run pytest tests/geometry/test_conversions.py -q --dtype=float32
283 passed, 22 xfailed, 8 warnings in 1.47s

$ .venv/bin/ruff check tests/geometry/test_conversions.py
All checks passed!

$ .venv/bin/ruff format --check tests/geometry/test_conversions.py
1 file already formatted
```

## AI Usage Disclosure *(pick the closest — the 🟡/🔴 line is fuzzy and only deception is sanctioned; none of these is a bad answer, see [AI_POLICY.md](https://github.com/kornia/kornia/blob/main/AI_POLICY.md))*
- [ ] 🟢 **Human-written**
- [ ] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests
- [x] 🔴 **AI-generated** — an agent wrote most of it; I verified the result and can address reviewer questions
