### PR TITLE
ci(policy): state the import-surface boundary and check it

### DIFF
--- a/.github/scripts/check_import_surface.py
+++ b/.github/scripts/check_import_surface.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Check that a change does not silently remove an importable name.
+
+Written after #3986, where ``kornia.geometry.transform.pyramid.pad`` stopped
+existing. It was never in ``__all__`` and never documented -- it was only
+``torch.nn.functional.pad`` leaking out of a ``from kornia.core import ...,
+pad, ...`` line -- so when the module switched to calling ``F.pad`` directly,
+the binding went with it. ComfyUI-LTXVideo was broken for three months.
+
+``pad`` was not special. The same release removed all 32 names from
+``kornia.core.__all__`` (#4024), which took 824 module-scope bindings with it
+across the tree, and a performance PR deleted the documented ``upscale_double``
+(#4025). None of it was visible in review, because nothing compared the export
+surface between two revisions.
+
+This script is that comparison. It is stdlib-only and never imports kornia, so
+it runs on any interpreter, needs no environment, and can read any git revision
+through ``git show``.
+
+Two modes:
+
+``regression``
+    Public module-scope names importable at ``--old`` and gone at ``--new``.
+    By default only losses of names that were in their module's ``__all__``
+    fail the run; undeclared losses are reported but do not fail. That split is
+    deliberate and matches the stability policy: what a module does not declare
+    is not API. Use ``--fail-on any`` to make every loss fatal.
+
+``inventory``
+    The undeclared public surface at one revision, graded:
+
+    ``L1a``  re-exported third-party/stdlib name (the #3986 class)
+    ``L1b``  re-exported kornia-internal name
+    ``L2``   defined here, module has ``__all__`` and excludes it (#4026)
+    ``L3``   module declares no ``__all__`` at all
+    ``X``    name in ``__all__`` with no module-scope binding -- a live bug,
+             since ``from <module> import *`` raises (#4023)
+
+Names bound only under ``if TYPE_CHECKING:`` are ignored throughout: they are
+not importable at runtime, so they are neither surface nor regression. A module
+with a module-level ``__getattr__`` is treated as shimmed -- that is the
+correct deprecation pattern (``kornia.utils`` uses it) and the check must not
+punish it.
+
+Usage::
+
+    python3 .github/scripts/check_import_surface.py regression --old main --new HEAD
+    python3 .github/scripts/check_import_surface.py regression --old v0.8.2 --new v0.8.3
+    python3 .github/scripts/check_import_surface.py inventory
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Binding:
+    """One name bound at module scope, and how it got there."""
+
+    name: str
+    kind: str  # import-external | import-kornia | def | class | assign
+    origin: str  # module the name was imported from; "" for def/class/assign
+    lineno: int
+
+
+@dataclass
+class Surface:
+    """The module-scope name surface of a single module."""
+
+    module: str
+    path: str
+    has_all: bool = False
+    has_getattr: bool = False
+    all_names: set[str] = field(default_factory=set)
+    bindings: dict[str, Binding] = field(default_factory=dict)
+
+    @property
+    def public(self) -> dict[str, Binding]:
+        return {n: b for n, b in self.bindings.items() if not n.startswith("_")}
+
+
+def _is_type_checking(test: ast.expr) -> bool:
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    if isinstance(test, ast.Attribute):
+        return test.attr == "TYPE_CHECKING"
+    return False
+
+
+def _string_literals(node: ast.expr) -> list[str] | None:
+    """Collect the string literals of an ``__all__`` value, or None if not literal."""
+    out: list[str] = []
+    stack: list[ast.AST] = [node]
+    while stack:
+        cur = stack.pop()
+        if isinstance(cur, (ast.List, ast.Tuple, ast.Set)):
+            stack.extend(cur.elts)
+        elif isinstance(cur, ast.BinOp):
+            stack.extend([cur.left, cur.right])
+        elif isinstance(cur, ast.Constant) and isinstance(cur.value, str):
+            out.append(cur.value)
+        else:
+            return out or None
+    return out
+
+
+def collect(source: str, module: str, path: str) -> Surface | None:
+    """Parse one module and return the names it binds at module scope."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    surf = Surface(module=module, path=path)
+
+    def walk(body: list[ast.stmt]) -> None:
+        for node in body:
+            if isinstance(node, ast.If):
+                # A TYPE_CHECKING guard binds nothing at runtime; its else does.
+                walk(node.orelse if _is_type_checking(node.test) else node.body + node.orelse)
+            elif isinstance(node, ast.Try):
+                walk(node.body + node.orelse + node.finalbody)
+                for handler in node.handlers:
+                    walk(handler.body)
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                _record_import(surf, node)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name == "__getattr__":
+                    surf.has_getattr = True
+                surf.bindings[node.name] = Binding(node.name, "def", "", node.lineno)
+            elif isinstance(node, ast.ClassDef):
+                surf.bindings[node.name] = Binding(node.name, "class", "", node.lineno)
+            elif isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+                _record_assign(surf, node)
+
+    walk(tree.body)
+    return surf
+
+
+def _record_import(surf: Surface, node: ast.Import | ast.ImportFrom) -> None:
+    if isinstance(node, ast.ImportFrom):
+        origin = ("." * node.level) + (node.module or "")
+        internal = node.level > 0 or (node.module or "").startswith("kornia")
+    else:
+        origin = ""
+        internal = False
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        bound = alias.asname or alias.name.split(".")[0]
+        source_module = origin or alias.name
+        kind = "import-kornia" if internal or source_module.startswith("kornia") else "import-external"
+        surf.bindings[bound] = Binding(bound, kind, source_module, node.lineno)
+
+
+def _record_assign(surf: Surface, node: ast.Assign | ast.AugAssign | ast.AnnAssign) -> None:
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    for target in targets:
+        if not isinstance(target, ast.Name):
+            continue
+        if target.id == "__all__":
+            names = _string_literals(node.value) if node.value is not None else None
+            if names is not None:
+                surf.has_all = True
+                surf.all_names.update(names)
+            continue
+        surf.bindings[target.id] = Binding(target.id, "assign", "", node.lineno)
+
+
+def _module_name(path: str) -> str:
+    stem = path[: -len(".py")]
+    if stem.endswith("/__init__"):
+        stem = stem[: -len("/__init__")]
+    return stem.replace("/", ".")
+
+
+def load(rev: str | None, root: str) -> dict[str, Surface]:
+    """Collect every module surface under ``root``, at ``rev`` or in the working tree."""
+    surfaces: dict[str, Surface] = {}
+    if rev:
+        listing = subprocess.run(  # noqa: S603
+            ["git", "ls-tree", "-r", "--name-only", rev, root],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        paths = [p for p in listing.splitlines() if p.endswith(".py")]
+    else:
+        paths = [str(p) for p in sorted(Path(root).rglob("*.py"))]
+
+    for path in paths:
+        try:
+            source = (
+                subprocess.run(  # noqa: S603
+                    ["git", "show", f"{rev}:{path}"],  # noqa: S607
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout
+                if rev
+                else Path(path).read_text(encoding="utf-8")
+            )
+        except (subprocess.CalledProcessError, UnicodeDecodeError):
+            continue
+        surface = collect(source, _module_name(path), path)
+        if surface is not None:
+            surfaces[surface.module] = surface
+    return surfaces
+
+
+# docs/source/get-started/stability.rst puts kornia.contrib in the Experimental tier:
+# "No stability promise." Removals there are reported, never fatal.
+EXPERIMENTAL = ("kornia.contrib",)
+
+
+def _experimental(module: str) -> bool:
+    return any(module == e or module.startswith(e + ".") for e in EXPERIMENTAL)
+
+
+def _grade(surf: Surface, binding: Binding) -> str:
+    if surf.has_all and binding.name in surf.all_names:
+        return ""
+    if binding.kind == "import-external":
+        return "L1a"
+    if binding.kind == "import-kornia":
+        return "L1b"
+    return "L2" if surf.has_all else "L3"
+
+
+def inventory(surfaces: dict[str, Surface]) -> int:
+    """Report the undeclared public surface; non-zero when a declared name does not resolve."""
+    buckets: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    broken: list[tuple[str, str]] = []
+    without_all = 0
+
+    for module, surf in sorted(surfaces.items()):
+        without_all += not surf.has_all
+        if not surf.has_getattr:
+            broken.extend((module, n) for n in sorted(surf.all_names) if n not in surf.bindings)
+        for name, binding in sorted(surf.public.items()):
+            grade = _grade(surf, binding)
+            if grade:
+                buckets[grade][module].append(name)
+
+    print(f"modules scanned: {len(surfaces)} · without __all__: {without_all}\n")
+    titles = {
+        "L1a": "re-exported third-party/stdlib name",
+        "L1b": "re-exported kornia-internal name",
+        "L2": "defined here, module has __all__ and excludes it",
+        "L3": "module declares no __all__",
+    }
+    for grade, title in titles.items():
+        rows = buckets.get(grade, {})
+        total = sum(len(v) for v in rows.values())
+        print(f"{grade} — {title}: {total} names in {len(rows)} modules")
+    print(f"X  — in __all__ with no module-scope binding: {len(broken)}")
+    for module, name in broken:
+        print(f"     {module}.{name}  ('from {module} import *' would raise AttributeError)")
+    return 1 if broken else 0
+
+
+def regression(old: dict[str, Surface], new: dict[str, Surface], old_rev: str, new_rev: str, fail_on: str) -> int:
+    """Report public module-scope names importable at old_rev and gone at new_rev."""
+    declared: list[tuple[str, str, str]] = []
+    undeclared: list[tuple[str, str, str]] = []
+    experimental: list[tuple[str, str, str]] = []
+
+    for module, old_surf in sorted(old.items()):
+        new_surf = new.get(module)
+        if new_surf is not None and new_surf.has_getattr:
+            continue  # a deprecation shim may resolve names the AST cannot see
+        current = new_surf.public if new_surf else {}
+        for name, binding in sorted(old_surf.public.items()):
+            if name in current:
+                continue
+            row = (module, name, binding.kind)
+            if _experimental(module):
+                experimental.append(row)
+            elif old_surf.has_all and name in old_surf.all_names:
+                declared.append(row)
+            else:
+                undeclared.append(row)
+
+    print(f"import surface: {old_rev} -> {new_rev}\n")
+    print(f"declared (in __all__) names removed: {len(declared)}")
+    for module, name, kind in declared:
+        print(f"  {module}.{name}  (was bound by: {kind})")
+    print(f"\nundeclared public names removed: {len(undeclared)}")
+    for module, name, kind in undeclared[:40]:
+        print(f"  {module}.{name}  (was bound by: {kind})")
+    if len(undeclared) > 40:
+        print(f"  ... and {len(undeclared) - 40} more")
+    if experimental:
+        print(f"\nexperimental-tier (kornia.contrib) names removed, not fatal: {len(experimental)}")
+
+    if declared:
+        print(
+            "\nA name in __all__ was removed. Per the API stability policy "
+            "(docs/source/get-started/stability.rst) a public symbol spends at least one minor "
+            "release as a deprecated shim before removal. If the deprecation window has passed, "
+            "record the removal in the release notes in this PR."
+        )
+    if undeclared:
+        print(
+            "\nThe undeclared names above are not API under the stability policy and do not fail "
+            "this check. They are listed because dropping one is how #3986 happened: if any is "
+            "plausibly relied on downstream, keep it or give it a deprecation shim."
+        )
+    if fail_on == "any":
+        return 1 if declared or undeclared else 0
+    return 1 if declared else 0
+
+
+def main() -> int:
+    """Parse arguments and run the requested mode."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("mode", choices=["regression", "inventory"])
+    parser.add_argument("--root", default="kornia", help="package directory to scan (default: kornia)")
+    parser.add_argument("--rev", help="inventory: git revision to scan (default: the working tree)")
+    parser.add_argument("--old", help="regression: the revision to compare from")
+    parser.add_argument("--new", default="HEAD", help="regression: the revision to compare to (default: HEAD)")
+    parser.add_argument(
+        "--fail-on",
+        choices=["declared", "any"],
+        default="declared",
+        help="regression: fail on __all__ removals only (default) or on every removal",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "inventory":
+        return inventory(load(args.rev, args.root))
+    if not args.old:
+        parser.error("regression requires --old")
+    return regression(load(args.old, args.root), load(args.new, args.root), args.old, args.new, args.fail_on)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/import-surface.yml
+++ b/.github/workflows/import-surface.yml
@@ -1,0 +1,45 @@
+name: Import surface
+
+on:
+  pull_request:
+    paths:
+      - 'kornia/**.py'
+      - '.github/scripts/check_import_surface.py'
+      - '.github/workflows/import-surface.yml'
+  schedule:
+    - cron: '15 7 * * 1'  # Mondays, 07:15 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  surface:
+    name: Check the importable surface
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # the check compares two revisions
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      # Compare against the merge base rather than the base branch tip, so the
+      # check sees what this PR removes and not what the base branch already
+      # lost. The script is stdlib-only and never imports kornia, so there is
+      # nothing to install.
+      - name: Check for removed public names
+        if: github.event_name == 'pull_request'
+        run: |
+          base="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          echo "merge base: ${base}"
+          python3 .github/scripts/check_import_surface.py regression --old "${base}" --new HEAD
+
+      # Informational: the standing undeclared surface, and any name that is in
+      # __all__ without resolving. The latter is a real bug (from <module>
+      # import * raises) but three exist on main today, tracked in #4023, so
+      # this step reports rather than fails until they are fixed.
+      - name: Inventory the undeclared surface
+        run: python3 .github/scripts/check_import_surface.py inventory || true

--- a/docs/source/get-started/stability.rst
+++ b/docs/source/get-started/stability.rst
@@ -56,6 +56,70 @@ A symbol is public when it appears in the rendered documentation at
 Underscore-prefixed modules and names, and undocumented helpers, are private
 regardless of importability.
 
+Importability is not publication
+--------------------------------
+
+Python exports whatever a module happens to bind, and ``import`` statements
+bind names too. A file that does ``from torch import Tensor`` makes
+``thatmodule.Tensor`` importable without anyone deciding that it should be.
+Most of what you can import from a kornia submodule is of that kind: plumbing
+a file needed, not API the project chose.
+
+The rule above settles those cases -- undocumented means private -- and it is
+the rule, not an aspiration. In 0.8.3 ``kornia.geometry.transform.pyramid``
+stopped exposing ``pad``, which had never been anything but
+``torch.nn.functional.pad`` leaking out of an import line. Downstream code
+importing it broke. That name was never public API, kornia did not restore it,
+and the fix belonged in the calling code.
+
+``__all__`` states the same thing in a form tools can read. Where a module
+defines it, it is that module's export declaration, and the project treats it
+as binding in both directions:
+
+* a name in ``__all__`` is covered by promise 1 below -- it gets a deprecation
+  window before it is removed;
+* a name that is not in ``__all__`` and not in the rendered documentation is
+  private, and may disappear in any release without a deprecation window.
+
+CI enforces the first half. ``.github/scripts/check_import_surface.py``
+compares the importable surface of a pull request against its merge base and
+fails the build when a name in ``__all__`` disappears. Removals of undeclared
+names are reported in the same output but do not fail the build: they are not
+API, and treating them as API would freeze thousands of incidental imports
+forever. The report exists so a reviewer can still notice when a dropped name
+looks load-bearing -- the judgement that was missing when ``pad`` went.
+
+Names removed before this section was written
+---------------------------------------------
+
+Publishing this rule does not restore what earlier releases removed under it,
+and kornia does not plan to re-add those names:
+
+* ``kornia.core`` re-exported 32 torch names (``Tensor``, ``Module``, ``pad``,
+  ``tensor``, ``zeros`` and friends) until 0.8.3. None was ever documented, so
+  none was public by the definition above. Each has a direct torch replacement
+  -- ``from kornia.core import Tensor`` becomes ``from torch import Tensor``,
+  and ``pad`` becomes ``torch.nn.functional.pad`` -- and restoring them would
+  rebuild the alias layer whose removal was the point.
+* ``upscale_double`` was documented, and so *was* public. It was a leftover
+  from the OpenCV-mimicking DoG implementation, superseded when that code was
+  improved, and it was removed with no deprecation window. It stays removed;
+  the role it served no longer exists.
+
+Both removals predate this policy. What they should have had, and what every
+future removal will have, is promise 3: a line in the release notes. Those
+lines are being written retroactively.
+
+If you depend on an undocumented name
+--------------------------------------
+
+Open an issue asking for it to be published. If it is a reasonable thing to
+support it gets an ``__all__`` entry, a documentation entry and a test, and
+from then on the promises on this page apply to it. That is a far better
+outcome than finding out at upgrade time that the name was never ours to
+keep, and it is cheap to ask -- please do that rather than pinning an old
+release.
+
 The promises (stable core)
 --------------------------
 


### PR DESCRIPTION
## What does this pull request do?

#3986 broke because `kornia.geometry.transform.pyramid.pad` was importable without ever being API — never in `__all__`, never documented, only `torch.nn.functional.pad` leaking out of a `from kornia.core import ..., pad, ...` line. A refactor to `F.pad(...)` dropped the binding and ComfyUI-LTXVideo was broken for three months across five ignored PRs.

An audit of the whole tree says `pad` was not special:

- the same release removed **all 32 names from `kornia.core.__all__`** with no shim and no release note, taking **824 module-scope bindings** with it across ~500 modules (#4024) — `pad` in pyramid is 1 of 19 lost `pad` bindings;
- a performance PR deleted `upscale_double`, which **was documented** and therefore was public API by the policy's own definition (#4025);
- three names sit in `__all__` today without resolving, so `from kornia.color import *` and `from kornia.core import *` raise (#4023);
- 57 more names are public-named, importable, and deliberately excluded from their module's `__all__` (#4026).

None of it was visible in review, because nothing compared the export surface between two revisions.

This PR adds the two halves that were missing. Neither works without the other: the check needs a stated rule to enforce, and the rule needs enforcement to be more than a wish.

**1. The boundary, written down** — `docs/source/get-started/stability.rst` gains three short sections:

- *Importability is not publication.* The page already says documented-means-public; this makes `__all__` the machine-readable half of that sentence, binding in both directions — a name in `__all__` gets promise 1, a name in neither `__all__` nor the docs may go in any release. `pad` is the worked example.
- *Names removed before this section was written.* States plainly that publishing the rule does not retroactively restore what earlier releases took, and why for each: the `kornia.core` 32 were never documented and every one has a direct torch replacement, so restoring them would rebuild the alias layer whose removal was the point; `upscale_double` was a leftover from the OpenCV-mimicking DoG implementation, superseded when that code was improved. Both stay removed, and both get the release-note line promise 3 requires.
- *If you depend on an undocumented name.* Tells downstream to open an issue and ask for publication rather than discovering at upgrade time that the name was never ours to keep.

**2. The check** — `.github/scripts/check_import_surface.py`, modelled on the existing `check_doc_links.py`. Stdlib-only, never imports kornia, reads any revision via `git show`, so there is nothing to install and no environment to get wrong.

On a pull request it compares against the **merge base** (not the base tip, so it sees what this PR removes rather than what the branch already lost) and **fails when a name in `__all__` disappears**.

The deliberate part: **undeclared removals are reported but do not fail.** They are not API under the policy, and failing on them would freeze 2144 incidental third-party re-exports as permanent surface — the check would be turned off within a month. So `pad` itself would have produced a warning line, not a red build. That is the honest outcome and it is still the one that would have helped: the reviewer of that PR would have seen "19 `pad` bindings removed" in the log. `upscale_double` **would** have failed the build.

`kornia.contrib` is excluded from the fatal path, matching its Experimental tier ("No stability promise") on the same policy page.

## Related issue or discussion

Refs #3986 (the break), #4023, #4024, #4025, #4026 (what the audit found). Complements #3898's `tests/test_api_surface.py`, which guards 12 top-level modules by runtime `__all__` and is the reason this script does not duplicate that job — note that guard cannot catch the `kornia.core` removal, because its baseline was recorded after the removal, nor the three broken exports, because it reads `__all__` without checking the names resolve (both tracked in #4023).

## What did you check?

Validated against the two known breaks and the current tree:

```text
$ python3 .github/scripts/check_import_surface.py regression --old v0.8.2 --new v0.8.3
declared (in __all__) names removed: 77
  kornia.color.AUTUMN  (was bound by: import-kornia)
  kornia.geometry.transform.pyramid.upscale_double  (was bound by: def)
  ...
undeclared public names removed: 1317
experimental-tier (kornia.contrib) names removed, not fatal: 396
$ echo $?
1

$ python3 .github/scripts/check_import_surface.py regression --old main --new HEAD
declared (in __all__) names removed: 0
undeclared public names removed: 0
$ echo $?
0

$ python3 .github/scripts/check_import_surface.py inventory
modules scanned: 500 · without __all__: 368
L1a — re-exported third-party/stdlib name: 2143 names in 425 modules
L1b — re-exported kornia-internal name: 1535 names in 373 modules
L2 — defined here, module has __all__ and excludes it: 57 names in 27 modules
L3 — module declares no __all__: 1148 names in 323 modules
X  — in __all__ with no module-scope binding: 3
     kornia.color.AUTUMN  ('from kornia.color import *' would raise AttributeError)
     kornia.core.eye_like  ('from kornia.core import *' would raise AttributeError)
     kornia.core.vec_like  ('from kornia.core import *' would raise AttributeError)
```

Each of those three was confirmed by hand at runtime (`from kornia.core import *` → `AttributeError: module 'kornia.core' has no attribute 'eye_like'`). The inventory step in the workflow is non-fatal for exactly that reason — it would be red on main today until #4023 lands, after which it should be made fatal.

Also ran:

```text
$ pre-commit run --files .github/scripts/check_import_surface.py .github/workflows/import-surface.yml docs/source/get-started/stability.rst
... ruff check Passed · ruff format Passed · check yaml Passed · codespell Passed · Add license header Passed
```

**Not checked:** I did not run a full Sphinx build for the docs change (`pixi run build-docs`); I verified section-underline lengths and inline-literal balance by script instead. Worth a docs CI pass before merge.

## How did AI help?

AI-assisted end to end. Claude wrote the audit script and the policy text, ran the cross-revision comparisons, and verified each claimed break at runtime rather than from the static output. I reviewed the findings and supplied the `upscale_double` provenance (OpenCV-mimic DoG leftover, superseded), which is what settles it as "stays removed" rather than "needs restoring".

Posted on behalf of @ducha-aiki by Claude (Opus 5).
