### PR TITLE
fix(feature): treat the image extent as w-1/h-1 in laf_is_inside_image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing FGINN tests pass unchanged on both sides, which is how this survived; two tests that discriminate it were
   added. `match_fginn`'s docstring now also records the saturation corner, where every candidate falls within
   `spatial_th` of the 1st nearest neighbor, the ratio collapses towards zero and the match is accepted.
+* Fix `laf_is_inside_image` treating the image extent as `(w, h)` rather than `(w - 1, h - 1)`, which made its
+  bounds asymmetric: the lower bound rejected anything left of `x = 0`, but the upper bound accepted `x = w`, a
+  full pixel past the last valid column `w - 1` (#4064). Valid pixel coordinates run `0 .. w-1` and `0 .. h-1` --
+  the convention `get_laf_center` documents and the one `normalize_laf`/`denormalize_laf` already use -- so the
+  upper bound is now `w - 1 - border` and `h - 1 - border`. A LAF whose boundary points reach past the last valid
+  pixel coordinate is now reported as outside; anything strictly inside is unchanged. The equivalent inlined check
+  in `ScaleSpaceDetector._process_octave` moved with it, so detections within one pixel of the right or bottom edge
+  that used to survive its `border=5` filter are now discarded.
 
 
 ## :rocket: [0.6.11] - 2022-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that used to survive its `border=5` filter are now discarded. That inlined check also computed its `max |sin|`
   constant with the wrong angular spacing (`2*pi/11` instead of the `2*pi/10` that `laf_to_boundary_points(n_pts=12)`
   actually samples), inflating the tested x-extent by 4% and making the inline check stricter than the reference it
-  claims to reproduce; the two now agree exactly. `ScaleSpaceDetector` output is unchanged.
+  claims to reproduce; the two now agree exactly. That correction is a loosening in x, so it can change
+  `ScaleSpaceDetector` output on its own: a detection whose x-extent falls between the two constants used to be
+  discarded and is now kept. It is rare -- the detection has to land in a band of width `0.039 * half_s` against the
+  x bound -- but when it fires it can promote the strongest response in the image, so it is not output-neutral.
 
 
 ## :rocket: [0.6.11] - 2022-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   upper bound is now `w - 1 - border` and `h - 1 - border`. A LAF whose boundary points reach past the last valid
   pixel coordinate is now reported as outside; anything strictly inside is unchanged. The equivalent inlined check
   in `ScaleSpaceDetector._process_octave` moved with it, so detections within one pixel of the right or bottom edge
-  that used to survive its `border=5` filter are now discarded.
+  that used to survive its `border=5` filter are now discarded. That inlined check also computed its `max |sin|`
+  constant with the wrong angular spacing (`2*pi/11` instead of the `2*pi/10` that `laf_to_boundary_points(n_pts=12)`
+  actually samples), inflating the tested x-extent by 4% and making the inline check stricter than the reference it
+  claims to reproduce; the two now agree exactly. `ScaleSpaceDetector` output is unchanged.
 
 
 ## :rocket: [0.6.11] - 2022-03-28

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -549,9 +549,11 @@ def laf_is_inside_image(laf: torch.Tensor, images: torch.Tensor, border: int = 0
     KORNIA_CHECK_LAF(laf)
     _, _, h, w = images.size()
     pts = laf_to_boundary_points(laf, 12)
-    good_lafs_mask = (
-        (pts[..., 0] >= border) * (pts[..., 0] <= w - border) * (pts[..., 1] >= border) * (pts[..., 1] <= h - border)
-    )
+    # Valid pixel coordinates run 0 .. w-1 and 0 .. h-1, matching the convention documented on
+    # `get_laf_center` and the `w - 1` / `h - 1` extent used by `normalize_laf` / `denormalize_laf`.
+    x_max = float(w - 1) - border
+    y_max = float(h - 1) - border
+    good_lafs_mask = (pts[..., 0] >= border) * (pts[..., 0] <= x_max) * (pts[..., 1] >= border) * (pts[..., 1] <= y_max)
     good_lafs_mask = good_lafs_mask.min(dim=2)[0]
     return good_lafs_mask
 

--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -299,11 +299,14 @@ class ScaleSpaceDetector(nn.Module):
         cx = current_lafs[:, :, 0, 2]
         cy = current_lafs[:, :, 1, 2]
         h, w = octave.shape[3], octave.shape[4]
+        # Valid pixel coordinates run 0 .. w-1 / 0 .. h-1, so the upper bound is (size - 1) - border.
+        x_max = float(w - 1) - 5
+        y_max = float(h - 1) - 5
         good_mask = (
             (cx - half_s * _MAX_ABS_SIN_12 >= 5)
-            & (cx + half_s * _MAX_ABS_SIN_12 <= w - 5)
+            & (cx + half_s * _MAX_ABS_SIN_12 <= x_max)
             & (cy - half_s >= 5)
-            & (cy + half_s <= h - 5)
+            & (cy + half_s <= y_max)
         )
         resp_flat_best = resp_flat_best * good_mask.to(dev, dtype)
         current_lafs.mul_(px_size)

--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -38,11 +38,11 @@ from .orientation import PassLAF
 from .responses import BlobHessian
 
 # Max |sin| among the 11 boundary points sampled by laf_to_boundary_points(n_pts=12):
-#   angles = linspace(0, 2π, 11) → k * 2π/11 for k=0..10
-#   max|sin| at k=3: sin(6π/11) ≈ 0.9898;  max|cos| at k=0: cos(0) = 1.0
+#   angles = linspace(0, 2π, n_pts - 1) = linspace(0, 2π, 11) → k * 2π/10 for k=0..10
+#   max|sin| at k=2 and k=3: sin(2π/5) ≈ 0.9511;  max|cos| at k=0: cos(0) = 1.0
 # Used to inline the boundary check in _process_octave for isotropic LAFs (rotmat=eye(2)),
 # avoiding CPU→GPU allocation + bmm every octave.
-_MAX_ABS_SIN_12: float = math.sin(3 * 2 * math.pi / 11)  # ≈ 0.9898
+_MAX_ABS_SIN_12: float = math.sin(2 * 2 * math.pi / 10)  # ≈ 0.9511
 
 
 def _scale_index_to_scale(max_coords: torch.Tensor, sigmas: torch.Tensor, num_levels: int) -> torch.Tensor:

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -594,6 +594,60 @@ class TestLAFIsTouchingBoundary(BaseTester):
         expected = torch.tensor([[False, True]], device=device)
         assert torch.all(kornia.feature.laf_is_inside_image(laf, img) == expected).item()
 
+    @staticmethod
+    def _radius_laf(cx, cy, radius, device, dtype):
+        return kornia.feature.laf_from_center_scale_ori(
+            torch.tensor([[[cx, cy]]], device=device, dtype=dtype),
+            torch.full((1, 1, 1, 1), radius, device=device, dtype=dtype),
+        )
+
+    def test_boundary_is_the_last_valid_pixel(self, device, dtype):
+        """Valid coordinates run 0 .. size-1, matching `get_laf_center`'s documented convention.
+
+        A LAF reaching exactly `w - 1` is inside; anything past it is not (see #4064).
+        """
+        if dtype not in (torch.float32, torch.float64):
+            pytest.skip("boundary comparison needs full precision")
+        w = h = 32  # valid coordinates 0 .. 31
+        img = torch.zeros(1, 1, h, w, device=device, dtype=dtype)
+        r = 2.0
+
+        # rightmost boundary lands exactly on 31.0 -> inside
+        assert bool(kornia.feature.laf_is_inside_image(self._radius_laf(29.0, 16.0, r, device, dtype), img)[0, 0])
+        # ... and half a pixel past it -> outside
+        assert not bool(kornia.feature.laf_is_inside_image(self._radius_laf(29.5, 16.0, r, device, dtype), img)[0, 0])
+        # same for the bottom edge
+        assert bool(kornia.feature.laf_is_inside_image(self._radius_laf(16.0, 29.0, r, device, dtype), img)[0, 0])
+        assert not bool(kornia.feature.laf_is_inside_image(self._radius_laf(16.0, 29.5, r, device, dtype), img)[0, 0])
+
+    def test_boundary_is_symmetric(self, device, dtype):
+        """The low and high edges must be equally strict."""
+        if dtype not in (torch.float32, torch.float64):
+            pytest.skip("boundary comparison needs full precision")
+        w = h = 32
+        img = torch.zeros(1, 1, h, w, device=device, dtype=dtype)
+        r = 2.0
+        # negative offsets push the LAF past the edge, which is where an asymmetric
+        # upper bound shows up: on the low side it is rejected, on the high side it was not.
+        for offset in (-1.0, -0.5, 0.0, 0.5, 1.0):
+            low = kornia.feature.laf_is_inside_image(self._radius_laf(r + offset, 16.0, r, device, dtype), img)
+            high = kornia.feature.laf_is_inside_image(
+                self._radius_laf(float(w - 1) - r - offset, 16.0, r, device, dtype), img
+            )
+            assert bool(low[0, 0]) == bool(high[0, 0]), f"asymmetric at offset {offset}"
+
+    def test_border_argument_shrinks_both_edges(self, device, dtype):
+        if dtype not in (torch.float32, torch.float64):
+            pytest.skip("boundary comparison needs full precision")
+        w = h = 32
+        img = torch.zeros(1, 1, h, w, device=device, dtype=dtype)
+        r = 2.0
+        # with border=3 the usable range is 3 .. 28, so a radius-2 LAF centred at 26 just fits
+        assert bool(kornia.feature.laf_is_inside_image(self._radius_laf(26.0, 16.0, r, device, dtype), img, 3)[0, 0])
+        assert not bool(
+            kornia.feature.laf_is_inside_image(self._radius_laf(26.5, 16.0, r, device, dtype), img, 3)[0, 0]
+        )
+
     @pytest.mark.jit()
     def test_jit(self, device, dtype):
         w, h = 10, 5

--- a/tests/feature/test_scale_space_detector.py
+++ b/tests/feature/test_scale_space_detector.py
@@ -18,7 +18,12 @@
 import torch
 
 import kornia
-from kornia.feature.scale_space_detector import MultiResolutionDetector, ScaleSpaceDetector, get_default_detector_config
+from kornia.feature.scale_space_detector import (
+    _MAX_ABS_SIN_12,
+    MultiResolutionDetector,
+    ScaleSpaceDetector,
+    get_default_detector_config,
+)
 from kornia.geometry.subpix import ConvQuadInterp3d
 
 from testing.base import BaseTester
@@ -108,6 +113,27 @@ class TestScaleSpaceDetector(BaseTester):
         lafs, resps = det(inp)
         assert lafs.shape == torch.Size([1, n_feats, 2, 3])
         assert resps.shape == torch.Size([1, n_feats])
+
+    def test_inline_boundary_constant_matches_reference(self):
+        """`_MAX_ABS_SIN_12` must be the x-extent `laf_to_boundary_points(laf, 12)` actually produces.
+
+        `_process_octave` inlines `laf_is_inside_image(scale_laf(lafs, 0.5), octave, 5)` for the
+        isotropic LAFs it builds. That inline form is only equivalent to the reference if the
+        constant is the maximum ``|sin|`` over the angles the reference samples, which are
+        ``linspace(0, 2 * pi, n_pts - 1)`` -- spacing ``2 * pi / 10``, not ``2 * pi / 11`` (#4064).
+        Device- and dtype-independent: this pins a Python float against a sampling convention.
+        """
+        cx, cy, half_s = 10.0, 20.0, 3.0
+        laf = kornia.feature.laf_from_center_scale_ori(
+            torch.tensor([[[cx, cy]]], dtype=torch.float64),
+            torch.full((1, 1, 1, 1), half_s, dtype=torch.float64),
+        )
+        pts = kornia.feature.laf_to_boundary_points(laf, 12)
+        # `laf_to_boundary_points` builds its angles in float32 before casting, so compare at
+        # float32 resolution -- the wrong spacing is off by 4e-2, four orders of magnitude more.
+        assert abs(((pts[..., 0].max() - cx) / half_s).item() - _MAX_ABS_SIN_12) < 1e-6
+        # ... and the y-extent the same block hardcodes as `half_s` (max|cos| = 1).
+        assert abs(((pts[..., 1].max() - cy) / half_s).item() - 1.0) < 1e-6
 
     def test_gradcheck(self, device):
         batch_size, channels, height, width = 1, 1, 7, 7


### PR DESCRIPTION
## Problem

`laf_is_inside_image` bounded the boundary points by `w - border` / `h - border`, while every other extent computation in `laf.py` uses `w - 1` / `h - 1`:

| line | function | extent |
|---|---|---|
| 339–340 | `denormalize_laf` | `w - 1`, `h - 1` |
| 370–371 | `normalize_laf` | `w - 1`, `h - 1` |
| 400–401 | `generate_patch_grid_from_normalized_LAF` | `w - 1`, `h - 1` |
| **527** | **`laf_is_inside_image`** | **`w`, `h`** |

Valid pixel coordinates run `0 .. w-1`, as documented on `get_laf_center`: *"the convention is that center of 5-pixel image (coordinates from 0 to 4) is 2, and not 2.5"*.

Because the lower bound (`>= border`) was already correct, the accepted window was **asymmetric** — strict at the low edge, one pixel loose at the high edge:

```
radius-2 LAF, 32-wide image (last valid x = 31)
                                       before   after
  centre x=29.0 -> rightmost 31.0      inside   inside
  centre x=29.5 -> rightmost 31.5      inside   OUTSIDE
  centre x=30.0 -> rightmost 32.0      inside   OUTSIDE
```

## The inline copy in `ScaleSpaceDetector`

`_process_octave` carries a hand-rolled version whose own comment calls it an *"Inline equivalent of `laf_is_inside_image(scale_laf(current_lafs, 0.5), octave[:, 0], 5)`"*. It had the same `w - 5` / `h - 5` bound and is updated in step — leaving it would have silently broken the equivalence that comment asserts.

### ... and its `max |sin|` constant was computed with the wrong spacing

The residual inline-vs-reference disagreement was **not** inherent to the approximation, as an earlier revision of this description claimed — the constant is simply wrong:

```python
_MAX_ABS_SIN_12: float = math.sin(3 * 2 * math.pi / 11)   # 0.98982
```

`laf_to_boundary_points(LAF, n_pts=12)` samples `torch.linspace(0, 2*pi, n_pts - 1)` = `linspace(0, 2π, 11)`, whose spacing is **2π/10**, not 2π/11:

```
max|sin| over linspace(0, 2pi, 11)                              : 0.95105654
_MAX_ABS_SIN_12 before                                          : 0.98982144  = sin(3*2pi/11)
sin(2*2pi/10)                                                   : 0.95105652
measured (max_x - cx)/half_s from laf_to_boundary_points(laf,12) : 0.95105648
```

So the inline check inflated the x-extent by 4%, making it *stricter* than the reference — the direction of every disagreement observed. With the corrected constant the block genuinely is the inline equivalent its comment claims:

```
4000 random isotropic LAFs spanning the borders of a 64x96 image, border=5:
  before  sin(3*2pi/11)=0.98982 : 7 disagreements (inline stricter: 7, looser: 0)
  after   sin(2*2pi/10)=0.95106 : 0 disagreements
```

`tests/feature/test_scale_space_detector.py::test_inline_boundary_constant_matches_reference` pins the constant against the extent `laf_to_boundary_points` actually produces, and fails on the old value (`assert 0.03876 < 1e-06`). Constant introduced in #3623.

## Practical impact

Small but **not zero**, and the earlier version of this section got that wrong. On a random 2×1×96×128 input `ScaleSpaceDetector` output is `torch.equal` before and after — under both changes together and under the constant change alone — because `border=5` keeps keypoints away from the edge and a random image rarely puts a detection in the affected band. That is a property of the input, not of the change.

The constant fix is a **loosening in x**: a detection whose x-extent falls between `sin(3*2pi/11)` and `sin(2*2pi/10)` used to be discarded and is now kept. Holding `w-1`/`h-1` fixed and toggling only `_MAX_ABS_SIN_12` on a 128x160 image with a sigma=4 blob at (136, 64) and a weak one at (40, 40), with `ScaleSpaceDetector(num_features=50)`:

```
new constant (0.95106):  laf[0] = [[25.933, 0, 135.184], [0, 25.933, 63.532]]   resp 0.04437
old constant (0.98982):  laf[0] = [[24.190, 0,  40.000], [0, 24.190, 40.000]]   resp 0.00396
```

The strongest detection in the image -- an order of magnitude above what replaced it -- was being discarded by the wrong constant. Sweeping the blob over sigma in {4, 6, 8, 12} and cx in [W-40, W-2) in 0.25 px steps, **6 of 608 positions change output**. It needs the detection to land in a band of width `0.039 * half_s` against the x bound, so it is rare on noise images (0 of 12 uniform-random inputs differ) -- but the case where it fires is exactly the case a user notices. The CHANGELOG entry says this rather than claiming the output is unchanged.

Detectors that call `laf_is_inside_image` with a small `border` will now drop LAFs reaching within one pixel of the right/bottom edge that were previously kept.

## Tests

The existing `test_touch` never discriminated this — its "inside" LAF is a radius-1 circle at `(5, 2)` in a 10×5 image, nowhere near the boundary. Three new tests do, and **all three fail without the change**:

```
FAILED ...::test_boundary_is_the_last_valid_pixel[cpu-float32] - assert not True
FAILED ...::test_boundary_is_symmetric[cpu-float32] - AssertionError: asymmetric at offset -1.0
FAILED ...::test_border_argument_shrinks_both_edges[cpu-float32] - assert not True
```

`test_inline_boundary_constant_matches_reference` is the fourth, pinning the corrected spacing.

`test_boundary_is_symmetric` probes offsets *past* the edge — an earlier revision only probed points that are inside under both behaviours and so passed on `main`, which would have made it worthless.

## Verification

```console
$ pytest tests/feature --device=cpu --dtype=float32,float64 -q
647 passed, 126 skipped

$ pixi run pre-commit-all
all hooks Passed
```

Closes #4064

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
