### PR TITLE
fix(feature): stop DenseSIFTDescriptor sharing the identity cache as a buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tensor; `.float()` on an already-float tensor returns the same object, so no copy happened between the cache and
   the buffer, and `load_state_dict` copies into buffers in place. Loading a checkpoint into one `DenseSIFTDescriptor`
   therefore overwrote the shared identity matrix, with no error raised and every descriptor built from it wrong from
-  then on. The cached tensor is now cloned before it is handed out. Descriptor output is byte-identical to before.
+  then on. The cache is removed rather than made safe: cloning on the way out is what a safe cache requires, and a
+  clone costs more than rebuilding the identity at every size measured (2.6 us against 2.0 us at the default
+  `numel = 8 * 4 * 4`; 3.9 ms against 2.8 ms at the former 4096 bound, which also retained 67 MB for the lifetime of
+  the process). Descriptor output is byte-identical to before.
 
 
 ## :rocket: [0.6.11] - 2022-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing FGINN tests pass unchanged on both sides, which is how this survived; two tests that discriminate it were
   added. `match_fginn`'s docstring now also records the saturation corner, where every candidate falls within
   `spatial_th` of the 1st nearest neighbor, the ratio collapses towards zero and the match is accepted.
+* Fix `DenseSIFTDescriptor` registering a process-global cached tensor as its `_poolingconv_weight` buffer, so that
+  one instance's `load_state_dict` silently corrupted every other instance and every instance constructed later
+  (#4068). `_get_reshape_kernel` memoises `torch.eye(numel)` per `numel` and used to return a *view* of the cached
+  tensor; `.float()` on an already-float tensor returns the same object, so no copy happened between the cache and
+  the buffer, and `load_state_dict` copies into buffers in place. Loading a checkpoint into one `DenseSIFTDescriptor`
+  therefore overwrote the shared identity matrix, with no error raised and every descriptor built from it wrong from
+  then on. The cached tensor is now cloned before it is handed out. Descriptor output is byte-identical to before.
 
 
 ## :rocket: [0.6.11] - 2022-03-28

--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -30,14 +30,9 @@ from kornia.geometry.conversions import pi
 def _get_reshape_kernel(kd: int, ky: int, kx: int) -> torch.Tensor:
     """Return neigh2channels conv kernel.
 
-    The identity matrix used to be memoised per ``numel`` and handed to the caller as a view of
-    the cached tensor, which let one consumer's in-place write -- ``load_state_dict`` copies into
-    buffers in place -- corrupt the cache and therefore every other consumer, including modules
-    constructed later (#4068). Making the cache safe means cloning on the way out, which costs
-    more than rebuilding the identity, so the cache is gone: measured on a 4-thread CPU, the
-    cached-and-cloned path is 2.6 us against 2.0 us for a plain ``torch.eye`` at the default
-    ``numel = 8 * 4 * 4``, and 3.9 ms against 2.8 ms at the old 4096 bound, where it also retained
-    67 MB for the lifetime of the process.
+    Deliberately not memoised: the result is registered as a buffer, so a shared cache has to clone
+    on the way out to keep callers from writing into it, and the clone costs more than rebuilding
+    the identity.
     """
     numel: int = kd * ky * kx
     return torch.eye(numel).view(numel, kd, ky, kx)

--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -28,11 +28,15 @@ from kornia.geometry.conversions import pi
 
 
 def _get_reshape_kernel(kd: int, ky: int, kx: int) -> torch.Tensor:
-    """Return neigh2channels conv kernel."""
+    """Return neigh2channels conv kernel.
+
+    The identity matrix is memoised per ``numel`` to avoid rebuilding it for the common kernel
+    sizes, but the caller always receives a **fresh copy**. Handing out the cached tensor itself
+    would let one consumer's in-place write -- ``load_state_dict`` copies into buffers in place --
+    corrupt the cache and therefore every other consumer, including modules constructed later.
+    """
     numel: int = kd * ky * kx
 
-    # Fast-path: use static _eye_cache if available for small numel
-    # (to avoid repeated allocations for common kernel sizes)
     # The cache size is limited for memory efficiency.
     # NOTE: If memory is a concern and large kd/ky/kx are rare, adjust _MAX_CACHED.
     _MAX_CACHED = 4096
@@ -44,7 +48,8 @@ def _get_reshape_kernel(kd: int, ky: int, kx: int) -> torch.Tensor:
         if res is None:
             res = torch.eye(numel)
             cache[numel] = res
-        return res.view(numel, kd, ky, kx)
+        # clone: never expose the cached tensor to the caller
+        return res.view(numel, kd, ky, kx).clone()
     else:
         # fallback to normal allocation for big kernels
         return torch.eye(numel).view(numel, kd, ky, kx)

--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -30,29 +30,17 @@ from kornia.geometry.conversions import pi
 def _get_reshape_kernel(kd: int, ky: int, kx: int) -> torch.Tensor:
     """Return neigh2channels conv kernel.
 
-    The identity matrix is memoised per ``numel`` to avoid rebuilding it for the common kernel
-    sizes, but the caller always receives a **fresh copy**. Handing out the cached tensor itself
-    would let one consumer's in-place write -- ``load_state_dict`` copies into buffers in place --
-    corrupt the cache and therefore every other consumer, including modules constructed later.
+    The identity matrix used to be memoised per ``numel`` and handed to the caller as a view of
+    the cached tensor, which let one consumer's in-place write -- ``load_state_dict`` copies into
+    buffers in place -- corrupt the cache and therefore every other consumer, including modules
+    constructed later (#4068). Making the cache safe means cloning on the way out, which costs
+    more than rebuilding the identity, so the cache is gone: measured on a 4-thread CPU, the
+    cached-and-cloned path is 2.6 us against 2.0 us for a plain ``torch.eye`` at the default
+    ``numel = 8 * 4 * 4``, and 3.9 ms against 2.8 ms at the old 4096 bound, where it also retained
+    67 MB for the lifetime of the process.
     """
     numel: int = kd * ky * kx
-
-    # The cache size is limited for memory efficiency.
-    # NOTE: If memory is a concern and large kd/ky/kx are rare, adjust _MAX_CACHED.
-    _MAX_CACHED = 4096
-    if numel <= _MAX_CACHED:
-        if not hasattr(_get_reshape_kernel, "_eye_cache"):
-            _get_reshape_kernel._eye_cache = {}  # type: ignore[attr-defined]
-        cache = _get_reshape_kernel._eye_cache  # type: ignore[attr-defined]
-        res = cache.get(numel)
-        if res is None:
-            res = torch.eye(numel)
-            cache[numel] = res
-        # clone: never expose the cached tensor to the caller
-        return res.view(numel, kd, ky, kx).clone()
-    else:
-        # fallback to normal allocation for big kernels
-        return torch.eye(numel).view(numel, kd, ky, kx)
+    return torch.eye(numel).view(numel, kd, ky, kx)
 
 
 def get_sift_pooling_kernel(ksize: int = 25) -> torch.Tensor:

--- a/tests/feature/test_siftdesc.py
+++ b/tests/feature/test_siftdesc.py
@@ -135,6 +135,34 @@ class TestDenseSIFTDescriptor(BaseTester):
         sift = DenseSIFTDescriptor()
         sift.__repr__()
 
+    def test_instances_do_not_share_buffer_storage(self, device):
+        """Instances must not alias the module-level identity cache (see #4068).
+
+        `_get_reshape_kernel` memoises `torch.eye(numel)`. Returning the cached tensor itself made
+        every `DenseSIFTDescriptor` with the same configuration share one storage, so a single
+        in-place write leaked into all of them.
+        """
+        a = DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)
+        b = DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)
+        assert a._poolingconv_weight.untyped_storage().data_ptr() != (
+            b._poolingconv_weight.untyped_storage().data_ptr()
+        )
+
+    def test_load_state_dict_does_not_leak_into_other_instances(self, device):
+        """`load_state_dict` copies into buffers in place; that must stay local to one module."""
+        a = DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)
+        b = DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)
+        expected = a._poolingconv_weight.clone()
+
+        state = b.state_dict()
+        state["_poolingconv_weight"] = torch.zeros_like(state["_poolingconv_weight"])
+        b.load_state_dict(state)
+
+        self.assert_close(a._poolingconv_weight, expected)
+        # and a module built afterwards is still healthy
+        c = DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)
+        self.assert_close(c._poolingconv_weight, expected)
+
     def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 1, 16, 16
         patches = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)

--- a/tests/feature/test_siftdesc.py
+++ b/tests/feature/test_siftdesc.py
@@ -136,10 +136,10 @@ class TestDenseSIFTDescriptor(BaseTester):
         sift.__repr__()
 
     def test_instances_do_not_share_buffer_storage(self, device):
-        """Instances must not alias the module-level identity cache (see #4068).
+        """Instances must not share storage for `_poolingconv_weight` (see #4068).
 
-        `_get_reshape_kernel` memoises `torch.eye(numel)`. Returning the cached tensor itself made
-        every `DenseSIFTDescriptor` with the same configuration share one storage, so a single
+        `_get_reshape_kernel` used to memoise `torch.eye(numel)` and hand out a view of it, so
+        every `DenseSIFTDescriptor` with the same configuration shared one storage and a single
         in-place write leaked into all of them.
         """
         a = DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)


### PR DESCRIPTION
## Problem

`_get_reshape_kernel` memoises `torch.eye(numel)` in a function attribute and returned a **view of the cached tensor**:

```python
res = cache.get(numel)
if res is None:
    res = torch.eye(numel)
    cache[numel] = res
return res.view(numel, kd, ky, kx)      # view of the shared tensor
```

`DenseSIFTDescriptor.__init__` registers that view directly as a buffer, and `.float()` on an already-float tensor is a no-op returning the *same object*, so no copy happened anywhere:

```python
Pw = _get_reshape_kernel(num_ang_bins, num_spatial_bins, num_spatial_bins).float()
self.register_buffer("_poolingconv_weight", Pw)
```

Every `DenseSIFTDescriptor` with the same `(num_ang_bins, num_spatial_bins)` therefore shared one storage with the process-global cache.

`load_state_dict` reaches this in ordinary use, because it copies into buffers **in place**:

```python
victim = DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)
sd = victim.state_dict()
sd["_poolingconv_weight"] = torch.zeros_like(sd["_poolingconv_weight"])
victim.load_state_dict(sd)
```
```
global cache zeroed by one instance's load_state_dict: True
a freshly constructed DenseSIFTDescriptor is now broken: True
```

No error is raised — the descriptors are simply wrong from then on, including from objects the caller never touched.

## Change

Remove the cache. `_get_reshape_kernel` is now:

```python
numel: int = kd * ky * kx
return torch.eye(numel).view(numel, kd, ky, kx)
```

An earlier revision of this PR kept the cache and cloned on the way out, on the assumption that "a memcpy is cheaper than `torch.eye`". Measured, that is not true — **a safe cache is slower than no cache at every size**, including the one every default `DenseSIFTDescriptor` hits (4 threads, min of 7 runs of 3000 iterations, cache pre-warmed):

| `kd,ky,kx` | `numel` | cached + `.clone()` | plain `torch.eye().view()` | speedup |
|---|--:|--:|--:|--:|
| (8, 4, 4) — the default | 128 | 2.60 µs | **2.00 µs** | **0.77×** |
| (8, 8, 8) | 512 | 33.43 µs | 33.90 µs | 1.01× |
| (8, 4, 16) | 512 | 34.11 µs | 33.70 µs | 0.99× |
| (16, 16, 16) | 4096 | 3901.87 µs | **2812.56 µs** | **0.72×** |

(0.77× at the default reproduced across three independent trials: 0.76×, 0.78×, 0.78×.) Whole-module: `DenseSIFTDescriptor()` construction goes 143.0 µs → 142.0 µs.

So there was nothing left to preserve, and no value of `_MAX_CACHED` worth keeping. Removing the cache also deletes `_MAX_CACHED`, the `hasattr`/function-attribute block and two `# type: ignore[attr-defined]`s, and removes the aliasing bug class rather than containing it. The cache was introduced by #3206, an automated micro-optimisation; the docstring now records the cost model so it is not silently re-added.

## Behaviour

Unchanged. Descriptor output and the resulting buffers are **byte-identical** to `main` (`torch.equal`) across three configurations, and re-verified byte-identical against the cached-and-cloned revision after the cache was removed:

```
8_4      byte-identical to main: True     8_4_buf  True
6_3      byte-identical to main: True     6_3_buf  True
8_2      byte-identical to main: True     8_2_buf  True
```

## Tests

Two regression tests on `TestDenseSIFTDescriptor`, both of which fail on unmodified `siftdesc.py`:

```
FAILED ...::test_instances_do_not_share_buffer_storage - assert 5100470272 != 5100470272
FAILED ...::test_load_state_dict_does_not_leak_into_other_instances - Tensor-likes are not close!
```

## Verification

```console
$ pytest tests/feature --device=cpu --dtype=float32,float64 -q
643 passed, 126 skipped

$ pixi run pre-commit-all
all hooks Passed
```

## Also resolved

Both secondary points from #4068 go away with the cache: it is no longer keyed only on `numel` (there is no key), and it no longer retains 67 MB for the process lifetime at the `_MAX_CACHED = 4096` bound.

## Not addressed here

`DenseSIFTDescriptor.get_pooling_kernel()` and `SIFTDescriptor.get_gaussian_kernel()` hand out a `.detach()` of a live module buffer, so a caller's in-place write lands on the module's own state. Same "handed a live reference to internal state" class, but instance-local rather than process-global — filed separately as #4083.

Closes #4068

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
