### PR TITLE
[BUG]: keep pad importable from pyramid module

### DIFF
--- a/kornia/geometry/transform/pyramid.py
+++ b/kornia/geometry/transform/pyramid.py
@@ -26,6 +26,13 @@ from torch import nn
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 from kornia.filters import filter2d, gaussian_blur2d
 
+# Kept as a module-level alias for backwards compatibility: earlier versions
+# imported `pad` from `kornia.core`, which made it importable from here too
+# (e.g. `from kornia.geometry.transform.pyramid import pad`). That import was
+# dropped when this module switched to calling `F.pad` directly, silently
+# breaking third-party code relying on it. See #3986.
+pad = F.pad
+
 __all__ = ["PyrDown", "PyrUp", "ScalePyramid", "build_laplacian_pyramid", "build_pyramid", "pyrdown", "pyrup"]
 
 

--- a/tests/geometry/transform/test_pyramid.py
+++ b/tests/geometry/transform/test_pyramid.py
@@ -243,3 +243,22 @@ class TestBuildLaplacianPyramid(BaseTester):
         batch_size, channels, height, width = 1, 2, 7, 9
         img = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(kornia.geometry.transform.build_laplacian_pyramid, (img, max_level), nondet_tol=1e-8)
+
+
+def test_pad_importable_from_pyramid_module():
+    """Regression test for https://github.com/kornia/kornia/issues/3986.
+
+    ``kornia.geometry.transform.pyramid`` used to bind ``pad`` at module
+    scope (via ``from kornia.core import ..., pad, ...``), so third-party
+    code importing it directly (e.g. ``from
+    kornia.geometry.transform.pyramid import pad``) worked. That import
+    was dropped as an incidental side effect of switching the module to
+    call ``torch.nn.functional.pad`` directly, breaking any downstream
+    code relying on it -- see the linked ComfyUI-LTXVideo issue in #3986.
+
+    ``pad`` is kept available and equal to ``torch.nn.functional.pad`` so
+    that import path keeps working.
+    """
+    from kornia.geometry.transform.pyramid import pad
+
+    assert pad is torch.nn.functional.pad


### PR DESCRIPTION
## Which lane?
- [x] 🟢 **Green lane** — test-first bug fix. No prior issue needed (but there is one: #3986).

**Fixes/Relates to:** #3986

## What does this PR do?

`kornia.geometry.transform.pyramid` used to bind `pad` at module scope via `from kornia.core import Module, Tensor, ones, pad, stack, tensor, zeros` (present in v0.8.2). That import was dropped as an incidental side effect of refactoring the module to call `torch.nn.functional.pad` directly via `F.pad(...)` (landed by v0.8.3), so `pad` silently stopped being importable from this module — `kornia.core` no longer re-exports it either (it was removed project-wide, not just here).

This broke third-party code relying on `from kornia.geometry.transform.pyramid import pad`, reported in #3986 with a downstream traceback from ComfyUI-LTXVideo:

```
ImportError: cannot import name 'pad' from 'kornia.geometry.transform.pyramid'
```

I confirmed the regression by diffing `pyramid.py` between the `v0.8.2` and `v0.8.3` tags — `pad` was dropped from the file's imports with no replacement export, while every internal call site switched to `F.pad(...)` directly. `pad` was never in the module's `__all__`, so this was always an implementation-detail import, but real downstream code depends on it, and restoring it is a zero-risk one-line fix.

Test that fails on `main` without this fix, in `tests/geometry/transform/test_pyramid.py`:

```python
def test_pad_importable_from_pyramid_module():
    from kornia.geometry.transform.pyramid import pad
    assert pad is torch.nn.functional.pad
```

Fix: `pad = F.pad` as a module-level alias in `pyramid.py`, matching the value it always held.

## Test log

```
$ pixi run test tests/geometry/transform/test_pyramid.py --dtype=float32 --device=cpu

tests/geometry/transform/test_pyramid.py ............................................................ [100%]
============================= 60 passed in 2.90s ==============================
```

Also ran `ruff check` and `ruff format --check` on both changed files — clean.

## AI Usage Disclosure
- [x] 🟡 **AI-assisted** — AI helped; I reviewed the resulting change and ran the relevant tests