### PR TITLE
fix(geometry): build the meshgrid pixel ramp with arange in eager too

### DIFF
--- a/kornia/geometry/grid.py
+++ b/kornia/geometry/grid.py
@@ -67,16 +67,17 @@ def create_meshgrid(
                   [1., 1.]]]])
 
     """
-    # Build the pixel ramp with ``arange`` in both eager and capture. ``linspace`` over
-    # ``(0, size - 1, size)`` and ``arange(size)`` are bitwise equal at float32/float64, but
-    # ``linspace`` rounds its endpoint into the coordinate dtype and fills the upper half of the
-    # ramp backwards from that rounded value, landing one ulp off the correctly rounded column
-    # index at float16/bfloat16 -- from width 258 in bfloat16 and 2050 in float16. Inductor lowers
-    # the same call to a per-index computation that rounds correctly, so eager and compiled grids
-    # disagreed by up to one ulp of the width. ``arange`` also retains the dynamic output length
-    # under export, where ``linspace`` specializes symbolic ``steps``. Match ``linspace``'s default
-    # floating dtype when none is given -- read off an empty tensor rather than via
-    # ``torch.get_default_dtype()``, for which TorchScript has no builtin.
+    # Build the pixel ramp with ``arange`` in both eager and capture. ``linspace`` rounds its
+    # endpoint into the coordinate dtype first and fills the upper half of the ramp backwards from
+    # that rounded value, so its step is exactly 1 only while ``size - 1`` is an exactly
+    # representable integer -- ``size <= 2 ** p + 1`` for a ``p``-bit significand. Past that it
+    # lands one ulp off the correctly rounded column index. The bound is 257 in bfloat16 and 2049
+    # in float16, and 2 ** 24 + 1 / 2 ** 53 + 1 in float32/float64, so no non-half grid can move.
+    # Inductor lowers the same call to a per-index computation that rounds correctly, so eager and
+    # compiled grids disagreed by up to one ulp of the width. ``arange`` also retains the dynamic
+    # output length under export, where ``linspace`` specializes symbolic ``steps``. Match
+    # ``linspace``'s default floating dtype when none is given -- read off an empty tensor rather
+    # than via ``torch.get_default_dtype()``, for which TorchScript has no builtin.
     ramp_dtype = dtype if dtype is not None else torch.empty(0).dtype
     xs = torch.arange(width, device=device, dtype=ramp_dtype)
     ys = torch.arange(height, device=device, dtype=ramp_dtype)

--- a/kornia/geometry/grid.py
+++ b/kornia/geometry/grid.py
@@ -67,15 +67,19 @@ def create_meshgrid(
                   [1., 1.]]]])
 
     """
-    if not torch.jit.is_scripting() and is_compiling():
-        # ``linspace`` specializes symbolic ``steps`` under export; ``arange`` retains the
-        # dynamic output length. Match ``linspace``'s default floating dtype when none is given.
-        arange_dtype = dtype if dtype is not None else torch.get_default_dtype()
-        xs = torch.arange(width, device=device, dtype=arange_dtype)
-        ys = torch.arange(height, device=device, dtype=arange_dtype)
-    else:
-        xs = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
-        ys = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
+    # Build the pixel ramp with ``arange`` in both eager and capture. ``linspace`` over
+    # ``(0, size - 1, size)`` and ``arange(size)`` are bitwise equal at float32/float64, but
+    # ``linspace`` rounds its endpoint into the coordinate dtype and fills the upper half of the
+    # ramp backwards from that rounded value, landing one ulp off the correctly rounded column
+    # index at float16/bfloat16 -- from width 258 in bfloat16 and 2050 in float16. Inductor lowers
+    # the same call to a per-index computation that rounds correctly, so eager and compiled grids
+    # disagreed by up to one ulp of the width. ``arange`` also retains the dynamic output length
+    # under export, where ``linspace`` specializes symbolic ``steps``. Match ``linspace``'s default
+    # floating dtype when none is given -- read off an empty tensor rather than via
+    # ``torch.get_default_dtype()``, for which TorchScript has no builtin.
+    ramp_dtype = dtype if dtype is not None else torch.empty(0).dtype
+    xs = torch.arange(width, device=device, dtype=ramp_dtype)
+    ys = torch.arange(height, device=device, dtype=ramp_dtype)
     # Fix TracerWarning
     # Note: keeping this formula inline avoids the extra tensors and shape checks incurred by
     #       normalize_pixel_coordinates. The two paths use the same singleton-centre policy.
@@ -146,15 +150,12 @@ def create_meshgrid3d(
         grid tensor with shape :math:`(1, D, H, W, 3)`.
 
     """
-    if not torch.jit.is_scripting() and is_compiling():
-        arange_dtype = dtype if dtype is not None else torch.get_default_dtype()
-        xs = torch.arange(width, device=device, dtype=arange_dtype)
-        ys = torch.arange(height, device=device, dtype=arange_dtype)
-        zs = torch.arange(depth, device=device, dtype=arange_dtype)
-    else:
-        xs = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
-        ys = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
-        zs = torch.linspace(0, depth - 1, depth, device=device, dtype=dtype)
+    # See ``create_meshgrid``: ``arange`` keeps eager and captured pixel ramps identical at
+    # float16/bfloat16, and keeps the output length dynamic under export.
+    ramp_dtype = dtype if dtype is not None else torch.empty(0).dtype
+    xs = torch.arange(width, device=device, dtype=ramp_dtype)
+    ys = torch.arange(height, device=device, dtype=ramp_dtype)
+    zs = torch.arange(depth, device=device, dtype=ramp_dtype)
     # Fix TracerWarning
     if normalized_coordinates:
         if not torch.jit.is_scripting() and (torch.jit.is_tracing() or is_compiling()):

--- a/kornia/geometry/grid.py
+++ b/kornia/geometry/grid.py
@@ -77,8 +77,11 @@ def create_meshgrid(
     # compiled grids disagreed by up to one ulp of the width. ``arange`` also retains the dynamic
     # output length under export, where ``linspace`` specializes symbolic ``steps``. Match
     # ``linspace``'s default floating dtype when none is given -- read off an empty tensor rather
-    # than via ``torch.get_default_dtype()``, for which TorchScript has no builtin.
-    ramp_dtype = dtype if dtype is not None else torch.empty(0).dtype
+    # than via ``torch.get_default_dtype()``, for which TorchScript has no builtin. The empty
+    # tensor takes ``device`` so that the read depends on an argument: a no-input factory call is
+    # constant-folded by TorchScript's optimizing executor after the first run, which would freeze
+    # the ramp at whatever the default dtype happened to be on that call.
+    ramp_dtype = dtype if dtype is not None else torch.empty(0, device=device).dtype
     xs = torch.arange(width, device=device, dtype=ramp_dtype)
     ys = torch.arange(height, device=device, dtype=ramp_dtype)
     # Fix TracerWarning
@@ -152,8 +155,9 @@ def create_meshgrid3d(
 
     """
     # See ``create_meshgrid``: ``arange`` keeps eager and captured pixel ramps identical at
-    # float16/bfloat16, and keeps the output length dynamic under export.
-    ramp_dtype = dtype if dtype is not None else torch.empty(0).dtype
+    # float16/bfloat16, keeps the output length dynamic under export, and reads the default dtype
+    # off a ``device``-bearing empty tensor so TorchScript cannot constant-fold the read.
+    ramp_dtype = dtype if dtype is not None else torch.empty(0, device=device).dtype
     xs = torch.arange(width, device=device, dtype=ramp_dtype)
     ys = torch.arange(height, device=device, dtype=ramp_dtype)
     zs = torch.arange(depth, device=device, dtype=ramp_dtype)

--- a/tests/geometry/test_grid.py
+++ b/tests/geometry/test_grid.py
@@ -225,6 +225,35 @@ def test_pixel_meshgrid_default_dtype_matches_compile(is_3d, default_dtype):
     assert_close(actual, expected, atol=0.0, rtol=0.0)
 
 
+@pytest.mark.parametrize("is_3d", [False, True], ids=["2d", "3d"])
+def test_pixel_meshgrid_scripted_ramp_follows_the_runtime_default_dtype(is_3d):
+    """A scripted grid with no explicit dtype must track ``torch.get_default_dtype()`` per call.
+
+    The default dtype is read off an empty tensor because TorchScript has no
+    ``aten::get_default_dtype``. A factory call with no graph input is constant-folded by
+    TorchScript's optimizing executor once profiling completes, which froze the ramp at whatever
+    the default happened to be on the first call -- ``linspace(0, size - 1, size)`` never folded
+    because it consumed ``size``. Passing ``device`` restores that dependency. The first call here
+    is deliberately made under a *different* default from the assertion, since the freeze only
+    shows from the second call onwards. No "compile"/"dynamo" in the name on purpose: this is
+    plain TorchScript and must run in the ordinary test jobs, which deselect those by name.
+    """
+    op = kornia.geometry.create_meshgrid3d if is_3d else kornia.geometry.create_meshgrid
+    args = (2, 3, 4) if is_3d else (3, 4)
+    scripted = torch.jit.script(op)
+
+    previous_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.float32)
+        assert scripted(*args).dtype == torch.float32
+
+        torch.set_default_dtype(torch.float64)
+        assert scripted(*args).dtype == torch.float64 == op(*args).dtype
+        assert scripted(*args).dtype == torch.float64, "the scripted ramp froze its default dtype"
+    finally:
+        torch.set_default_dtype(previous_dtype)
+
+
 @pytest.mark.parametrize("grid_dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("is_3d", [False, True], ids=["2d", "3d"])
 def test_pixel_meshgrid_half_dtype_matches_compile(is_3d, grid_dtype):

--- a/tests/geometry/test_grid.py
+++ b/tests/geometry/test_grid.py
@@ -225,6 +225,40 @@ def test_pixel_meshgrid_default_dtype_matches_compile(is_3d, default_dtype):
     assert_close(actual, expected, atol=0.0, rtol=0.0)
 
 
+@pytest.mark.parametrize("grid_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("is_3d", [False, True], ids=["2d", "3d"])
+def test_pixel_meshgrid_half_dtype_matches_compile(is_3d, grid_dtype):
+    """A half-precision pixel ramp must not change when the grid is built under ``torch.compile``.
+
+    ``linspace`` rounds its endpoint into the coordinate dtype and fills the upper half of the ramp
+    backwards from that rounded value, so it lands one ulp off the correctly rounded column index --
+    ``linspace(0, 299, 300)`` gives 258 at index 257 where bfloat16 holds 257 as 256. Inductor lowers
+    the same call to a per-index computation that rounds correctly, so the eager and compiled grids
+    disagreed by up to one ulp of the width. The sizes here are the first at which the two diverge:
+    258 for bfloat16 and 2050 for float16.
+    """
+
+    class MeshGrid(torch.nn.Module):
+        def forward(self, image):
+            if is_3d:
+                return kornia.geometry.create_meshgrid3d(
+                    image.shape[-3], image.shape[-2], image.shape[-1], False, device=image.device, dtype=image.dtype
+                )
+            return kornia.geometry.create_meshgrid(
+                image.shape[-2], image.shape[-1], False, device=image.device, dtype=image.dtype
+            )
+
+    size = 258 if grid_dtype == torch.bfloat16 else 2050
+    shape = (1, 1, 2, 2, size) if is_3d else (1, 1, 2, size)
+    image = torch.zeros(*shape, dtype=grid_dtype)
+
+    expected = MeshGrid()(image)
+    actual = torch.compile(MeshGrid(), fullgraph=True)(image)
+
+    assert actual.dtype == expected.dtype == grid_dtype
+    assert_close(actual, expected, atol=0.0, rtol=0.0)
+
+
 def test_create_meshgrid3d(device, dtype):
     depth, height, width = 5, 4, 6
     normalized_coordinates = False


### PR DESCRIPTION
## What does this pull request do?

`create_meshgrid` / `create_meshgrid3d` built the pixel ramp with `torch.linspace` in eager but with
`torch.arange` under capture (the branch added in #4006). The two do not agree at
`float16`/`bfloat16`, so a half-precision grid silently changed the moment the model was wrapped in
`torch.compile`. This builds the ramp with `arange` on both paths.

### Root cause

`torch.linspace` rounds its endpoint into the output dtype *first*, then fills the upper half of the
ramp backwards from that rounded value. Reconstructing ATen's CPU kernel as an executable model and
checking it bitwise against `torch.linspace` across 705 sizes at bfloat16, float16 and float32 gives
0 mismatches:

```
end    = dtype(end)                          # endpoint rounded into the output dtype
step   = (end - start) / dtype(steps - 1)
out[i] = start + step*i           for i <  steps//2   (ascending)
out[i] = end   - step*(steps-1-i) for i >= steps//2   (descending from the rounded end)
```

For `linspace(0, 299, 300, bfloat16)`: `299` is an exact tie between 298 and 300, so ties-to-even
makes `bfloat16(299) = 300`. `halfway = 150`, so index 257 takes the descending branch and yields
`300 - 42 = 258`, where the correctly rounded value is 256. Inductor lowers the same call to a
per-index computation that rounds correctly, giving 256. At bfloat16 n=300 every one of the 128
wrong values sits in the descending half; the ascending half is exact.

```
torch.tensor(257.0, dtype=torch.bfloat16)               -> 256.0   # correctly rounded
torch.linspace(0, 299, 300, dtype=torch.bfloat16)[257]  -> 258.0   # eager
torch.arange(300,          dtype=torch.bfloat16)[257]   -> 256.0   # what inductor produces
```

First divergent width is **258** for bfloat16 and **2050** for float16.

### Impact

The error is one ulp of the image width, so it doubles every binade rather than staying at the
"2 px" quoted for width 300 in the issue:

| width | bf16 ulp | max grid error |
|------:|---------:|---------------:|
|   300 |        2 |         2.0 px |
|   600 |        4 |         4.0 px |
|  1200 |        8 |         8.0 px |
|  2400 |       16 |        16.0 px |

With `normalized_coordinates=True` the same divergence is worth ~2.34 px at bfloat16 w=300 and
~2.93 px at float16 w=3000 once converted back to sampling positions. It reaches `homography_warp` /
`HomographyWarper`, `warp_image_tps`, `undistort_image` and `camera/stereo.py`, all of which pass
`image.dtype` straight into `create_meshgrid`.

This is **pre-existing**, not introduced by #4006 -- checking out `3c1d7265`, where both paths call
`linspace`, reproduces byte-identical values.

### The change

`arange` on both paths. It is a **no-op at float32/float64**: `linspace(0, n-1, n)` and `arange(n)`
are bitwise equal for every size in `range(2, 20001)` at both dtypes, so no non-half result moves.
At half precision it moves the eager values onto the *correctly rounded* side (258 to 256, 2050 to
2048), closing the gap from the accurate direction. It is still an eager numerical change at
float16/bfloat16 above those widths and probably deserves a release note.

The default floating dtype is read as `torch.empty(0).dtype` rather than `torch.get_default_dtype()`
because TorchScript has no builtin for the latter -- with `get_default_dtype()` on the unconditional
path, `TestWarpImage::test_jit` fails with `Unknown builtin op: aten::get_default_dtype`.

### Known remaining gaps

Two things this PR deliberately does **not** close. Both are pre-existing and independent of #4006,
which is why the issue is referenced rather than closed:

1. **`normalized_coordinates=True` still diverges by ~1 ulp.** Eager evaluates
   `(xs / (width - 1) - 0.5) * 2` as three separate half-precision ops, rounding after each;
   inductor fuses the chain, computes it in fp32 and rounds once on store. Residual after this fix:
   0.01171875 (bfloat16, w=300) and 0.001220703125 (float16, w=3000). Confirmed independent of
   #4006 by applying this same `arange` change on top of `3c1d7265`, where both paths share a single
   normalization expression -- it still diverges there (0.0078125 / 0.0009765625). Fixing it likely
   means doing the normalization in fp32 and casting once on both paths; happy to follow up in a
   separate PR if that is the direction you want.

2. **CPU `torch.arange` at bfloat16 is itself wrong above index 4112**, returning 4096 where 4128 is
   correct, first visible at width 4128. So on CPU the eager/compiled gap closes only up to width
   4127 at bfloat16 -- still far better than 257 today (450 of 6000 entries differ at n=6000, versus
   1909 with `linspace`). CUDA `arange` is correctly rounded across all 65536 indices checked, so on
   GPU the fix is complete at every size tested. This looks like an upstream PyTorch CPU-kernel
   issue rather than a kornia one, and is worth a separate torch report.

For context: bfloat16 spacing is already 2 above width 256, so a half-precision pixel grid cannot
give adjacent columns distinct coordinates past that width regardless of which kernel builds it.
Building the ramp in fp32 and casting only at the end of the warp pipeline would remove this whole
class of problem -- a larger change than this PR, but likely the right long-term shape.

## Related issue or discussion

Refs #4030 (reported by @ducha-aiki). Referenced rather than `Fixes`, because
`normalized_coordinates=True` still diverges for the separate reason described above, so the stated
expectation in that issue is not yet fully met.

## What did you check?

Reproduced and confirmed fixed on both backends -- CPU/inductor (torch 2.12.0+cpu, Python 3.13) and
CUDA/triton (torch 2.11.0+cu130, RTX 5070 sm_120, triton 3.7.1). Both produce identical numbers
(maxdiff 2.0 at the reported sizes before the change, 0.0 after), and the eager grids are bitwise
identical across CPU and CUDA, so this is purely an eager-vs-compile gap and not a device gap.

```text
$ KORNIA_TEST_OPTIMIZER=inductor pytest tests/geometry/test_grid.py -q
47 passed

$ pytest tests/geometry -q
2386 passed, 60 skipped, 19 xfailed, 5 xpassed

$ pytest tests/geometry/transform/test_homography_warper.py tests/geometry/test_depth.py tests/geometry/transform/test_thin_plate_spline.py tests/geometry/subpix tests/geometry/calibration tests/geometry/camera -q
426 passed, 3 skipped, 1 xfailed

$ pytest tests/contrib/test_conv_distance_transformer.py tests/contrib/test_extract_tensor_patch.py tests/feature/test_mkd.py -q
132 passed, 2 skipped
```

No failures and no errors. The skipped / xfailed / xpassed counts are the suite's existing baseline
on this machine, not anything this change introduces -- running `pytest tests/geometry -q` on an
unmodified checkout of `9e45dddc` gives exactly the same `2386 passed, 60 skipped, 19 xfailed,
5 xpassed`. The skips are optional dependencies and unavailable devices; the xfails are cases the
suite already records as known.

The new test `test_pixel_meshgrid_half_dtype_matches_compile` is a genuine regression test: on the
unpatched tree it fails 4/4 with differences of 1.0 in the pixel ramp, and passes 4/4 with the fix.
It uses widths 258 (bfloat16) and 2050 (float16) -- the first sizes at which the two paths diverge --
and asserts bitwise equality (`atol=0.0, rtol=0.0`). The existing compile test covers only
float32/float64 on a 3x4 image, two dimensions away from the failure in both dtype and size, which
is why this went unnoticed.
