### PR TITLE
test(testing): precision and degenerate-path helpers, pixi run verify-delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `testing.precision`: `unrepresentable_sizes`, `assert_capture_matches_eager`, `assert_degenerate_path_parity`
-  for reduced-precision, graph-capture and degenerate-path tests.
+  for reduced-precision, graph-capture and degenerate-path tests, and `pixi run verify-delta`, which diffs the
+  failing-test *sets* of a branch and its base revision across the cpu, half, MPS and inductor surfaces.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `testing.precision`: `unrepresentable_sizes`, `assert_capture_matches_eager`, `assert_degenerate_path_parity`
   for reduced-precision, graph-capture and degenerate-path tests, and `pixi run verify-delta`, which diffs the
   failing-test *sets* of a branch and its base revision across the cpu, half, MPS and inductor surfaces. (#4034)
-  `verify-delta` refuses to run on a dirty checkout, since its scope is `base...HEAD` and its verdict must
-  describe HEAD, and it exits non-zero whenever a selected, available surface could not be measured.
+  `verify-delta` refuses to run on a dirty checkout by default, since its automatic scope is `base...HEAD`;
+  `--allow-dirty` requires explicit test paths. It exits non-zero whenever a selected, available surface could
+  not be measured.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `testing.precision`: `unrepresentable_sizes`, `assert_capture_matches_eager`, `assert_degenerate_path_parity`
   for reduced-precision, graph-capture and degenerate-path tests, and `pixi run verify-delta`, which diffs the
-  failing-test *sets* of a branch and its base revision across the cpu, half, MPS and inductor surfaces.
+  failing-test *sets* of a branch and its base revision across the cpu, half, MPS and inductor surfaces. (#4034)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `testing.precision`: `unrepresentable_sizes`, `assert_capture_matches_eager`, `assert_degenerate_path_parity`
   for reduced-precision, graph-capture and degenerate-path tests, and `pixi run verify-delta`, which diffs the
   failing-test *sets* of a branch and its base revision across the cpu, half, MPS and inductor surfaces. (#4034)
+  `verify-delta` refuses to run on a dirty checkout, since its scope is `base...HEAD` and its verdict must
+  describe HEAD, and it exits non-zero whenever a selected, available surface could not be measured.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* `testing.precision`: `unrepresentable_sizes`, `assert_capture_matches_eager`, `assert_degenerate_path_parity`
+  for reduced-precision, graph-capture and degenerate-path tests.
+
 ### Breaking changes
 
 * The shape guards of `normalize_homography` and `denormalize_homography` now reject everything but a

--- a/TESTING.md
+++ b/TESTING.md
@@ -290,7 +290,8 @@ from testing import assert_capture_matches_eager, unrepresentable_sizes
 
 def test_trace_matches_eager(device, dtype):
     def grid(image):
-        return kornia.geometry.create_meshgrid(image.shape[-2], image.shape[-1], device=image.device, dtype=image.dtype)
+        h, w = image.shape[-2], image.shape[-1]
+        return kornia.geometry.create_meshgrid(h, w, device=image.device, dtype=image.dtype)
 
     assert_capture_matches_eager(
         grid,
@@ -307,6 +308,8 @@ Rules the helpers enforce, for code that is written by hand:
 - Resolve `dtype=None` to `torch.get_default_dtype()` *before* deciding whether to promote.
 - Guard a cast-back on `is_floating_point()` — an integral grid dtype must stay promoted.
 - Compile tests carry `dynamo` or `compile` in their name (they are deselected otherwise).
+
+---
 
 ## Writing Robust Tests
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -268,6 +268,46 @@ The `padding_mode="border"` issue in `F.grid_sample` (2D) is worked around in th
 
 ---
 
+## Precision and Degenerate-Path Helpers
+
+`testing.precision` carries three assertions for the bug classes that recur in dtype/capture work
+(see kornia#4006 for the history). Use them instead of hand-picking a "boundary" size.
+
+- `unrepresentable_sizes(dtype)` — sizes at which `n` or `n - 1` is inexact in `dtype`. Sweep a
+  slice of this list; never pick one size. 257 is vacuous against a rounded divisor and decisive
+  against a rounded size; 258 is the reverse.
+- `assert_capture_matches_eager(fn, make_inputs, sizes=..., device=..., dtype=..., capture="trace"|"compile")`
+  — byte-equality (`torch.equal`) between eager and `torch.jit.trace` / `torch.compile(fullgraph=True,
+  dynamic=True)`, size by size. Derive sizes from tensor shapes inside `fn`. `sizes` must not be
+  empty: `float32`/`float64` return `[]` from `unrepresentable_sizes`, so always include the
+  degenerate sizes 1 and 2, e.g. `sizes=[1, 2, *unrepresentable_sizes(dtype)[:8]]`.
+- `assert_degenerate_path_parity(fn, full_kwargs, degenerate_kwargs, bad_inputs)` — an empty or
+  singleton path must raise exactly what the full path raises for the same invalid input.
+
+```python
+from testing import assert_capture_matches_eager, unrepresentable_sizes
+
+
+def test_trace_matches_eager(device, dtype):
+    def grid(image):
+        return kornia.geometry.create_meshgrid(image.shape[-2], image.shape[-1], device=image.device, dtype=image.dtype)
+
+    assert_capture_matches_eager(
+        grid,
+        lambda size, device, dtype: (torch.zeros(1, 1, size, 4, device=device, dtype=dtype),),
+        sizes=[1, 2, *unrepresentable_sizes(dtype)[:8]],
+        device=device,
+        dtype=dtype,
+    )
+```
+
+Rules the helpers enforce, for code that is written by hand:
+
+- Under capture, divide by the *unrounded* size and cast the quotient; never cast the divisor.
+- Resolve `dtype=None` to `torch.get_default_dtype()` *before* deciding whether to promote.
+- Guard a cast-back on `is_floating_point()` — an integral grid dtype must stay promoted.
+- Compile tests carry `dynamo` or `compile` in their name (they are deselected otherwise).
+
 ## Writing Robust Tests
 
 - **Seed the RNG** when the test compares against reference values: `torch.manual_seed(seed)`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -276,8 +276,8 @@ The `padding_mode="border"` issue in `F.grid_sample` (2D) is worked around in th
 - `unrepresentable_sizes(dtype)` — sizes at which `n` or `n - 1` is inexact in `dtype`. Sweep a
   slice of this list; never pick one size. 257 is vacuous against a rounded divisor and decisive
   against a rounded size; 258 is the reverse. `hi` above `torch.finfo(dtype).max` raises
-  `ValueError`: every candidate there casts to `inf` and round-trips back unchanged, so the sweep
-  would be sizes no test can allocate.
+  `ValueError`: candidates there cast to non-finite values and conversion back to `int64` produces
+  a sentinel rather than the original size, corrupting the sweep.
 - `assert_capture_matches_eager(fn, make_inputs, sizes=..., device=..., dtype=..., capture="trace"|"compile")`
   — byte-equality between eager and `torch.jit.trace` / `torch.compile(fullgraph=True,
   dynamic=True)`, size by size. The comparison is on the raw bytes, not `torch.equal`, which is
@@ -317,6 +317,21 @@ Rules the helpers enforce, for code that is written by hand:
 - Resolve `dtype=None` to `torch.get_default_dtype()` *before* deciding whether to promote.
 - Guard a cast-back on `is_floating_point()` — an integral grid dtype must stay promoted.
 - Compile tests carry `dynamo` or `compile` in their name (they are deselected otherwise).
+
+### Comparing branch and base failures
+
+`pixi run verify-delta` compares failing-test sets between the branch and `--base` across the CPU,
+reduced-precision, available MPS, and inductor surfaces. Its automatic test selection is deliberately
+local: a change under `kornia/geometry` maps to `tests/geometry`. That cannot discover every
+cross-package consumer (for example, augmentation code that calls geometry), so pass `--tests tests`
+for shared primitives or any cross-cutting change.
+
+The default refuses a dirty checkout because it describes committed `HEAD`. To intentionally test
+working-tree changes, pass both `--allow-dirty` and explicit `--tests`, listing every affected target;
+the tool cannot infer whether a caller-chosen scope omits a tracked or untracked change outside
+`base...HEAD`. Every selected and available surface must produce a measurement. A machine without MPS
+records that row as unavailable, but a run that selects only unavailable rows still exits non-zero
+because it verified nothing.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -275,14 +275,20 @@ The `padding_mode="border"` issue in `F.grid_sample` (2D) is worked around in th
 
 - `unrepresentable_sizes(dtype)` — sizes at which `n` or `n - 1` is inexact in `dtype`. Sweep a
   slice of this list; never pick one size. 257 is vacuous against a rounded divisor and decisive
-  against a rounded size; 258 is the reverse.
+  against a rounded size; 258 is the reverse. `hi` above `torch.finfo(dtype).max` raises
+  `ValueError`: every candidate there casts to `inf` and round-trips back unchanged, so the sweep
+  would be sizes no test can allocate.
 - `assert_capture_matches_eager(fn, make_inputs, sizes=..., device=..., dtype=..., capture="trace"|"compile")`
   — byte-equality (`torch.equal`) between eager and `torch.jit.trace` / `torch.compile(fullgraph=True,
   dynamic=True)`, size by size. Derive sizes from tensor shapes inside `fn`. `sizes` must not be
   empty: `float32`/`float64` return `[]` from `unrepresentable_sizes`, so always include the
   degenerate sizes 1 and 2, e.g. `sizes=[1, 2, *unrepresentable_sizes(dtype)[:8]]`.
 - `assert_degenerate_path_parity(fn, full_kwargs, degenerate_kwargs, bad_inputs)` — an empty or
-  singleton path must raise exactly what the full path raises for the same invalid input.
+  singleton path must raise exactly what the full path raises for the same invalid input. Every
+  `bad_inputs` name must already be a key of both kwargs dicts (an unknown name would be *added*
+  rather than substituted, and both paths would raise `TypeError` over a call never made); parity
+  is compared on the exception type, so check the messages when two paths could raise the same type
+  for unrelated reasons.
 
 ```python
 from testing import assert_capture_matches_eager, unrepresentable_sizes

--- a/TESTING.md
+++ b/TESTING.md
@@ -279,14 +279,17 @@ The `padding_mode="border"` issue in `F.grid_sample` (2D) is worked around in th
   `ValueError`: every candidate there casts to `inf` and round-trips back unchanged, so the sweep
   would be sizes no test can allocate.
 - `assert_capture_matches_eager(fn, make_inputs, sizes=..., device=..., dtype=..., capture="trace"|"compile")`
-  — byte-equality (`torch.equal`) between eager and `torch.jit.trace` / `torch.compile(fullgraph=True,
-  dynamic=True)`, size by size. Derive sizes from tensor shapes inside `fn`. `sizes` must not be
+  — byte-equality between eager and `torch.jit.trace` / `torch.compile(fullgraph=True,
+  dynamic=True)`, size by size. The comparison is on the raw bytes, not `torch.equal`, which is
+  numeric: it calls two NaNs unequal (a spurious failure) and `+0.0` equal to `-0.0` (a missed
+  sign-bit change). Derive sizes from tensor shapes inside `fn`. `sizes` must not be
   empty: `float32`/`float64` return `[]` from `unrepresentable_sizes`, so always include the
   degenerate sizes 1 and 2, e.g. `sizes=[1, 2, *unrepresentable_sizes(dtype)[:8]]`.
 - `assert_degenerate_path_parity(fn, full_kwargs, degenerate_kwargs, bad_inputs)` — an empty or
   singleton path must raise exactly what the full path raises for the same invalid input. Every
   `bad_inputs` name must already be a key of both kwargs dicts (an unknown name would be *added*
-  rather than substituted, and both paths would raise `TypeError` over a call never made); parity
+  rather than substituted, and both paths would raise `TypeError` over a call never made), and
+  `bad_inputs` must not be empty (with no pairs only the two baseline calls run); parity
   is compared on the exception type, so check the messages when two paths could raise the same type
   for unrelated reasons.
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -44,6 +44,7 @@ test-f64 = { cmd = "uv run pytest -v tests/", env = { KORNIA_TEST_DTYPE = "float
 test-slow = { cmd = "uv run pytest -v tests/", env = { KORNIA_TEST_RUNSLOW = "true" } }
 test-quick = { cmd = "uv run pytest -v -m 'not (jit or grad or nn)' tests/" }
 test-half = { cmd = "uv run pytest -v tests/", env = { KORNIA_TEST_DTYPE = "float16,bfloat16" }, description = "Run CPU half-precision tests" }
+verify-delta = { cmd = "uv run python -m testing.verify_delta", description = "Diff failing-test sets vs origin/main on cpu/half/mps/inductor (usage: pixi run verify-delta [-- --only 'cpu float32'])" }
 test-module = { cmd = "uv run pytest -v", description = "Run tests for a specific module (usage: pixi run test-module tests/<module_path>, e.g., pixi run test-module tests/contrib/)" }
 # Quality
 lint = { cmd = "uv run pre-commit run ruff-check --all-files && uv run pre-commit run ruff-format --all-files" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -51,7 +51,7 @@ lint = { cmd = "uv run pre-commit run ruff-check --all-files && uv run pre-commi
 pre-commit-all = { cmd = "uv run pre-commit run --all-files", description = "Run all repository pre-commit checks" }
 pre-commit-install = { cmd = "uv run pre-commit install", description = "Install the pre-commit Git hook" }
 typecheck = { cmd = "ty check kornia" }
-doctest = { cmd = "uv run pytest -v --doctest-modules kornia/" }
+doctest = { cmd = "uv run pytest -v --doctest-modules kornia/ testing/precision.py" }
 toml-fmt = { cmd = "tombi format", description = "Format TOML files" }
 toml-fmt-check = { cmd = "tombi format --check", description = "Check TOML formatting" }
 # Docs

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -16,5 +16,6 @@
 #
 
 from .parametrized_tester import parametrized_test
+from .precision import unrepresentable_sizes
 
-__all__ = ["parametrized_test"]
+__all__ = ["parametrized_test", "unrepresentable_sizes"]

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -16,6 +16,6 @@
 #
 
 from .parametrized_tester import parametrized_test
-from .precision import unrepresentable_sizes
+from .precision import assert_capture_matches_eager, unrepresentable_sizes
 
-__all__ = ["parametrized_test", "unrepresentable_sizes"]
+__all__ = ["assert_capture_matches_eager", "parametrized_test", "unrepresentable_sizes"]

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -16,6 +16,11 @@
 #
 
 from .parametrized_tester import parametrized_test
-from .precision import assert_capture_matches_eager, unrepresentable_sizes
+from .precision import assert_capture_matches_eager, assert_degenerate_path_parity, unrepresentable_sizes
 
-__all__ = ["assert_capture_matches_eager", "parametrized_test", "unrepresentable_sizes"]
+__all__ = [
+    "assert_capture_matches_eager",
+    "assert_degenerate_path_parity",
+    "parametrized_test",
+    "unrepresentable_sizes",
+]

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -26,7 +26,8 @@ empty/singleton code path that validated less (or more) than the non-empty path.
 from __future__ import annotations
 
 import warnings
-from typing import Any, Callable, Literal, Sequence
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Literal, Sequence
 
 import pytest
 import torch
@@ -45,12 +46,16 @@ def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) ->
     Args:
         dtype: a floating dtype. Integer dtypes raise ``TypeError``.
         lo: smallest size to consider (inclusive).
-        hi: largest size to consider (inclusive). Keep it below ``torch.finfo(dtype).max`` (65504 for
-            float16): above that every candidate casts to ``inf`` and the round-trip back to
+        hi: largest size to consider (inclusive). Must not exceed ``torch.finfo(dtype).max`` (65504
+            for float16): above that every candidate casts to ``inf`` and the round-trip back to
             ``int64`` is meaningless, so the result would be garbage rather than a size sweep.
 
     Returns:
         sorted sizes, empty when every integer in range is exact (float32/float64 below 2**24).
+
+    Raises:
+        TypeError: when ``dtype`` is not a floating dtype.
+        ValueError: when ``hi`` exceeds ``torch.finfo(dtype).max``.
 
     Example:
         >>> unrepresentable_sizes(torch.bfloat16)[:3]
@@ -60,10 +65,37 @@ def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) ->
     """
     if not dtype.is_floating_point:
         raise TypeError(f"unrepresentable_sizes needs a floating dtype, got {dtype}")
+    finite_max = torch.finfo(dtype).max
+    if hi > finite_max:
+        raise ValueError(
+            f"hi={hi} is above torch.finfo({dtype}).max={finite_max:g}: every candidate there casts to inf "
+            "and round-trips back to the same int64, so the sweep would be garbage rather than sizes"
+        )
     n = torch.arange(lo, hi + 1, dtype=torch.int64)
     inexact_n = n.to(dtype).to(torch.int64) != n
     inexact_prev = (n - 1).to(dtype).to(torch.int64) != n - 1
     return n[inexact_n | inexact_prev].tolist()
+
+
+@contextmanager
+def _restoring_rng(device: torch.device) -> Iterator[None]:
+    """Restore the RNG state on exit, so the next call inside starts where this one did.
+
+    Tracing runs ``fn`` once itself, and the eager reference call runs it again; without this a
+    function that consumes randomness would be compared against a different draw and fail with the
+    rounding message below, which is not what went wrong.
+    """
+    cpu_state = torch.get_rng_state()
+    module = getattr(torch, device.type, None) if device.type != "cpu" else None
+    # ``torch.cuda``/``torch.mps``/``torch.xpu`` all take the device explicitly; the no-argument
+    # form would read whichever device is current, which need not be the one under test.
+    device_state = module.get_rng_state(device) if hasattr(module, "get_rng_state") else None
+    try:
+        yield
+    finally:
+        torch.set_rng_state(cpu_state)
+        if device_state is not None:
+            module.set_rng_state(device_state, device)
 
 
 def _as_tuple(out: Any) -> tuple[torch.Tensor, ...]:
@@ -129,11 +161,13 @@ def assert_capture_matches_eager(
     for size in sizes:
         inputs = make_inputs(size, torch.device(device), dtype)
         if capture == "trace":
-            with warnings.catch_warnings():
+            with warnings.catch_warnings(), _restoring_rng(torch.device(device)):
                 warnings.simplefilter("ignore", torch.jit.TracerWarning)
                 captured_fn = torch.jit.trace(fn, inputs, check_trace=False)
-        expected = _as_tuple(fn(*inputs))
-        actual = _as_tuple(captured_fn(*inputs))
+        with _restoring_rng(torch.device(device)):
+            expected = _as_tuple(fn(*inputs))
+        with _restoring_rng(torch.device(device)):
+            actual = _as_tuple(captured_fn(*inputs))
         if len(expected) != len(actual):
             raise AssertionError(
                 f"size {size}: eager returned {len(expected)} outputs, {capture} returned {len(actual)}"
@@ -182,11 +216,28 @@ def assert_degenerate_path_parity(
         full_kwargs: a call that takes the ordinary, non-degenerate path and succeeds.
         degenerate_kwargs: the same call routed through the degenerate path (``dsize=(0, w)``, a
             singleton axis, an empty batch).
-        bad_inputs: ``(argument name, invalid value)`` pairs to substitute into both calls.
+        bad_inputs: ``(argument name, invalid value)`` pairs to substitute into both calls. Each
+            name must already be a key of both kwargs dicts.
 
     Raises:
+        ValueError: when a ``bad_inputs`` name is absent from either kwargs dict.
         AssertionError: naming the argument and the two outcomes, ``None`` meaning "no exception".
+
+    Note:
+        Parity is compared on the exception *type* only. Two paths that raise the same type for
+        unrelated reasons read as parity here; check the messages when that is plausible.
     """
+    for name, _ in bad_inputs:
+        # substituting an unknown name *adds* a key rather than replacing one, so both paths raise
+        # TypeError("unexpected keyword argument") and the assertion below passes having tested nothing
+        missing = [
+            label for label, kwargs in (("full", full_kwargs), ("degenerate", degenerate_kwargs)) if name not in kwargs
+        ]
+        if missing:
+            raise ValueError(
+                f"{name!r} is not a key of {' or '.join(missing)}_kwargs; substituting an unknown argument name "
+                "raises TypeError on both paths and passes vacuously"
+            )
     for label, kwargs in (("full", full_kwargs), ("degenerate", degenerate_kwargs)):
         baseline = _outcome(fn, kwargs)
         if baseline is not None:

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -1,0 +1,60 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Helpers for tests that exercise reduced-precision dtypes, graph capture, and degenerate sizes.
+
+These exist because the same three bug classes recurred across kornia#4006's review rounds:
+a size rounded into a half dtype before a division under ``torch.jit.trace``/``torch.compile``,
+regression tests that passed vacuously because the chosen size happened to be exact, and an
+empty/singleton code path that validated less (or more) than the non-empty path.
+"""
+
+from __future__ import annotations
+
+import torch
+
+__all__ = ["unrepresentable_sizes"]
+
+
+def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) -> list[int]:
+    """Return the sizes in ``[lo, hi]`` at which ``n`` or ``n - 1`` is not exact in ``dtype``.
+
+    A test of eager-vs-captured parity must sweep these rather than pick one: which operand a
+    given implementation rounds is unknown in advance. In bfloat16, 257 rounds as a *size* but
+    256 is an exact *divisor*, so a test at 257 passed vacuously against a divisor-rounding bug
+    while catching a size-rounding one; 258 does the opposite.
+
+    Args:
+        dtype: a floating dtype. Integer dtypes raise ``TypeError``.
+        lo: smallest size to consider (inclusive).
+        hi: largest size to consider (inclusive).
+
+    Returns:
+        sorted sizes, empty when every integer in range is exact (float32/float64 below 2**24).
+
+    Example:
+        >>> unrepresentable_sizes(torch.bfloat16)[:3]
+        [257, 258, 259]
+        >>> unrepresentable_sizes(torch.float16)[:2]
+        [2049, 2050]
+    """
+    if not dtype.is_floating_point:
+        raise TypeError(f"unrepresentable_sizes needs a floating dtype, got {dtype}")
+    n = torch.arange(lo, hi + 1, dtype=torch.int64)
+    inexact_n = n.to(dtype).to(torch.int64) != n
+    inexact_prev = (n - 1).to(dtype).to(torch.int64) != n - 1
+    return n[inexact_n | inexact_prev].tolist()

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -45,7 +45,9 @@ def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) ->
     Args:
         dtype: a floating dtype. Integer dtypes raise ``TypeError``.
         lo: smallest size to consider (inclusive).
-        hi: largest size to consider (inclusive).
+        hi: largest size to consider (inclusive). Keep it below ``torch.finfo(dtype).max`` (65504 for
+            float16): above that every candidate casts to ``inf`` and the round-trip back to
+            ``int64`` is meaningless, so the result would be garbage rather than a size sweep.
 
     Returns:
         sorted sizes, empty when every integer in range is exact (float32/float64 below 2**24).
@@ -102,11 +104,13 @@ def assert_capture_matches_eager(
             ``"compile"`` for ``torch.compile(fullgraph=True, dynamic=True)``.
 
     Raises:
-        ValueError: when ``sizes`` is empty.
+        ValueError: when ``capture`` is not ``"trace"`` or ``"compile"``, or when ``sizes`` is empty.
         AssertionError: on the first size where an output differs, naming size, output index,
             shape/dtype mismatch or max abs difference.
 
     """
+    if capture not in ("trace", "compile"):
+        raise ValueError(f"capture must be 'trace' or 'compile', got {capture!r}")
     if len(sizes) == 0:
         raise ValueError(
             "assert_capture_matches_eager needs at least one size: an empty sweep asserts nothing and "

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -31,7 +31,7 @@ from typing import Any, Callable, Literal, Sequence
 import pytest
 import torch
 
-__all__ = ["assert_capture_matches_eager", "unrepresentable_sizes"]
+__all__ = ["assert_capture_matches_eager", "assert_degenerate_path_parity", "unrepresentable_sizes"]
 
 
 def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) -> list[int]:
@@ -150,3 +150,49 @@ def assert_capture_matches_eager(
                     f"({e.dtype}). Under capture the size arithmetic must not round into {dtype}; "
                     "divide by the unrounded size and cast the quotient."
                 )
+
+
+def _outcome(fn: Callable[..., Any], kwargs: dict[str, Any]) -> type[BaseException] | None:
+    try:
+        fn(**kwargs)
+    except Exception as exc:  # noqa: BLE001 — the exception *type* is the observation
+        return type(exc)
+    return None
+
+
+def assert_degenerate_path_parity(
+    fn: Callable[..., Any],
+    full_kwargs: dict[str, Any],
+    degenerate_kwargs: dict[str, Any],
+    bad_inputs: Sequence[tuple[str, Any]],
+) -> None:
+    """Assert that a degenerate (empty/singleton) path rejects exactly what the full path rejects.
+
+    For each ``(name, bad_value)`` the function is called once with ``full_kwargs`` and once with
+    ``degenerate_kwargs``, each with ``name`` replaced by ``bad_value``. Both calls must raise the
+    same exception type, or both must succeed. A degenerate early-return that skips validation
+    (laxer) or adds its own (stricter) fails here.
+
+    Args:
+        fn: the function under test, called with keyword arguments only.
+        full_kwargs: a call that takes the ordinary, non-degenerate path and succeeds.
+        degenerate_kwargs: the same call routed through the degenerate path (``dsize=(0, w)``, a
+            singleton axis, an empty batch).
+        bad_inputs: ``(argument name, invalid value)`` pairs to substitute into both calls.
+
+    Raises:
+        AssertionError: naming the argument and the two outcomes, ``None`` meaning "no exception".
+    """
+    for label, kwargs in (("full", full_kwargs), ("degenerate", degenerate_kwargs)):
+        baseline = _outcome(fn, kwargs)
+        if baseline is not None:
+            raise AssertionError(f"the {label} baseline call raised {baseline.__name__}; fix the fixture first")
+    for name, bad in bad_inputs:
+        full = _outcome(fn, {**full_kwargs, name: bad})
+        degenerate = _outcome(fn, {**degenerate_kwargs, name: bad})
+        if full is not degenerate:
+            raise AssertionError(
+                f"{name}={type(bad).__name__}: full path -> {full and full.__name__} vs degenerate path -> "
+                f"{degenerate and degenerate.__name__}. The degenerate path must validate exactly what the "
+                "full path validates."
+            )

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -98,6 +98,15 @@ def _restoring_rng(device: torch.device) -> Iterator[None]:
             module.set_rng_state(device_state, device)
 
 
+def _bits(t: torch.Tensor) -> torch.Tensor:
+    """Return ``t``'s raw bytes as a flat ``uint8`` tensor, for a bitwise rather than numeric compare.
+
+    ``view(torch.uint8)`` needs a last stride of 1 and at least one dimension, so the tensor is made
+    contiguous and flattened first; the callers have already established that the two shapes match.
+    """
+    return t.detach().contiguous().reshape(-1).view(torch.uint8)
+
+
 def _as_tuple(out: Any) -> tuple[torch.Tensor, ...]:
     if isinstance(out, torch.Tensor):
         return (out,)
@@ -115,12 +124,15 @@ def assert_capture_matches_eager(
     dtype: torch.dtype,
     capture: Literal["trace", "compile"] = "trace",
 ) -> None:
-    """Assert that ``fn`` returns byte-identical outputs eagerly and under graph capture, per size.
+    """Assert that ``fn`` returns bit-identical outputs eagerly and under graph capture, per size.
 
     ``fn`` receives the tensors built by ``make_inputs(size, device, dtype)`` and must derive every
     size from a tensor shape (not from a Python int closed over), otherwise the capture cannot see
-    the size at all. Comparison is ``torch.equal`` -- the contract for a capture branch is the same
-    rounding sequence as eager, not "close enough".
+    the size at all. Outputs are compared as raw bytes -- the contract for a capture branch is the
+    same rounding sequence as eager, not "close enough". That is deliberately stricter than
+    ``torch.equal``, which is numeric rather than bitwise: it calls two NaNs unequal (a
+    spurious failure) and ``+0.0`` equal to ``-0.0`` (a missed sign-bit change). Under a byte
+    comparison a NaN matches a NaN with the same payload, and the two zeros differ.
 
     Args:
         fn: callable of the tensors produced by ``make_inputs``; returns a tensor or tuple of tensors.
@@ -137,8 +149,9 @@ def assert_capture_matches_eager(
 
     Raises:
         ValueError: when ``capture`` is not ``"trace"`` or ``"compile"``, or when ``sizes`` is empty.
-        AssertionError: on the first size where an output differs, naming size, output index,
-            shape/dtype mismatch or max abs difference.
+        AssertionError: on the first size where an output differs, naming size, output index, and
+            either the shape/dtype mismatch, the max abs difference, or -- when the values agree but
+            the bytes do not -- that only the bit pattern moved.
 
     """
     if capture not in ("trace", "compile"):
@@ -177,14 +190,20 @@ def assert_capture_matches_eager(
                 raise AssertionError(
                     f"size {size}, output {i}: eager {tuple(e.shape)} {e.dtype} vs {capture} {tuple(a.shape)} {a.dtype}"
                 )
-            if not torch.equal(e, a):
+            if not torch.equal(_bits(e), _bits(a)):
                 # via CPU float64: MPS has no float64, and subtracting in the tensor's own
                 # half dtype would round the very difference being reported.
                 lhs = e.detach().cpu().to(torch.float64)
                 rhs = a.detach().cpu().to(torch.float64)
-                diff = (lhs - rhs).abs().max().item()
+                # a NaN on both sides is the same *value*; only its payload bits moved
+                if bool(((lhs == rhs) | (lhs.isnan() & rhs.isnan())).all()):
+                    detail = "the values are equal but their bits are not (a signed zero or a NaN payload changed)"
+                else:
+                    # nan_to_num after the subtraction: a NaN on one side only must not hide the mismatch
+                    diff = (lhs - rhs).abs().nan_to_num(nan=float("inf")).max().item()
+                    detail = f"max abs diff {diff:.3g}"
                 raise AssertionError(
-                    f"size {size}, output {i}: {capture} output differs from eager, max abs diff {diff:.3g} "
+                    f"size {size}, output {i}: {capture} output differs from eager, {detail} "
                     f"({e.dtype}). Under capture the size arithmetic must not round into {dtype}; "
                     "divide by the unrounded size and cast the quotient."
                 )
@@ -217,16 +236,24 @@ def assert_degenerate_path_parity(
         degenerate_kwargs: the same call routed through the degenerate path (``dsize=(0, w)``, a
             singleton axis, an empty batch).
         bad_inputs: ``(argument name, invalid value)`` pairs to substitute into both calls. Each
-            name must already be a key of both kwargs dicts.
+            name must already be a key of both kwargs dicts. Must not be empty -- with no pairs
+            only the two baseline calls run and nothing is compared.
 
     Raises:
-        ValueError: when a ``bad_inputs`` name is absent from either kwargs dict.
+        ValueError: when ``bad_inputs`` is empty, or a ``bad_inputs`` name is absent from either
+            kwargs dict.
         AssertionError: naming the argument and the two outcomes, ``None`` meaning "no exception".
 
     Note:
         Parity is compared on the exception *type* only. Two paths that raise the same type for
         unrelated reasons read as parity here; check the messages when that is plausible.
     """
+    if len(bad_inputs) == 0:
+        raise ValueError(
+            "assert_degenerate_path_parity needs at least one (name, bad_value) pair: with none, only the two "
+            "baseline calls run, no invalid input is ever substituted, and the parity assertion passes having "
+            "compared nothing -- the vacuous green this helper exists to prevent."
+        )
     for name, _ in bad_inputs:
         # substituting an unknown name *adds* a key rather than replacing one, so both paths raise
         # TypeError("unexpected keyword argument") and the assertion below passes having tested nothing

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -47,8 +47,9 @@ def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) ->
         dtype: a floating dtype. Integer dtypes raise ``TypeError``.
         lo: smallest size to consider (inclusive).
         hi: largest size to consider (inclusive). Must not exceed ``torch.finfo(dtype).max`` (65504
-            for float16): above that every candidate casts to ``inf`` and the round-trip back to
-            ``int64`` is meaningless, so the result would be garbage rather than a size sweep.
+            for float16): above that candidates cast to non-finite values and converting them back
+            to ``int64`` produces a sentinel rather than the original integer, so the result would
+            be garbage rather than a usable size sweep.
 
     Returns:
         sorted sizes, empty when every integer in range is exact (float32/float64 below 2**24).
@@ -68,8 +69,8 @@ def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) ->
     finite_max = torch.finfo(dtype).max
     if hi > finite_max:
         raise ValueError(
-            f"hi={hi} is above torch.finfo({dtype}).max={finite_max:g}: every candidate there casts to inf "
-            "and round-trips back to the same int64, so the sweep would be garbage rather than sizes"
+            f"hi={hi} is above torch.finfo({dtype}).max={finite_max:g}: candidates there cast to non-finite "
+            "values and conversion back to int64 yields a sentinel, so the sweep would be garbage rather than sizes"
         )
     n = torch.arange(lo, hi + 1, dtype=torch.int64)
     inexact_n = n.to(dtype).to(torch.int64) != n
@@ -111,8 +112,15 @@ def _as_tuple(out: Any) -> tuple[torch.Tensor, ...]:
     if isinstance(out, torch.Tensor):
         return (out,)
     if isinstance(out, (tuple, list)) and all(isinstance(t, torch.Tensor) for t in out):
+        if not out:
+            raise ValueError("assert_capture_matches_eager cannot compare an empty output sequence")
         return tuple(out)
     raise TypeError(f"assert_capture_matches_eager expects a tensor or a tuple of tensors, got {type(out)}")
+
+
+def _snapshot(out: Any) -> tuple[torch.Tensor, ...]:
+    """Copy outputs before a later invocation can mutate tensors that they alias."""
+    return tuple(t.detach().clone() for t in _as_tuple(out))
 
 
 def assert_capture_matches_eager(
@@ -172,15 +180,17 @@ def assert_capture_matches_eager(
         _dynamo.reset()
         captured_fn = torch.compile(fn, fullgraph=True, dynamic=True)
     for size in sizes:
-        inputs = make_inputs(size, torch.device(device), dtype)
         if capture == "trace":
             with warnings.catch_warnings(), _restoring_rng(torch.device(device)):
                 warnings.simplefilter("ignore", torch.jit.TracerWarning)
-                captured_fn = torch.jit.trace(fn, inputs, check_trace=False)
+                trace_inputs = make_inputs(size, torch.device(device), dtype)
+                captured_fn = torch.jit.trace(fn, trace_inputs, check_trace=False)
         with _restoring_rng(torch.device(device)):
-            expected = _as_tuple(fn(*inputs))
+            eager_inputs = make_inputs(size, torch.device(device), dtype)
+            expected = _snapshot(fn(*eager_inputs))
         with _restoring_rng(torch.device(device)):
-            actual = _as_tuple(captured_fn(*inputs))
+            captured_inputs = make_inputs(size, torch.device(device), dtype)
+            actual = _snapshot(captured_fn(*captured_inputs))
         if len(expected) != len(actual):
             raise AssertionError(
                 f"size {size}: eager returned {len(expected)} outputs, {capture} returned {len(actual)}"

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -91,18 +91,28 @@ def assert_capture_matches_eager(
     Args:
         fn: callable of the tensors produced by ``make_inputs``; returns a tensor or tuple of tensors.
         make_inputs: builds the inputs for one size; the size goes into a tensor shape.
-        sizes: sizes to sweep -- normally ``unrepresentable_sizes(dtype)`` or a slice of it, plus
-            the degenerate sizes 1 and 2.
+        sizes: sizes to sweep. Write it as ``[1, 2, *unrepresentable_sizes(dtype)[:8]]``: the
+            degenerate sizes 1 and 2 always exercise the singleton and smallest non-trivial
+            paths, and they keep the list non-empty on an exact dtype, where
+            ``unrepresentable_sizes`` is ``[]`` (float32/float64 below ``2**24``). Must not be
+            empty -- a sweep of nothing is the vacuous green this helper exists to prevent.
         device: device for the inputs.
         dtype: dtype for the inputs (and the dtype the sizes were chosen for).
         capture: ``"trace"`` for ``torch.jit.trace`` (re-traced per size),
             ``"compile"`` for ``torch.compile(fullgraph=True, dynamic=True)``.
 
     Raises:
+        ValueError: when ``sizes`` is empty.
         AssertionError: on the first size where an output differs, naming size, output index,
             shape/dtype mismatch or max abs difference.
 
     """
+    if len(sizes) == 0:
+        raise ValueError(
+            "assert_capture_matches_eager needs at least one size: an empty sweep asserts nothing and "
+            "passes silently. unrepresentable_sizes is empty for exact dtypes such as float32, so pass "
+            "sizes=[1, 2, *unrepresentable_sizes(dtype)[:8]] rather than the bare call."
+        )
     if capture == "compile" and torch.device(device).type == "mps":
         pytest.skip("torch.compile inductor backend is not available on MPS")
     if capture == "compile":

--- a/testing/precision.py
+++ b/testing/precision.py
@@ -25,9 +25,13 @@ empty/singleton code path that validated less (or more) than the non-empty path.
 
 from __future__ import annotations
 
+import warnings
+from typing import Any, Callable, Literal, Sequence
+
+import pytest
 import torch
 
-__all__ = ["unrepresentable_sizes"]
+__all__ = ["assert_capture_matches_eager", "unrepresentable_sizes"]
 
 
 def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) -> list[int]:
@@ -58,3 +62,81 @@ def unrepresentable_sizes(dtype: torch.dtype, *, lo: int = 2, hi: int = 4096) ->
     inexact_n = n.to(dtype).to(torch.int64) != n
     inexact_prev = (n - 1).to(dtype).to(torch.int64) != n - 1
     return n[inexact_n | inexact_prev].tolist()
+
+
+def _as_tuple(out: Any) -> tuple[torch.Tensor, ...]:
+    if isinstance(out, torch.Tensor):
+        return (out,)
+    if isinstance(out, (tuple, list)) and all(isinstance(t, torch.Tensor) for t in out):
+        return tuple(out)
+    raise TypeError(f"assert_capture_matches_eager expects a tensor or a tuple of tensors, got {type(out)}")
+
+
+def assert_capture_matches_eager(
+    fn: Callable[..., Any],
+    make_inputs: Callable[[int, torch.device, torch.dtype], tuple[torch.Tensor, ...]],
+    *,
+    sizes: Sequence[int],
+    device: torch.device,
+    dtype: torch.dtype,
+    capture: Literal["trace", "compile"] = "trace",
+) -> None:
+    """Assert that ``fn`` returns byte-identical outputs eagerly and under graph capture, per size.
+
+    ``fn`` receives the tensors built by ``make_inputs(size, device, dtype)`` and must derive every
+    size from a tensor shape (not from a Python int closed over), otherwise the capture cannot see
+    the size at all. Comparison is ``torch.equal`` -- the contract for a capture branch is the same
+    rounding sequence as eager, not "close enough".
+
+    Args:
+        fn: callable of the tensors produced by ``make_inputs``; returns a tensor or tuple of tensors.
+        make_inputs: builds the inputs for one size; the size goes into a tensor shape.
+        sizes: sizes to sweep -- normally ``unrepresentable_sizes(dtype)`` or a slice of it, plus
+            the degenerate sizes 1 and 2.
+        device: device for the inputs.
+        dtype: dtype for the inputs (and the dtype the sizes were chosen for).
+        capture: ``"trace"`` for ``torch.jit.trace`` (re-traced per size),
+            ``"compile"`` for ``torch.compile(fullgraph=True, dynamic=True)``.
+
+    Raises:
+        AssertionError: on the first size where an output differs, naming size, output index,
+            shape/dtype mismatch or max abs difference.
+
+    """
+    if capture == "compile" and torch.device(device).type == "mps":
+        pytest.skip("torch.compile inductor backend is not available on MPS")
+    if capture == "compile":
+        # ``from torch import _dynamo`` rather than ``import torch._dynamo``: the latter would rebind
+        # the name ``torch`` as a function-local and shadow the module-level import below.
+        from torch import _dynamo
+
+        _dynamo.reset()
+        captured_fn = torch.compile(fn, fullgraph=True, dynamic=True)
+    for size in sizes:
+        inputs = make_inputs(size, torch.device(device), dtype)
+        if capture == "trace":
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", torch.jit.TracerWarning)
+                captured_fn = torch.jit.trace(fn, inputs, check_trace=False)
+        expected = _as_tuple(fn(*inputs))
+        actual = _as_tuple(captured_fn(*inputs))
+        if len(expected) != len(actual):
+            raise AssertionError(
+                f"size {size}: eager returned {len(expected)} outputs, {capture} returned {len(actual)}"
+            )
+        for i, (e, a) in enumerate(zip(expected, actual)):
+            if e.shape != a.shape or e.dtype != a.dtype:
+                raise AssertionError(
+                    f"size {size}, output {i}: eager {tuple(e.shape)} {e.dtype} vs {capture} {tuple(a.shape)} {a.dtype}"
+                )
+            if not torch.equal(e, a):
+                # via CPU float64: MPS has no float64, and subtracting in the tensor's own
+                # half dtype would round the very difference being reported.
+                lhs = e.detach().cpu().to(torch.float64)
+                rhs = a.detach().cpu().to(torch.float64)
+                diff = (lhs - rhs).abs().max().item()
+                raise AssertionError(
+                    f"size {size}, output {i}: {capture} output differs from eager, max abs diff {diff:.3g} "
+                    f"({e.dtype}). Under capture the size arithmetic must not round into {dtype}; "
+                    "divide by the unrounded size and cast the quotient."
+                )

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -19,6 +19,12 @@
 
 Run as ``pixi run verify-delta`` (``python -m testing.verify_delta``). Counts are never compared —
 a branch can add and fix an equal number of tests and look unchanged by count.
+
+Exit codes: ``0`` no new failures on any surface that ran; ``1`` at least one ``new`` failure;
+``2`` at least one selected, available surface could not be measured, so the gate is partial. A
+surface excluded by ``--only`` (``not selected``) or absent from the machine (``unavailable``) is
+not a gap and does not affect the code. The branch side is refused when the checkout is dirty —
+the scope is ``base...HEAD`` but pytest runs the working tree, so the two must agree.
 """
 
 from __future__ import annotations
@@ -36,7 +42,10 @@ WIDEN_PREFIXES = ("testing/", "tests/conftest.py", "conftest.py", "pyproject.tom
 
 
 def changed_test_dirs(changed_files: Iterable[str], repo: Path | None = None) -> list[str]:
-    """Map changed paths to the test directories that exercise them (``["tests"]`` when everything).
+    """Map changed paths to the test targets that exercise them (``["tests"]`` when everything).
+
+    A test file directly under ``tests/`` maps to itself: it has no package directory to stand for
+    it, and a shared one there (``tests/__init__.py``, ``tests/benchmark.py``) widens to the suite.
 
     Pass ``repo`` to check the mapping against the tree: a library module with no ``tests/<mod>``
     directory of its own (``kornia/transpiler/`` today) widens the run to the whole suite instead of
@@ -56,8 +65,17 @@ def changed_test_dirs(changed_files: Iterable[str], repo: Path | None = None) ->
                 print(f"{f} maps to {mapped}, which does not exist; widening to the whole suite")
                 return ["tests"]
             dirs.add(mapped)
-        elif parts[0] == "tests" and len(parts) > 2:
-            dirs.add(f"tests/{parts[1]}")
+        elif parts[0] == "tests":
+            if len(parts) > 2:
+                dirs.add(f"tests/{parts[1]}")
+            elif Path(f).name.startswith("test_") or Path(f).name.endswith("_test.py"):
+                # tests/test_import.py, tests/smoke_test.py: no package directory to map to, but the
+                # file is itself a runnable pytest target. Dropping it left such a change unverified,
+                # and a diff containing nothing else printed "nothing to verify" and exited 0.
+                dirs.add(f)
+            else:
+                # tests/__init__.py, tests/benchmark.py: shared by the whole tree, like tests/conftest.py
+                return ["tests"]
     return sorted(dirs)
 
 
@@ -92,24 +110,35 @@ def diff_failures(branch: set[str], main: set[str], *, baseline: bool = True) ->
     )
 
 
-def render_table(rows: Sequence[tuple[str, FailureDelta | None]]) -> str:
-    """Render one markdown row per surface (``None`` means the surface was skipped) plus the NEW/FIXED ids."""
+#: statuses a surface can carry instead of a measurement. Only ``UNVERIFIED`` is a failure: the other
+#: two say the surface was never meant to run here, while ``UNVERIFIED`` says it was and did not.
+NOT_SELECTED = "not selected"
+UNAVAILABLE = "unavailable"
+UNVERIFIED = "unverified"
+
+
+def render_table(rows: Sequence[tuple[str, FailureDelta | str]]) -> str:
+    """Render one markdown row per surface (a ``str`` in place of a delta is a status) plus the NEW/FIXED ids."""
     lines = ["| surface | new | fixed | unchanged |", "|---|---|---|---|"]
     details: list[str] = []
     no_baseline = False
     for name, delta in rows:
-        if delta is None:
-            lines.append(f"| {name} | skipped | | |")
+        if isinstance(delta, str):
+            lines.append(f"| {name} | {delta} | | |")
             continue
-        # a run with no baseline is a real measurement, so it must not share the `skipped` label,
+        # a run with no baseline is a real measurement, so it must not share a status label,
         # but its `new` count is unconditional and should not be read as a regression
         new_cell = f"{len(delta.new)}*" if not delta.baseline else str(len(delta.new))
         no_baseline |= not delta.baseline
         lines.append(f"| {name} | {new_cell} | {len(delta.fixed)} | {len(delta.unchanged)} |")
         details.extend(f"NEW [{name}] {t}" for t in delta.new)
         details.extend(f"FIXED [{name}] {t}" for t in delta.fixed)
-    legend = ["", "* no baseline on the base revision for these paths; every failure there counts as new"]
-    return "\n".join(lines + (legend if no_baseline else []) + ([""] + details if details else []))
+    legend: list[str] = []
+    if no_baseline:
+        legend.append("* no baseline on the base revision for these paths; every failure there counts as new")
+    if any(delta == UNVERIFIED for _, delta in rows):
+        legend.append(f"{UNVERIFIED}: selected and available, but could not be measured -- not a pass")
+    return "\n".join(lines + ([""] + legend if legend else []) + ([""] + details if details else []))
 
 
 # eq=False keeps these hashable: a `dict` field makes a frozen dataclass's generated __eq__/__hash__
@@ -123,13 +152,15 @@ class Surface:
     extra_args: tuple[str, ...] = ()
 
 
+MPS_SURFACE = "mps float32"
+
 SURFACES: list[Surface] = [
     Surface("cpu float32", {"KORNIA_TEST_DEVICE": "cpu", "KORNIA_TEST_DTYPE": "float32"}),
     Surface(
         "cpu float16,bfloat16,float64",
         {"KORNIA_TEST_DEVICE": "cpu", "KORNIA_TEST_DTYPE": "float16,bfloat16,float64"},
     ),
-    Surface("mps float32", {"KORNIA_TEST_DEVICE": "mps", "KORNIA_TEST_DTYPE": "float32"}),
+    Surface(MPS_SURFACE, {"KORNIA_TEST_DEVICE": "mps", "KORNIA_TEST_DTYPE": "float32"}),
     Surface(
         "inductor cpu float32",
         {"KORNIA_TEST_DEVICE": "cpu", "KORNIA_TEST_DTYPE": "float32", "KORNIA_TEST_OPTIMIZER": "inductor"},
@@ -149,6 +180,11 @@ def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     p.add_argument("--only", nargs="+", help="surface names to run")
     p.add_argument("--main-worktree", type=Path, help="where to check out --base (default: a sibling dir)")
     p.add_argument("--no-fetch", action="store_true")
+    p.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="gate the working tree instead of HEAD (the default refuses an uncommitted change)",
+    )
     p.add_argument("--out", type=Path, help="directory for junit files (default: <repo>/../.<repo>-verify-delta)")
     return p.parse_args(args)
 
@@ -174,7 +210,7 @@ def select_surfaces(args: argparse.Namespace, *, mps_available: bool) -> list[Su
     """Keep the surfaces named by ``--only`` (all of them by default), dropping MPS when it is unavailable."""
     wanted = _resolve_only(args.only) if args.only else []
     chosen = [s for s in SURFACES if not wanted or s.name in wanted]
-    return [s for s in chosen if s.name != "mps float32" or mps_available]
+    return [s for s in chosen if s.name != MPS_SURFACE or mps_available]
 
 
 def _present_paths(tree: Path, tests: Sequence[str]) -> list[str]:
@@ -198,6 +234,11 @@ def _git(repo: Path, *cmd: str) -> str:
         capture_output=True,
         text=True,
     ).stdout.strip()
+
+
+def _dirty(tree: Path) -> list[str]:
+    """Return the ``git status --porcelain`` lines of ``tree``; empty when it has nothing uncommitted."""
+    return [line for line in _git(tree, "status", "--porcelain").splitlines() if line.strip()]
 
 
 def _git_common_dir(tree: Path) -> Path:
@@ -255,10 +296,19 @@ def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> str
                 f"{path} looks like a user checkout (its HEAD is on a branch, or it is the repo's main "
                 f"worktree), not a scratch worktree; remove it or pass --main-worktree"
             )
+        # `checkout --detach` carries non-conflicting modifications across instead of refusing, so a
+        # leftover edit here would be measured as part of the baseline and make a real branch failure
+        # read as `unchanged`. Refuse rather than reset: the edit may be somebody's work.
+        if dirty := _dirty(path):
+            raise SystemExit(
+                f"{path} has uncommitted changes and would contaminate the baseline:\n"
+                + "\n".join(f"  {line}" for line in dirty[:10])
+                + f"\nclean it (git -C {path} reset --hard && git -C {path} clean -fd) or pass --main-worktree"
+            )
         try:
             _git(path, "checkout", "--detach", rev)
         except subprocess.CalledProcessError as exc:
-            raise SystemExit(f"{path} is dirty or cannot check out {base}: {(exc.stderr or '').strip()}") from exc
+            raise SystemExit(f"{path} cannot check out {base}: {(exc.stderr or '').strip()}") from exc
     else:
         _git(repo, "worktree", "add", "--detach", str(path), rev)
     return rev
@@ -317,9 +367,22 @@ def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run every selected surface on both trees and print the failing-set delta."""
+    """Run every selected surface on both trees, print the failing-set delta, and return an exit code.
+
+    ``0`` clean, ``1`` a ``new`` failure somewhere, ``2`` a selected and available surface was never
+    measured (see the module docstring).
+    """
     args = parse_args(argv)
     repo = Path(_git(Path.cwd(), "rev-parse", "--show-toplevel"))
+    # the scope comes from `base...HEAD` but pytest runs the checkout, so an uncommitted change is
+    # measured while the table names two commits: an unpushed fix can make a broken HEAD read green,
+    # and an unpushed break can fail a HEAD that is fine.
+    if (dirty := _dirty(repo)) and not args.allow_dirty:
+        raise SystemExit(
+            f"{repo} has uncommitted changes, so the run would not describe HEAD:\n"
+            + "\n".join(f"  {line}" for line in dirty[:10])
+            + "\ncommit or stash them, or pass --allow-dirty to gate the working tree instead"
+        )
     main_wt = args.main_worktree or repo.parent / f".{repo.name}-verify-main"
     out = args.out or repo.parent / f".{repo.name}-verify-delta"
     out.mkdir(parents=True, exist_ok=True)
@@ -332,26 +395,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     branch_rev = _git(repo, "rev-parse", "--short", "HEAD")
     base_rev = _git(repo, "rev-parse", "--short", base)
-    print(f"branch {branch_rev} vs {args.base} {base_rev}")
+    suffix = " + uncommitted changes (--allow-dirty)" if dirty else ""
+    print(f"branch {branch_rev}{suffix} vs {args.base} {base_rev}")
     print(f"tests: {' '.join(tests)}")
 
     import torch
 
-    selected = select_surfaces(args, mps_available=torch.backends.mps.is_available())
+    mps_available = torch.backends.mps.is_available()
+    selected = select_surfaces(args, mps_available=mps_available)
     branch_paths = _present_paths(repo, tests)
     base_paths = _present_paths(main_wt, tests)
     # a base tree holding only some of the branch's test paths is a *partial* baseline: failures under
     # a path it never ran are unconditionally new, so such a row earns the `*` an absent baseline gets.
     complete_baseline = set(branch_paths) <= set(base_paths)
-    rows: list[tuple[str, FailureDelta | None]] = []
+    rows: list[tuple[str, FailureDelta | str]] = []
     for surface in SURFACES:
         if surface not in selected:
-            rows.append((surface.name, None))
+            # a surface nobody asked for, or one this machine does not have, is not a gap in the gate;
+            # a surface that *was* asked for and did not run is, so the two must not share a label.
+            absent = surface.name == MPS_SURFACE and not mps_available
+            rows.append((surface.name, UNAVAILABLE if absent else NOT_SELECTED))
             continue
         slug = surface.name.replace(" ", "_").replace(",", "-")
         branch_fail = _run_surface(repo, surface, tests, out / f"{slug}-branch.xml")
         if branch_fail is None:  # nothing to verify on this surface at all
-            rows.append((surface.name, None))
+            rows.append((surface.name, UNVERIFIED))
             continue
         main_fail = _run_surface(main_wt, surface, tests, out / f"{slug}-main.xml")
         if main_fail is None and not base_paths:
@@ -364,16 +432,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             # the base tree has the paths but pytest did not finish there; reading that as an empty
             # baseline would report every branch failure as new, the false positive `*` exists for.
             print(f"{surface.name}: the base tree did not finish, so this surface was not verified")
-            rows.append((surface.name, None))
+            rows.append((surface.name, UNVERIFIED))
             continue
         rows.append((surface.name, diff_failures(branch_fail, main_fail, baseline=complete_baseline)))
     table = render_table(rows)
     print("\n" + table)
     (out / "summary.md").write_text(table + "\n")
-    if all(delta is None for _, delta in rows):
+    measured = [name for name, delta in rows if isinstance(delta, FailureDelta)]
+    unverified = [name for name, delta in rows if delta == UNVERIFIED]
+    if any(isinstance(d, FailureDelta) and d.new for _, d in rows):
+        return 1  # named by the NEW lines above; the loudest signal, so it wins over an unverified row
+    if not measured:
         print("nothing was verified: no surface ran pytest on the branch; this is not a pass")
         return 2
-    return 1 if any(d is not None and d.new for _, d in rows) else 0
+    if unverified:
+        # one measured surface does not cover for another: a gate with a hole is not a pass, and the
+        # holes have to be nonzero or a crash on half/MPS reads exactly like a clean run.
+        print(f"not verified on {', '.join(unverified)}; the gate is partial, which is not a pass")
+        return 2
+    return 0
 
 
 if __name__ == "__main__":

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -23,8 +23,10 @@ a branch can add and fix an equal number of tests and look unchanged by count.
 Exit codes: ``0`` no new failures on any surface that ran; ``1`` at least one ``new`` failure;
 ``2`` at least one selected, available surface could not be measured, so the gate is partial. A
 surface excluded by ``--only`` (``not selected``) or absent from the machine (``unavailable``) is
-not a gap and does not affect the code. The branch side is refused when the checkout is dirty —
-the scope is ``base...HEAD`` but pytest runs the working tree, so the two must agree.
+not itself a gap. A run that selects only unavailable surfaces still exits 2 because it measured
+nothing. The branch side is refused when the checkout is dirty unless ``--allow-dirty`` is paired
+with explicit ``--tests`` — the automatic scope is ``base...HEAD`` and cannot see working-tree-only
+paths.
 """
 
 from __future__ import annotations
@@ -176,14 +178,21 @@ def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         args = args[1:]
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--base", default="origin/main", help="revision to compare against")
-    p.add_argument("--tests", nargs="+", help="test dirs to run (default: derived from the diff)")
+    p.add_argument(
+        "--tests",
+        nargs="+",
+        help=(
+            "test paths to run (default: a local module mapping derived from the diff; "
+            "use 'tests' for cross-cutting changes)"
+        ),
+    )
     p.add_argument("--only", nargs="+", help="surface names to run")
     p.add_argument("--main-worktree", type=Path, help="where to check out --base (default: a sibling dir)")
     p.add_argument("--no-fetch", action="store_true")
     p.add_argument(
         "--allow-dirty",
         action="store_true",
-        help="gate the working tree instead of HEAD (the default refuses an uncommitted change)",
+        help="gate the working tree instead of HEAD; requires explicit --tests when the tree is dirty",
     )
     p.add_argument("--out", type=Path, help="directory for junit files (default: <repo>/../.<repo>-verify-delta)")
     return p.parse_args(args)
@@ -214,8 +223,30 @@ def select_surfaces(args: argparse.Namespace, *, mps_available: bool) -> list[Su
 
 
 def _present_paths(tree: Path, tests: Sequence[str]) -> list[str]:
-    """Return the subset of ``tests`` that exists in ``tree``; pytest aborts collection on a missing path."""
-    return [t for t in tests if (tree / t).exists()]
+    """Return test targets that exist inside ``tree``; reject symlinks escaping the checkout."""
+    root = tree.resolve()
+    present: list[str] = []
+    for target in tests:
+        candidate = (tree / target).resolve()
+        if not candidate.is_relative_to(root):
+            raise SystemExit(f"test target {target!r} resolves outside checkout {tree}")
+        if candidate.exists():
+            present.append(target)
+    return present
+
+
+def _normalize_test_targets(tests: Sequence[str]) -> list[str]:
+    """Normalize relative test targets and reject paths that can escape either checkout."""
+    normalized: list[str] = []
+    for target in tests:
+        path = Path(target)
+        if path.is_absolute() or ".." in path.parts:
+            raise SystemExit(f"test target {target!r} must be a relative path confined to each checkout")
+        clean = path.as_posix()
+        if clean in ("", "."):
+            raise SystemExit(f"test target {target!r} does not name a test path")
+        normalized.append(clean)
+    return normalized
 
 
 def _failures_or_empty(junit: Path) -> set[str]:
@@ -267,10 +298,16 @@ def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> str
     """Create (or re-point) a detached worktree of ``base`` at ``path``; return the sha it resolved to."""
     remote, _, ref = base.partition("/")
     if fetch and ref:  # a local revision such as `--base HEAD~1` has nothing to fetch
-        subprocess.run(  # noqa: S603 -- trusted: fixed argv, no shell
-            ["git", "-C", str(repo), "fetch", remote, ref],  # noqa: S607 -- trusted: git resolved from PATH
-            check=True,
-        )
+        try:
+            subprocess.run(  # noqa: S603 -- trusted: fixed argv, no shell
+                ["git", "-C", str(repo), "fetch", remote, ref],  # noqa: S607 -- trusted: git resolved from PATH
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or "fetch failed").strip()
+            raise SystemExit(f"cannot fetch {remote} {ref}: {detail}; retry when online or pass --no-fetch") from exc
     # resolve against the repo, once. On a reused worktree `git -C <path> checkout --detach <base>`
     # would resolve a relative revision (`HEAD~1`) against the worktree's own HEAD -- the previous
     # run's base -- so it walks back one commit per run while `git diff <base>...HEAD` in the repo
@@ -316,14 +353,18 @@ def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> str
 
 def _assert_imports_from(tree: Path, env: dict[str, str]) -> None:
     """Refuse to run when ``import kornia`` in ``tree`` resolves to a checkout other than ``tree``."""
-    out = subprocess.run(
-        [sys.executable, "-c", "import kornia, pathlib; print(pathlib.Path(kornia.__file__).resolve())"],
-        cwd=tree,
-        env=env,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
+    try:
+        out = subprocess.run(
+            [sys.executable, "-c", "import kornia, pathlib; print(pathlib.Path(kornia.__file__).resolve())"],
+            cwd=tree,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "import failed").strip()
+        raise SystemExit(f"{tree}: could not import kornia with the active interpreter: {detail}") from exc
     if not Path(out).is_relative_to(tree.resolve()):
         raise SystemExit(f"{tree}: `import kornia` resolved to {out}; refusing to test the wrong tree")
 
@@ -340,7 +381,9 @@ def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path
         return None
     if missing:
         print(f"{tree}: {' '.join(missing)} does not exist here; running {' '.join(present)}")
-    env = {**os.environ, **surface.env, "PYTHONPATH": str(tree)}
+    existing_pythonpath = os.environ.get("PYTHONPATH")
+    pythonpath = str(tree) if not existing_pythonpath else os.pathsep.join((str(tree), existing_pythonpath))
+    env = {**os.environ, **surface.env, "PYTHONPATH": pythonpath}
     _assert_imports_from(tree, env)
     junit.unlink(missing_ok=True)  # a stale report from a previous run must never be read as this run's result
     cmd = [
@@ -356,10 +399,10 @@ def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path
         *present,
     ]
     proc = subprocess.run(cmd, cwd=tree, env=env, check=False)  # noqa: S603 -- trusted: fixed argv, no shell
-    # 0 all passed, 1 tests failed, 5 nothing collected are the only codes where an absent or partial
-    # report really does mean "no failures here". 2 interrupted, 3 internal error, 4 usage error (a
-    # broken conftest, a bad -k) leave no junit at all, which would otherwise read as a clean surface.
-    if proc.returncode not in (0, 1, 5):
+    # Only 0 (all passed) and 1 (tests failed) prove that tests ran. Exit 5 means nothing was
+    # collected, which is especially dangerous for the inductor surface's `-k` filter: an empty
+    # selection must be unverified, not a clean measurement. 2/3/4 likewise did not finish.
+    if proc.returncode not in (0, 1):
         print(f"{tree}: pytest exited {proc.returncode}; this surface was not verified")
         junit.unlink(missing_ok=True)
         return None
@@ -374,6 +417,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     """
     args = parse_args(argv)
     repo = Path(_git(Path.cwd(), "rev-parse", "--show-toplevel"))
+    explicit_tests = _normalize_test_targets(args.tests) if args.tests else None
     # the scope comes from `base...HEAD` but pytest runs the checkout, so an uncommitted change is
     # measured while the table names two commits: an unpushed fix can make a broken HEAD read green,
     # and an unpushed break can fail a HEAD that is fine.
@@ -383,13 +427,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             + "\n".join(f"  {line}" for line in dirty[:10])
             + "\ncommit or stash them, or pass --allow-dirty to gate the working tree instead"
         )
+    if dirty and args.allow_dirty and not args.tests:
+        raise SystemExit(
+            "--allow-dirty requires explicit --tests: the base...HEAD diff cannot discover tracked or untracked "
+            "working-tree-only changes, so automatic test selection could omit the regression"
+        )
     main_wt = args.main_worktree or repo.parent / f".{repo.name}-verify-main"
     out = args.out or repo.parent / f".{repo.name}-verify-delta"
     out.mkdir(parents=True, exist_ok=True)
     base = _ensure_main_worktree(repo, args.base, main_wt, fetch=not args.no_fetch)
 
     changed = _git(repo, "diff", "--name-only", f"{base}...HEAD").splitlines()
-    tests = args.tests or changed_test_dirs(changed, repo)
+    tests = explicit_tests or _normalize_test_targets(changed_test_dirs(changed, repo))
     if not tests:
         print("no test directories map to the changed files; nothing to verify")
         return 0

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -1,0 +1,84 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Diff failing-test SETS between this branch and ``origin/main`` on every supported surface.
+
+Run as ``pixi run verify-delta`` (``python -m testing.verify_delta``). Counts are never compared —
+a branch can add and fix an equal number of tests and look unchanged by count.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+WIDEN_PREFIXES = ("testing/", "tests/conftest.py", "conftest.py", "pyproject.toml", "pixi.toml")
+
+
+def changed_test_dirs(changed_files: Iterable[str]) -> list[str]:
+    """Map changed paths to the test directories that exercise them (``["tests"]`` when everything)."""
+    dirs: set[str] = set()
+    for f in changed_files:
+        if f.startswith(WIDEN_PREFIXES):
+            return ["tests"]
+        parts = Path(f).parts
+        if parts[0] == "kornia":
+            if len(parts) == 2:  # kornia/constants.py and friends have no dedicated test dir
+                return ["tests"]
+            dirs.add(f"tests/{parts[1]}")
+        elif parts[0] == "tests" and len(parts) > 2:
+            dirs.add(f"tests/{parts[1]}")
+    return sorted(dirs)
+
+
+def failing_ids(junit_xml: str | Path) -> set[str]:
+    """Return ``classname::name`` for every testcase with a ``failure`` or ``error`` child."""
+    path = Path(junit_xml)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    root = ET.parse(path).getroot()  # noqa: S314 -- locally generated pytest junit report, not untrusted input
+    ids: set[str] = set()
+    for case in root.iter("testcase"):
+        if case.find("failure") is not None or case.find("error") is not None:
+            ids.add(f"{case.get('classname')}::{case.get('name')}")
+    return ids
+
+
+@dataclass(frozen=True)
+class FailureDelta:
+    new: list[str] = field(default_factory=list)
+    fixed: list[str] = field(default_factory=list)
+    unchanged: list[str] = field(default_factory=list)
+
+
+def diff_failures(branch: set[str], main: set[str]) -> FailureDelta:
+    return FailureDelta(new=sorted(branch - main), fixed=sorted(main - branch), unchanged=sorted(branch & main))
+
+
+def render_table(rows: Sequence[tuple[str, FailureDelta | None]]) -> str:
+    lines = ["| surface | new | fixed | unchanged |", "|---|---|---|---|"]
+    details: list[str] = []
+    for name, delta in rows:
+        if delta is None:
+            lines.append(f"| {name} | skipped | | |")
+            continue
+        lines.append(f"| {name} | {len(delta.new)} | {len(delta.fixed)} | {len(delta.unchanged)} |")
+        details.extend(f"NEW {t}" for t in delta.new)
+        details.extend(f"FIXED {t}" for t in delta.fixed)
+    return "\n".join(lines + ([""] + details if details else []))

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -35,8 +35,14 @@ from pathlib import Path
 WIDEN_PREFIXES = ("testing/", "tests/conftest.py", "conftest.py", "pyproject.toml", "pixi.toml")
 
 
-def changed_test_dirs(changed_files: Iterable[str]) -> list[str]:
-    """Map changed paths to the test directories that exercise them (``["tests"]`` when everything)."""
+def changed_test_dirs(changed_files: Iterable[str], repo: Path | None = None) -> list[str]:
+    """Map changed paths to the test directories that exercise them (``["tests"]`` when everything).
+
+    Pass ``repo`` to check the mapping against the tree: a library module with no ``tests/<mod>``
+    directory of its own (``kornia/transpiler/`` today) widens the run to the whole suite instead of
+    mapping to a path that does not exist, which would otherwise leave the change unverified while
+    the tool still reported a pass.
+    """
     dirs: set[str] = set()
     for f in changed_files:
         if f.startswith(WIDEN_PREFIXES):
@@ -45,7 +51,11 @@ def changed_test_dirs(changed_files: Iterable[str]) -> list[str]:
         if parts[0] == "kornia":
             if len(parts) == 2:  # kornia/constants.py and friends have no dedicated test dir
                 return ["tests"]
-            dirs.add(f"tests/{parts[1]}")
+            mapped = f"tests/{parts[1]}"
+            if repo is not None and not (repo / mapped).exists():
+                print(f"{f} maps to {mapped}, which does not exist; widening to the whole suite")
+                return ["tests"]
+            dirs.add(mapped)
         elif parts[0] == "tests" and len(parts) > 2:
             dirs.add(f"tests/{parts[1]}")
     return sorted(dirs)
@@ -137,7 +147,7 @@ def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     p.add_argument("--only", nargs="+", help="surface names to run")
     p.add_argument("--main-worktree", type=Path, help="where to check out --base (default: a sibling dir)")
     p.add_argument("--no-fetch", action="store_true")
-    p.add_argument("--out", type=Path, help="directory for junit files (default: <main-worktree>/../.verify-delta)")
+    p.add_argument("--out", type=Path, help="directory for junit files (default: <repo>/../.<repo>-verify-delta)")
     return p.parse_args(args)
 
 
@@ -188,6 +198,23 @@ def _git_common_dir(tree: Path) -> Path:
     return (tree / _git(tree, "rev-parse", "--git-common-dir")).resolve()
 
 
+def _is_detached(tree: Path) -> bool:
+    """Report whether ``tree`` has a detached HEAD; ``symbolic-ref`` exits non-zero exactly then."""
+    try:
+        _git(tree, "symbolic-ref", "-q", "HEAD")
+    except subprocess.CalledProcessError:
+        return True
+    return False
+
+
+def _primary_worktree(repo: Path) -> Path | None:
+    """Return the repo's main (non-linked) worktree, the first ``git worktree list --porcelain`` entry."""
+    lines = _git(repo, "worktree", "list", "--porcelain").splitlines()
+    if not lines or not lines[0].startswith("worktree "):
+        return None  # unrecognised output: leave the verdict to the detached-HEAD check
+    return Path(lines[0][len("worktree ") :]).resolve()
+
+
 def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> None:
     """Create (or re-point) a detached worktree of ``base`` at ``path``."""
     remote, _, ref = base.partition("/")
@@ -205,7 +232,18 @@ def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> Non
             same_repo = False
         if not same_repo:
             raise SystemExit(f"{path} exists but is not a worktree of {repo}; remove it or pass --main-worktree")
-        _git(path, "checkout", "--detach", base)
+        # a worktree of this repo is still not ours to detach: an attached HEAD or the repo's own
+        # primary worktree is somebody's working copy, and checking `base` out there would move the
+        # branch they are on out from under them.
+        if not _is_detached(path) or path.resolve() == _primary_worktree(repo):
+            raise SystemExit(
+                f"{path} looks like a user checkout (its HEAD is on a branch, or it is the repo's main "
+                f"worktree), not a scratch worktree; remove it or pass --main-worktree"
+            )
+        try:
+            _git(path, "checkout", "--detach", base)
+        except subprocess.CalledProcessError as exc:
+            raise SystemExit(f"{path} is dirty or cannot check out {base}: {(exc.stderr or '').strip()}") from exc
     else:
         _git(repo, "worktree", "add", "--detach", str(path), base)
 
@@ -265,7 +303,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     _ensure_main_worktree(repo, args.base, main_wt, fetch=not args.no_fetch)
 
     changed = _git(repo, "diff", "--name-only", f"{args.base}...HEAD").splitlines()
-    tests = args.tests or [d for d in changed_test_dirs(changed) if (repo / d).exists()]
+    tests = args.tests or changed_test_dirs(changed, repo)
     if not tests:
         print("no test directories map to the changed files; nothing to verify")
         return 0

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -171,6 +171,11 @@ def _git(repo: Path, *cmd: str) -> str:
     ).stdout.strip()
 
 
+def _git_common_dir(tree: Path) -> Path:
+    """Return the shared ``.git`` directory backing ``tree``, which every worktree of a repo has in common."""
+    return (tree / _git(tree, "rev-parse", "--git-common-dir")).resolve()
+
+
 def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> None:
     """Create (or re-point) a detached worktree of ``base`` at ``path``."""
     remote, _, ref = base.partition("/")
@@ -180,6 +185,14 @@ def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> Non
             check=True,
         )
     if path.exists():
+        # `git -C` walks up out of a plain directory, so a leftover non-worktree here would silently
+        # check `base` out in whatever repository encloses it -- possibly the user's own checkout.
+        try:
+            same_repo = _git_common_dir(path) == _git_common_dir(repo)
+        except subprocess.CalledProcessError:
+            same_repo = False
+        if not same_repo:
+            raise SystemExit(f"{path} exists but is not a worktree of {repo}; remove it or pass --main-worktree")
         _git(path, "checkout", "--detach", base)
     else:
         _git(repo, "worktree", "add", "--detach", str(path), base)
@@ -199,18 +212,20 @@ def _assert_imports_from(tree: Path, env: dict[str, str]) -> None:
         raise SystemExit(f"{tree}: `import kornia` resolved to {out}; refusing to test the wrong tree")
 
 
-def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path) -> set[str]:
-    """Run one surface's pytest invocation inside ``tree`` and return its failing-test ids."""
-    env = {**os.environ, **surface.env, "PYTHONPATH": str(tree)}
-    _assert_imports_from(tree, env)
-    junit.unlink(missing_ok=True)  # a stale report from a previous run must never be read as this run's result
+def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path) -> set[str] | None:
+    """Run one surface inside ``tree`` and return its failing-test ids, or ``None`` if pytest could not run."""
     # pytest aborts collection outright when any argument path is missing, so a directory that the base
     # revision does not have yet would empty its whole failure set and make every branch failure look new.
     present = [t for t in tests if (tree / t).exists()]
-    if missing := [t for t in tests if t not in present]:
-        print(f"{tree}: {' '.join(missing)} does not exist here; running the rest")
+    missing = [t for t in tests if t not in present]
     if not present:
-        return set()
+        print(f"{tree}: none of {' '.join(tests)} exist here; nothing to run")
+        return None
+    if missing:
+        print(f"{tree}: {' '.join(missing)} does not exist here; running {' '.join(present)}")
+    env = {**os.environ, **surface.env, "PYTHONPATH": str(tree)}
+    _assert_imports_from(tree, env)
+    junit.unlink(missing_ok=True)  # a stale report from a previous run must never be read as this run's result
     cmd = [
         sys.executable,
         "-m",
@@ -257,10 +272,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         slug = surface.name.replace(" ", "_").replace(",", "-")
         branch_fail = _run_surface(repo, surface, tests, out / f"{slug}-branch.xml")
         main_fail = _run_surface(main_wt, surface, tests, out / f"{slug}-main.xml")
+        if branch_fail is None or main_fail is None:  # no baseline, or nothing to compare it against
+            rows.append((surface.name, None))
+            continue
         rows.append((surface.name, diff_failures(branch_fail, main_fail)))
     table = render_table(rows)
     print("\n" + table)
     (out / "summary.md").write_text(table + "\n")
+    if all(delta is None for _, delta in rows):
+        print("nothing was verified: no surface ran pytest on both trees; this is not a pass")
+        return 2
     return 1 if any(d is not None and d.new for _, d in rows) else 0
 
 

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-"""Diff failing-test SETS between this branch and ``origin/main`` on every supported surface.
+"""Diff failing-test SETS between this branch and ``--base`` (``origin/main``) on every supported surface.
 
 Run as ``pixi run verify-delta`` (``python -m testing.verify_delta``). Counts are never compared —
 a branch can add and fix an equal number of tests and look unchanged by count.
@@ -106,13 +106,15 @@ def render_table(rows: Sequence[tuple[str, FailureDelta | None]]) -> str:
         new_cell = f"{len(delta.new)}*" if not delta.baseline else str(len(delta.new))
         no_baseline |= not delta.baseline
         lines.append(f"| {name} | {new_cell} | {len(delta.fixed)} | {len(delta.unchanged)} |")
-        details.extend(f"NEW {t}" for t in delta.new)
-        details.extend(f"FIXED {t}" for t in delta.fixed)
+        details.extend(f"NEW [{name}] {t}" for t in delta.new)
+        details.extend(f"FIXED [{name}] {t}" for t in delta.fixed)
     legend = ["", "* no baseline on the base revision for these paths; every failure there counts as new"]
     return "\n".join(lines + (legend if no_baseline else []) + ([""] + details if details else []))
 
 
-@dataclass(frozen=True)
+# eq=False keeps these hashable: a `dict` field makes a frozen dataclass's generated __eq__/__hash__
+# unusable (`unhashable type: 'dict'`), and identity is the right comparison for the fixed registry below.
+@dataclass(frozen=True, eq=False)
 class Surface:
     """One test surface: a display name, the ``KORNIA_TEST_*`` environment it needs, and extra pytest args."""
 
@@ -175,6 +177,11 @@ def select_surfaces(args: argparse.Namespace, *, mps_available: bool) -> list[Su
     return [s for s in chosen if s.name != "mps float32" or mps_available]
 
 
+def _present_paths(tree: Path, tests: Sequence[str]) -> list[str]:
+    """Return the subset of ``tests`` that exists in ``tree``; pytest aborts collection on a missing path."""
+    return [t for t in tests if (tree / t).exists()]
+
+
 def _failures_or_empty(junit: Path) -> set[str]:
     """Read a junit report, treating a missing one (collection error, no tests) as zero failures."""
     if not Path(junit).exists():
@@ -215,14 +222,22 @@ def _primary_worktree(repo: Path) -> Path | None:
     return Path(lines[0][len("worktree ") :]).resolve()
 
 
-def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> None:
-    """Create (or re-point) a detached worktree of ``base`` at ``path``."""
+def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> str:
+    """Create (or re-point) a detached worktree of ``base`` at ``path``; return the sha it resolved to."""
     remote, _, ref = base.partition("/")
     if fetch and ref:  # a local revision such as `--base HEAD~1` has nothing to fetch
         subprocess.run(  # noqa: S603 -- trusted: fixed argv, no shell
             ["git", "-C", str(repo), "fetch", remote, ref],  # noqa: S607 -- trusted: git resolved from PATH
             check=True,
         )
+    # resolve against the repo, once. On a reused worktree `git -C <path> checkout --detach <base>`
+    # would resolve a relative revision (`HEAD~1`) against the worktree's own HEAD -- the previous
+    # run's base -- so it walks back one commit per run while `git diff <base>...HEAD` in the repo
+    # does not, and the two trees quietly stop being the pair the table claims to compare.
+    try:
+        rev = _git(repo, "rev-parse", base)
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(f"{repo}: cannot resolve --base {base}: {(exc.stderr or '').strip()}") from exc
     if path.exists():
         # `git -C` walks up out of a plain directory, so a leftover non-worktree here would silently
         # check `base` out in whatever repository encloses it -- possibly the user's own checkout.
@@ -241,11 +256,12 @@ def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> Non
                 f"worktree), not a scratch worktree; remove it or pass --main-worktree"
             )
         try:
-            _git(path, "checkout", "--detach", base)
+            _git(path, "checkout", "--detach", rev)
         except subprocess.CalledProcessError as exc:
             raise SystemExit(f"{path} is dirty or cannot check out {base}: {(exc.stderr or '').strip()}") from exc
     else:
-        _git(repo, "worktree", "add", "--detach", str(path), base)
+        _git(repo, "worktree", "add", "--detach", str(path), rev)
+    return rev
 
 
 def _assert_imports_from(tree: Path, env: dict[str, str]) -> None:
@@ -266,7 +282,7 @@ def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path
     """Run one surface inside ``tree`` and return its failing-test ids, or ``None`` if pytest could not run."""
     # pytest aborts collection outright when any argument path is missing, so a directory that the base
     # revision does not have yet would empty its whole failure set and make every branch failure look new.
-    present = [t for t in tests if (tree / t).exists()]
+    present = _present_paths(tree, tests)
     missing = [t for t in tests if t not in present]
     if not present:
         print(f"{tree}: none of {' '.join(tests)} exist here; nothing to run")
@@ -289,7 +305,14 @@ def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path
         *surface.extra_args,
         *present,
     ]
-    subprocess.run(cmd, cwd=tree, env=env, check=False)  # noqa: S603 -- trusted: fixed argv, no shell
+    proc = subprocess.run(cmd, cwd=tree, env=env, check=False)  # noqa: S603 -- trusted: fixed argv, no shell
+    # 0 all passed, 1 tests failed, 5 nothing collected are the only codes where an absent or partial
+    # report really does mean "no failures here". 2 interrupted, 3 internal error, 4 usage error (a
+    # broken conftest, a bad -k) leave no junit at all, which would otherwise read as a clean surface.
+    if proc.returncode not in (0, 1, 5):
+        print(f"{tree}: pytest exited {proc.returncode}; this surface was not verified")
+        junit.unlink(missing_ok=True)
+        return None
     return _failures_or_empty(junit)
 
 
@@ -300,21 +323,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     main_wt = args.main_worktree or repo.parent / f".{repo.name}-verify-main"
     out = args.out or repo.parent / f".{repo.name}-verify-delta"
     out.mkdir(parents=True, exist_ok=True)
-    _ensure_main_worktree(repo, args.base, main_wt, fetch=not args.no_fetch)
+    base = _ensure_main_worktree(repo, args.base, main_wt, fetch=not args.no_fetch)
 
-    changed = _git(repo, "diff", "--name-only", f"{args.base}...HEAD").splitlines()
+    changed = _git(repo, "diff", "--name-only", f"{base}...HEAD").splitlines()
     tests = args.tests or changed_test_dirs(changed, repo)
     if not tests:
         print("no test directories map to the changed files; nothing to verify")
         return 0
     branch_rev = _git(repo, "rev-parse", "--short", "HEAD")
-    base_rev = _git(main_wt, "rev-parse", "--short", "HEAD")
+    base_rev = _git(repo, "rev-parse", "--short", base)
     print(f"branch {branch_rev} vs {args.base} {base_rev}")
     print(f"tests: {' '.join(tests)}")
 
     import torch
 
     selected = select_surfaces(args, mps_available=torch.backends.mps.is_available())
+    branch_paths = _present_paths(repo, tests)
+    base_paths = _present_paths(main_wt, tests)
+    # a base tree holding only some of the branch's test paths is a *partial* baseline: failures under
+    # a path it never ran are unconditionally new, so such a row earns the `*` an absent baseline gets.
+    complete_baseline = set(branch_paths) <= set(base_paths)
     rows: list[tuple[str, FailureDelta | None]] = []
     for surface in SURFACES:
         if surface not in selected:
@@ -326,13 +354,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             rows.append((surface.name, None))
             continue
         main_fail = _run_surface(main_wt, surface, tests, out / f"{slug}-main.xml")
-        if main_fail is None:
+        if main_fail is None and not base_paths:
             # a path the base revision does not have yet is a legitimately empty baseline, not a failure
             # to measure: the branch side really ran, and everything failing on it really is new.
             print(f"no baseline on {args.base} for {' '.join(tests)}; branch failures there are unconditionally new")
             rows.append((surface.name, diff_failures(branch_fail, set(), baseline=False)))
             continue
-        rows.append((surface.name, diff_failures(branch_fail, main_fail)))
+        if main_fail is None:
+            # the base tree has the paths but pytest did not finish there; reading that as an empty
+            # baseline would report every branch failure as new, the false positive `*` exists for.
+            print(f"{surface.name}: the base tree did not finish, so this surface was not verified")
+            rows.append((surface.name, None))
+            continue
+        rows.append((surface.name, diff_failures(branch_fail, main_fail, baseline=complete_baseline)))
     table = render_table(rows)
     print("\n" + table)
     (out / "summary.md").write_text(table + "\n")

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -23,6 +23,10 @@ a branch can add and fix an equal number of tests and look unchanged by count.
 
 from __future__ import annotations
 
+import argparse
+import os
+import subprocess
+import sys
 import xml.etree.ElementTree as ET
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
@@ -68,10 +72,12 @@ class FailureDelta:
 
 
 def diff_failures(branch: set[str], main: set[str]) -> FailureDelta:
+    """Split the two failing-test sets into the new, the fixed, and the already-failing ones."""
     return FailureDelta(new=sorted(branch - main), fixed=sorted(main - branch), unchanged=sorted(branch & main))
 
 
 def render_table(rows: Sequence[tuple[str, FailureDelta | None]]) -> str:
+    """Render one markdown row per surface (``None`` means the surface was skipped) plus the NEW/FIXED ids."""
     lines = ["| surface | new | fixed | unchanged |", "|---|---|---|---|"]
     details: list[str] = []
     for name, delta in rows:
@@ -82,3 +88,181 @@ def render_table(rows: Sequence[tuple[str, FailureDelta | None]]) -> str:
         details.extend(f"NEW {t}" for t in delta.new)
         details.extend(f"FIXED {t}" for t in delta.fixed)
     return "\n".join(lines + ([""] + details if details else []))
+
+
+@dataclass(frozen=True)
+class Surface:
+    """One test surface: a display name, the ``KORNIA_TEST_*`` environment it needs, and extra pytest args."""
+
+    name: str
+    env: dict[str, str]
+    extra_args: tuple[str, ...] = ()
+
+
+SURFACES: list[Surface] = [
+    Surface("cpu float32", {"KORNIA_TEST_DEVICE": "cpu", "KORNIA_TEST_DTYPE": "float32"}),
+    Surface(
+        "cpu float16,bfloat16,float64",
+        {"KORNIA_TEST_DEVICE": "cpu", "KORNIA_TEST_DTYPE": "float16,bfloat16,float64"},
+    ),
+    Surface("mps float32", {"KORNIA_TEST_DEVICE": "mps", "KORNIA_TEST_DTYPE": "float32"}),
+    Surface(
+        "inductor cpu float32",
+        {"KORNIA_TEST_DEVICE": "cpu", "KORNIA_TEST_DTYPE": "float32", "KORNIA_TEST_OPTIMIZER": "inductor"},
+        ("-k", "dynamo or compile"),
+    ),
+]
+
+
+def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    """Parse the command line of ``python -m testing.verify_delta``."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args and args[0] == "--":  # `pixi run verify-delta -- ...` forwards the separator itself
+        args = args[1:]
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--base", default="origin/main", help="revision to compare against")
+    p.add_argument("--tests", nargs="+", help="test dirs to run (default: derived from the diff)")
+    p.add_argument("--only", nargs="+", help="surface names to run")
+    p.add_argument("--main-worktree", type=Path, help="where to check out --base (default: a sibling dir)")
+    p.add_argument("--no-fetch", action="store_true")
+    p.add_argument("--out", type=Path, help="directory for junit files (default: <main-worktree>/../.verify-delta)")
+    return p.parse_args(args)
+
+
+def _resolve_only(tokens: Sequence[str]) -> list[str]:
+    """Rejoin ``--only`` tokens into surface names, longest first, since a task shell drops the quoting."""
+    names = [s.name for s in SURFACES]
+    wanted: list[str] = []
+    i = 0
+    while i < len(tokens):
+        for width in range(len(tokens) - i, 0, -1):
+            candidate = " ".join(tokens[i : i + width])
+            if candidate in names:
+                wanted.append(candidate)
+                i += width
+                break
+        else:
+            raise SystemExit(f"unknown surface {tokens[i]!r}; choose from {names}")
+    return wanted
+
+
+def select_surfaces(args: argparse.Namespace, *, mps_available: bool) -> list[Surface]:
+    """Keep the surfaces named by ``--only`` (all of them by default), dropping MPS when it is unavailable."""
+    wanted = _resolve_only(args.only) if args.only else []
+    chosen = [s for s in SURFACES if not wanted or s.name in wanted]
+    return [s for s in chosen if s.name != "mps float32" or mps_available]
+
+
+def _failures_or_empty(junit: Path) -> set[str]:
+    """Read a junit report, treating a missing one (collection error, no tests) as zero failures."""
+    if not Path(junit).exists():
+        print(f"no junit report at {junit}; reading it as zero failures")
+        return set()
+    return failing_ids(junit)
+
+
+def _git(repo: Path, *cmd: str) -> str:
+    """Run a git command inside ``repo`` and return its stripped stdout."""
+    return subprocess.run(  # noqa: S603 -- trusted: fixed argv, no shell
+        ["git", "-C", str(repo), *cmd],  # noqa: S607 -- trusted: git resolved from PATH
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _ensure_main_worktree(repo: Path, base: str, path: Path, fetch: bool) -> None:
+    """Create (or re-point) a detached worktree of ``base`` at ``path``."""
+    remote, _, ref = base.partition("/")
+    if fetch and ref:  # a local revision such as `--base HEAD~1` has nothing to fetch
+        subprocess.run(  # noqa: S603 -- trusted: fixed argv, no shell
+            ["git", "-C", str(repo), "fetch", remote, ref],  # noqa: S607 -- trusted: git resolved from PATH
+            check=True,
+        )
+    if path.exists():
+        _git(path, "checkout", "--detach", base)
+    else:
+        _git(repo, "worktree", "add", "--detach", str(path), base)
+
+
+def _assert_imports_from(tree: Path, env: dict[str, str]) -> None:
+    """Refuse to run when ``import kornia`` in ``tree`` resolves to a checkout other than ``tree``."""
+    out = subprocess.run(
+        [sys.executable, "-c", "import kornia, pathlib; print(pathlib.Path(kornia.__file__).resolve())"],
+        cwd=tree,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if not Path(out).is_relative_to(tree.resolve()):
+        raise SystemExit(f"{tree}: `import kornia` resolved to {out}; refusing to test the wrong tree")
+
+
+def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path) -> set[str]:
+    """Run one surface's pytest invocation inside ``tree`` and return its failing-test ids."""
+    env = {**os.environ, **surface.env, "PYTHONPATH": str(tree)}
+    _assert_imports_from(tree, env)
+    junit.unlink(missing_ok=True)  # a stale report from a previous run must never be read as this run's result
+    # pytest aborts collection outright when any argument path is missing, so a directory that the base
+    # revision does not have yet would empty its whole failure set and make every branch failure look new.
+    present = [t for t in tests if (tree / t).exists()]
+    if missing := [t for t in tests if t not in present]:
+        print(f"{tree}: {' '.join(missing)} does not exist here; running the rest")
+    if not present:
+        return set()
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "-p",
+        "no:cacheprovider",
+        "--continue-on-collection-errors",
+        f"--junitxml={junit}",
+        *surface.extra_args,
+        *present,
+    ]
+    subprocess.run(cmd, cwd=tree, env=env, check=False)  # noqa: S603 -- trusted: fixed argv, no shell
+    return _failures_or_empty(junit)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run every selected surface on both trees and print the failing-set delta."""
+    args = parse_args(argv)
+    repo = Path(_git(Path.cwd(), "rev-parse", "--show-toplevel"))
+    main_wt = args.main_worktree or repo.parent / f".{repo.name}-verify-main"
+    out = args.out or repo.parent / f".{repo.name}-verify-delta"
+    out.mkdir(parents=True, exist_ok=True)
+    _ensure_main_worktree(repo, args.base, main_wt, fetch=not args.no_fetch)
+
+    changed = _git(repo, "diff", "--name-only", f"{args.base}...HEAD").splitlines()
+    tests = args.tests or [d for d in changed_test_dirs(changed) if (repo / d).exists()]
+    if not tests:
+        print("no test directories map to the changed files; nothing to verify")
+        return 0
+    branch_rev = _git(repo, "rev-parse", "--short", "HEAD")
+    base_rev = _git(main_wt, "rev-parse", "--short", "HEAD")
+    print(f"branch {branch_rev} vs {args.base} {base_rev}")
+    print(f"tests: {' '.join(tests)}")
+
+    import torch
+
+    selected = select_surfaces(args, mps_available=torch.backends.mps.is_available())
+    rows: list[tuple[str, FailureDelta | None]] = []
+    for surface in SURFACES:
+        if surface not in selected:
+            rows.append((surface.name, None))
+            continue
+        slug = surface.name.replace(" ", "_").replace(",", "-")
+        branch_fail = _run_surface(repo, surface, tests, out / f"{slug}-branch.xml")
+        main_fail = _run_surface(main_wt, surface, tests, out / f"{slug}-main.xml")
+        rows.append((surface.name, diff_failures(branch_fail, main_fail)))
+    table = render_table(rows)
+    print("\n" + table)
+    (out / "summary.md").write_text(table + "\n")
+    return 1 if any(d is not None and d.new for _, d in rows) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/testing/verify_delta.py
+++ b/testing/verify_delta.py
@@ -69,25 +69,37 @@ class FailureDelta:
     new: list[str] = field(default_factory=list)
     fixed: list[str] = field(default_factory=list)
     unchanged: list[str] = field(default_factory=list)
+    baseline: bool = True  # False when the base revision had no such tests, so every failure counts as new
 
 
-def diff_failures(branch: set[str], main: set[str]) -> FailureDelta:
+def diff_failures(branch: set[str], main: set[str], *, baseline: bool = True) -> FailureDelta:
     """Split the two failing-test sets into the new, the fixed, and the already-failing ones."""
-    return FailureDelta(new=sorted(branch - main), fixed=sorted(main - branch), unchanged=sorted(branch & main))
+    return FailureDelta(
+        new=sorted(branch - main),
+        fixed=sorted(main - branch),
+        unchanged=sorted(branch & main),
+        baseline=baseline,
+    )
 
 
 def render_table(rows: Sequence[tuple[str, FailureDelta | None]]) -> str:
     """Render one markdown row per surface (``None`` means the surface was skipped) plus the NEW/FIXED ids."""
     lines = ["| surface | new | fixed | unchanged |", "|---|---|---|---|"]
     details: list[str] = []
+    no_baseline = False
     for name, delta in rows:
         if delta is None:
             lines.append(f"| {name} | skipped | | |")
             continue
-        lines.append(f"| {name} | {len(delta.new)} | {len(delta.fixed)} | {len(delta.unchanged)} |")
+        # a run with no baseline is a real measurement, so it must not share the `skipped` label,
+        # but its `new` count is unconditional and should not be read as a regression
+        new_cell = f"{len(delta.new)}*" if not delta.baseline else str(len(delta.new))
+        no_baseline |= not delta.baseline
+        lines.append(f"| {name} | {new_cell} | {len(delta.fixed)} | {len(delta.unchanged)} |")
         details.extend(f"NEW {t}" for t in delta.new)
         details.extend(f"FIXED {t}" for t in delta.fixed)
-    return "\n".join(lines + ([""] + details if details else []))
+    legend = ["", "* no baseline on the base revision for these paths; every failure there counts as new"]
+    return "\n".join(lines + (legend if no_baseline else []) + ([""] + details if details else []))
 
 
 @dataclass(frozen=True)
@@ -220,6 +232,7 @@ def _run_surface(tree: Path, surface: Surface, tests: Sequence[str], junit: Path
     missing = [t for t in tests if t not in present]
     if not present:
         print(f"{tree}: none of {' '.join(tests)} exist here; nothing to run")
+        junit.unlink(missing_ok=True)
         return None
     if missing:
         print(f"{tree}: {' '.join(missing)} does not exist here; running {' '.join(present)}")
@@ -271,16 +284,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             continue
         slug = surface.name.replace(" ", "_").replace(",", "-")
         branch_fail = _run_surface(repo, surface, tests, out / f"{slug}-branch.xml")
-        main_fail = _run_surface(main_wt, surface, tests, out / f"{slug}-main.xml")
-        if branch_fail is None or main_fail is None:  # no baseline, or nothing to compare it against
+        if branch_fail is None:  # nothing to verify on this surface at all
             rows.append((surface.name, None))
+            continue
+        main_fail = _run_surface(main_wt, surface, tests, out / f"{slug}-main.xml")
+        if main_fail is None:
+            # a path the base revision does not have yet is a legitimately empty baseline, not a failure
+            # to measure: the branch side really ran, and everything failing on it really is new.
+            print(f"no baseline on {args.base} for {' '.join(tests)}; branch failures there are unconditionally new")
+            rows.append((surface.name, diff_failures(branch_fail, set(), baseline=False)))
             continue
         rows.append((surface.name, diff_failures(branch_fail, main_fail)))
     table = render_table(rows)
     print("\n" + table)
     (out / "summary.md").write_text(table + "\n")
     if all(delta is None for _, delta in rows):
-        print("nothing was verified: no surface ran pytest on both trees; this is not a pass")
+        print("nothing was verified: no surface ran pytest on the branch; this is not a pass")
         return 2
     return 1 if any(d is not None and d.new for _, d in rows) else 0
 

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -1,0 +1,16 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/testing/_historical.py
+++ b/tests/testing/_historical.py
@@ -1,0 +1,94 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Graph-capture branches of kornia functions as they stood at named commits of kornia#4006.
+
+Each function is the exact arithmetic of its commit's ``torch.jit.is_tracing()`` branch, with the
+eager branch kept so that ``assert_capture_matches_eager`` can compare the two. They are the
+regression fixtures for ``testing.precision``: the helper must FAIL on each of them.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def _xs_ys(height: int, width: int, device: torch.device | None, dtype: torch.dtype | None):
+    xs = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
+    ys = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
+    return xs, ys
+
+
+def _stack(xs: torch.Tensor, ys: torch.Tensor) -> torch.Tensor:
+    base_grid = torch.stack(torch.meshgrid([xs, ys], indexing="ij"), dim=-1)
+    return base_grid.permute(1, 0, 2).unsqueeze(0)
+
+
+def create_meshgrid_9ed891c5(height, width, device=None, dtype=None):
+    """kornia#4006 @ 9ed891c5 — divisor built directly in the coordinate dtype (wave-5 finding)."""
+    xs, ys = _xs_ys(height, width, device, dtype)
+    if torch.jit.is_tracing():
+        width_t = torch.scalar_tensor(width, device=xs.device, dtype=xs.dtype)
+        height_t = torch.scalar_tensor(height, device=ys.device, dtype=ys.dtype)
+        xs = torch.where(width_t > 1, (xs / (width_t - 1) - 0.5) * 2, torch.zeros_like(xs))
+        ys = torch.where(height_t > 1, (ys / (height_t - 1) - 0.5) * 2, torch.zeros_like(ys))
+    else:
+        xs = (xs / (width - 1) - 0.5) * 2 if width > 1 else xs * 0.0
+        ys = (ys / (height - 1) - 0.5) * 2 if height > 1 else ys * 0.0
+    return _stack(xs, ys)
+
+
+def create_meshgrid_32ab0eeb(height, width, device=None, dtype=None):
+    """kornia#4006 @ 32ab0eeb — float32 arithmetic, but the divisor is cast down first (wave-8)."""
+    xs, ys = _xs_ys(height, width, device, dtype)
+    if torch.jit.is_tracing():
+        work_dtype = torch.float32 if xs.dtype in (torch.float16, torch.bfloat16) else xs.dtype
+        width_t = torch.scalar_tensor(width, device=xs.device, dtype=work_dtype)
+        height_t = torch.scalar_tensor(height, device=ys.device, dtype=work_dtype)
+        w_den = (width_t - 1).to(xs.dtype)
+        h_den = (height_t - 1).to(ys.dtype)
+        xs = torch.where(width_t > 1, (xs / w_den - 0.5) * 2, torch.zeros_like(xs))
+        ys = torch.where(height_t > 1, (ys / h_den - 0.5) * 2, torch.zeros_like(ys))
+    else:
+        xs = (xs / (width - 1) - 0.5) * 2 if width > 1 else xs * 0.0
+        ys = (ys / (height - 1) - 0.5) * 2 if height > 1 else ys * 0.0
+    return _stack(xs, ys)
+
+
+def normal_transform_pixel_1522441d(height, width, device=None, dtype=None):
+    """kornia#4006 @ 1522441d — promotion keyed off the ``dtype`` ARGUMENT, so ``dtype=None`` under a
+    half default dtype rounds the size (wave-9 finding)."""
+    if not torch.jit.is_tracing():
+        sx = 1.0 if width == 1 else 2.0 / (width - 1.0)
+        sy = 1.0 if height == 1 else 2.0 / (height - 1.0)
+        tx = 0.0 if width == 1 else -1.0
+        ty = 0.0 if height == 1 else -1.0
+        return torch.tensor([[sx, 0.0, tx], [0.0, sy, ty], [0.0, 0.0, 1.0]], device=device, dtype=dtype)[None]
+    work_dtype = torch.float32 if dtype in (torch.float16, torch.bfloat16) else dtype
+    if work_dtype not in (torch.float32, torch.float64):
+        work_dtype = torch.get_default_dtype()
+    width_t = torch.scalar_tensor(width, device=device, dtype=work_dtype)
+    height_t = torch.scalar_tensor(height, device=device, dtype=work_dtype)
+    one = torch.ones((), device=device, dtype=work_dtype)
+    zero = torch.zeros((), device=device, dtype=work_dtype)
+    sx_t = torch.where(width_t == 1, one, 2.0 / (width_t - 1.0))
+    sy_t = torch.where(height_t == 1, one, 2.0 / (height_t - 1.0))
+    tx_t = torch.where(width_t == 1, zero, -one)
+    ty_t = torch.where(height_t == 1, zero, -one)
+    return torch.stack(
+        [torch.stack([sx_t, zero, tx_t]), torch.stack([zero, sy_t, ty_t]), torch.stack([zero, zero, one])]
+    ).to(dtype=dtype)[None]

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -193,6 +193,26 @@ class TestAssertCaptureMatchesEager:
                 dtype=torch.float32,
             )
 
+    def test_a_sign_bit_change_that_torch_equal_calls_equal_is_caught(self, device, dtype):
+        # torch.equal is numeric, not bitwise: it reads -0.0 as equal to +0.0, so a capture branch
+        # that flipped the sign of a zero coordinate would have compared clean under it.
+        class NegatesZerosUnderTrace(torch.nn.Module):
+            def forward(self, image: torch.Tensor) -> torch.Tensor:
+                zeros = torch.zeros_like(image)
+                return zeros * -1.0 if torch.jit.is_tracing() else zeros
+
+        with pytest.raises(AssertionError, match="the values are equal but their bits are not"):
+            assert_capture_matches_eager(NegatesZerosUnderTrace(), _image_hw, sizes=[3], device=device, dtype=dtype)
+
+    def test_matching_nans_are_not_reported_as_a_divergence(self, device, dtype):
+        # the other half of the same defect: torch.equal calls NaN != NaN, so an op that legitimately
+        # produces NaN on both sides used to fail with the rounding message, which is not what broke.
+        def all_nan(image):
+            zeros = torch.zeros_like(image)
+            return zeros / zeros
+
+        assert_capture_matches_eager(all_nan, _image_hw, sizes=[1, 3], device=device, dtype=dtype)
+
     def test_a_function_that_consumes_randomness_is_not_a_false_failure(self, device, dtype):
         # Tracing runs ``fn`` once itself and the eager reference runs it again, so without an RNG
         # restore around each call the two draw different numbers and the helper reports a rounding
@@ -294,6 +314,22 @@ class TestAssertDegeneratePathParity:
                 {"x": torch.zeros(2), "dsize": (2,)},
                 {"x": torch.zeros(2), "dsize": (0,)},
                 [("xx", torch.zeros(2, dtype=torch.int64))],
+            )
+
+    def test_rejects_an_empty_bad_inputs_sweep(self):
+        # with no pairs only the two baseline calls run, nothing invalid is ever substituted, and the
+        # helper returns green having compared nothing -- the vacuous pass it exists to prevent.
+        def op(x, dsize):
+            if not x.is_floating_point():
+                raise TypeError("float only")
+            return x
+
+        with pytest.raises(ValueError, match=r"at least one \(name, bad_value\) pair"):
+            assert_degenerate_path_parity(
+                op,
+                {"x": torch.zeros(2), "dsize": (2,)},
+                {"x": torch.zeros(2), "dsize": (0,)},
+                [],
             )
 
     def test_detects_a_stricter_degenerate_path(self):

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -58,6 +58,16 @@ class TestUnrepresentableSizes:
         with pytest.raises(TypeError, match="floating"):
             unrepresentable_sizes(torch.int64)
 
+    def test_rejects_an_hi_above_the_dtype_max(self):
+        # Above finfo.max every candidate casts to inf and round-trips back to itself, so `n` reads
+        # as "exact" and the sweep silently becomes a list of sizes no test can allocate. The
+        # docstring warned about it; the check is what makes it impossible.
+        with pytest.raises(ValueError, match=r"hi=70000 is above torch.finfo\(torch.float16\).max=65504"):
+            unrepresentable_sizes(torch.float16, lo=65000, hi=70000)
+
+    def test_accepts_an_hi_exactly_at_the_dtype_max(self):
+        assert unrepresentable_sizes(torch.float16, lo=65000, hi=65504)  # the boundary itself is fine
+
 
 def _image_hw(size: int, device: torch.device, dtype: torch.dtype) -> tuple[torch.Tensor]:
     return (torch.zeros(1, 1, size, 4, device=device, dtype=dtype),)
@@ -183,6 +193,15 @@ class TestAssertCaptureMatchesEager:
                 dtype=torch.float32,
             )
 
+    def test_a_function_that_consumes_randomness_is_not_a_false_failure(self, device, dtype):
+        # Tracing runs ``fn`` once itself and the eager reference runs it again, so without an RNG
+        # restore around each call the two draw different numbers and the helper reports a rounding
+        # divergence that never happened.
+        def adds_noise(image):
+            return image + torch.rand_like(image)
+
+        assert_capture_matches_eager(adds_noise, _image_hw, sizes=[1, 2, 5], device=device, dtype=dtype)
+
     def test_rejects_an_unknown_capture(self, device):
         # an unrecognised value used to fall through both branches and surface as an
         # UnboundLocalError on ``captured_fn``, which reads as a helper bug rather than a typo.
@@ -258,6 +277,23 @@ class TestAssertDegeneratePathParity:
                 {"x": torch.zeros(2), "dsize": (2,)},
                 {"x": torch.zeros(2), "dsize": (0,)},
                 [("x", torch.zeros(2, dtype=torch.int64))],
+            )
+
+    def test_rejects_a_bad_input_name_that_is_not_an_argument(self):
+        # ``{**kwargs, "srcc": v}`` ADDS a key instead of replacing one, so both paths raise
+        # TypeError("unexpected keyword argument") and parity holds over a call that was never made.
+        # A typo'd name is the vacuous green this module exists to make unwritable.
+        def op(x, dsize):
+            if not x.is_floating_point():
+                raise TypeError("float only")
+            return x
+
+        with pytest.raises(ValueError, match=r"'xx' is not a key of full or degenerate_kwargs"):
+            assert_degenerate_path_parity(
+                op,
+                {"x": torch.zeros(2), "dsize": (2,)},
+                {"x": torch.zeros(2), "dsize": (0,)},
+                [("xx", torch.zeros(2, dtype=torch.int64))],
             )
 
     def test_detects_a_stricter_degenerate_path(self):

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -1,0 +1,55 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import torch
+
+from testing import unrepresentable_sizes
+
+
+class TestUnrepresentableSizes:
+    def test_bfloat16_includes_the_known_traps(self):
+        sizes = unrepresentable_sizes(torch.bfloat16)
+        # 258/300/1000/2050/3000: ``n - 1`` rounds (wave-5 and wave-8 divisor bugs in kornia#4006).
+        # 257: ``n`` itself rounds to 256 (wave-9 size bug). Both operands matter.
+        for n in (257, 258, 300, 1000, 2050, 3000):
+            assert n in sizes
+
+    def test_bfloat16_excludes_exact_neighbourhoods(self):
+        sizes = unrepresentable_sizes(torch.bfloat16)
+        # Every integer up to 256 is exact in bfloat16, so ``n`` and ``n - 1`` are both exact.
+        assert all(n not in sizes for n in range(2, 257))
+
+    def test_float16_boundary(self):
+        sizes = unrepresentable_sizes(torch.float16)
+        assert all(n not in sizes for n in range(2, 2049))
+        for n in (2049, 2050, 3000, 3001):
+            assert n in sizes
+
+    def test_float32_is_empty_in_range(self):
+        assert unrepresentable_sizes(torch.float32) == []
+        assert unrepresentable_sizes(torch.float64) == []
+
+    def test_is_sorted_and_bounded(self):
+        sizes = unrepresentable_sizes(torch.bfloat16, lo=250, hi=270)
+        assert sizes == sorted(sizes)
+        assert sizes[0] >= 250 and sizes[-1] <= 270
+        assert sizes == list(range(257, 271))  # every odd n is inexact; every even n has an odd n - 1
+
+    def test_rejects_non_floating_dtype(self):
+        with pytest.raises(TypeError, match="floating"):
+            unrepresentable_sizes(torch.int64)

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -88,15 +88,20 @@ class TestAssertCaptureMatchesEager:
             capture="trace",
         )
 
-    @pytest.mark.parametrize("wave_fn", [hist.create_meshgrid_9ed891c5, hist.create_meshgrid_32ab0eeb])
-    def test_historical_meshgrid_bodies_fail_under_trace(self, wave_fn, device):
+    @pytest.mark.parametrize(
+        ("wave_fn", "expected_size"),
+        [(hist.create_meshgrid_9ed891c5, 257), (hist.create_meshgrid_32ab0eeb, 258)],
+        ids=["9ed891c5", "32ab0eeb"],
+    )
+    def test_historical_meshgrid_bodies_fail_under_trace(self, wave_fn, expected_size, device):
         # These bodies are byte-equal to eager at every size that is exact in bfloat16, which is
         # why 1/2/4 let them through three review rounds. The sweep is what catches them -- and the
-        # two bodies need different sizes: 9ed891c5 rounds the size itself, so it already differs at
-        # 257 (divisor 255 instead of 256), while 32ab0eeb only rounds the divisor and so first
-        # differs at 258 (257 is exact as a divisor). A single hand-picked size catches one or the
-        # other, never both.
-        with pytest.raises(AssertionError, match=r"size (257|258|259|260|261|262)"):
+        # two bodies first differ at DIFFERENT sizes, which is why ``expected_size`` is pinned per
+        # body rather than matched loosely: 9ed891c5 rounds the size itself, so at 257 its divisor
+        # is 255 instead of 256 and it already differs; 32ab0eeb rounds only the divisor, and 256 is
+        # exact in bfloat16, so 257 passes vacuously there and 258 is the first size that catches
+        # it. A single hand-picked size catches one body or the other, never both.
+        with pytest.raises(AssertionError, match=rf"size {expected_size}, output"):
             assert_capture_matches_eager(
                 _meshgrid_of(wave_fn),
                 _image_hw,
@@ -142,7 +147,7 @@ class TestAssertCaptureMatchesEager:
         finally:
             torch.set_default_dtype(previous)
 
-    def test_reports_index_and_difference_for_tuple_outputs(self, device):
+    def test_accepts_tuple_outputs(self, device):
         def two_outputs(image):
             a = kornia.geometry.create_meshgrid(
                 image.shape[-2], image.shape[-1], device=image.device, dtype=image.dtype
@@ -150,6 +155,32 @@ class TestAssertCaptureMatchesEager:
             return a, a + 1
 
         assert_capture_matches_eager(two_outputs, _image_hw, sizes=[3], device=device, dtype=torch.float32)
+
+    def test_reports_index_and_difference_for_tuple_outputs(self, device):
+        # Output 0 is the fixed library function and agrees under trace; output 1 is the wave-8 body
+        # at 258, the size where it first diverges. The helper must name the offending index, not
+        # merely the size.
+        def good_then_bad(image):
+            h, w = image.shape[-2], image.shape[-1]
+            good = kornia.geometry.create_meshgrid(h, w, device=image.device, dtype=image.dtype)
+            bad = hist.create_meshgrid_32ab0eeb(h, w, device=image.device, dtype=image.dtype)
+            return good, bad
+
+        with pytest.raises(AssertionError, match=r"size 258, output 1.*max abs diff"):
+            assert_capture_matches_eager(good_then_bad, _image_hw, sizes=[258], device=device, dtype=torch.bfloat16)
+
+    def test_rejects_an_empty_sweep(self, device):
+        # unrepresentable_sizes is [] for float32/float64, so the documented-looking call
+        # ``sizes=unrepresentable_sizes(dtype)`` would otherwise be a green test that checked
+        # nothing under the default --dtype=float32 fixture.
+        with pytest.raises(ValueError, match="at least one size"):
+            assert_capture_matches_eager(
+                _meshgrid_of(kornia.geometry.create_meshgrid),
+                _image_hw,
+                sizes=unrepresentable_sizes(torch.float32),
+                device=device,
+                dtype=torch.float32,
+            )
 
     def test_compile_capture_runs_or_skips(self, device, torch_optimizer):
         # ``torch_optimizer`` is the conftest fixture; the test name carries ``compile`` so it is

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -127,7 +127,8 @@ class TestAssertCaptureMatchesEager:
         previous = torch.get_default_dtype()
         torch.set_default_dtype(default_dtype)
         try:
-            with pytest.raises(AssertionError, match="size"):
+            first_bad = unrepresentable_sizes(default_dtype)[0]
+            with pytest.raises(AssertionError, match=rf"size {first_bad}, output 0"):
                 assert_capture_matches_eager(
                     _ntp_default_dtype(hist.normal_transform_pixel_1522441d),
                     lambda size, device, dtype: (torch.zeros(1, 1, size, 5, device=device),),
@@ -182,6 +183,19 @@ class TestAssertCaptureMatchesEager:
                 dtype=torch.float32,
             )
 
+    def test_rejects_an_unknown_capture(self, device):
+        # an unrecognised value used to fall through both branches and surface as an
+        # UnboundLocalError on ``captured_fn``, which reads as a helper bug rather than a typo.
+        with pytest.raises(ValueError, match="capture must be 'trace' or 'compile', got 'inductor'"):
+            assert_capture_matches_eager(
+                _meshgrid_of(kornia.geometry.create_meshgrid),
+                _image_hw,
+                sizes=[2],
+                device=device,
+                dtype=torch.float32,
+                capture="inductor",
+            )
+
     def test_compile_capture_runs_or_skips(self, device, torch_optimizer):
         # ``torch_optimizer`` is the conftest fixture; the test name carries ``compile`` so it is
         # deselected unless KORNIA_TEST_OPTIMIZER is set, exactly like the rest of the suite.
@@ -212,25 +226,22 @@ class TestAssertDegeneratePathParity:
             # zero-shaped, even though src is not. Reproduces with a bare
             # ``F.grid_sample(torch.zeros(1, 1, 4, 4, device="mps"), torch.zeros(1, 0, 4, 2,
             # device="mps"), align_corners=True, mode="bilinear", padding_mode="zeros")``, so this
-            # is a real, reportable MPS gap in warp_affine's degenerate path -- see
-            # task-4-report.md.
+            # is a real, reportable MPS gap in warp_affine's degenerate path -- kornia#4032.
             pytest.skip("warp_affine's empty-dsize path crashes on MPS: F.grid_sample asserts on a zero-sized grid")
         full = self._warp_kwargs(device, (4, 4))
         empty = self._warp_kwargs(device, (0, 4))
         bad = [
             ("M", torch.eye(2, 3, device=device, dtype=torch.int64)[None]),
             ("M", torch.eye(3, 3, device=device, dtype=torch.float32)[None]),
+            # float64 is safe to build here: MPS, which has no float64 tensors at all, skipped above.
+            ("M", torch.zeros(1, 2, 3, device=device, dtype=torch.float64)),
             # NOT an integral ``src`` (torch.zeros(1, 1, 4, 4, dtype=torch.int64)): on the full
             # path it reaches ``F.grid_sample``, which raises NotImplementedError
             # ("grid_sampler_2d_cpu_kernel_impl" not implemented for 'Long'); on the degenerate
             # (dsize with a zero dimension) path, ``_empty_warp_output_2d`` raises its own
             # RuntimeError ("Expected a floating point src, got torch.int64.") before ever
-            # reaching grid_sample. Real discrepancy -- see task-4-report.md.
+            # reaching grid_sample. Real discrepancy -- kornia#4031.
         ]
-        if torch.device(device).type != "mps":
-            # MPS has no float64 tensors at all (construction itself raises TypeError), so this
-            # dtype-mismatch case can only be exercised on cpu/cuda.
-            bad.append(("M", torch.zeros(1, 2, 3, device=device, dtype=torch.float64)))
         assert_degenerate_path_parity(kornia.geometry.transform.warp_affine, full, empty, bad)
 
     def test_detects_a_laxer_degenerate_path(self):

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -18,7 +18,11 @@
 import pytest
 import torch
 
-from testing import unrepresentable_sizes
+import kornia
+
+from testing import assert_capture_matches_eager, unrepresentable_sizes
+
+from tests.testing import _historical as hist
 
 
 class TestUnrepresentableSizes:
@@ -53,3 +57,109 @@ class TestUnrepresentableSizes:
     def test_rejects_non_floating_dtype(self):
         with pytest.raises(TypeError, match="floating"):
             unrepresentable_sizes(torch.int64)
+
+
+def _image_hw(size: int, device: torch.device, dtype: torch.dtype) -> tuple[torch.Tensor]:
+    return (torch.zeros(1, 1, size, 4, device=device, dtype=dtype),)
+
+
+def _meshgrid_of(fn):
+    def run(image):
+        return fn(image.shape[-2], image.shape[-1], device=image.device, dtype=image.dtype)
+
+    return run
+
+
+def _ntp_default_dtype(fn):
+    def run(image):
+        return fn(image.shape[-2], image.shape[-1], device=image.device)
+
+    return run
+
+
+class TestAssertCaptureMatchesEager:
+    def test_current_meshgrid_passes_under_trace(self, device, dtype):
+        assert_capture_matches_eager(
+            _meshgrid_of(kornia.geometry.create_meshgrid),
+            _image_hw,
+            sizes=[1, 2, *unrepresentable_sizes(torch.bfloat16)[:6], 2050, 3000],
+            device=device,
+            dtype=dtype,
+            capture="trace",
+        )
+
+    @pytest.mark.parametrize("wave_fn", [hist.create_meshgrid_9ed891c5, hist.create_meshgrid_32ab0eeb])
+    def test_historical_meshgrid_bodies_fail_under_trace(self, wave_fn, device):
+        # These bodies are byte-equal to eager at every size that is exact in bfloat16, which is
+        # why 1/2/4 let them through three review rounds. The sweep is what catches them -- and the
+        # two bodies need different sizes: 9ed891c5 rounds the size itself, so it already differs at
+        # 257 (divisor 255 instead of 256), while 32ab0eeb only rounds the divisor and so first
+        # differs at 258 (257 is exact as a divisor). A single hand-picked size catches one or the
+        # other, never both.
+        with pytest.raises(AssertionError, match=r"size (257|258|259|260|261|262)"):
+            assert_capture_matches_eager(
+                _meshgrid_of(wave_fn),
+                _image_hw,
+                sizes=unrepresentable_sizes(torch.bfloat16)[:6],
+                device=device,
+                dtype=torch.bfloat16,
+                capture="trace",
+            )
+
+    def test_historical_meshgrid_bodies_pass_at_the_vacuous_sizes(self, device):
+        # Documents the trap: the old test sizes cannot distinguish the buggy body from the fix.
+        assert_capture_matches_eager(
+            _meshgrid_of(hist.create_meshgrid_32ab0eeb),
+            _image_hw,
+            sizes=[1, 2, 4, 257],
+            device=device,
+            dtype=torch.bfloat16,
+            capture="trace",
+        )
+
+    @pytest.mark.parametrize("default_dtype", [torch.float16, torch.bfloat16], ids=["float16", "bfloat16"])
+    def test_historical_normal_transform_pixel_fails_under_half_default_dtype(self, default_dtype, device):
+        previous = torch.get_default_dtype()
+        torch.set_default_dtype(default_dtype)
+        try:
+            with pytest.raises(AssertionError, match="size"):
+                assert_capture_matches_eager(
+                    _ntp_default_dtype(hist.normal_transform_pixel_1522441d),
+                    lambda size, device, dtype: (torch.zeros(1, 1, size, 5, device=device),),
+                    sizes=unrepresentable_sizes(default_dtype)[:4],
+                    device=device,
+                    dtype=default_dtype,
+                    capture="trace",
+                )
+            assert_capture_matches_eager(
+                _ntp_default_dtype(kornia.geometry.conversions.normal_transform_pixel),
+                lambda size, device, dtype: (torch.zeros(1, 1, size, 5, device=device),),
+                sizes=unrepresentable_sizes(default_dtype)[:4],
+                device=device,
+                dtype=default_dtype,
+                capture="trace",
+            )
+        finally:
+            torch.set_default_dtype(previous)
+
+    def test_reports_index_and_difference_for_tuple_outputs(self, device):
+        def two_outputs(image):
+            a = kornia.geometry.create_meshgrid(
+                image.shape[-2], image.shape[-1], device=image.device, dtype=image.dtype
+            )
+            return a, a + 1
+
+        assert_capture_matches_eager(two_outputs, _image_hw, sizes=[3], device=device, dtype=torch.float32)
+
+    def test_compile_capture_runs_or_skips(self, device, torch_optimizer):
+        # ``torch_optimizer`` is the conftest fixture; the test name carries ``compile`` so it is
+        # deselected unless KORNIA_TEST_OPTIMIZER is set, exactly like the rest of the suite.
+        del torch_optimizer
+        assert_capture_matches_eager(
+            _meshgrid_of(kornia.geometry.create_meshgrid),
+            _image_hw,
+            sizes=[1, 2, 258, 300],
+            device=device,
+            dtype=torch.float32,
+            capture="compile",
+        )

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -20,7 +20,7 @@ import torch
 
 import kornia
 
-from testing import assert_capture_matches_eager, unrepresentable_sizes
+from testing import assert_capture_matches_eager, assert_degenerate_path_parity, unrepresentable_sizes
 
 from tests.testing import _historical as hist
 
@@ -194,3 +194,71 @@ class TestAssertCaptureMatchesEager:
             dtype=torch.float32,
             capture="compile",
         )
+
+
+class TestAssertDegeneratePathParity:
+    @staticmethod
+    def _warp_kwargs(device, dsize):
+        src = torch.zeros(1, 1, 4, 4, device=device, dtype=torch.float32)
+        m = torch.eye(2, 3, device=device, dtype=torch.float32)[None]
+        return {"src": src, "M": m, "dsize": dsize}
+
+    def test_current_warp_affine_validates_the_same_on_the_empty_path(self, device):
+        if torch.device(device).type == "mps":
+            # Not a parity gap to weaken around: even the baseline (non-empty src, valid M,
+            # dsize=(0, 4)) crashes. kornia's empty-destination fast path still delegates to
+            # ``F.grid_sample`` with a zero-sized grid for validation/autograd, and MPS's
+            # grid_sampler asserts "Placeholder tensor is empty!" whenever the grid is
+            # zero-shaped, even though src is not. Reproduces with a bare
+            # ``F.grid_sample(torch.zeros(1, 1, 4, 4, device="mps"), torch.zeros(1, 0, 4, 2,
+            # device="mps"), align_corners=True, mode="bilinear", padding_mode="zeros")``, so this
+            # is a real, reportable MPS gap in warp_affine's degenerate path -- see
+            # task-4-report.md.
+            pytest.skip("warp_affine's empty-dsize path crashes on MPS: F.grid_sample asserts on a zero-sized grid")
+        full = self._warp_kwargs(device, (4, 4))
+        empty = self._warp_kwargs(device, (0, 4))
+        bad = [
+            ("M", torch.eye(2, 3, device=device, dtype=torch.int64)[None]),
+            ("M", torch.eye(3, 3, device=device, dtype=torch.float32)[None]),
+            # NOT an integral ``src`` (torch.zeros(1, 1, 4, 4, dtype=torch.int64)): on the full
+            # path it reaches ``F.grid_sample``, which raises NotImplementedError
+            # ("grid_sampler_2d_cpu_kernel_impl" not implemented for 'Long'); on the degenerate
+            # (dsize with a zero dimension) path, ``_empty_warp_output_2d`` raises its own
+            # RuntimeError ("Expected a floating point src, got torch.int64.") before ever
+            # reaching grid_sample. Real discrepancy -- see task-4-report.md.
+        ]
+        if torch.device(device).type != "mps":
+            # MPS has no float64 tensors at all (construction itself raises TypeError), so this
+            # dtype-mismatch case can only be exercised on cpu/cuda.
+            bad.append(("M", torch.zeros(1, 2, 3, device=device, dtype=torch.float64)))
+        assert_degenerate_path_parity(kornia.geometry.transform.warp_affine, full, empty, bad)
+
+    def test_detects_a_laxer_degenerate_path(self):
+        def op(x, dsize):
+            if dsize[0] == 0:
+                return x.new_zeros(0)
+            if x.dtype != torch.float32:
+                raise TypeError("float32 only")
+            return x
+
+        with pytest.raises(AssertionError, match=r"x=.*TypeError.*vs.*None"):
+            assert_degenerate_path_parity(
+                op,
+                {"x": torch.zeros(2), "dsize": (2,)},
+                {"x": torch.zeros(2), "dsize": (0,)},
+                [("x", torch.zeros(2, dtype=torch.int64))],
+            )
+
+    def test_detects_a_stricter_degenerate_path(self):
+        def op(x, dsize):
+            if dsize[0] == 0 and x.dtype != torch.float32:
+                raise TypeError("float32 only on the empty path")
+            return x
+
+        with pytest.raises(AssertionError, match=r"None.*vs.*TypeError"):
+            assert_degenerate_path_parity(
+                op,
+                {"x": torch.zeros(2), "dsize": (2,)},
+                {"x": torch.zeros(2), "dsize": (0,)},
+                [("x", torch.zeros(2, dtype=torch.int64))],
+            )

--- a/tests/testing/test_precision.py
+++ b/tests/testing/test_precision.py
@@ -59,9 +59,9 @@ class TestUnrepresentableSizes:
             unrepresentable_sizes(torch.int64)
 
     def test_rejects_an_hi_above_the_dtype_max(self):
-        # Above finfo.max every candidate casts to inf and round-trips back to itself, so `n` reads
-        # as "exact" and the sweep silently becomes a list of sizes no test can allocate. The
-        # docstring warned about it; the check is what makes it impossible.
+        # Above finfo.max candidates cast to inf and conversion back to int64 produces a sentinel,
+        # so the resulting list no longer describes representable, allocatable sizes. The check
+        # rejects that meaningless range before doing the conversion.
         with pytest.raises(ValueError, match=r"hi=70000 is above torch.finfo\(torch.float16\).max=65504"):
             unrepresentable_sizes(torch.float16, lo=65000, hi=70000)
 
@@ -167,6 +167,23 @@ class TestAssertCaptureMatchesEager:
 
         assert_capture_matches_eager(two_outputs, _image_hw, sizes=[3], device=device, dtype=torch.float32)
 
+    def test_rejects_an_empty_output_sequence(self, device, monkeypatch):
+        # A zero-element tensor still has a shape/dtype/bit contract, but an empty tuple has no
+        # output to compare and would make every execution look equal vacuously.
+        monkeypatch.setattr(torch.jit, "trace", lambda fn, inputs, check_trace: fn)
+
+        with pytest.raises(ValueError, match="empty output sequence"):
+            assert_capture_matches_eager(
+                lambda image: (), _image_hw, sizes=[1], device=device, dtype=torch.float32, capture="trace"
+            )
+
+    def test_accepts_a_zero_element_tensor_output(self, device):
+        # Empty tensors are not vacuous: their shape and dtype are checked and their empty byte
+        # representation is the correct result for many degenerate paths.
+        assert_capture_matches_eager(
+            lambda image: image[..., :0], _image_hw, sizes=[1], device=device, dtype=torch.float32
+        )
+
     def test_reports_index_and_difference_for_tuple_outputs(self, device):
         # Output 0 is the fixed library function and agrees under trace; output 1 is the wave-8 body
         # at 258, the size where it first diverges. The helper must name the offending index, not
@@ -221,6 +238,18 @@ class TestAssertCaptureMatchesEager:
             return image + torch.rand_like(image)
 
         assert_capture_matches_eager(adds_noise, _image_hw, sizes=[1, 2, 5], device=device, dtype=dtype)
+
+    def test_in_place_outputs_cannot_alias_across_executions(self, device):
+        # With one shared input, trace adds 2, eager adds 1, then captured adds 2 to the same tensor.
+        # The saved eager output aliases that tensor and ends equal to captured, hiding the mismatch.
+        class DifferentInPlaceUpdateUnderTrace(torch.nn.Module):
+            def forward(self, image: torch.Tensor) -> torch.Tensor:
+                return image.add_(2.0 if torch.jit.is_tracing() else 1.0)
+
+        with pytest.raises(AssertionError, match=r"size 1, output 0.*max abs diff 1"):
+            assert_capture_matches_eager(
+                DifferentInPlaceUpdateUnderTrace(), _image_hw, sizes=[1], device=device, dtype=torch.float32
+            )
 
     def test_rejects_an_unknown_capture(self, device):
         # an unrecognised value used to fall through both branches and surface as an

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -15,9 +15,22 @@
 # limitations under the License.
 #
 
+import os
 from pathlib import Path
+from types import SimpleNamespace
 
-from testing.verify_delta import FailureDelta, changed_test_dirs, diff_failures, failing_ids, render_table
+from testing import verify_delta
+from testing.verify_delta import (
+    SURFACES,
+    FailureDelta,
+    _failures_or_empty,
+    changed_test_dirs,
+    diff_failures,
+    failing_ids,
+    parse_args,
+    render_table,
+    select_surfaces,
+)
 
 
 class TestChangedTestDirs:
@@ -87,3 +100,124 @@ class TestRenderTable:
         assert "| cpu float32 | 1 | 0 | 1 |" in out
         assert "| mps float32 | skipped |" in out
         assert "NEW x::t1" in out
+
+
+class TestSurfaces:
+    def test_default_surfaces(self):
+        assert [s.name for s in SURFACES] == [
+            "cpu float32",
+            "cpu float16,bfloat16,float64",
+            "mps float32",
+            "inductor cpu float32",
+        ]
+
+    def test_select_skips_mps_when_unavailable(self):
+        chosen = select_surfaces(parse_args([]), mps_available=False)
+        assert "mps float32" not in [s.name for s in chosen]
+
+    def test_select_honours_only_flag(self):
+        chosen = select_surfaces(parse_args(["--only", "cpu float32"]), mps_available=True)
+        assert [s.name for s in chosen] == ["cpu float32"]
+
+    def test_tests_override(self):
+        assert parse_args(["--tests", "tests/geometry", "tests/filters"]).tests == ["tests/geometry", "tests/filters"]
+
+
+class TestFailuresOrEmpty:
+    def test_missing_junit_reads_as_no_failures(self, tmp_path: Path, capsys):
+        assert _failures_or_empty(tmp_path / "nope.xml") == set()
+        assert "no junit report" in capsys.readouterr().out
+
+    def test_existing_junit_is_parsed(self, tmp_path: Path):
+        p = tmp_path / "junit.xml"
+        p.write_text(JUNIT)
+        assert _failures_or_empty(p) == failing_ids(p)
+
+
+class TestOnlyThroughATaskShell:
+    """`pixi run verify-delta -- --only "cpu float32"` forwards `--` and drops the quoting."""
+
+    def test_leading_double_dash_separator_is_dropped(self):
+        assert parse_args(["--", "--only", "cpu float32"]).only == ["cpu float32"]
+
+    def test_space_split_surface_name_is_rejoined(self):
+        chosen = select_surfaces(parse_args(["--only", "cpu", "float32"]), mps_available=True)
+        assert [s.name for s in chosen] == ["cpu float32"]
+
+    def test_longest_name_wins_over_a_shorter_prefix_match(self):
+        chosen = select_surfaces(parse_args(["--only", "inductor", "cpu", "float32"]), mps_available=True)
+        assert [s.name for s in chosen] == ["inductor cpu float32"]
+
+    def test_several_space_split_names_in_one_flag(self):
+        chosen = select_surfaces(parse_args(["--only", "cpu", "float32", "mps", "float32"]), mps_available=True)
+        assert [s.name for s in chosen] == ["cpu float32", "mps float32"]
+
+    def test_unknown_surface_is_an_error(self):
+        import pytest
+
+        with pytest.raises(SystemExit, match="unknown surface"):
+            select_surfaces(parse_args(["--only", "cuda", "float32"]), mps_available=True)
+
+
+class _FakeRun:
+    """Stand-in for ``subprocess.run`` that records argv and never launches anything."""
+
+    def __init__(self, stdout: str = ""):
+        self.stdout = stdout
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append([str(a) for a in argv])
+        return SimpleNamespace(stdout=self.stdout, returncode=0)
+
+
+class TestRunSurface:
+    def test_a_stale_junit_from_a_previous_run_is_not_reused(self, tmp_path: Path, monkeypatch, capsys):
+        (tmp_path / "tests").mkdir()
+        junit = tmp_path / "j.xml"
+        junit.write_text(JUNIT)  # a previous run's failures, which this run must not inherit
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], junit) == set()
+        assert not junit.exists()
+        assert "no junit report" in capsys.readouterr().out
+
+    def test_the_tree_under_test_is_on_pythonpath(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        monkeypatch.delenv("PYTHONPATH", raising=False)
+        (tmp_path / "tests").mkdir()
+        verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], tmp_path / "j.xml")
+        assert os.environ.get("PYTHONPATH") is None  # the child env is not leaked into this process
+
+    def test_paths_absent_from_the_tree_are_dropped_not_fatal(self, tmp_path: Path, monkeypatch, capsys):
+        # pytest aborts collection entirely when any argument path is missing, which would silently
+        # empty the base tree's failure set and report every branch failure as new.
+        (tmp_path / "tests" / "geometry").mkdir(parents=True)
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        verify_delta._run_surface(tmp_path, SURFACES[0], ["tests/geometry", "tests/testing"], tmp_path / "j.xml")
+        pytest_argv = fake.calls[-1]
+        assert pytest_argv[-1] == "tests/geometry"
+        assert "tests/testing" not in pytest_argv
+        assert "tests/testing" in capsys.readouterr().out
+
+    def test_no_present_paths_means_no_run_and_no_failures(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests/testing"], tmp_path / "j.xml") == set()
+        assert not any("pytest" in call for call in fake.calls)
+
+
+class TestEnsureMainWorktree:
+    def test_a_local_base_revision_is_not_fetched(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun()
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        verify_delta._ensure_main_worktree(tmp_path, "HEAD~1", tmp_path, fetch=True)
+        assert not any("fetch" in call for call in fake.calls)
+
+    def test_a_remote_base_revision_is_fetched(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun()
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        verify_delta._ensure_main_worktree(tmp_path, "origin/main", tmp_path, fetch=True)
+        assert ["git", "-C", str(tmp_path), "fetch", "origin", "main"] in fake.calls

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -16,8 +16,11 @@
 #
 
 import os
+import re
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from testing import verify_delta
 from testing.verify_delta import (
@@ -54,6 +57,17 @@ class TestChangedTestDirs:
     def test_top_level_module_files(self):
         assert changed_test_dirs(["kornia/constants.py"]) == ["tests"]
 
+    def test_a_module_without_a_test_dir_of_its_own_widens_to_everything(self, tmp_path: Path, capsys):
+        # kornia/transpiler/ is the live example: mapping it to a non-existent tests/transpiler and
+        # then dropping the missing path would leave the change unverified behind a clean verdict.
+        (tmp_path / "tests" / "geometry").mkdir(parents=True)
+        assert changed_test_dirs(["kornia/transpiler/transpiler.py"], tmp_path) == ["tests"]
+        assert "kornia/transpiler/transpiler.py maps to tests/transpiler" in capsys.readouterr().out
+
+    def test_a_module_with_a_test_dir_is_not_widened(self, tmp_path: Path):
+        (tmp_path / "tests" / "geometry").mkdir(parents=True)
+        assert changed_test_dirs(["kornia/geometry/grid.py"], tmp_path) == ["tests/geometry"]
+
 
 JUNIT = """<?xml version="1.0" encoding="utf-8"?>
 <testsuites><testsuite name="pytest" errors="1" failures="1" skipped="1" tests="4">
@@ -77,8 +91,6 @@ class TestFailingIds:
         }
 
     def test_missing_file_is_an_error(self, tmp_path: Path):
-        import pytest
-
         with pytest.raises(FileNotFoundError):
             failing_ids(tmp_path / "nope.xml")
 
@@ -167,8 +179,6 @@ class TestOnlyThroughATaskShell:
         assert [s.name for s in chosen] == ["cpu float32", "mps float32"]
 
     def test_unknown_surface_is_an_error(self):
-        import pytest
-
         with pytest.raises(SystemExit, match="unknown surface"):
             select_surfaces(parse_args(["--only", "cuda", "float32"]), mps_available=True)
 
@@ -176,10 +186,19 @@ class TestOnlyThroughATaskShell:
 class _FakeRun:
     """Stand-in for ``subprocess.run`` that records argv and kwargs and never launches anything."""
 
-    def __init__(self, stdout: str = "", stdout_by_arg: dict[str, str] | None = None, junit: str | None = None):
+    def __init__(
+        self,
+        stdout: str = "",
+        stdout_by_arg: dict[str, str] | None = None,
+        junit: str | None = None,
+        fails_for: tuple[str, ...] = (),
+        stderr: str = "",
+    ):
         self.stdout = stdout
         self.stdout_by_arg = stdout_by_arg or {}  # first matching argv entry wins, e.g. keyed by a tree path
         self.junit = junit  # written to the --junitxml path, standing in for what pytest would report
+        self.fails_for = fails_for  # argv entries whose command exits non-zero, e.g. "symbolic-ref"
+        self.stderr = stderr
         self.calls: list[list[str]] = []
         self.kwargs: list[dict] = []
 
@@ -187,6 +206,8 @@ class _FakeRun:
         argv = [str(a) for a in argv]
         self.calls.append(argv)
         self.kwargs.append(kwargs)
+        if any(token in argv for token in self.fails_for):
+            raise verify_delta.subprocess.CalledProcessError(1, argv, stderr=self.stderr)
         for arg in argv if self.junit is not None else []:
             if arg.startswith("--junitxml="):
                 Path(arg.split("=", 1)[1]).write_text(self.junit)
@@ -221,7 +242,8 @@ class TestRunSurface:
             assert kwargs["env"]["KORNIA_TEST_DEVICE"] == "cpu"
             assert kwargs["env"]["KORNIA_TEST_OPTIMIZER"] == "inductor"
         assert fake.calls[-1][-3:] == ["-k", "dynamo or compile", "tests"]
-        assert os.environ.get("PYTHONPATH") is None  # the child env is not leaked into this process
+        # a fresh dict, so setting PYTHONPATH for the child never mutates this process's environment
+        assert all(kwargs["env"] is not os.environ for kwargs in fake.kwargs)
 
     def test_paths_absent_from_the_tree_are_dropped_not_fatal(self, tmp_path: Path, monkeypatch, capsys):
         # pytest aborts collection entirely when any argument path is missing, which would silently
@@ -246,18 +268,29 @@ class TestRunSurface:
         assert "nothing to run" in capsys.readouterr().out
 
 
+def _reusable_worktree_run(repo: Path, **kwargs) -> _FakeRun:
+    """A fake git in which the reused path is a detached worktree of ``repo`` and ``repo`` is primary."""
+    defaults = {
+        "stdout": str(repo / ".git"),  # both trees report the same .git common dir
+        "stdout_by_arg": {"--porcelain": f"worktree {repo}\nHEAD abc1234\nbranch refs/heads/main\n"},
+        # `git symbolic-ref -q HEAD` exits non-zero exactly when HEAD is detached
+        "fails_for": ("symbolic-ref",),
+    }
+    return _FakeRun(**{**defaults, **kwargs})
+
+
 class TestEnsureMainWorktree:
     def test_a_local_base_revision_is_not_fetched(self, tmp_path: Path, monkeypatch):
-        fake = _FakeRun()
+        fake = _reusable_worktree_run(tmp_path / "repo")
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
-        verify_delta._ensure_main_worktree(tmp_path, "HEAD~1", tmp_path, fetch=True)
+        verify_delta._ensure_main_worktree(tmp_path / "repo", "HEAD~1", tmp_path, fetch=True)
         assert not any("fetch" in call for call in fake.calls)
 
     def test_a_remote_base_revision_is_fetched(self, tmp_path: Path, monkeypatch):
-        fake = _FakeRun()
+        fake = _reusable_worktree_run(tmp_path / "repo")
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
-        verify_delta._ensure_main_worktree(tmp_path, "origin/main", tmp_path, fetch=True)
-        assert ["git", "-C", str(tmp_path), "fetch", "origin", "main"] in fake.calls
+        verify_delta._ensure_main_worktree(tmp_path / "repo", "origin/main", tmp_path, fetch=True)
+        assert ["git", "-C", str(tmp_path / "repo"), "fetch", "origin", "main"] in fake.calls
 
 
 class TestAssertImportsFrom:
@@ -267,8 +300,6 @@ class TestAssertImportsFrom:
         verify_delta._assert_imports_from(tmp_path, {"PYTHONPATH": str(tmp_path)})  # does not raise
 
     def test_rejects_kornia_imported_from_another_checkout(self, tmp_path: Path, monkeypatch):
-        import pytest
-
         # the shared .venv re-points its editable kornia install to whichever tree ran uv last
         fake = _FakeRun(stdout=str(tmp_path.parent / "elsewhere" / "kornia" / "__init__.py"))
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
@@ -277,18 +308,49 @@ class TestAssertImportsFrom:
 
 
 class TestEnsureMainWorktreeReuse:
-    def test_reuses_a_path_that_is_a_worktree_of_this_repo(self, tmp_path: Path, monkeypatch):
+    def test_reuses_a_detached_scratch_worktree_of_this_repo(self, tmp_path: Path, monkeypatch):
         repo, wt = tmp_path / "repo", tmp_path / "wt"
         repo.mkdir()
         wt.mkdir()
-        fake = _FakeRun(stdout=str(repo / ".git"))  # both trees share one .git common dir
+        fake = _reusable_worktree_run(repo)
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
         assert ["git", "-C", str(wt), "checkout", "--detach", "origin/main"] in fake.calls
 
-    def test_refuses_a_leftover_directory_that_belongs_to_another_repo(self, tmp_path: Path, monkeypatch):
-        import pytest
+    def test_refuses_a_worktree_whose_head_is_on_a_branch(self, tmp_path: Path, monkeypatch):
+        # a linked worktree of this same repo, but with a branch checked out: detaching it at `base`
+        # would move somebody off the branch they were working on.
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        repo.mkdir()
+        wt.mkdir()
+        fake = _FakeRun(stdout=str(repo / ".git"))  # symbolic-ref succeeds -> HEAD is attached
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        with pytest.raises(SystemExit, match=rf"{re.escape(str(wt))}.*looks like a user checkout"):
+            verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
+        assert not any("checkout" in call for call in fake.calls)
 
+    def test_refuses_the_repos_own_main_worktree(self, tmp_path: Path, monkeypatch):
+        # detached, same repo, but it is the primary worktree -- the user's own checkout.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        fake = _reusable_worktree_run(repo)
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        with pytest.raises(SystemExit, match=rf"{re.escape(str(repo))}.*looks like a user checkout"):
+            verify_delta._ensure_main_worktree(repo, "origin/main", repo, fetch=False)
+        assert not any("checkout" in call for call in fake.calls)
+
+    def test_a_checkout_that_fails_is_reported_not_raised_raw(self, tmp_path: Path, monkeypatch):
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        repo.mkdir()
+        wt.mkdir()
+        fake = _reusable_worktree_run(repo, fails_for=("symbolic-ref", "checkout"), stderr="local changes")
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        with pytest.raises(
+            SystemExit, match=rf"{re.escape(str(wt))} is dirty or cannot check out origin/main: local changes"
+        ):
+            verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
+
+    def test_refuses_a_leftover_directory_that_belongs_to_another_repo(self, tmp_path: Path, monkeypatch):
         repo, wt = tmp_path / "repo", tmp_path / "wt"
         repo.mkdir()
         wt.mkdir()
@@ -300,8 +362,6 @@ class TestEnsureMainWorktreeReuse:
         assert not any("checkout" in call for call in fake.calls)
 
     def test_refuses_a_path_that_is_not_in_any_repository(self, tmp_path: Path, monkeypatch):
-        import pytest
-
         repo, wt = tmp_path / "repo", tmp_path / "wt"
         repo.mkdir()
         wt.mkdir()

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -101,6 +101,20 @@ class TestRenderTable:
         assert "| mps float32 | skipped |" in out
         assert "NEW x::t1" in out
 
+    def test_distinguishes_a_row_that_had_no_baseline_from_a_deselected_one(self):
+        out = render_table(
+            [
+                ("cpu float32", FailureDelta(new=["x::t1"], baseline=False)),
+                ("mps float32", None),
+            ]
+        )
+        assert "| cpu float32 | 1* | 0 | 0 |" in out
+        assert "| mps float32 | skipped |" in out
+        assert "* no baseline on the base revision" in out
+
+    def test_no_legend_when_every_row_had_a_baseline(self):
+        assert "no baseline" not in render_table([("cpu float32", FailureDelta(new=["x::t1"]))])
+
 
 class TestSurfaces:
     def test_default_surfaces(self):
@@ -162,9 +176,10 @@ class TestOnlyThroughATaskShell:
 class _FakeRun:
     """Stand-in for ``subprocess.run`` that records argv and kwargs and never launches anything."""
 
-    def __init__(self, stdout: str = "", stdout_by_arg: dict[str, str] | None = None):
+    def __init__(self, stdout: str = "", stdout_by_arg: dict[str, str] | None = None, junit: str | None = None):
         self.stdout = stdout
         self.stdout_by_arg = stdout_by_arg or {}  # first matching argv entry wins, e.g. keyed by a tree path
+        self.junit = junit  # written to the --junitxml path, standing in for what pytest would report
         self.calls: list[list[str]] = []
         self.kwargs: list[dict] = []
 
@@ -172,6 +187,9 @@ class _FakeRun:
         argv = [str(a) for a in argv]
         self.calls.append(argv)
         self.kwargs.append(kwargs)
+        for arg in argv if self.junit is not None else []:
+            if arg.startswith("--junitxml="):
+                Path(arg.split("=", 1)[1]).write_text(self.junit)
         for key, stdout in self.stdout_by_arg.items():
             if key in argv:
                 return SimpleNamespace(stdout=stdout, returncode=0)
@@ -298,11 +316,11 @@ class TestEnsureMainWorktreeReuse:
             verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
 
 
-class TestMainRefusesAVacuousPass:
-    """Exiting 0 without having compared anything would make the gate useless."""
+class TestMainExitCodes:
+    """0 verified clean, 1 something is newly failing, 2 nothing was verified at all."""
 
     @staticmethod
-    def _stub_repo(monkeypatch, tmp_path: Path) -> _FakeRun:
+    def _stub_repo(monkeypatch, tmp_path: Path, junit: str | None = None) -> _FakeRun:
         def fake_git(repo, *cmd):
             if cmd[:2] == ("rev-parse", "--show-toplevel"):
                 return str(tmp_path)
@@ -310,7 +328,7 @@ class TestMainRefusesAVacuousPass:
                 return ""
             return "abc1234"
 
-        fake = _FakeRun()
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"), junit=junit)
         monkeypatch.setattr(verify_delta, "_git", fake_git)
         monkeypatch.setattr(verify_delta, "_ensure_main_worktree", lambda *a, **k: None)
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
@@ -332,6 +350,30 @@ class TestMainRefusesAVacuousPass:
         assert code == 2
         assert "nothing was verified" in capsys.readouterr().out
         assert fake.calls == []
+
+    def test_a_path_only_the_branch_has_is_an_empty_baseline_not_a_refusal(self, tmp_path: Path, monkeypatch, capsys):
+        # tests/ exists here but not in the base worktree: the branch side really ran, so its failures
+        # are real and unconditionally new -- that is a verdict, not a failure to measure.
+        fake = self._stub_repo(monkeypatch, tmp_path, junit=JUNIT)
+        (tmp_path / "tests").mkdir()
+        code = verify_delta.main(self._argv(tmp_path, "--only", "cpu float32", "--tests", "tests"))
+        out = capsys.readouterr().out
+        assert code == 1
+        assert "no baseline on origin/main for tests; branch failures there are unconditionally new" in out
+        assert "| cpu float32 | 2* | 0 | 0 |" in out
+        assert "* no baseline on the base revision" in out
+        assert "NEW tests.geometry.test_grid::test_b[cpu-float32]" in out
+        assert not any("| cpu float32 | skipped" in line for line in out.splitlines())
+        assert sum("pytest" in call for call in fake.calls) == 1  # only the branch side had anything to run
+
+    def test_an_empty_baseline_with_a_clean_branch_still_passes(self, tmp_path: Path, monkeypatch, capsys):
+        self._stub_repo(monkeypatch, tmp_path)  # no junit written, so the branch side has no failures
+        (tmp_path / "tests").mkdir()
+        code = verify_delta.main(self._argv(tmp_path, "--only", "cpu float32", "--tests", "tests"))
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "| cpu float32 | 0* | 0 | 0 |" in out
+        assert "no baseline on origin/main" in out
 
     def test_selecting_only_an_unavailable_surface_is_not_a_pass(self, tmp_path: Path, monkeypatch, capsys):
         import torch

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -1,0 +1,89 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pathlib import Path
+
+from testing.verify_delta import FailureDelta, changed_test_dirs, diff_failures, failing_ids, render_table
+
+
+class TestChangedTestDirs:
+    def test_maps_library_modules_to_test_dirs(self):
+        assert changed_test_dirs(["kornia/geometry/grid.py", "kornia/geometry/conversions.py"]) == ["tests/geometry"]
+
+    def test_includes_test_dirs_touched_directly(self):
+        assert changed_test_dirs(["tests/filters/test_sobel.py", "kornia/color/gray.py"]) == [
+            "tests/color",
+            "tests/filters",
+        ]
+
+    def test_shared_infrastructure_widens_to_everything(self):
+        assert changed_test_dirs(["testing/base.py", "kornia/geometry/grid.py"]) == ["tests"]
+        assert changed_test_dirs(["tests/conftest.py"]) == ["tests"]
+        assert changed_test_dirs(["pyproject.toml"]) == ["tests"]
+
+    def test_ignores_docs_and_other_paths(self):
+        assert changed_test_dirs(["docs/source/geometry.rst", "CHANGELOG.md", "AGENTS.md"]) == []
+
+    def test_top_level_module_files(self):
+        assert changed_test_dirs(["kornia/constants.py"]) == ["tests"]
+
+
+JUNIT = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites><testsuite name="pytest" errors="1" failures="1" skipped="1" tests="4">
+<testcase classname="tests.geometry.test_grid" name="test_a[cpu-float32]" time="0.1"/>
+<testcase classname="tests.geometry.test_grid" name="test_b[cpu-float32]" time="0.1">
+<failure message="x">t</failure></testcase>
+<testcase classname="tests.geometry.test_grid" name="test_c[cpu-float32]" time="0.1">
+<error message="y">t</error></testcase>
+<testcase classname="tests.geometry.test_grid" name="test_d[cpu-float32]" time="0.1"><skipped message="z"/></testcase>
+</testsuite></testsuites>
+"""
+
+
+class TestFailingIds:
+    def test_collects_failures_and_errors_not_skips(self, tmp_path: Path):
+        p = tmp_path / "junit.xml"
+        p.write_text(JUNIT)
+        assert failing_ids(p) == {
+            "tests.geometry.test_grid::test_b[cpu-float32]",
+            "tests.geometry.test_grid::test_c[cpu-float32]",
+        }
+
+    def test_missing_file_is_an_error(self, tmp_path: Path):
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            failing_ids(tmp_path / "nope.xml")
+
+
+class TestDiffFailures:
+    def test_sets_not_counts(self):
+        d = diff_failures(branch={"a", "b", "c"}, main={"b", "c", "d"})
+        assert d == FailureDelta(new=["a"], fixed=["d"], unchanged=["b", "c"])
+
+
+class TestRenderTable:
+    def test_lists_new_and_fixed_ids_and_marks_skipped_surfaces(self):
+        out = render_table(
+            [
+                ("cpu float32", FailureDelta(new=["x::t1"], fixed=[], unchanged=["x::t0"])),
+                ("mps float32", None),
+            ]
+        )
+        assert "| cpu float32 | 1 | 0 | 1 |" in out
+        assert "| mps float32 | skipped |" in out
+        assert "NEW x::t1" in out

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -24,7 +24,10 @@ import pytest
 
 from testing import verify_delta
 from testing.verify_delta import (
+    NOT_SELECTED,
     SURFACES,
+    UNAVAILABLE,
+    UNVERIFIED,
     FailureDelta,
     _failures_or_empty,
     changed_test_dirs,
@@ -56,6 +59,22 @@ class TestChangedTestDirs:
 
     def test_top_level_module_files(self):
         assert changed_test_dirs(["kornia/constants.py"]) == ["tests"]
+
+    def test_a_test_file_directly_under_tests_maps_to_itself(self):
+        # these have no tests/<package> directory to stand for them; they used to map to nothing, so
+        # a diff of only tests/test_import.py printed "nothing to verify" and exited 0.
+        assert changed_test_dirs(["tests/test_import.py"]) == ["tests/test_import.py"]
+        assert changed_test_dirs(["tests/smoke_test.py"]) == ["tests/smoke_test.py"]
+        assert changed_test_dirs(["tests/test_api_surface.py", "kornia/color/gray.py"]) == [
+            "tests/color",
+            "tests/test_api_surface.py",
+        ]
+
+    def test_a_shared_file_directly_under_tests_widens_to_everything(self):
+        # not a pytest target: tests/benchmark.py and tests/__init__.py are imported by the tree,
+        # so running them alone would collect nothing and report a pass over an unmeasured suite.
+        assert changed_test_dirs(["tests/benchmark.py"]) == ["tests"]
+        assert changed_test_dirs(["tests/__init__.py"]) == ["tests"]
 
     def test_a_module_without_a_test_dir_of_its_own_widens_to_everything(self, tmp_path: Path, capsys):
         # kornia/transpiler/ is the live example: mapping it to a non-existent tests/transpiler and
@@ -102,26 +121,47 @@ class TestDiffFailures:
 
 
 class TestRenderTable:
-    def test_lists_new_and_fixed_ids_and_marks_skipped_surfaces(self):
+    def test_lists_new_and_fixed_ids_and_marks_unrun_surfaces(self):
         out = render_table(
             [
                 ("cpu float32", FailureDelta(new=["x::t1"], fixed=[], unchanged=["x::t0"])),
-                ("mps float32", None),
+                ("mps float32", NOT_SELECTED),
             ]
         )
         assert "| cpu float32 | 1 | 0 | 1 |" in out
-        assert "| mps float32 | skipped |" in out
+        assert "| mps float32 | not selected |" in out
         assert "NEW [cpu float32] x::t1" in out
+
+    def test_a_surface_that_could_not_be_measured_is_not_labelled_like_one_nobody_asked_for(self):
+        # `skipped` used to cover both, so a crashed half-precision run and a `--only cpu float32`
+        # run printed the same cell -- and only the second of those is a green gate.
+        out = render_table(
+            [
+                ("cpu float32", FailureDelta()),
+                ("cpu float16,bfloat16,float64", UNVERIFIED),
+                ("mps float32", UNAVAILABLE),
+                ("inductor cpu float32", NOT_SELECTED),
+            ]
+        )
+        assert "| cpu float16,bfloat16,float64 | unverified |" in out
+        assert "| mps float32 | unavailable |" in out
+        assert "| inductor cpu float32 | not selected |" in out
+        assert "unverified: selected and available, but could not be measured -- not a pass" in out
+
+    def test_no_unverified_legend_when_every_selected_surface_ran(self):
+        assert "could not be measured" not in render_table(
+            [("cpu float32", FailureDelta()), ("mps float32", NOT_SELECTED)]
+        )
 
     def test_distinguishes_a_row_that_had_no_baseline_from_a_deselected_one(self):
         out = render_table(
             [
                 ("cpu float32", FailureDelta(new=["x::t1"], baseline=False)),
-                ("mps float32", None),
+                ("mps float32", NOT_SELECTED),
             ]
         )
         assert "| cpu float32 | 1* | 0 | 0 |" in out
-        assert "| mps float32 | skipped |" in out
+        assert "| mps float32 | not selected |" in out
         assert "* no baseline on the base revision" in out
 
     def test_no_legend_when_every_row_had_a_baseline(self):
@@ -299,7 +339,12 @@ def _reusable_worktree_run(repo: Path, **kwargs) -> _FakeRun:
     """A fake git in which the reused path is a detached worktree of ``repo`` and ``repo`` is primary."""
     defaults = {
         "stdout": str(repo / ".git"),  # both trees report the same .git common dir
-        "stdout_by_arg": {"--porcelain": f"worktree {repo}\nHEAD abc1234\nbranch refs/heads/main\n"},
+        # "status" is matched before "--porcelain" so that `git status --porcelain`, whose argv holds
+        # both tokens, answers "clean" rather than picking up the worktree listing below
+        "stdout_by_arg": {
+            "status": "",
+            "--porcelain": f"worktree {repo}\nHEAD abc1234\nbranch refs/heads/main\n",
+        },
         # `git symbolic-ref -q HEAD` exits non-zero exactly when HEAD is detached
         "fails_for": ("symbolic-ref",),
     }
@@ -329,6 +374,7 @@ class TestBaseRevisionIsResolvedOnce:
         fake = _reusable_worktree_run(
             repo,
             stdout_by_arg={
+                "status": "",
                 "--porcelain": f"worktree {repo}\nHEAD abc1234\n",
                 "HEAD~1": "deadbee",  # what the relative revision resolves to *in the repo*
             },
@@ -405,15 +451,31 @@ class TestEnsureMainWorktreeReuse:
             verify_delta._ensure_main_worktree(repo, "origin/main", repo, fetch=False)
         assert not any("checkout" in call for call in fake.calls)
 
+    def test_refuses_a_dirty_baseline_worktree_instead_of_carrying_the_edit_across(self, tmp_path: Path, monkeypatch):
+        # `git checkout --detach` keeps non-conflicting modifications rather than refusing them, so a
+        # leftover edit here is measured as part of the baseline and a real branch failure reads
+        # `unchanged`. Refuse rather than reset: the edit may be somebody's work.
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        wt.mkdir()
+        fake = _reusable_worktree_run(
+            repo,
+            stdout_by_arg={
+                "status": " M kornia/geometry/grid.py\n",
+                "--porcelain": f"worktree {repo}\nHEAD abc1234\nbranch refs/heads/main\n",
+            },
+        )
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        with pytest.raises(SystemExit, match="would contaminate the baseline"):
+            verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
+        assert not any("checkout" in call for call in fake.calls)
+
     def test_a_checkout_that_fails_is_reported_not_raised_raw(self, tmp_path: Path, monkeypatch):
         repo, wt = tmp_path / "repo", tmp_path / "wt"
         repo.mkdir()
         wt.mkdir()
         fake = _reusable_worktree_run(repo, fails_for=("symbolic-ref", "checkout"), stderr="local changes")
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
-        with pytest.raises(
-            SystemExit, match=rf"{re.escape(str(wt))} is dirty or cannot check out origin/main: local changes"
-        ):
+        with pytest.raises(SystemExit, match=rf"{re.escape(str(wt))} cannot check out origin/main: local changes"):
             verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
 
     def test_refuses_a_leftover_directory_that_belongs_to_another_repo(self, tmp_path: Path, monkeypatch):
@@ -446,12 +508,14 @@ class TestMainExitCodes:
     """0 verified clean, 1 something is newly failing, 2 nothing was verified at all."""
 
     @staticmethod
-    def _stub_repo(monkeypatch, tmp_path: Path, junit: str | None = None) -> _FakeRun:
+    def _stub_repo(monkeypatch, tmp_path: Path, junit: str | None = None, dirty: str = "") -> _FakeRun:
         def fake_git(repo, *cmd):
             if cmd[:2] == ("rev-parse", "--show-toplevel"):
                 return str(tmp_path)
             if cmd[0] == "diff":
                 return ""
+            if cmd[0] == "status":
+                return dirty
             return "abc1234"
 
         fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"), junit=junit)
@@ -489,7 +553,7 @@ class TestMainExitCodes:
         assert "| cpu float32 | 2* | 0 | 0 |" in out
         assert "* no baseline on the base revision" in out
         assert "NEW [cpu float32] tests.geometry.test_grid::test_b[cpu-float32]" in out
-        assert not any("| cpu float32 | skipped" in line for line in out.splitlines())
+        assert not any(f"| cpu float32 | {status}" in out for status in (UNVERIFIED, NOT_SELECTED, UNAVAILABLE))
         assert sum("pytest" in call for call in fake.calls) == 1  # only the branch side had anything to run
 
     def test_an_empty_baseline_with_a_clean_branch_still_passes(self, tmp_path: Path, monkeypatch, capsys):
@@ -547,8 +611,45 @@ class TestMainExitCodes:
         out = capsys.readouterr().out
         assert code == 2
         assert "the base tree did not finish, so this surface was not verified" in out
-        assert "| cpu float32 | skipped |" in out
+        assert "| cpu float32 | unverified |" in out
         assert "no baseline on origin/main" not in out
+
+    def test_one_surface_that_could_not_be_measured_sinks_a_run_the_others_passed(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        # The hole this closes: only the all-surfaces-unmeasured case used to be nonzero, so a clean
+        # cpu row carried the run while half precision -- which has no CI job at all -- never ran.
+        self._stub_repo(monkeypatch, tmp_path)
+        (tmp_path / "tests").mkdir()
+        monkeypatch.setattr(
+            verify_delta,
+            "_run_surface",
+            lambda tree, surface, tests, junit: set() if surface.name == "cpu float32" else None,
+        )
+        code = verify_delta.main(
+            self._argv(tmp_path, "--only", "cpu float32", "cpu float16,bfloat16,float64", "--tests", "tests")
+        )
+        out = capsys.readouterr().out
+        assert code == 2
+        assert "| cpu float32 | 0* | 0 | 0 |" in out  # this surface really was measured, and is clean
+        assert "| cpu float16,bfloat16,float64 | unverified |" in out
+        assert "not verified on cpu float16,bfloat16,float64; the gate is partial" in out
+
+    def test_an_uncommitted_change_is_refused_because_the_run_would_not_describe_head(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # The scope is `base...HEAD` but pytest runs the checkout, so an uncommitted fix makes a
+        # broken, pushable HEAD read green -- the gate would be measuring code nobody can review.
+        self._stub_repo(monkeypatch, tmp_path, dirty="?? tests/testing/scratch.py\n")
+        with pytest.raises(SystemExit, match="uncommitted changes, so the run would not describe HEAD"):
+            verify_delta.main(self._argv(tmp_path, "--only", "cpu float32", "--tests", "tests"))
+
+    def test_allow_dirty_runs_but_says_the_branch_side_is_the_working_tree(self, tmp_path: Path, monkeypatch, capsys):
+        self._stub_repo(monkeypatch, tmp_path, dirty=" M kornia/geometry/grid.py\n")
+        (tmp_path / "tests").mkdir()
+        code = verify_delta.main(self._argv(tmp_path, "--allow-dirty", "--only", "cpu float32", "--tests", "tests"))
+        assert code == 0
+        assert "+ uncommitted changes (--allow-dirty) vs origin/main" in capsys.readouterr().out
 
     def test_selecting_only_an_unavailable_surface_is_not_a_pass(self, tmp_path: Path, monkeypatch, capsys):
         import torch
@@ -559,6 +660,6 @@ class TestMainExitCodes:
         code = verify_delta.main(self._argv(tmp_path, "--only", "mps float32", "--tests", "tests"))
         assert code == 2
         out = capsys.readouterr().out
-        assert "| mps float32 | skipped |" in out
+        assert "| mps float32 | unavailable |" in out
         assert "nothing was verified" in out
         assert fake.calls == []

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -293,6 +293,17 @@ class TestRunSurface:
         # a fresh dict, so setting PYTHONPATH for the child never mutates this process's environment
         assert all(kwargs["env"] is not os.environ for kwargs in fake.kwargs)
 
+    def test_the_tree_is_prepended_to_an_existing_pythonpath(self, tmp_path: Path, monkeypatch):
+        extra = str(tmp_path / "support")
+        monkeypatch.setenv("PYTHONPATH", extra)
+        (tmp_path / "tests").mkdir()
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+
+        verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], tmp_path / "j.xml")
+
+        assert all(kwargs["env"]["PYTHONPATH"] == os.pathsep.join((str(tmp_path), extra)) for kwargs in fake.kwargs)
+
     def test_paths_absent_from_the_tree_are_dropped_not_fatal(self, tmp_path: Path, monkeypatch, capsys):
         # pytest aborts collection entirely when any argument path is missing, which would silently
         # empty the base tree's failure set and report every branch failure as new.
@@ -314,15 +325,26 @@ class TestRunSurface:
         assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], tmp_path / "j.xml") is None
         assert "pytest exited 4" in capsys.readouterr().out
 
-    @pytest.mark.parametrize("code", [0, 1, 5], ids=["all-passed", "tests-failed", "nothing-collected"])
+    @pytest.mark.parametrize("code", [0, 1], ids=["all-passed", "tests-failed"])
     def test_the_ordinary_pytest_exit_codes_still_report_failures(self, code, tmp_path: Path, monkeypatch):
-        # 0/1/5 are the three codes where an absent or empty report really does mean zero failures.
+        # 0/1 prove pytest ran; their junit failure set is a real measurement.
         (tmp_path / "tests").mkdir()
         fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"), junit=JUNIT, pytest_returncode=code)
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], tmp_path / "j.xml") == failing_ids(
             tmp_path / "j.xml"
         )
+
+    def test_nothing_collected_is_unverified_even_with_a_junit_report(self, tmp_path: Path, monkeypatch, capsys):
+        # In particular, the inductor surface can select no tests with its `-k` expression. That is
+        # not evidence of a clean compile surface, even if pytest writes an empty junit report.
+        (tmp_path / "tests").mkdir()
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"), junit=JUNIT, pytest_returncode=5)
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+
+        assert verify_delta._run_surface(tmp_path, SURFACES[3], ["tests"], tmp_path / "j.xml") is None
+        assert "pytest exited 5" in capsys.readouterr().out
+        assert not (tmp_path / "j.xml").exists()
 
     def test_no_present_paths_reports_that_it_could_not_run_not_that_it_passed(
         self, tmp_path: Path, monkeypatch, capsys
@@ -363,6 +385,13 @@ class TestEnsureMainWorktree:
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         verify_delta._ensure_main_worktree(tmp_path / "repo", "origin/main", tmp_path, fetch=True)
         assert ["git", "-C", str(tmp_path / "repo"), "fetch", "origin", "main"] in fake.calls
+
+    def test_a_fetch_failure_is_reported_with_the_no_fetch_escape_hatch(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun(fails_for=("fetch",), stderr="network unreachable")
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+
+        with pytest.raises(SystemExit, match=r"cannot fetch origin main: network unreachable;.*--no-fetch"):
+            verify_delta._ensure_main_worktree(tmp_path / "repo", "origin/main", tmp_path / "wt", fetch=True)
 
 
 class TestBaseRevisionIsResolvedOnce:
@@ -414,6 +443,13 @@ class TestAssertImportsFrom:
         fake = _FakeRun(stdout=str(tmp_path.parent / "elsewhere" / "kornia" / "__init__.py"))
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         with pytest.raises(SystemExit, match="refusing to test the wrong tree"):
+            verify_delta._assert_imports_from(tmp_path, {"PYTHONPATH": str(tmp_path)})
+
+    def test_an_import_failure_reports_stderr_without_a_traceback(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun(fails_for=("-c",), stderr="missing torch")
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+
+        with pytest.raises(SystemExit, match=r"could not import kornia.*missing torch"):
             verify_delta._assert_imports_from(tmp_path, {"PYTHONPATH": str(tmp_path)})
 
 
@@ -650,6 +686,30 @@ class TestMainExitCodes:
         code = verify_delta.main(self._argv(tmp_path, "--allow-dirty", "--only", "cpu float32", "--tests", "tests"))
         assert code == 0
         assert "+ uncommitted changes (--allow-dirty) vs origin/main" in capsys.readouterr().out
+
+    def test_allow_dirty_requires_explicit_tests_so_working_tree_changes_are_in_scope(
+        self, tmp_path: Path, monkeypatch
+    ):
+        self._stub_repo(monkeypatch, tmp_path, dirty="?? kornia/new_module.py\n")
+
+        with pytest.raises(SystemExit, match=r"--allow-dirty requires explicit --tests"):
+            verify_delta.main(self._argv(tmp_path, "--allow-dirty", "--only", "cpu float32"))
+
+    @pytest.mark.parametrize("target", ["/branch/tests", "../branch/tests", "tests/../../branch/tests"])
+    def test_explicit_tests_must_be_confined_relative_paths(self, target, tmp_path: Path, monkeypatch):
+        self._stub_repo(monkeypatch, tmp_path)
+
+        with pytest.raises(SystemExit, match="relative path confined to each checkout"):
+            verify_delta.main(self._argv(tmp_path, "--only", "cpu float32", "--tests", target))
+
+    def test_an_explicit_test_symlink_must_stay_inside_the_checkout(self, tmp_path: Path, monkeypatch):
+        self._stub_repo(monkeypatch, tmp_path)
+        outside = tmp_path.parent / f"{tmp_path.name}-outside"
+        outside.mkdir()
+        (tmp_path / "tests-link").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(SystemExit, match="resolves outside checkout"):
+            verify_delta.main(self._argv(tmp_path, "--only", "cpu float32", "--tests", "tests-link"))
 
     def test_selecting_only_an_unavailable_surface_is_not_a_pass(self, tmp_path: Path, monkeypatch, capsys):
         import torch

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -111,7 +111,7 @@ class TestRenderTable:
         )
         assert "| cpu float32 | 1 | 0 | 1 |" in out
         assert "| mps float32 | skipped |" in out
-        assert "NEW x::t1" in out
+        assert "NEW [cpu float32] x::t1" in out
 
     def test_distinguishes_a_row_that_had_no_baseline_from_a_deselected_one(self):
         out = render_table(
@@ -144,6 +144,11 @@ class TestSurfaces:
     def test_select_honours_only_flag(self):
         chosen = select_surfaces(parse_args(["--only", "cpu float32"]), mps_available=True)
         assert [s.name for s in chosen] == ["cpu float32"]
+
+    def test_surfaces_are_hashable(self):
+        # a frozen dataclass with a `dict` field is unhashable, so `surface in selected` works only
+        # because `selected` is a list; a set/dict of surfaces would raise TypeError at the callsite.
+        assert len(set(SURFACES)) == len(SURFACES)
 
     def test_tests_override(self):
         assert parse_args(["--tests", "tests/geometry", "tests/filters"]).tests == ["tests/geometry", "tests/filters"]
@@ -193,12 +198,14 @@ class _FakeRun:
         junit: str | None = None,
         fails_for: tuple[str, ...] = (),
         stderr: str = "",
+        pytest_returncode: int = 0,
     ):
         self.stdout = stdout
         self.stdout_by_arg = stdout_by_arg or {}  # first matching argv entry wins, e.g. keyed by a tree path
         self.junit = junit  # written to the --junitxml path, standing in for what pytest would report
         self.fails_for = fails_for  # argv entries whose command exits non-zero, e.g. "symbolic-ref"
         self.stderr = stderr
+        self.pytest_returncode = pytest_returncode  # what the pytest child exits with, e.g. 4 for a usage error
         self.calls: list[list[str]] = []
         self.kwargs: list[dict] = []
 
@@ -214,7 +221,8 @@ class _FakeRun:
         for key, stdout in self.stdout_by_arg.items():
             if key in argv:
                 return SimpleNamespace(stdout=stdout, returncode=0)
-        return SimpleNamespace(stdout=self.stdout, returncode=0)
+        returncode = self.pytest_returncode if "pytest" in argv else 0
+        return SimpleNamespace(stdout=self.stdout, returncode=returncode)
 
 
 class TestRunSurface:
@@ -257,6 +265,25 @@ class TestRunSurface:
         assert "tests/testing" not in pytest_argv
         assert "tests/testing" in capsys.readouterr().out
 
+    def test_a_pytest_that_could_not_start_is_unverified_not_clean(self, tmp_path: Path, monkeypatch, capsys):
+        # exit 4 (usage error: a broken conftest, a bad -k) leaves no junit behind, and reading that
+        # as an empty failing set turns a tree where nothing ran into a green row and a zero exit.
+        (tmp_path / "tests").mkdir()
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"), pytest_returncode=4)
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], tmp_path / "j.xml") is None
+        assert "pytest exited 4" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("code", [0, 1, 5], ids=["all-passed", "tests-failed", "nothing-collected"])
+    def test_the_ordinary_pytest_exit_codes_still_report_failures(self, code, tmp_path: Path, monkeypatch):
+        # 0/1/5 are the three codes where an absent or empty report really does mean zero failures.
+        (tmp_path / "tests").mkdir()
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"), junit=JUNIT, pytest_returncode=code)
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], tmp_path / "j.xml") == failing_ids(
+            tmp_path / "j.xml"
+        )
+
     def test_no_present_paths_reports_that_it_could_not_run_not_that_it_passed(
         self, tmp_path: Path, monkeypatch, capsys
     ):
@@ -293,6 +320,43 @@ class TestEnsureMainWorktree:
         assert ["git", "-C", str(tmp_path / "repo"), "fetch", "origin", "main"] in fake.calls
 
 
+class TestBaseRevisionIsResolvedOnce:
+    """A relative ``--base`` must not be re-resolved against the reused worktree's own HEAD."""
+
+    def test_the_reused_worktree_checks_out_the_repo_resolved_sha(self, tmp_path: Path, monkeypatch):
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        wt.mkdir()
+        fake = _reusable_worktree_run(
+            repo,
+            stdout_by_arg={
+                "--porcelain": f"worktree {repo}\nHEAD abc1234\n",
+                "HEAD~1": "deadbee",  # what the relative revision resolves to *in the repo*
+            },
+        )
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        assert verify_delta._ensure_main_worktree(repo, "HEAD~1", wt, fetch=False) == "deadbee"
+        checkout = [call for call in fake.calls if "checkout" in call][-1]
+        # `checkout --detach HEAD~1` inside the worktree would resolve against the PREVIOUS run's
+        # base and walk one commit further back on every invocation.
+        assert checkout[-1] == "deadbee"
+        assert "HEAD~1" not in checkout
+
+    def test_a_fresh_worktree_is_added_at_the_resolved_sha(self, tmp_path: Path, monkeypatch):
+        repo = tmp_path / "repo"
+        fake = _FakeRun(stdout="deadbee")
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        assert verify_delta._ensure_main_worktree(repo, "origin/main", tmp_path / "absent", fetch=False) == "deadbee"
+        assert [call for call in fake.calls if "worktree" in call][-1][-1] == "deadbee"
+
+
+class TestBaseRevisionCannotBeResolved:
+    def test_an_unresolvable_base_is_reported_not_raised_raw(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun(fails_for=("rev-parse",), stderr="unknown revision 'origin/nope'")
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        with pytest.raises(SystemExit, match="cannot resolve --base origin/nope"):
+            verify_delta._ensure_main_worktree(tmp_path / "repo", "origin/nope", tmp_path / "wt", fetch=False)
+
+
 class TestAssertImportsFrom:
     def test_accepts_kornia_imported_from_the_tree_under_test(self, tmp_path: Path, monkeypatch):
         fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
@@ -315,7 +379,9 @@ class TestEnsureMainWorktreeReuse:
         fake = _reusable_worktree_run(repo)
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
-        assert ["git", "-C", str(wt), "checkout", "--detach", "origin/main"] in fake.calls
+        # the checkout target is the sha `origin/main` resolved to in the repo, not the ref name
+        resolved = str(repo / ".git")  # this fake answers every rev-parse with the same stdout
+        assert ["git", "-C", str(wt), "checkout", "--detach", resolved] in fake.calls
 
     def test_refuses_a_worktree_whose_head_is_on_a_branch(self, tmp_path: Path, monkeypatch):
         # a linked worktree of this same repo, but with a branch checked out: detaching it at `base`
@@ -390,7 +456,7 @@ class TestMainExitCodes:
 
         fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"), junit=junit)
         monkeypatch.setattr(verify_delta, "_git", fake_git)
-        monkeypatch.setattr(verify_delta, "_ensure_main_worktree", lambda *a, **k: None)
+        monkeypatch.setattr(verify_delta, "_ensure_main_worktree", lambda *a, **k: "abc1234")
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         return fake
 
@@ -422,7 +488,7 @@ class TestMainExitCodes:
         assert "no baseline on origin/main for tests; branch failures there are unconditionally new" in out
         assert "| cpu float32 | 2* | 0 | 0 |" in out
         assert "* no baseline on the base revision" in out
-        assert "NEW tests.geometry.test_grid::test_b[cpu-float32]" in out
+        assert "NEW [cpu float32] tests.geometry.test_grid::test_b[cpu-float32]" in out
         assert not any("| cpu float32 | skipped" in line for line in out.splitlines())
         assert sum("pytest" in call for call in fake.calls) == 1  # only the branch side had anything to run
 
@@ -434,6 +500,55 @@ class TestMainExitCodes:
         assert code == 0
         assert "| cpu float32 | 0* | 0 | 0 |" in out
         assert "no baseline on origin/main" in out
+
+    def test_a_baseline_that_ran_fewer_paths_than_the_branch_is_marked_partial(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        # The base tree has tests/geometry but not tests/testing, so its failing set is missing a
+        # whole path. Without the `*` the row reads as a like-for-like comparison it never was.
+        self._stub_repo(monkeypatch, tmp_path, junit=JUNIT)
+        for tree in (tmp_path, tmp_path / "wt"):
+            (tree / "tests" / "geometry").mkdir(parents=True)
+        # the import guard answers from argv alone here, so it cannot tell the two trees apart;
+        # it has its own tests in TestAssertImportsFrom
+        monkeypatch.setattr(verify_delta, "_assert_imports_from", lambda tree, env: None)
+        (tmp_path / "tests" / "testing").mkdir()
+        code = verify_delta.main(
+            self._argv(tmp_path, "--only", "cpu float32", "--tests", "tests/geometry", "tests/testing")
+        )
+        out = capsys.readouterr().out
+        # both trees report the same failures here, so the delta is clean -- the `*` is the whole
+        # point: it says the comparison covered fewer paths on the base side than on the branch.
+        assert code == 0
+        assert "| cpu float32 | 0* | 0 | 2 |" in out
+        assert "* no baseline on the base revision" in out
+
+    def test_a_base_tree_where_pytest_could_not_run_is_not_an_empty_baseline(self, tmp_path: Path, monkeypatch, capsys):
+        # The base tree HAS the paths, so an unfinished pytest there is a failure to measure, not a
+        # legitimately empty baseline -- reading it as empty would report every branch failure NEW.
+        fake = self._stub_repo(monkeypatch, tmp_path, junit=JUNIT)
+        for tree in (tmp_path, tmp_path / "wt"):
+            (tree / "tests").mkdir(parents=True)
+        # the import guard answers from argv alone here, so it cannot tell the two trees apart;
+        # it has its own tests in TestAssertImportsFrom
+        monkeypatch.setattr(verify_delta, "_assert_imports_from", lambda tree, env: None)
+
+        real_run_surface = verify_delta._run_surface
+
+        def only_the_base_tree_crashes(tree, surface, tests, junit):
+            if tree == tmp_path / "wt":
+                fake.pytest_returncode = 3  # internal error on the base side only
+            result = real_run_surface(tree, surface, tests, junit)
+            fake.pytest_returncode = 0
+            return result
+
+        monkeypatch.setattr(verify_delta, "_run_surface", only_the_base_tree_crashes)
+        code = verify_delta.main(self._argv(tmp_path, "--only", "cpu float32", "--tests", "tests"))
+        out = capsys.readouterr().out
+        assert code == 2
+        assert "the base tree did not finish, so this surface was not verified" in out
+        assert "| cpu float32 | skipped |" in out
+        assert "no baseline on origin/main" not in out
 
     def test_selecting_only_an_unavailable_surface_is_not_a_pass(self, tmp_path: Path, monkeypatch, capsys):
         import torch

--- a/tests/testing/test_verify_delta.py
+++ b/tests/testing/test_verify_delta.py
@@ -160,14 +160,21 @@ class TestOnlyThroughATaskShell:
 
 
 class _FakeRun:
-    """Stand-in for ``subprocess.run`` that records argv and never launches anything."""
+    """Stand-in for ``subprocess.run`` that records argv and kwargs and never launches anything."""
 
-    def __init__(self, stdout: str = ""):
+    def __init__(self, stdout: str = "", stdout_by_arg: dict[str, str] | None = None):
         self.stdout = stdout
+        self.stdout_by_arg = stdout_by_arg or {}  # first matching argv entry wins, e.g. keyed by a tree path
         self.calls: list[list[str]] = []
+        self.kwargs: list[dict] = []
 
     def __call__(self, argv, **kwargs):
-        self.calls.append([str(a) for a in argv])
+        argv = [str(a) for a in argv]
+        self.calls.append(argv)
+        self.kwargs.append(kwargs)
+        for key, stdout in self.stdout_by_arg.items():
+            if key in argv:
+                return SimpleNamespace(stdout=stdout, returncode=0)
         return SimpleNamespace(stdout=self.stdout, returncode=0)
 
 
@@ -182,12 +189,20 @@ class TestRunSurface:
         assert not junit.exists()
         assert "no junit report" in capsys.readouterr().out
 
-    def test_the_tree_under_test_is_on_pythonpath(self, tmp_path: Path, monkeypatch):
+    def test_the_child_gets_the_tree_on_pythonpath_and_the_surface_env(self, tmp_path: Path, monkeypatch):
         fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         monkeypatch.delenv("PYTHONPATH", raising=False)
         (tmp_path / "tests").mkdir()
-        verify_delta._run_surface(tmp_path, SURFACES[0], ["tests"], tmp_path / "j.xml")
+        inductor = SURFACES[3]
+        verify_delta._run_surface(tmp_path, inductor, ["tests"], tmp_path / "j.xml")
+        assert len(fake.kwargs) == 2  # the import guard and pytest itself
+        for kwargs in fake.kwargs:
+            assert kwargs["cwd"] == tmp_path
+            assert kwargs["env"]["PYTHONPATH"] == str(tmp_path)
+            assert kwargs["env"]["KORNIA_TEST_DEVICE"] == "cpu"
+            assert kwargs["env"]["KORNIA_TEST_OPTIMIZER"] == "inductor"
+        assert fake.calls[-1][-3:] == ["-k", "dynamo or compile", "tests"]
         assert os.environ.get("PYTHONPATH") is None  # the child env is not leaked into this process
 
     def test_paths_absent_from_the_tree_are_dropped_not_fatal(self, tmp_path: Path, monkeypatch, capsys):
@@ -202,11 +217,15 @@ class TestRunSurface:
         assert "tests/testing" not in pytest_argv
         assert "tests/testing" in capsys.readouterr().out
 
-    def test_no_present_paths_means_no_run_and_no_failures(self, tmp_path: Path, monkeypatch):
+    def test_no_present_paths_reports_that_it_could_not_run_not_that_it_passed(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
         fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
-        assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests/testing"], tmp_path / "j.xml") == set()
-        assert not any("pytest" in call for call in fake.calls)
+        # `set()` here would read as "this tree has no failures", which is a pass it never measured.
+        assert verify_delta._run_surface(tmp_path, SURFACES[0], ["tests/testing"], tmp_path / "j.xml") is None
+        assert fake.calls == []
+        assert "nothing to run" in capsys.readouterr().out
 
 
 class TestEnsureMainWorktree:
@@ -221,3 +240,108 @@ class TestEnsureMainWorktree:
         monkeypatch.setattr(verify_delta.subprocess, "run", fake)
         verify_delta._ensure_main_worktree(tmp_path, "origin/main", tmp_path, fetch=True)
         assert ["git", "-C", str(tmp_path), "fetch", "origin", "main"] in fake.calls
+
+
+class TestAssertImportsFrom:
+    def test_accepts_kornia_imported_from_the_tree_under_test(self, tmp_path: Path, monkeypatch):
+        fake = _FakeRun(stdout=str(tmp_path / "kornia" / "__init__.py"))
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        verify_delta._assert_imports_from(tmp_path, {"PYTHONPATH": str(tmp_path)})  # does not raise
+
+    def test_rejects_kornia_imported_from_another_checkout(self, tmp_path: Path, monkeypatch):
+        import pytest
+
+        # the shared .venv re-points its editable kornia install to whichever tree ran uv last
+        fake = _FakeRun(stdout=str(tmp_path.parent / "elsewhere" / "kornia" / "__init__.py"))
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        with pytest.raises(SystemExit, match="refusing to test the wrong tree"):
+            verify_delta._assert_imports_from(tmp_path, {"PYTHONPATH": str(tmp_path)})
+
+
+class TestEnsureMainWorktreeReuse:
+    def test_reuses_a_path_that_is_a_worktree_of_this_repo(self, tmp_path: Path, monkeypatch):
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        repo.mkdir()
+        wt.mkdir()
+        fake = _FakeRun(stdout=str(repo / ".git"))  # both trees share one .git common dir
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
+        assert ["git", "-C", str(wt), "checkout", "--detach", "origin/main"] in fake.calls
+
+    def test_refuses_a_leftover_directory_that_belongs_to_another_repo(self, tmp_path: Path, monkeypatch):
+        import pytest
+
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        repo.mkdir()
+        wt.mkdir()
+        # `git -C <plain dir>` walks up to whatever repo encloses it, so the checkout would land there
+        fake = _FakeRun(stdout_by_arg={str(repo): str(repo / ".git"), str(wt): str(tmp_path / "other" / ".git")})
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        with pytest.raises(SystemExit, match="is not a worktree of"):
+            verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
+        assert not any("checkout" in call for call in fake.calls)
+
+    def test_refuses_a_path_that_is_not_in_any_repository(self, tmp_path: Path, monkeypatch):
+        import pytest
+
+        repo, wt = tmp_path / "repo", tmp_path / "wt"
+        repo.mkdir()
+        wt.mkdir()
+
+        def explode(argv, **kwargs):
+            if str(wt) in [str(a) for a in argv]:
+                raise verify_delta.subprocess.CalledProcessError(128, argv)
+            return SimpleNamespace(stdout=str(repo / ".git"), returncode=0)
+
+        monkeypatch.setattr(verify_delta.subprocess, "run", explode)
+        with pytest.raises(SystemExit, match="is not a worktree of"):
+            verify_delta._ensure_main_worktree(repo, "origin/main", wt, fetch=False)
+
+
+class TestMainRefusesAVacuousPass:
+    """Exiting 0 without having compared anything would make the gate useless."""
+
+    @staticmethod
+    def _stub_repo(monkeypatch, tmp_path: Path) -> _FakeRun:
+        def fake_git(repo, *cmd):
+            if cmd[:2] == ("rev-parse", "--show-toplevel"):
+                return str(tmp_path)
+            if cmd[0] == "diff":
+                return ""
+            return "abc1234"
+
+        fake = _FakeRun()
+        monkeypatch.setattr(verify_delta, "_git", fake_git)
+        monkeypatch.setattr(verify_delta, "_ensure_main_worktree", lambda *a, **k: None)
+        monkeypatch.setattr(verify_delta.subprocess, "run", fake)
+        return fake
+
+    def _argv(self, tmp_path: Path, *extra: str) -> list[str]:
+        return [
+            "--no-fetch",
+            "--main-worktree",
+            str(tmp_path / "wt"),
+            "--out",
+            str(tmp_path / "out"),
+            *extra,
+        ]
+
+    def test_a_test_path_on_neither_tree_is_not_a_pass(self, tmp_path: Path, monkeypatch, capsys):
+        fake = self._stub_repo(monkeypatch, tmp_path)
+        code = verify_delta.main(self._argv(tmp_path, "--only", "cpu float32", "--tests", "tests/gone"))
+        assert code == 2
+        assert "nothing was verified" in capsys.readouterr().out
+        assert fake.calls == []
+
+    def test_selecting_only_an_unavailable_surface_is_not_a_pass(self, tmp_path: Path, monkeypatch, capsys):
+        import torch
+
+        fake = self._stub_repo(monkeypatch, tmp_path)
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+        (tmp_path / "tests").mkdir()
+        code = verify_delta.main(self._argv(tmp_path, "--only", "mps float32", "--tests", "tests"))
+        assert code == 2
+        out = capsys.readouterr().out
+        assert "| mps float32 | skipped |" in out
+        assert "nothing was verified" in out
+        assert fake.calls == []


### PR DESCRIPTION
## Why

Classifying every review finding on kornia#4006 by origin (not by reviewer) showed the fix loop
itself was the defect generator: of ~24 actionable findings after review round 2, ~20 were
introduced by an earlier fix commit on the same PR, not present in the original diff. The same
half-precision rounding bug — a size cast into fp16/bf16 before a division, under
`torch.jit.trace`/`torch.compile` — was "fixed" three times across waves 5, 8, and 9, each one
layer deeper, while two regression tests (sizes 257 and 3001) passed vacuously even though both
authors knew the rounding rule. Half-precision and MPS have no CI job, so nothing catches this
class before a human reviewer does. This PR puts the knowledge into code: three test helpers that
make the vacuous case and the eager/capture divergence structurally hard to write, plus a tool
that gates a push against `origin/main` on exactly the surfaces CI does not cover.

## What

Three helpers in `testing/precision.py`, exported from `testing/__init__.py` alongside
`BaseTester`:

- `unrepresentable_sizes(dtype, *, lo=2, hi=4096) -> list[int]` — sizes `n` in `[lo, hi]` where `n`
  or `n - 1` is not exact in `dtype`; empty for float32/float64.
- `assert_capture_matches_eager(fn, make_inputs, *, sizes, device, dtype, capture)` — asserts
  `torch.equal` (byte-equality, not `allclose`) between eager and `torch.jit.trace` /
  `torch.compile(fullgraph=True, dynamic=True)` outputs, per size; reports the first disagreeing
  size and max abs diff; skips cleanly when the backend lacks the capture mode (MPS + inductor).
- `assert_degenerate_path_parity(fn, full_kwargs, degenerate_kwargs, bad_inputs)` — asserts an
  empty/singleton code path raises exactly what the full path raises, for the same invalid input.

Historical negatives in `tests/testing/_historical.py` vendor the exact `torch.jit.is_tracing()`
bodies from three kornia#4006 commits as small local functions, so `assert_capture_matches_eager`
has a deterministic proof it would have caught each wave:

- `create_meshgrid_9ed891c5` (wave 5) — divisor built directly in the coordinate dtype.
- `create_meshgrid_32ab0eeb` (wave 8) — float32 arithmetic, but the divisor is cast down first.
- `normal_transform_pixel_1522441d` (wave 9) — promotion keyed off the `dtype` *argument*, so
  `dtype=None` under a half default dtype still rounds the size.

`pixi run verify-delta` (`testing/verify_delta.py`, run as `python -m testing.verify_delta`) diffs
**failing-test sets**, never counts, between the branch and `origin/main` on four surfaces: `cpu
float32`, `cpu float16,bfloat16,float64`, `mps float32` (skipped if unavailable), and `inductor cpu
float32` (`-k "dynamo or compile"`). Exit codes: `0` = no new failures, `1` = some surface has a
`new` id, `2` = nothing was verified at all (no surface ran pytest on the branch side — a typo'd
`--tests` path or an unavailable `--only` surface), which is a failure state, not a pass. A row
with no baseline on `origin/main` (a path that only exists on the branch) prints its new-failure
count as `N*` with a legend line, rather than silently using an empty baseline. Test-directory
selection derives from `git diff origin/main...HEAD --name-only` by default; pass `--tests
tests/<module>` / `--only "<surface>"` **after `--`** to bound it (pixi forwards `--` literally and
its task shell re-splits the string, so `parse_args` strips a leading `--` and `--only` tokens are
rejoined longest-match-first against the four surface names). It maintains two sibling directories
next to the repo so reruns are fast and nothing pollutes the source tree: a detached worktree of
`origin/main` at `../.<repo>-verify-main`, and junit/summary output at
`../.<repo>-verify-delta` (both overridable, `--main-worktree` and `--out`). Before trusting either
tree's result, `_assert_imports_from` asserts `import kornia` resolves inside the tree actually
under test — the `.venv` here is shared/symlinked across worktrees, and `uv run` re-points the
editable install to whichever tree ran last, so without this guard a stale import would silently
verify the wrong code.

## Design notes

- **`testing/precision.py` imports `pytest`.** So does `testing/base.py` already — `pytest.skip`
  is how `assert_capture_matches_eager` cleanly skips the compile-capture sweep on MPS. This
  follows the existing convention rather than introducing a parallel "no pytest in `testing/`"
  rule.
- **The tool lives in `testing/`, not a new top-level `scripts/`.** It ships as
  `testing/verify_delta.py`, invoked via `python -m testing.verify_delta`, so its pure functions
  (`changed_test_dirs`, `failing_ids`, `diff_failures`, `render_table`) are unit-tested the same
  way as the rest of `testing/` — from `tests/testing/`, with subprocess and git calls behind a
  recording fake, no real pytest/git process launched by the test suite itself.
- **Cost of touching `testing/`, `pyproject.toml`, or `pixi.toml`.** `changed_test_dirs` treats
  changes under `testing/`, `tests/conftest.py`, `conftest.py`, `pyproject.toml`, or `pixi.toml` as
  affecting everything and widens the run to the whole `tests/` tree instead of a narrow
  `tests/<module>` mapping. That is deliberate — these files are load-bearing for every test — but
  it means the no-argument invocation on a PR like this one costs roughly 20 minutes per surface,
  up to an hour or more across all four; use `--tests`/`--only` to scope while iterating.
- **`changed_test_dirs` assumes test locality.** The `kornia/<mod>` → `tests/<mod>` mapping is
  right for the common case, but a `kornia/geometry` change routinely breaks `tests/augmentation`,
  so the gate's promise ("zero `new` failures") is narrower than it sounds under the default
  scoping. For a cross-cutting change, pass `--tests tests` and take the full cost.

## Verification

Six commands from the pre-`verify_delta` snapshot (`tests/testing` only, run from
`/Users/oldufo/dev/kornia-review-skills`):

| # | Command | Result |
|---|---|---|
| 1 | `uv run pre-commit run --all-files` | all 13 hooks passed |
| 2 | `uv run pytest tests/testing -q --dtype=float32,float64,float16,bfloat16` | 21 passed (22 collected, 1 compile test deselected — `KORNIA_TEST_OPTIMIZER` unset) |
| 3 | `KORNIA_TEST_OPTIMIZER=inductor uv run pytest tests/testing -q -k "compile or dynamo"` | 1 passed, 18 deselected |
| 4 | `uv run pytest tests/testing -q --device=mps --dtype=float32` | 17 passed, 1 skipped (documented: `warp_affine`'s empty-dsize path crashes `F.grid_sample` on MPS) |
| 5 | `uv run pytest --doctest-modules testing/precision.py -q` | 1 passed |
| 6 | `uvx ty@0.0.9 check kornia testing` | all checks passed |

Final state, after `verify_delta.py` and its tests landed:

```
$ uv run pytest tests/testing -q --dtype=float32,bfloat16,float16
collected 64 items
63 passed in 0.68s
```

(64th is the `compile` test, deselected because `KORNIA_TEST_OPTIMIZER` is unset — rule 7 of
`kornia-precision-testing` working as documented.)

`pixi run verify-delta` run on this branch against itself (the tool verifying its own change):

| run | scope | wall time | new / fixed / unchanged (all 4 rows) |
|---|---|---|---|
| `-- --only "cpu float32"` (`efb4c4b6` vs `9e45dddc`) | full suite (`testing/` widens) | 19:55.68 | cpu float32 `0/0/0`; other three surfaces `skipped` |
| `--tests tests/testing tests/geometry` (`efb4c4b6` vs `9e45dddc`) | bounded, all 4 surfaces | 3:27.42 | cpu float32 `0/0/0`; cpu half/f64 `0/0/697`; mps float32 `0/0/25`; inductor `0/0/0` |
| `-- --tests tests/testing tests/geometry` (`032a38f5` vs `9e45dddc`, final PR-B-adjacent state) | bounded, all 4 surfaces | 3m31s (211s) | cpu float32 `0/0/0`; cpu half/f64 `0/0/697`; mps float32 `0/0/25`; inductor `0/0/0` |

The 697 half-precision and 25 MPS failures are `unchanged` — present identically on
`origin/main` — which is the argument for the tool: a count-based or "did the suite go green"
check would have reported this branch as breaking 722 tests it never touched. `new = 0` on every
row in both bounded runs; exit 0. (A pre-fix version of the runner, exercised the same way, exited
1 with `new = 723` on the same invocation — a false positive from pytest aborting collection
entirely when `tests/testing` does not exist on `origin/main` — fixed before this state.)

## Found while building

Two real, reportable gaps in kornia surfaced the first time the parity helper was pointed at
`warp_affine`'s degenerate path — filed rather than fixed here, since this PR only ships test
infrastructure:

- kornia#4031 — `warp_affine`'s empty-dsize path does not reject a non-floating `M` the way the
  full path does (an integral `src` should raise, and doesn't).
- kornia#4032 — `warp_affine`'s empty-dsize path crashes on MPS (`F.grid_sample` asserts on a
  zero-sized grid) rather than returning an empty tensor.

kornia#4033 — follow-up: add a nightly CI job covering half-precision and MPS, using
`verify_delta`'s four surfaces. Explicitly out of scope here per the design's non-goals; this PR
only adds the manual gate.

## Relates to

Relates to #4006 (the wave analysis that motivated this PR; not closed by it — #4006 itself was
merged separately).

---

## Evaluation

The helpers and `verify-delta` were used by the with-skill arm of a paired agent evaluation (three historical #4006 review rounds, Opus 5 and Sonnet 5, with and without the skills from #4035). Relevant to this PR: `assert_capture_matches_eager` + `unrepresentable_sizes` distinguished a correct fix from the historical one in every graded run (the without-skill Sonnet run wrote the wave-8 divisor cast verbatim and its own 257-only test passed on it; the sweep test fails 4 ways on that tree), and `verify-delta` ran end to end from a pre-fix worktree in 5 runs (exit 0/1/2 semantics and the `N*` row all exercised). Full tables and the confound handling are in #4035's description.

Posted on behalf of @ducha-aiki by Claude (Fable 5, Opus 5).
