### PR TITLE
fix(tests): avoid old torch bfloat16 eye kernel

### DIFF
--- a/tests/geometry/test_conversions.py
+++ b/tests/geometry/test_conversions.py
@@ -1396,7 +1396,9 @@ class TestQuaternionToRotationMatrix(BaseTester):
         matrix = kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion)
 
         assert matrix.dtype == half_dtype, f"kornia#3954: quaternion_to_rotation_matrix returned {matrix.dtype}"
-        self.assert_close(matrix, torch.eye(3, device=device, dtype=half_dtype))
+        # torch.eye has no CPU bfloat16 kernel before PyTorch 2.3, while direct tensor construction does (#4051).
+        expected = torch.tensor(((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)), device=device, dtype=half_dtype)
+        self.assert_close(matrix, expected)
         assert kornia.geometry.conversions.quaternion_to_rotation_matrix(quaternion[None]).dtype == half_dtype
 
     def test_unit_quaternion(self, device, dtype, atol, rtol):


### PR DESCRIPTION
## What does this pull request do?

Replaces the `torch.eye(..., dtype=torch.bfloat16)` value oracle in the #3954 quaternion dtype regression with an explicit identity tensor.

`quaternion_to_rotation_matrix` itself succeeds and returns `bfloat16` on PyTorch 2.1/2.2, but those versions have no CPU bfloat16 kernel for `torch.eye`. The oracle therefore failed all six scheduled 2.1.2/2.2.2 Ubuntu jobs after #3982 landed immediately before #4043. Direct tensor construction is supported there and keeps the regression's value assertion plus both batched and unbatched dtype assertions intact.

## Related issue or discussion

Closes #4051.

## What did you check?

```text
$ pixi run -e py311 uv run --no-sync python -c 'import torch; assert torch.__version__.startswith("2.2.2"); print(torch.__version__)'
2.2.2

$ pixi run -e py311 uv run --no-sync pytest -q tests/geometry/test_conversions.py::TestQuaternionToRotationMatrix::test_convention_output_dtype_equals_input_dtype_3954 --device=cpu
2 passed

$ .venv/bin/python -m pytest -q tests/geometry/test_conversions.py::TestQuaternionToRotationMatrix::test_convention_output_dtype_equals_input_dtype_3954 --device=cpu
# PyTorch 2.9.1
2 passed

$ pixi run pre-commit-all
# all hooks passed
```

## How did AI help?

Codex traced the post-merge scheduled failures across #3982 and #4043, identified the unsupported test-only kernel, implemented the compatible oracle, reproduced the fix on real PyTorch 2.2.2, and ran the repository checks above.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (GPT-5).
