### PR TITLE
docs(feature): fix ggiven typo in get_sift_bin_ksize_stride_pad

### DIFF
--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -71,7 +71,7 @@ def get_sift_bin_ksize_stride_pad(patch_size: int, num_spatial_bins: int) -> Tup
 
     Args:
         patch_size: the given patch size.
-        num_spatial_bins: the ggiven number of spatial bins.
+        num_spatial_bins: the given number of spatial bins.
 
     Returns:
         ksize, stride, pad.


### PR DESCRIPTION
Fixes a `ggiven` typo in `get_sift_bin_ksize_stride_pad`'s docstring.

Originally this PR was larger, but it overlapped #4072 (now merged) and the `matching.py` hunk was dropped per review. The `lafs1` question is being handled in #4075.

Part of #4067.
