### PR TITLE
fix(feature): make integrated.py's empty results match its non-empty ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ScaleSpaceDetector` output on its own: a detection whose x-extent falls between the two constants used to be
   discarded and is now kept. It is rare -- the detection has to land in a band of width `0.039 * half_s` against the
   x bound -- but when it fires it can promote the strongest response in the image, so it is not output-neutral.
+* Fix the empty-result paths in `kornia.feature.integrated` disagreeing with the corresponding non-empty ones
+  (#4065). `get_laf_descriptors` returned a hardcoded width of 128 with the *LAF's* dtype and device when it was
+  handed no keypoints, so an empty batch through, say, a 256-d descriptor produced a `(B, 0, 128)` result that could
+  not be concatenated with a real one; it now probes the descriptor once and returns its actual width, dtype and
+  device. `LocalFeatureMatcher.no_match_output` returned `lafs0`/`lafs1` of shape `(0, 0, 2, 3)` where the success
+  path returns `(1, NC, 2, 3)`, so `lafs0[0]` raised `IndexError` exactly when nothing matched; the empty tensors
+  now keep the leading batch of 1. `LocalFeatureMatcher.forward`'s docstring also stops claiming `confidence` is in
+  `[0, 1]`: it is `1 - distance`, which for the raw-distance matchers `nn` and `mnn` reaches -1 on unit-norm
+  descriptors.
 
 
 ## :rocket: [0.6.11] - 2022-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,12 +157,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix the empty-result paths in `kornia.feature.integrated` disagreeing with the corresponding non-empty ones
   (#4065). `get_laf_descriptors` returned a hardcoded width of 128 with the *LAF's* dtype and device when it was
   handed no keypoints, so an empty batch through, say, a 256-d descriptor produced a `(B, 0, 128)` result that could
-  not be concatenated with a real one; it now probes the descriptor once and returns its actual width, dtype and
-  device. `LocalFeatureMatcher.no_match_output` returned `lafs0`/`lafs1` of shape `(0, 0, 2, 3)` where the success
-  path returns `(1, NC, 2, 3)`, so `lafs0[0]` raised `IndexError` exactly when nothing matched; the empty tensors
-  now keep the leading batch of 1. `LocalFeatureMatcher.forward`'s docstring also stops claiming `confidence` is in
-  `[0, 1]`: it is `1 - distance`, which for the raw-distance matchers `nn` and `mnn` reaches -1 on unit-norm
-  descriptors.
+  not be concatenated with a real one; it now runs the descriptor once on a zero patch and returns its actual width
+  (the flattened per-patch output, matching the non-empty path's `.view(B, N, -1)`), dtype and device. That is a
+  widening of the empty path's failure surface: a third-party descriptor that raises on a zero input now raises here
+  where it previously returned quietly. `LocalFeatureMatcher.no_match_output` returned `lafs0`/`lafs1` of shape
+  `(0, 0, 2, 3)` where the success path returns `(1, NC, 2, 3)`, so `lafs0[0]` raised `IndexError` exactly when
+  nothing matched; the empty tensors now keep the leading batch of 1. That is a shape change on a public return
+  value -- code using `out["lafs0"].shape[0] == 0` as its no-match signal now sees `1` and should test
+  `out["keypoints0"].shape[0] == 0`, which was already the consistent signal. `LocalFeatureMatcher.forward`'s
+  docstring also stops claiming `confidence` is in `[0, 1]`: it is `1 - distance`, which for the raw-distance
+  matchers `nn` and `mnn` goes at least down to -1 on unit-norm descriptors, and is unbounded below for arbitrary
+  ones.
 
 
 ## :rocket: [0.6.11] - 2022-03-28

--- a/kornia/feature/integrated.py
+++ b/kornia/feature/integrated.py
@@ -78,7 +78,9 @@ def get_laf_descriptors(
         # Probe the descriptor for its output width instead of assuming 128, so the empty result
         # has the same trailing dimension and dtype as a non-empty one.
         with torch.no_grad():
-            probe = patch_descriptor(torch.zeros(1, timg.size(1), patch_size, patch_size).to(timg))
+            probe = patch_descriptor(
+                torch.zeros(1, timg.size(1), patch_size, patch_size, dtype=timg.dtype, device=timg.device)
+            )
         return torch.empty(lafs.shape[0], 0, probe.shape[-1], dtype=probe.dtype, device=probe.device)
 
     patches: torch.Tensor = extract_patches_from_pyramid(timg, lafs, patch_size)

--- a/kornia/feature/integrated.py
+++ b/kornia/feature/integrated.py
@@ -76,12 +76,15 @@ def get_laf_descriptors(
     if lafs.shape[1] == 0:
         warnings.warn(f"LAF contains no keypoints {lafs.shape}, returning empty torch.Tensor", stacklevel=1)
         # Probe the descriptor for its output width instead of assuming 128, so the empty result
-        # has the same trailing dimension and dtype as a non-empty one.
+        # has the same trailing dimension and dtype as a non-empty one. The non-empty path ends in
+        # `.view(B, N, -1)`, which flattens everything the descriptor produced per patch, so the
+        # matching width is the whole probe -- `probe.shape[-1]` would only agree for descriptors
+        # whose output is 2-D. The probe has a batch of one, so its numel is that width.
         with torch.no_grad():
             probe = patch_descriptor(
                 torch.zeros(1, timg.size(1), patch_size, patch_size, dtype=timg.dtype, device=timg.device)
             )
-        return torch.empty(lafs.shape[0], 0, probe.shape[-1], dtype=probe.dtype, device=probe.device)
+        return torch.empty(lafs.shape[0], 0, probe.numel(), dtype=probe.dtype, device=probe.device)
 
     patches: torch.Tensor = extract_patches_from_pyramid(timg, lafs, patch_size)
     # Descriptor accepts standard torch.Tensor [B, CH, H, W], while patches are [B, N, CH, H, W] shape
@@ -436,8 +439,9 @@ class LocalFeatureMatcher(nn.Module):
             - ``keypoints1``, matching keypoints from image1 :math:`(NC, 2)`.
             - ``confidence``, ``1 - descriptor distance`` :math:`(NC)`. This lies in :math:`[0, 1]`
               only for ratio-based matchers (``snn``, ``smnn``, ``fginn``, ``adalam``); ``nn`` and
-              ``mnn`` return raw distances, which reach 2.0 for unit-norm descriptors and therefore
-              give confidences down to -1.
+              ``mnn`` return raw distances, which are unbounded for an arbitrary descriptor, so the
+              confidence has no lower bound in general -- it goes at least down to -1, the value
+              reached by unit-norm descriptors, whose distance tops out at 2.0.
             - ``lafs0``, matching LAFs from image0 :math:`(1, NC, 2, 3)`.
             - ``lafs1``, matching LAFs from image1 :math:`(1, NC, 2, 3)`.
             - ``batch_indexes``, batch indexes for the keypoints and lafs :math:`(NC)`.

--- a/kornia/feature/integrated.py
+++ b/kornia/feature/integrated.py
@@ -438,7 +438,7 @@ class LocalFeatureMatcher(nn.Module):
             - ``keypoints0``, matching keypoints from image0 :math:`(NC, 2)`.
             - ``keypoints1``, matching keypoints from image1 :math:`(NC, 2)`.
             - ``confidence``, ``1 - descriptor distance`` :math:`(NC)`. This lies in :math:`[0, 1]`
-              only for ratio-based matchers (``snn``, ``smnn``, ``fginn``, ``adalam``); ``nn`` and
+              only for the ratio-based ``DescriptorMatcher`` modes (``snn``, ``smnn``); ``nn`` and
               ``mnn`` return raw distances, which are unbounded for an arbitrary descriptor, so the
               confidence has no lower bound in general -- it goes at least down to -1, the value
               reached by unit-norm descriptors, whose distance tops out at 2.0.

--- a/kornia/feature/integrated.py
+++ b/kornia/feature/integrated.py
@@ -70,11 +70,16 @@ def get_laf_descriptors(
     patch_descriptor.eval()
 
     timg: torch.Tensor = img
-    if lafs.shape[1] == 0:
-        warnings.warn(f"LAF contains no keypoints {lafs.shape}, returning empty torch.Tensor", stacklevel=1)
-        return torch.empty(lafs.shape[0], lafs.shape[1], 128, dtype=lafs.dtype, device=lafs.device)
     if grayscale_descriptor and img.size(1) == 3:
         timg = rgb_to_grayscale(img)
+
+    if lafs.shape[1] == 0:
+        warnings.warn(f"LAF contains no keypoints {lafs.shape}, returning empty torch.Tensor", stacklevel=1)
+        # Probe the descriptor for its output width instead of assuming 128, so the empty result
+        # has the same trailing dimension and dtype as a non-empty one.
+        with torch.no_grad():
+            probe = patch_descriptor(torch.zeros(1, timg.size(1), patch_size, patch_size).to(timg))
+        return torch.empty(lafs.shape[0], 0, probe.shape[-1], dtype=probe.dtype, device=probe.device)
 
     patches: torch.Tensor = extract_patches_from_pyramid(timg, lafs, patch_size)
     # Descriptor accepts standard torch.Tensor [B, CH, H, W], while patches are [B, N, CH, H, W] shape
@@ -404,8 +409,10 @@ class LocalFeatureMatcher(nn.Module):
         return {
             "keypoints0": torch.empty(0, 2, device=device, dtype=dtype),
             "keypoints1": torch.empty(0, 2, device=device, dtype=dtype),
-            "lafs0": torch.empty(0, 0, 2, 3, device=device, dtype=dtype),
-            "lafs1": torch.empty(0, 0, 2, 3, device=device, dtype=dtype),
+            # batch dim 1, matching the success path's `.view(1, -1, 2, 3)`, so that callers
+            # can index `lafs0[0]` regardless of whether anything matched.
+            "lafs0": torch.empty(1, 0, 2, 3, device=device, dtype=dtype),
+            "lafs1": torch.empty(1, 0, 2, 3, device=device, dtype=dtype),
             "confidence": torch.empty(0, device=device, dtype=dtype),
             "batch_indexes": torch.empty(0, device=device, dtype=torch.long),
         }
@@ -425,7 +432,10 @@ class LocalFeatureMatcher(nn.Module):
         Returns:
             - ``keypoints0``, matching keypoints from image0 :math:`(NC, 2)`.
             - ``keypoints1``, matching keypoints from image1 :math:`(NC, 2)`.
-            - ``confidence``, confidence score [0, 1] :math:`(NC)`.
+            - ``confidence``, ``1 - descriptor distance`` :math:`(NC)`. This lies in :math:`[0, 1]`
+              only for ratio-based matchers (``snn``, ``smnn``, ``fginn``, ``adalam``); ``nn`` and
+              ``mnn`` return raw distances, which reach 2.0 for unit-norm descriptors and therefore
+              give confidences down to -1.
             - ``lafs0``, matching LAFs from image0 :math:`(1, NC, 2, 3)`.
             - ``lafs1``, matching LAFs from image1 :math:`(1, NC, 2, 3)`.
             - ``batch_indexes``, batch indexes for the keypoints and lafs :math:`(NC)`.

--- a/tests/feature/test_integrated.py
+++ b/tests/feature/test_integrated.py
@@ -91,6 +91,44 @@ class TestGetLAFDescriptors(BaseTester):
         )
 
 
+class TestGetLAFDescriptorsEmptyPath(BaseTester):
+    """The empty-LAF result must agree with the non-empty one (see #4065)."""
+
+    @pytest.mark.parametrize("output_dims", [64, 128, 238])
+    def test_empty_matches_the_descriptor_width(self, device, dtype, output_dims):
+        """The width came from a hardcoded 128 rather than from the descriptor module."""
+        img = torch.rand(1, 1, 64, 64, device=device, dtype=dtype)
+        desc = kornia.feature.MKDDescriptor(patch_size=32, output_dims=output_dims).to(device, dtype)
+        laf = kornia.feature.laf_from_center_scale_ori(
+            torch.tensor([[[32.0, 32.0]]], device=device, dtype=dtype),
+            torch.full((1, 1, 1, 1), 8.0, device=device, dtype=dtype),
+        )
+        non_empty = kornia.feature.get_laf_descriptors(img, laf, desc, 32)
+        with pytest.warns(UserWarning):
+            empty = kornia.feature.get_laf_descriptors(
+                img, torch.zeros(1, 0, 2, 3, device=device, dtype=dtype), desc, 32
+            )
+        assert empty.shape == (1, 0, non_empty.shape[-1])
+        assert empty.dtype == non_empty.dtype
+        assert empty.device.type == non_empty.device.type
+
+
+class TestLocalFeatureMatcherEmptyPath(BaseTester):
+    """`no_match_output` must keep the rank the success path uses (see #4065)."""
+
+    def test_empty_lafs_keep_the_batch_dimension(self, device, dtype):
+        matcher = kornia.feature.LocalFeatureMatcher(
+            kornia.feature.SIFTFeature(50), kornia.feature.DescriptorMatcher("snn", 0.9)
+        )
+        out = matcher.no_match_output(device, dtype)
+        # the success path returns `.view(1, -1, 2, 3)`
+        assert out["lafs0"].shape == (1, 0, 2, 3)
+        assert out["lafs1"].shape == (1, 0, 2, 3)
+        # so indexing the batch works either way
+        assert out["lafs0"][0].shape == (0, 2, 3)
+        assert out["keypoints0"].shape == (0, 2)
+
+
 class TestLAFDescriptor(BaseTester):
     def test_same(self, device, dtype):
         B, C, H, W = 1, 3, 64, 64

--- a/tests/feature/test_integrated.py
+++ b/tests/feature/test_integrated.py
@@ -112,6 +112,43 @@ class TestGetLAFDescriptorsEmptyPath(BaseTester):
         assert empty.dtype == non_empty.dtype
         assert empty.device.type == non_empty.device.type
 
+    @pytest.mark.parametrize("descriptor", ["four_dim", "dense_sift"])
+    def test_empty_matches_a_non_2d_descriptor(self, device, dtype, descriptor):
+        """The width must be what `.view(B, N, -1)` produces, not the probe's last dimension.
+
+        The non-empty path flattens *everything* the descriptor produced per patch, so taking
+        `probe.shape[-1]` agreed only for descriptors whose output is 2-D. `patch_descriptor` is
+        typed as a bare `nn.Module`; `DenseSIFTDescriptor` returns `(N, C, H, W)` and so does any
+        user module of that shape, and those got a narrower empty result that could not be
+        concatenated with a non-empty one -- the very defect this path exists to remove (#4065).
+        """
+
+        class FourDimDescriptor(nn.Module):
+            """Minimal descriptor whose output is not 2-D."""
+
+            def forward(self, patches: torch.Tensor) -> torch.Tensor:
+                return patches.new_zeros(patches.shape[0], 3, 2, 5)
+
+        desc = (
+            FourDimDescriptor()
+            if descriptor == "four_dim"
+            else kornia.feature.DenseSIFTDescriptor(num_ang_bins=8, num_spatial_bins=4)
+        )
+        desc = desc.to(device, dtype)
+        img = torch.rand(1, 1, 32, 32, device=device, dtype=dtype)
+        laf = kornia.feature.laf_from_center_scale_ori(
+            torch.tensor([[[16.0, 16.0]]], device=device, dtype=dtype),
+            torch.full((1, 1, 1, 1), 8.0, device=device, dtype=dtype),
+        )
+        non_empty = kornia.feature.get_laf_descriptors(img, laf, desc, 32)
+        with pytest.warns(UserWarning):
+            empty = kornia.feature.get_laf_descriptors(
+                img, torch.zeros(1, 0, 2, 3, device=device, dtype=dtype), desc, 32
+            )
+        assert empty.shape == (1, 0, non_empty.shape[-1])
+        # which is the point: an empty batch has to be concatenable with a non-empty one
+        assert torch.cat([non_empty, empty], dim=1).shape == non_empty.shape
+
 
 class TestLocalFeatureMatcherEmptyPath(BaseTester):
     """`no_match_output` must keep the rank the success path uses (see #4065)."""


### PR DESCRIPTION
## Problem

Three "nothing was found" paths in `integrated.py` disagreed with their corresponding normal paths.

### 1. `get_laf_descriptors` hardcoded a width of 128

```python
if lafs.shape[1] == 0:
    return torch.empty(lafs.shape[0], lafs.shape[1], 128, dtype=lafs.dtype, device=lafs.device)
```

so the descriptor width depended on whether anything was detected:

```
MKDDescriptor(output_dims= 64)   non-empty=  64   empty= 128
MKDDescriptor(output_dims=128)   non-empty= 128   empty= 128
MKDDescriptor(output_dims=238)   non-empty= 238   empty= 128
```

The dtype came from `lafs` rather than from the descriptor's output too.

**Fix:** probe the descriptor with a single dummy patch and take the width, dtype and device from that. The grayscale conversion moves above the early return so the probe uses the correct channel count.

The width is `probe.numel()`, not `probe.shape[-1]`. The non-empty path ends in `.view(B, N, -1)`, which flattens *everything* the descriptor produced per patch, so the last dimension only agrees for descriptors whose output is 2-D. `patch_descriptor` is typed as a bare `nn.Module`, and `DenseSIFTDescriptor` — or any user module returning `(N, C, H, W)` — is not:

```
DenseSIFTDescriptor    non-empty=(1, 1, 131072)   empty=(1, 0, 32)
  torch.cat FAILS: Expected size 131072 but got size 32
```

which would have reintroduced the exact defect this PR removes. The probe has a batch of one, so its numel is by construction the width `.view(B, N, -1)` produces.

**New failure surface:** the empty path now *executes* the descriptor, so a third-party descriptor that raises on a zero patch raises here where it previously returned quietly. Rare and cheap enough not to guard, but it is a real widening and is named in the changelog.

Checked that a zero patch is safe for every patch descriptor in `kornia.feature` — `SIFTDescriptor`, `MKDDescriptor` (64/128/238), `HardNet`, `HardNet8`, `HyNet`, `TFeat`, `SOSNet` — all return finite output and none raise.

After:
```
SIFTDescriptor(32)     non-empty= 128  empty= 128
MKD(output_dims=64)    non-empty=  64  empty=  64
MKD(output_dims=238)   non-empty= 238  empty= 238
```

### 2. `no_match_output` dropped the batch dimension

It returned `lafs0`/`lafs1` as `(0, 0, 2, 3)` while the success path returns `.view(1, -1, 2, 3)`. So `out["lafs0"][0]` worked when something matched and raised when nothing did. The sibling `keypoints0` was already consistent (`(0, 2)` vs `(-1, 2)`); only the LAFs disagreed.

**Fix:** `(1, 0, 2, 3)`.

This is a shape change on a public return value: code using `out["lafs0"].shape[0] == 0` as its no-match signal now sees `1`. `out["keypoints0"].shape[0] == 0` was already the consistent signal and is unaffected. Named explicitly in the changelog.

### 3. `confidence` is documented as `[0, 1]` but can reach −1

`confidence = 1.0 - dists`. That holds for the ratio-based `DescriptorMatcher` modes (`snn`, `smnn`), but `match_nn` / `match_mnn` return raw L2 distances, which reach 2.0 for unit-norm descriptors. (`fginn` and `adalam` are ratio-based too, but they belong to `GeometryAwareDescriptorMatcher`, whose `forward` takes `lafs1`/`lafs2` as well — `LocalFeatureMatcher` calls its matcher with two arguments, so those modes cannot reach this code path and are not listed.)

**Fix: documentation only.** Clamping would silently change user-visible confidence values and destroy ordering for the `nn` matchers, so the docstring now states the real range and which matchers guarantee `[0, 1]`. Since the function accepts arbitrary descriptors, the raw distance is unbounded in general: the docstring says the confidence has no lower bound and goes *at least* down to −1, which is the unit-norm case.

## Tests

Both code fixes are pinned, and the new tests fail on unmodified `integrated.py`:

```
FAILED ...TestGetLAFDescriptorsEmptyPath::test_empty_matches_the_descriptor_width[cpu-float32-64]  - assert torch.Size([1, 0, 128]) == (1, 0, 64)
FAILED ...TestGetLAFDescriptorsEmptyPath::test_empty_matches_the_descriptor_width[cpu-float32-238] - assert torch.Size([1, 0, 128]) == (1, 0, 238)
FAILED ...TestLocalFeatureMatcherEmptyPath::test_empty_lafs_keep_the_batch_dimension[cpu-float32]  - assert torch.Size([0, 0, 2, 3]) == (1, 0, 2, 3)
```

A third test pins the non-2-D case, parametrised over a 2-line `nn.Module` returning `(N, 3, 2, 5)` and a real `DenseSIFTDescriptor`, and asserts the concatenation rather than just the width. Both fail on `probe.shape[-1]`:

```
FAILED ...::test_empty_matches_a_non_2d_descriptor[cpu-float32-four_dim]    - assert torch.Size([1, 0, 5])  == (1, 0, 30)
FAILED ...::test_empty_matches_a_non_2d_descriptor[cpu-float32-dense_sift]  - assert torch.Size([1, 0, 32]) == (1, 0, 131072)
```

(The `output_dims=128` case passes either way — it is the value that was hardcoded — and is kept as a parametrisation so the fix is exercised at the previously-correct width too.)

## Note on `integrated.py` coverage

This file sits at **51% line coverage**, the lowest of the hand-written (non-vendored) files in `kornia/feature`. Items 2 and 3 were both on lines no test touched.

## Verification

```console
$ pytest tests/feature --device=cpu --dtype=float32,float64 -q
649 passed, 126 skipped

$ pixi run pre-commit-all
all hooks Passed
```

Closes #4065

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
