### PR TITLE
docs(feature): fix SIFTDescriptor input shape and error message formatting

### DIFF
--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -83,9 +83,8 @@ def get_sift_bin_ksize_stride_pad(patch_size: int, num_spatial_bins: int) -> Tup
     out_size: int = (patch_size + 2 * pad - (ksize - 1) - 1) // stride + 1
     if out_size != num_spatial_bins:
         raise ValueError(
-            f"Patch size {patch_size} is incompatible with             requested number of spatial bins"
-            f" {num_spatial_bins}             for SIFT descriptor. Usually it happens when patch size is too small     "
-            "       for num_spatial_bins specified"
+            f"Patch size {patch_size} is incompatible with requested number of spatial bins {num_spatial_bins} "
+            "for SIFT descriptor. Usually it happens when patch size is too small for num_spatial_bins specified"
         )
     return ksize, stride, pad
 
@@ -101,11 +100,12 @@ class SIFTDescriptor(nn.Module):
         rootsift: if ``True``, RootSIFT (Arandjelović et. al, 2012) is computed.
 
     Returns:
-        SIFT descriptor of the patches with shape.
+        SIFT descriptor of the patches with shape
+        :math:`(B, \text{num\_ang\_bins} \times \text{num\_spatial\_bins}^2)`.
 
     Shape:
-        - Input: :math:`(B, 1, \text{num_spatial_bins}, \text{num_spatial_bins})`
-        - Output: :math:`(B, \text{num_ang_bins * num_spatial_bins ** 2})`
+        - Input: :math:`(B, 1, \text{patch\_size}, \text{patch\_size})`
+        - Output: :math:`(B, \text{num\_ang\_bins} \times \text{num\_spatial\_bins}^2)`
 
     Example:
         >>> input = torch.rand(23, 1, 32, 32)


### PR DESCRIPTION
Closes #4067

### Description

Three small fixes in `kornia/feature/siftdesc.py`:

1. **`SIFTDescriptor`'s documented input shape was wrong.** The docstring said `(B, 1, num_spatial_bins, num_spatial_bins)`, but `forward` checks `KORNIA_CHECK_SHAPE(input, ["B", "1", f"{self.patch_size}", f"{self.patch_size}"])`, so following the docs raised:

   ```
   Shape mismatch at dimension 2: expected 32, got 4.
     Expected shape: ['B', '1', '32', '32']
   ```

   It now reads `(B, 1, \text{patch\_size}, \text{patch\_size})`.

2. **The `Returns:` line was truncated mid-sentence** — *"SIFT descriptor of the patches with shape."* It now names the actual output shape. The `Output:` line was also normalized to escaped underscores, since raw `_` inside `\text{}` does not render correctly.

3. **`get_sift_bin_ksize_stride_pad` raised with mangled whitespace.** A broken implicit string concatenation leaked runs of spaces into the user-facing message:

   ```
   Patch size 16 is incompatible with             requested number of spatial bins 4             for SIFT descriptor. Usually it happens when patch size is too small            for num_spatial_bins specified
   ```

   It now reads as one clean sentence:

   ```
   Patch size 16 is incompatible with requested number of spatial bins 4 for SIFT descriptor. Usually it happens when patch size is too small for num_spatial_bins specified
   ```

### Status

Ready for review — docstring text and a string literal only, no behavior change.

### Types of changes

- [x] Docs change / refactoring / dependency upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
