### PR TITLE
Fix PyTorch 2.1-2.4 compatibility failures

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -105,12 +105,6 @@ jobs:
           - os: windows-latest
             pytorch-version: "2.5.1"
         include:
-          # Keep the oldest supported PyTorch version visible on every PR without
-          # duplicating the full scheduled compatibility matrix.
-          - os: ubuntu-latest
-            pytorch-dtype: "float32"
-            python-version: "3.11"
-            pytorch-version: "2.1.2"
           - os: windows-2022
             pytorch-dtype: "float32"
             python-version: "3.11"

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -105,6 +105,12 @@ jobs:
           - os: windows-latest
             pytorch-version: "2.5.1"
         include:
+          # Keep the oldest supported PyTorch version visible on every PR without
+          # duplicating the full scheduled compatibility matrix.
+          - os: ubuntu-latest
+            pytorch-dtype: "float32"
+            python-version: "3.11"
+            pytorch-version: "2.1.2"
           - os: windows-2022
             pytorch-dtype: "float32"
             python-version: "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   partially padded sequence no longer produces a fully masked row. A row whose mask is entirely zero — an empty
   caption in a batch — is still fully masked and still follows the SDPA behavior above.
 
+* Fix `find_essential` and `run_5point` raising `TypeError: all() received an invalid combination of arguments` on
+  PyTorch before 2.2 (#4043). `run_5point`, `_solve_2x2_tikhonov_safe` and the scripted Nister helper each reduced
+  over two axes at once with `Tensor.any(dim=(-2, -1))` / `Tensor.all(dim=(-1, -2))`, and multi-dimension `any`/`all`
+  only landed in PyTorch 2.2, so the whole five-point solver was unusable on the declared `torch>=2.0` floor. The
+  reductions now flatten the two trailing axes first, which is equivalent on every version.
+
+* Fix `torch.jit.script` of `rgb_to_yuv`, `yuv_to_rgb`, `rgb_to_xyz` and `xyz_to_rgb` on older PyTorch (#4043). Their
+  shared `kornia.color.utils._apply_linear_transformation` helper annotated its optional argument with the PEP 604
+  `torch.Tensor | None` form, which the TorchScript compiler on the declared floor does not accept (reproduced on
+  PyTorch 2.1.2, while PyTorch 2.9.1 compiles it), so scripting any of the four conversions failed. The annotation is
+  `Optional[torch.Tensor]` now, which every supported version accepts.
+
 * Define singleton pixel axes at normalized center, reject non-positive normalization sizes, preserve empty warp
   destinations, and deprecate the now-unused `eps` normalization parameters (#4006). The four
   `{de,}normalize_pixel_coordinates{,3d}` helpers and `normal_transform_pixel{,3d}` now derive their scale from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fix the inverted `SigLip2` attention-mask polarity, so every call that passes an `attention_mask` changes (#4043).
+  All three mask branches of `SigLip2Attention` (2-D `(B, N)`, 3-D `(B, N, N)` and 4-D `(B, 1, N, N)`) negated the
+  mask before handing it to `torch.nn.functional.scaled_dot_product_attention`, whose boolean form reads `True` as
+  *attend*, not as *mask out*. Every position the caller asked to attend to was masked out and every padded position
+  attended to, so an all-ones mask left every query row fully masked. The symptom is version-dependent because a
+  fully masked row returns `0` from SDPA on PyTorch 2.5 and later and `nan` on PyTorch 2.4 and earlier:
+  `SigLip2.get_text_features(..., attention_mask=...)` has been returning a zeroed attention output on current
+  PyTorch and `nan` text features on the declared `torch>=2.0` floor. 2-D padding masks are now broadcast over the
+  key axis only, matching `SiglipTextTransformer.create_bidirectional_mask` in Hugging Face `transformers`, so a
+  partially padded sequence no longer produces a fully masked row. A row whose mask is entirely zero — an empty
+  caption in a batch — is still fully masked and still follows the SDPA behavior above.
+
 * Define singleton pixel axes at normalized center, reject non-positive normalization sizes, preserve empty warp
   destinations, and deprecate the now-unused `eps` normalization parameters (#4006). The four
   `{de,}normalize_pixel_coordinates{,3d}` helpers and `normal_transform_pixel{,3d}` now derive their scale from the

--- a/kornia/color/utils.py
+++ b/kornia/color/utils.py
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+from typing import Optional
+
 import torch
 from torch.nn import functional as F
 
 
 def _apply_linear_transformation(
-    image: torch.Tensor, kernel: torch.Tensor, bias: torch.Tensor | None = None
+    image: torch.Tensor, kernel: torch.Tensor, bias: Optional[torch.Tensor] = None
 ) -> torch.Tensor:
     """Apply a 3x3 linear color transformation with device-aware optimization.
 

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -72,7 +72,7 @@ def run_5point(points1: torch.Tensor, points2: torch.Tensor, weights: Optional[t
     X = torch.cat([x1 * x2, x1 * y2, x1, y1 * x2, y1 * y2, y1, x2, y2, ones], dim=-1)
     # use Nister's 5PC to solve essential matrix
     E = null_to_Nister_solution(X, batch_size)
-    bad = torch.isnan(E).all(dim=(-1, -2)).all(dim=-1)  # (B,)
+    bad = torch.isnan(E).flatten(-2).all(-1).all(-1)  # (B,)
     if bad.any():
         eye3 = torch.eye(3, device=E.device, dtype=E.dtype).view(1, 1, 3, 3).expand(batch_size, 10, 3, 3)
         E = torch.where(bad.view(batch_size, 1, 1, 1), eye3, E)

--- a/kornia/geometry/epipolar/essential.py
+++ b/kornia/geometry/epipolar/essential.py
@@ -180,7 +180,7 @@ def _solve_2x2_tikhonov_safe(A: torch.Tensor, b: torch.Tensor, eps: float = 1e-1
     x = torch.where(bad.unsqueeze(-1).unsqueeze(-1), x_fb, x_dir)
 
     # if still non-finite, mark bad and zero it
-    nonfinite = torch.isnan(x).any(dim=(-2, -1)) | torch.isinf(x).any(dim=(-2, -1))
+    nonfinite = torch.isnan(x).flatten(-2).any(-1) | torch.isinf(x).flatten(-2).any(-1)
     bad = bad | nonfinite
     x = torch.where(bad.unsqueeze(-1).unsqueeze(-1), torch.zeros_like(x), x)
 
@@ -275,7 +275,7 @@ def _null_to_Nister_solution_script(
     eliminated = torch.linalg.solve(A10, b_poly)  # (B,10,10)
 
     # Detect NaN/Inf from singular solve and fix with damping solve
-    bad = torch.isnan(eliminated).any(dim=(-2, -1)) | torch.isinf(eliminated).any(dim=(-2, -1))  # (B,)
+    bad = torch.isnan(eliminated).flatten(-2).any(-1) | torch.isinf(eliminated).flatten(-2).any(-1)  # (B,)
     if bad.any():
         # Damped solve only for bad rows but WITHOUT compaction:
         # build damped A = A10 + λI, where λ depends on scale

--- a/kornia/models/siglip2/attention.py
+++ b/kornia/models/siglip2/attention.py
@@ -112,19 +112,17 @@ class SigLip2Attention(nn.Module):
         if attention_mask is not None:
             # Handle different mask formats
             if attention_mask.dim() == 2:
-                # (batch_size, seq_len) -> (batch_size, 1, seq_len, seq_len)
-                # Create 2D mask: both query and key positions must be valid
-                # Convert to boolean: 1 = attend (False = don't mask), 0 = mask (True = mask out)
-                mask_bool = attention_mask.bool()
-                # Expand to (batch_size, 1, seq_len, seq_len) where True means mask out
-                # We need: if either query or key is masked, then mask that attention
-                attn_mask = ~(mask_bool.unsqueeze(1).unsqueeze(2) & mask_bool.unsqueeze(1).unsqueeze(3))
+                # (batch_size, seq_len) -> (batch_size, 1, 1, seq_len)
+                # Mask keys only so padded query positions do not create fully masked
+                # rows, which produce NaNs in older SDPA implementations.
+                # Boolean SDPA masks use True = attend and False = mask out.
+                attn_mask = attention_mask.bool().unsqueeze(1).unsqueeze(2)
             elif attention_mask.dim() == 3:
                 # (batch_size, seq_len, seq_len) -> (batch_size, 1, seq_len, seq_len)
-                attn_mask = ~attention_mask.bool().unsqueeze(1)
+                attn_mask = attention_mask.bool().unsqueeze(1)
             elif attention_mask.dim() == 4:
                 # Already in correct format (batch_size, 1, seq_len, seq_len)
-                attn_mask = ~attention_mask.bool()
+                attn_mask = attention_mask.bool()
             else:
                 raise ValueError(f"Unsupported attention_mask dimension: {attention_mask.dim()}")
 

--- a/kornia/models/siglip2/attention.py
+++ b/kornia/models/siglip2/attention.py
@@ -82,10 +82,20 @@ class SigLip2Attention(nn.Module):
 
         Args:
             hidden_states: Input tensor of shape (batch_size, seq_len, hidden_size).
-            attention_mask: Optional attention mask. Can be:
-                - (batch_size, seq_len): 1D mask where 1 = attend, 0 = mask
-                - (batch_size, seq_len, seq_len): 2D mask where 1 = attend, 0 = mask
-                - (batch_size, 1, seq_len, seq_len): 4D mask (broadcastable)
+            attention_mask: Optional attention mask, where ``1``/``True`` means attend and ``0``/``False``
+                means mask out. Can be:
+
+                - (batch_size, seq_len): a padding mask, broadcast over the key axis only, matching
+                  ``SiglipTextTransformer.create_bidirectional_mask`` in Hugging Face ``transformers``.
+                  A padded query row is therefore *not* masked and its output is finite but meaningless;
+                  callers are expected to discard those positions.
+                - (batch_size, seq_len, seq_len): a per-query mask, broadcast over the head axis.
+                - (batch_size, 1, seq_len, seq_len): already in the layout
+                  ``torch.nn.functional.scaled_dot_product_attention`` expects.
+
+                A query row whose mask is entirely ``0`` follows the behavior of
+                ``scaled_dot_product_attention`` for a fully masked row: ``0`` on PyTorch 2.5 and later,
+                ``nan`` before it.
 
         Returns:
             Output tensor of shape (batch_size, seq_len, hidden_size).
@@ -121,7 +131,7 @@ class SigLip2Attention(nn.Module):
                 # (batch_size, seq_len, seq_len) -> (batch_size, 1, seq_len, seq_len)
                 attn_mask = attention_mask.bool().unsqueeze(1)
             elif attention_mask.dim() == 4:
-                # Already in correct format (batch_size, 1, seq_len, seq_len)
+                # Already in the SDPA layout (batch_size, 1, seq_len, seq_len); True = attend
                 attn_mask = attention_mask.bool()
             else:
                 raise ValueError(f"Unsupported attention_mask dimension: {attention_mask.dim()}")

--- a/testing/base.py
+++ b/testing/base.py
@@ -33,15 +33,26 @@ from kornia.core._compat import torch_version_lt
 Dtype = Union[torch.dtype, None]
 Tensor = torch.Tensor
 
-DYNAMO_UNAVAILABLE_REASON = "torch.compile requires torch>=2.5 on Python>=3.12 and torch>=2.6 on Python>=3.13"
+DYNAMO_UNAVAILABLE_REASON = "torch.compile requires torch>=2.4 on Python>=3.12 and torch>=2.6 on Python>=3.13"
+DYNAMIC_EXPORT_UNAVAILABLE_REASON = (
+    f"named torch.export dynamic shapes require torch>=2.2, and {DYNAMO_UNAVAILABLE_REASON}"
+)
 
 
 def dynamo_is_available() -> bool:
     """Return whether this Torch/Python pair can run Dynamo-backed capture."""
     return not (
-        (torch_version_lt(2, 5, 0) and sys.version_info >= (3, 12))
+        (torch_version_lt(2, 4, 0) and sys.version_info >= (3, 12))
         or (torch_version_lt(2, 6, 0) and sys.version_info >= (3, 13))
     )
+
+
+def dynamic_export_is_available() -> bool:
+    """Return whether ``torch.export`` accepts named dynamic shapes on this Torch/Python pair.
+
+    ``torch.export.Dim`` and the ``dynamic_shapes`` argument both landed in PyTorch 2.2.
+    """
+    return dynamo_is_available() and hasattr(getattr(torch, "export", None), "Dim")
 
 
 # {dtype: (rtol, atol)}

--- a/testing/base.py
+++ b/testing/base.py
@@ -33,12 +33,15 @@ from kornia.core._compat import torch_version_lt
 Dtype = Union[torch.dtype, None]
 Tensor = torch.Tensor
 
-DYNAMO_UNAVAILABLE_REASON = "torch.compile requires torch>=2.6 on Python>=3.13"
+DYNAMO_UNAVAILABLE_REASON = "torch.compile requires torch>=2.5 on Python>=3.12 and torch>=2.6 on Python>=3.13"
 
 
 def dynamo_is_available() -> bool:
     """Return whether this Torch/Python pair can run Dynamo-backed capture."""
-    return not (torch_version_lt(2, 6, 0) and sys.version_info >= (3, 13))
+    return not (
+        (torch_version_lt(2, 5, 0) and sys.version_info >= (3, 12))
+        or (torch_version_lt(2, 6, 0) and sys.version_info >= (3, 13))
+    )
 
 
 # {dtype: (rtol, atol)}

--- a/tests/augmentation/test_base.py
+++ b/tests/augmentation/test_base.py
@@ -222,8 +222,8 @@ class TestIntensityAugmentationBase3D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
-        if device.type == "cpu" and torch_version_lt(2, 5, 0):
-            pytest.skip("3D CPU autocast requires bfloat16 eye support from PyTorch 2.5")
+        if device.type == "cpu" and torch_version_lt(2, 3, 0):
+            pytest.skip("3D CPU autocast requires bfloat16 eye support from PyTorch 2.3")
 
         # Uses some subclass of `IntensityAugmentationBase3D` which perform some op which can mismatch the dtype
         # Will cover RigidAffineAugmentationBase3D and AugmentationBase3D too
@@ -245,8 +245,8 @@ class TestGeometricAugmentationBase3D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
-        if device.type == "cpu" and torch_version_lt(2, 5, 0):
-            pytest.skip("3D CPU autocast requires bfloat16 eye support from PyTorch 2.5")
+        if device.type == "cpu" and torch_version_lt(2, 3, 0):
+            pytest.skip("3D CPU autocast requires bfloat16 eye support from PyTorch 2.3")
 
         # Uses some subclass of `GeometricAugmentationBase3D` which perform some op which can mismatch the dtype
         # Will cover RigidAffineAugmentationBase3D and AugmentationBase3D too

--- a/tests/augmentation/test_base.py
+++ b/tests/augmentation/test_base.py
@@ -182,6 +182,7 @@ class TestGeometricAugmentationBase2D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
+
         # Uses some subclass of `GeometricAugmentationBase2D` which perform some op which can mismatch the dtype
         # Will cover AugmentationBase2D and RigidAffineAugmentationBase2D too
         aug = RandomAffine(0.5, (0.1, 0.5), (0.5, 1.5), 1.2, p=1.0)
@@ -202,6 +203,7 @@ class TestIntensityAugmentationBase2D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
+
         # Uses some subclass of `IntensityAugmentationBase2D` which perform some op which can mismatch the dtype
         # Will cover AugmentationBase2D and RigidAffineAugmentationBase2D too
         aug = RandomGaussianBlur((3, 3), (0.1, 3), p=1)

--- a/tests/augmentation/test_base.py
+++ b/tests/augmentation/test_base.py
@@ -26,6 +26,7 @@ from kornia.augmentation._2d.intensity.gaussian_blur import RandomGaussianBlur
 from kornia.augmentation._3d.geometric.affine import RandomAffine3D
 from kornia.augmentation._3d.intensity.motion_blur import RandomMotionBlur3D
 from kornia.augmentation.base import _BasicAugmentationBase
+from kornia.core._compat import torch_version_lt
 
 from testing.base import BaseTester
 
@@ -181,7 +182,6 @@ class TestGeometricAugmentationBase2D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
-
         # Uses some subclass of `GeometricAugmentationBase2D` which perform some op which can mismatch the dtype
         # Will cover AugmentationBase2D and RigidAffineAugmentationBase2D too
         aug = RandomAffine(0.5, (0.1, 0.5), (0.5, 1.5), 1.2, p=1.0)
@@ -202,7 +202,6 @@ class TestIntensityAugmentationBase2D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
-
         # Uses some subclass of `IntensityAugmentationBase2D` which perform some op which can mismatch the dtype
         # Will cover AugmentationBase2D and RigidAffineAugmentationBase2D too
         aug = RandomGaussianBlur((3, 3), (0.1, 3), p=1)
@@ -223,6 +222,8 @@ class TestIntensityAugmentationBase3D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
+        if device.type == "cpu" and torch_version_lt(2, 5, 0):
+            pytest.skip("3D CPU autocast requires bfloat16 eye support from PyTorch 2.5")
 
         # Uses some subclass of `IntensityAugmentationBase3D` which perform some op which can mismatch the dtype
         # Will cover RigidAffineAugmentationBase3D and AugmentationBase3D too
@@ -244,6 +245,8 @@ class TestGeometricAugmentationBase3D:
     def test_autocast(self, batch_prob, device, dtype):
         if not hasattr(torch, "autocast"):
             pytest.skip("PyTorch version without autocast support")
+        if device.type == "cpu" and torch_version_lt(2, 5, 0):
+            pytest.skip("3D CPU autocast requires bfloat16 eye support from PyTorch 2.5")
 
         # Uses some subclass of `GeometricAugmentationBase3D` which perform some op which can mismatch the dtype
         # Will cover RigidAffineAugmentationBase3D and AugmentationBase3D too

--- a/tests/augmentation/test_onnx_export.py
+++ b/tests/augmentation/test_onnx_export.py
@@ -54,6 +54,11 @@ import pytest
 import torch
 
 import kornia.augmentation as K
+from kornia.core._compat import torch_version_ge, torch_version_lt
+
+pytestmark = pytest.mark.skipif(
+    torch_version_lt(2, 4, 0), reason="augmentation ONNX regression tests require opset 20 support from PyTorch 2.4"
+)
 
 
 def _hflip() -> torch.nn.Module:
@@ -158,21 +163,25 @@ EXPORTABLE_OPS: list[Tuple[str, Callable[[], torch.nn.Module]]] = [
 XFAIL_OPS: list[Tuple[str, Callable[[], torch.nn.Module], str]] = []
 
 
+def _legacy_onnx_export(module: torch.nn.Module, x: torch.Tensor, buf: io.BytesIO) -> None:
+    """Export through the legacy tracer across supported PyTorch versions."""
+    kwargs: dict[str, Any] = {
+        "opset_version": 20,
+        "input_names": ["input"],
+        "output_names": ["output"],
+    }
+    if torch_version_ge(2, 5, 0):
+        kwargs["dynamo"] = False
+    torch.onnx.export(module, (x,), buf, **kwargs)
+
+
 def _try_export(module: torch.nn.Module, x: torch.Tensor) -> int:
     """Run ``torch.onnx.export`` against an in-memory buffer and return the byte count."""
     module.eval()
     buf = io.BytesIO()
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        torch.onnx.export(
-            module,
-            (x,),
-            buf,
-            opset_version=20,
-            input_names=["input"],
-            output_names=["output"],
-            dynamo=False,
-        )
+        _legacy_onnx_export(module, x, buf)
     return len(buf.getvalue())
 
 
@@ -293,15 +302,7 @@ def _run_onnx(module: torch.nn.Module, x: torch.Tensor) -> Any:
     buf = io.BytesIO()
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        torch.onnx.export(
-            module,
-            (x,),
-            buf,
-            opset_version=20,
-            dynamo=False,
-            input_names=["input"],
-            output_names=["output"],
-        )
+        _legacy_onnx_export(module, x, buf)
     sess = ort.InferenceSession(buf.getvalue())
     return sess.run(["output"], {"input": x.numpy()})[0]
 

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -50,7 +50,14 @@ from kornia.geometry.conversions import (
 )
 from kornia.geometry.quaternion import Quaternion
 
-from testing.base import DYNAMO_UNAVAILABLE_REASON, BaseTester, assert_close, dynamo_is_available
+from testing.base import (
+    DYNAMIC_EXPORT_UNAVAILABLE_REASON,
+    DYNAMO_UNAVAILABLE_REASON,
+    BaseTester,
+    assert_close,
+    dynamic_export_is_available,
+    dynamo_is_available,
+)
 
 
 @pytest.fixture()
@@ -3459,7 +3466,7 @@ def test_pixel_coordinate_singleton_policy_scripts(op_name, args, device, dtype)
         ("denormalize_pixel_coordinates3d", 3),
     ],
 )
-@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
+@pytest.mark.skipif(not dynamic_export_is_available(), reason=DYNAMIC_EXPORT_UNAVAILABLE_REASON)
 def test_pixel_coordinate_export_crosses_singleton_boundary(op_name, ndim):
     op = getattr(kornia.geometry.conversions, op_name)
 
@@ -3525,7 +3532,7 @@ def test_non_default_eps_does_not_break_fullgraph_compile(op_name, sizes):
     ],
     ids=["float32", "bfloat16-rounding-boundary", "float16-rounding-boundary"],
 )
-@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
+@pytest.mark.skipif(not dynamic_export_is_available(), reason=DYNAMIC_EXPORT_UNAVAILABLE_REASON)
 def test_normal_transform_export_crosses_singleton_boundary(is_3d, dtype, runtime_sizes):
     class ExportTransform(torch.nn.Module):
         def forward(self, image):

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -3494,6 +3494,7 @@ def test_pixel_coordinate_export_crosses_singleton_boundary(op_name, ndim):
         ("normal_transform_pixel3d", (4, 5, 6)),
     ],
 )
+@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
 def test_non_default_eps_does_not_break_fullgraph_compile(op_name, sizes):
     op = getattr(kornia.geometry, op_name)
     value = torch.zeros(1, len(sizes))

--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -30,7 +30,7 @@ import pytest
 import torch
 
 import kornia
-from kornia.core._compat import torch_version
+from kornia.core._compat import torch_version, torch_version_lt
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 from kornia.core.exceptions import BaseError, ShapeError
 from kornia.core.ops import eye_like
@@ -3267,9 +3267,13 @@ def test_wart_float16_underflowed_default_eps_flips_branches(device):
     #     -> 0.0  (not sqrt(eps) = 1e-4: eps underflows the sum inside the sqrt)
     #   convert_points_from_homogeneous(torch.tensor([[2., 4., 2e-8]], dtype=torch.float16))
     #     -> [[2., 4.]]  (w underflows to 0 and takes the abs(w) <= eps passthrough branch)
-    zero = torch.tensor(0.0, device=device, dtype=torch.float16)
-    rho = kornia.geometry.conversions.cart2pol(zero, zero)[0]
-    assert_close(rho, zero, atol=0.0, rtol=0.0)
+    # The cart2pol half is narrowed rather than skipped whole: it reaches torch.atan2, whose CPU
+    # float16 kernel ("atan2_cpu" not implemented for 'Half') only landed in PyTorch 2.2, while the
+    # convert_points_from_homogeneous claim below has no such floor and stays pinned everywhere.
+    if not (device.type == "cpu" and torch_version_lt(2, 2, 0)):
+        zero = torch.tensor(0.0, device=device, dtype=torch.float16)
+        rho = kornia.geometry.conversions.cart2pol(zero, zero)[0]
+        assert_close(rho, zero, atol=0.0, rtol=0.0)
 
     out = kornia.geometry.conversions.convert_points_from_homogeneous(
         torch.tensor([[2.0, 4.0, 2e-8]], device=device, dtype=torch.float16)

--- a/tests/geometry/test_grid.py
+++ b/tests/geometry/test_grid.py
@@ -20,7 +20,13 @@ import torch
 
 import kornia
 
-from testing.base import DYNAMO_UNAVAILABLE_REASON, assert_close, dynamo_is_available
+from testing.base import (
+    DYNAMIC_EXPORT_UNAVAILABLE_REASON,
+    DYNAMO_UNAVAILABLE_REASON,
+    assert_close,
+    dynamic_export_is_available,
+    dynamo_is_available,
+)
 
 
 def test_create_meshgrid(device, dtype):
@@ -169,7 +175,7 @@ def test_normalized_meshgrid_trace_matches_eager_at_unrepresentable_sizes(is_3d,
 
 @pytest.mark.parametrize("normalized_coordinates", [False, True], ids=["pixel", "normalized"])
 @pytest.mark.parametrize("is_3d", [False, True], ids=["2d", "3d"])
-@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
+@pytest.mark.skipif(not dynamic_export_is_available(), reason=DYNAMIC_EXPORT_UNAVAILABLE_REASON)
 def test_meshgrid_export_crosses_singleton_boundary(is_3d, normalized_coordinates):
     class MeshGrid(torch.nn.Module):
         def forward(self, image):

--- a/tests/geometry/test_grid.py
+++ b/tests/geometry/test_grid.py
@@ -203,6 +203,7 @@ def test_meshgrid_export_crosses_singleton_boundary(is_3d, normalized_coordinate
 
 @pytest.mark.parametrize("default_dtype", [torch.float32, torch.float64])
 @pytest.mark.parametrize("is_3d", [False, True], ids=["2d", "3d"])
+@pytest.mark.skipif(not dynamo_is_available(), reason=DYNAMO_UNAVAILABLE_REASON)
 def test_pixel_meshgrid_default_dtype_matches_compile(is_3d, default_dtype):
     class MeshGrid(torch.nn.Module):
         def forward(self, image):

--- a/tests/geometry/test_linalg.py
+++ b/tests/geometry/test_linalg.py
@@ -20,6 +20,7 @@ import torch
 
 import kornia
 import kornia.geometry.linalg as kgl
+from kornia.core._compat import torch_version_lt
 
 from testing.base import BaseTester
 from testing.geometry.create import create_random_homography
@@ -81,6 +82,10 @@ class TestTransformPoints(BaseTester):
     @pytest.mark.parametrize("points_dtype", [torch.float16, torch.float32, torch.float64])
     def test_mixed_dtypes(self, device, trans_dtype, points_dtype):
         # Regression test for https://github.com/kornia/kornia/issues/3705
+        if trans_dtype == torch.float16 and device.type == "cpu" and torch_version_lt(2, 2, 0):
+            # transform_points harmonises at the bmm site in the transform's dtype, and CPU
+            # float16 bmm ("bmm" not implemented for 'Half') only landed in PyTorch 2.2.
+            pytest.skip("CPU float16 bmm requires PyTorch 2.2")
         points_src = torch.rand(2, 3, 2, device=device, dtype=points_dtype)
         trans = kornia.core.ops.eye_like(3, points_src).to(trans_dtype)
         out = kgl.transform_points(trans, points_src)

--- a/tests/models/test_siglip2.py
+++ b/tests/models/test_siglip2.py
@@ -126,6 +126,7 @@ class TestSigLip2Model(BaseTester):
             features = model.get_text_features(input_ids, attention_mask=attention_mask)
 
         assert features.shape == (batch_size, config.projection_dim)
+        assert torch.isfinite(features).all()
         # Check normalization
         norms = features.norm(dim=-1)
         self.assert_close(norms, torch.ones_like(norms), rtol=1e-5, atol=1e-5)
@@ -135,7 +136,9 @@ class TestSigLip2Model(BaseTester):
 
         batch_size = 2
         seq_len = 10
-        input_ids = _create_input_ids(batch_size, seq_len, config, device)
+        input_ids = torch.zeros(batch_size, seq_len, dtype=torch.long, device=device)
+        input_ids[0, :5] = torch.arange(1, 6, device=device)
+        input_ids[1, :8] = torch.arange(11, 19, device=device)
 
         # Create attention mask with different lengths
         attention_mask = torch.ones(batch_size, seq_len, device=device)
@@ -146,6 +149,8 @@ class TestSigLip2Model(BaseTester):
             features = model.get_text_features(input_ids, attention_mask=attention_mask)
 
         assert features.shape == (batch_size, config.projection_dim)
+        assert torch.isfinite(features).all()
+        assert not torch.allclose(features[0], features[1])
 
     def test_return_loss(self, device, dtype, model, config):
         """Test forward pass with return_loss=True and verify logit_scale clamping."""
@@ -336,9 +341,11 @@ class TestSigLip2Components(BaseTester):
 
         with torch.no_grad():
             output = attention(hidden_states, attention_mask=attention_mask)
+            output_without_mask = attention(hidden_states)
 
         # Attention returns a single tensor, not a tuple
         assert output.shape == (batch_size, seq_len, hidden_size)
+        self.assert_close(output, output_without_mask)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     @pytest.mark.parametrize("input_size", [(256, 256), (300, 400), (512, 512)])

--- a/tests/models/test_siglip2.py
+++ b/tests/models/test_siglip2.py
@@ -345,7 +345,11 @@ class TestSigLip2Components(BaseTester):
 
         # Attention returns a single tensor, not a tuple
         assert output.shape == (batch_size, seq_len, hidden_size)
-        self.assert_close(output, output_without_mask)
+        # An all-ones mask must be a no-op. Passing any ``attn_mask`` disqualifies the CUDA flash
+        # backend, so the two calls can run different SDPA kernels and agree only up to kernel-level
+        # rounding, which is the same order as the default half-precision tolerance.
+        tol = {"rtol": 5e-2, "atol": 5e-2} if dtype in (torch.float16, torch.bfloat16) else {}
+        self.assert_close(output, output_without_mask, **tol)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     @pytest.mark.parametrize("input_size", [(256, 256), (300, 400), (512, 512)])


### PR DESCRIPTION
## What does this pull request do?

Restores the declared PyTorch 2.1-2.4 compatibility paths exposed by the scheduled matrix:

- **fixes an inverted SigLip2 attention mask on every PyTorch version.** All three `attention_mask` branches of `SigLip2Attention` negated the mask before handing it to `scaled_dot_product_attention`, whose boolean form reads `True` as *attend*. Every position the caller asked to attend to was masked out, so an all-ones mask left every query row fully masked. Only the symptom is version-dependent: a fully masked row returns `0` from SDPA on PyTorch 2.5+ and `nan` on PyTorch <=2.4, so `get_text_features(..., attention_mask=...)` has been returning a **zeroed** attention output on current PyTorch and `nan` text features on the declared floor. 2-D padding masks are now broadcast over keys only, matching `SiglipTextTransformer.create_bidirectional_mask` in HF `transformers`, so a partially padded sequence no longer produces a fully masked row
- replaces `Tensor.any(dim=(-2, -1))` and `Tensor.all(dim=(-1, -2))` in `find_essential` with flattened reductions; multi-dimension `any`/`all` only landed in PyTorch 2.2, so the previous form raised `TypeError` on the declared `torch>=2.0.0` floor
- replaces the PEP 604 `torch.Tensor | None` annotation in `kornia/color/utils.py` with `Optional[...]`, so `torch.jit.script(kornia.color.rgb_to_yuv)` compiles again on the floor
- gates the legacy ONNX exporter argument by PyTorch version and skips the opset-20 suite where that opset is unsupported
- skips the two CPU 3-D autocast cases below PyTorch 2.3, where `eye` has no bfloat16 kernel
- adds `dynamic_export_is_available()` for the three `torch.export` dynamic-shape tests, since `torch.export.Dim` and `dynamic_shapes` only exist from PyTorch 2.2
- narrows the Dynamo availability guard to Python 3.12 / PyTorch <2.4 (the Python 3.12 restriction was lifted in 2.4, not 2.5) and applies it to the two unguarded compile tests
- narrows two float16 pins to PyTorch 2.2 on CPU, where the `bmm` and `atan2` half kernels landed: the three float16-transform cases of `TestTransformPoints::test_mixed_dtypes`, and the `cart2pol` half of `test_wart_float16_underflowed_default_eps_flips_branches` (the `convert_points_from_homogeneous` claim in that pin stays live on every version)

## Related issue or discussion

Closes #4042.

## What did you check?

- `pixi run pre-commit-all`
- `pixi run typecheck` (passes with one pre-existing deprecation diagnostic)
- 75 SigLip2 and augmentation-base tests on PyTorch 2.9.1
- 130 `find_essential` tests, plus an explicit `torch.jit.script` check on both changed helpers
- 24 geometry export/compile tests with Inductor
- 27 ONNX export/numerical tests on PyTorch 2.9.1 and PyTorch 2.4.0
- `tests/color/` + `tests/geometry/epipolar/` at `--dtype=float32,float64`: `1100 passed, 3 skipped, 8 xpassed`, identical on PyTorch 2.1.2 and 2.9.1
- the five files carrying the remaining 2.1.2 failures (`test_linalg`, `test_conversions`, `test_grid`, `test_yuv`, `test_essential`) at `--dtype=float32,float64`: `960 passed` on PyTorch 2.9.1 and `941 passed, 19 skipped` on PyTorch 2.1.2 — the difference is exactly the version guards, with no failures on either end
- each version boundary above cross-checked against the per-version job logs of scheduled run `33097880044`, so no boundary skips a case that already passes; the `bmm`/`atan2` boundary was additionally measured directly on PyTorch 2.1.2 (raises) and 2.2.2 (passes), and the SDPA fully-masked-row boundary on 2.1.2/2.2.2 (`nan`), 2.5.1 and 2.9.1 (`0`)

## How did AI help?

Codex investigated the scheduled failures, implemented the compatibility fixes and regression tests, reproduced the behavior in isolated PyTorch 2.1.2 and 2.4.0 environments, and ran an independent review before opening this PR. Claude then reviewed the result against the scheduled-run logs, corrected four version boundaries, dropped the proposed PyTorch 2.1.2 PR leg (that version is old enough that the scheduled matrix is the right place for it), found the two remaining `torch<2.2` library gaps in a real 2.1.2 environment, and narrowed the last two float16 pins.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (GPT-5) and Claude (Opus 5).

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
