### PR TITLE
docs: refresh the half-precision numbers and annotate the morphology row

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Leverage pre-trained AI models optimized for a variety of vision tasks, all with
 | `kornia.color` | ⚠️ | ⚠️ | Most conversions work for both; FFT-based ops may fail |
 | `kornia.filters` | ⚠️ | ⚠️ | Basic filters work; FFT-based ops may fail on CUDA |
 | `kornia.enhance` | ⚠️ | ⚠️ | Histogram eq / gamma / ZCA work (linalg ops use cast helpers) |
-| `kornia.morphology` | ✅ | ✅ | Pure conv/pool ops; no dtype restrictions |
+| `kornia.morphology` | ✅ | ⚠️ | Pure conv/pool ops. `top_hat` / `bottom_hat` / `gradient` subtract two dilation/erosion results, so bfloat16 loses ~0.4% relative accuracy ([#4081](https://github.com/kornia/kornia/issues/4081)) |
 | `kornia.augmentation` | ⚠️ | ⚠️ | Most ops work; precision-sensitive transforms may be inaccurate |
 | `kornia.geometry.transform` | ⚠️ | ⚠️ | Affine/warp/resize work via cast helpers; thin-plate spline may fail |
 | `kornia.geometry.camera` | ⚠️ | ⚠️ | Pinhole model and most camera ops work; `StereoCamera` accepts both |
@@ -99,16 +99,19 @@ Leverage pre-trained AI models optimized for a variety of vision tasks, all with
 
 ✅ Supported &nbsp; ⚠️ Partial &nbsp; ❌ Not supported
 
-**Test results** (commit `6131e98`, 2026-03-21):
+**Test results:**
 
-| Run | Passed | Failed | Skipped | Pass% |
-|-----|-------:|-------:|--------:|------:|
-| CPU float32 *(baseline)* | 7647 | 3 | 3269 | **99.9%** |
-| CUDA float32 *(baseline)* | 7634 | 3 | 3280 | **99.9%** |
-| CPU float16 | 6866 | 747 | 3306 | **90.1%** |
-| CPU bfloat16 | 6838 | 812 | 3269 | **89.3%** |
-| CUDA float16 *(KORNIA_TEST_IN_SUBPROCESS=1)* | 6727 | 643 | 3556 | **91.3%** |
-| CUDA bfloat16 *(KORNIA_TEST_IN_SUBPROCESS=1)* | 6695 | 713 | 3518 | **90.4%** |
+| Run | Passed | Failed | Skipped | Pass% | Measured |
+|-----|-------:|-------:|--------:|------:|----------|
+| CPU float32 *(baseline)* | 8499 | 0 | 3535 | **100.0%** | `4ab79c78`, 2026-08-29 |
+| CPU float16 | 7751 | 689 | 3595 | **91.8%** | `4ab79c78`, 2026-08-29 |
+| CPU bfloat16 | 7794 | 695 | 3545 | **91.8%** | `4ab79c78`, 2026-08-29 |
+| CUDA float32 *(baseline)* | 7634 | 3 | 3280 | **99.9%** | `6131e98`, 2026-03-21 |
+| CUDA float16 *(KORNIA_TEST_IN_SUBPROCESS=1)* | 6727 | 643 | 3556 | **91.3%** | `6131e98`, 2026-03-21 |
+| CUDA bfloat16 *(KORNIA_TEST_IN_SUBPROCESS=1)* | 6695 | 713 | 3518 | **90.4%** | `6131e98`, 2026-03-21 |
+
+Reproduce the CPU rows with `pixi run test-half`. The half-precision suite is not run in CI
+(see [#4070](https://github.com/kornia/kornia/issues/4070)), so these numbers are refreshed by hand.
 
 See the [full precision guide](https://kornia.readthedocs.io/en/stable/get-started/precision.html) for details.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Leverage pre-trained AI models optimized for a variety of vision tasks, all with
 | `kornia.color` | ⚠️ | ⚠️ | Most conversions work for both; FFT-based ops may fail |
 | `kornia.filters` | ⚠️ | ⚠️ | Basic filters work; FFT-based ops may fail on CUDA |
 | `kornia.enhance` | ⚠️ | ⚠️ | Histogram eq / gamma / ZCA work (linalg ops use cast helpers) |
-| `kornia.morphology` | ✅ | ⚠️ | Pure conv/pool ops. `top_hat` / `bottom_hat` / `gradient` subtract two dilation/erosion results, so bfloat16 loses ~0.4% relative accuracy ([#4081](https://github.com/kornia/kornia/issues/4081)) |
+| `kornia.morphology` | ✅ | ✅ | Conv/pool ops; `top_hat` / `bottom_hat` / `gradient` also subtract two dilation/erosion results, so bfloat16 loses ~0.4% relative accuracy — within kornia's own bfloat16 tolerance, though 6 tests override it with a tighter one ([#4081](https://github.com/kornia/kornia/issues/4081)) |
 | `kornia.augmentation` | ⚠️ | ⚠️ | Most ops work; precision-sensitive transforms may be inaccurate |
 | `kornia.geometry.transform` | ⚠️ | ⚠️ | Affine/warp/resize work via cast helpers; thin-plate spline may fail |
 | `kornia.geometry.camera` | ⚠️ | ⚠️ | Pinhole model and most camera ops work; `StereoCamera` accepts both |
@@ -110,8 +110,10 @@ Leverage pre-trained AI models optimized for a variety of vision tasks, all with
 | CUDA float16 *(KORNIA_TEST_IN_SUBPROCESS=1)* | 6727 | 643 | 3556 | **91.3%** | `6131e98`, 2026-03-21 |
 | CUDA bfloat16 *(KORNIA_TEST_IN_SUBPROCESS=1)* | 6695 | 713 | 3518 | **90.4%** | `6131e98`, 2026-03-21 |
 
-Reproduce the CPU rows with `pixi run test-half`. The half-precision suite is not run in CI
-(see [#4070](https://github.com/kornia/kornia/issues/4070)), so these numbers are refreshed by hand.
+Reproduce the two CPU half rows with `pixi run test-half` and the CPU float32 baseline with `pixi run test-f32`
+(`test-half` pins `KORNIA_TEST_DTYPE` to `float16,bfloat16`, so it cannot produce the baseline). The half-precision
+suite is not run in CI (see [#4070](https://github.com/kornia/kornia/issues/4070)), so these numbers are refreshed
+by hand.
 
 See the [full precision guide](https://kornia.readthedocs.io/en/stable/get-started/precision.html) for details.
 

--- a/docs/source/get-started/precision.rst
+++ b/docs/source/get-started/precision.rst
@@ -30,10 +30,12 @@ This page documents which kornia modules support half-precision floating-point d
        ``_torch_inverse_cast`` which promote to float32 before computing.
    * - ``kornia.morphology``
      - ✅ Yes
-     - ⚠️ Partial
-     - Uses only convolution and pooling. ``top_hat``, ``bottom_hat`` and
-       ``gradient`` subtract two dilation/erosion results, so bfloat16 loses
-       roughly 0.4% relative accuracy on them; see `issue #4081 <https://github.com/kornia/kornia/issues/4081>`_.
+     - ✅ Yes
+     - Convolution and pooling; ``top_hat``, ``bottom_hat`` and ``gradient``
+       also subtract two dilation/erosion results, so bfloat16 loses roughly
+       0.4% relative accuracy on them. That is within kornia's own bfloat16
+       tolerance, but six tests override it with a tighter constant and fail;
+       see `issue #4081 <https://github.com/kornia/kornia/issues/4081>`_.
    * - ``kornia.augmentation``
      - ⚠️ Partial
      - ⚠️ Partial
@@ -117,8 +119,10 @@ Full test suite (no ``--runslow``). Pass% = passed ÷ (passed + failed);
 skipped and xfailed tests are excluded. CPU rows were measured on commit
 ``4ab79c78`` (2026-08-29); CUDA rows are still from ``6131e98`` (2026-03-21).
 
-The half-precision suite is not run in CI (see `issue #4070 <https://github.com/kornia/kornia/issues/4070>`_), so these numbers
-are refreshed by hand with ``pixi run test-half``.
+The half-precision suite is not run in CI (see `issue #4070
+<https://github.com/kornia/kornia/issues/4070>`_), so these numbers are refreshed by hand: the two CPU half rows
+with ``pixi run test-half``, and the CPU float32 baseline with ``pixi run test-f32``, since ``test-half`` pins
+``KORNIA_TEST_DTYPE`` to ``float16,bfloat16``.
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/get-started/precision.rst
+++ b/docs/source/get-started/precision.rst
@@ -30,8 +30,10 @@ This page documents which kornia modules support half-precision floating-point d
        ``_torch_inverse_cast`` which promote to float32 before computing.
    * - ``kornia.morphology``
      - ✅ Yes
-     - ✅ Yes
-     - Uses only convolution and pooling; no dtype restrictions.
+     - ⚠️ Partial
+     - Uses only convolution and pooling. ``top_hat``, ``bottom_hat`` and
+       ``gradient`` subtract two dilation/erosion results, so bfloat16 loses
+       roughly 0.4% relative accuracy on them; see `issue #4081 <https://github.com/kornia/kornia/issues/4081>`_.
    * - ``kornia.augmentation``
      - ⚠️ Partial
      - ⚠️ Partial
@@ -111,8 +113,12 @@ Legend
 Test Results
 ------------
 
-Measured on commit ``6131e98`` (2026-03-21), full test suite (no ``--runslow``).
-Pass% = passed ÷ (passed + failed); skipped and xfailed tests are excluded.
+Full test suite (no ``--runslow``). Pass% = passed ÷ (passed + failed);
+skipped and xfailed tests are excluded. CPU rows were measured on commit
+``4ab79c78`` (2026-08-29); CUDA rows are still from ``6131e98`` (2026-03-21).
+
+The half-precision suite is not run in CI (see `issue #4070 <https://github.com/kornia/kornia/issues/4070>`_), so these numbers
+are refreshed by hand with ``pixi run test-half``.
 
 .. list-table::
    :header-rows: 1
@@ -124,25 +130,25 @@ Pass% = passed ÷ (passed + failed); skipped and xfailed tests are excluded.
      - Skipped
      - Pass%
    * - CPU float32 *(baseline)*
-     - 7647
-     - 3
-     - 3269
-     - **99.9%**
+     - 8499
+     - 0
+     - 3535
+     - **100.0%**
+   * - CPU float16
+     - 7751
+     - 689
+     - 3595
+     - **91.8%**
+   * - CPU bfloat16
+     - 7794
+     - 695
+     - 3545
+     - **91.8%**
    * - CUDA float32 *(baseline)*
      - 7634
      - 3
      - 3280
      - **99.9%**
-   * - CPU float16
-     - 6866
-     - 747
-     - 3306
-     - **90.1%**
-   * - CPU bfloat16
-     - 6838
-     - 812
-     - 3269
-     - **89.3%**
    * - CUDA float16 *(KORNIA_TEST_IN_SUBPROCESS=1)*
      - 6727
      - 643


### PR DESCRIPTION
## What

Refreshes the half-precision numbers in `README.md` and `docs/source/get-started/precision.rst`, and annotates the one module row whose ✅ is checkable.

## Refreshed numbers

Both tables were measured on commit `6131e98` (2026-03-21). Re-measured on `4ab79c78`, torch 2.9.1, CPU:

| Run | Passed | Failed | Skipped | Pass% | previously |
|---|---:|---:|---:|---:|---|
| CPU float32 *(baseline)* | 8499 | 0 | 3535 | **100.0%** | 7647 / 3 / 99.9% |
| CPU float16 | 7751 | **689** | 3595 | **91.8%** | 6866 / 747 / 90.1% |
| CPU bfloat16 | 7794 | **695** | 3545 | **91.8%** | 6838 / 812 / 89.3% |

Half precision has **improved** since March (747 → 689, 812 → 695) while the suite grew by ~900 tests, so the published figures were stale in the pessimistic direction.

The CUDA rows are left exactly as they were — this machine has no CUDA to re-measure them with. Both tables gain a **Measured** column carrying the commit and date per row, so the two vintages can't be silently conflated again.

## The `kornia.morphology` row

It was marked ✅ *Supported* for both dtypes — the only module in the table making that claim, and therefore the only checkable one. It fails 6 bfloat16 tests:

```
tests/morphology/test_bottom_hat.py::TestBottomHat::test_kernel[cpu-bfloat16]
tests/morphology/test_bottom_hat.py::TestBottomHat::test_structural_element[cpu-bfloat16]
tests/morphology/test_gradient.py::TestGradient::test_kernel[cpu-bfloat16]
tests/morphology/test_gradient.py::TestGradient::test_structural_element[cpu-bfloat16]
tests/morphology/test_top_hat.py::TestTopHat::test_kernel[cpu-bfloat16]
tests/morphology/test_top_hat.py::TestTopHat::test_structural_element[cpu-bfloat16]
```

`top_hat`, `bottom_hat` and `gradient` are the composite ops that subtract two dilation/erosion results, so the error compounds:

```
top_hat     float16 0.00026   bfloat16 0.00263
bottom_hat  float16 0.00052   bfloat16 0.00325
gradient    float16 0.00044   bfloat16 0.00359
```

~0.4% relative — ordinary for an 8-bit mantissa. float16 is clean (0 failures).

**The row keeps ✅ / ✅.** An earlier revision of this PR downgraded bfloat16 to ⚠️ *Partial*; that was withdrawn in review. #4081's root cause is that those six tests pass an explicit `atol=1e-3, rtol=1e-3` that overrides the harness's own dtype-aware `bfloat16: (7.8e-3, 7.8e-3)` — which comfortably covers the measured `3.6e-3`. The numerics are within kornia's stated bfloat16 tolerance, the fix in #4081 is test-only and changes no library behavior, so marking the module Partial would have described test-suite state as runtime support and would have had to be reverted with no behavior change. Instead both rows gain a note describing the subtraction, the ~0.4% bfloat16 error and the #4081 link, so the failing tests stay discoverable.

## Also

A line in each document recording that the half-precision suite is not run in CI (#4070), so a reader understands why these numbers are hand-refreshed and how to reproduce them: `pixi run test-half` for the two CPU half rows, `pixi run test-f32` for the CPU float32 baseline (`test-half` pins `KORNIA_TEST_DTYPE` to `float16,bfloat16`, so it cannot produce the baseline row).

## What I did not change

No other ✅/⚠️/❌ mark. I only re-measured at whole-suite and `tests/<dir>` granularity, which is coarser than several of the table's rows (`kornia.geometry.homography`, `kornia.geometry.transform`, …). Every ⚠️ module still has failures in at least one dtype, so none of them warrants promotion on the evidence I have; changing marks I hadn't measured at the right granularity would just be guessing.

## Verification

```console
$ pixi run build-docs
build succeeded.       # no warnings on get-started/precision

$ pixi run pre-commit-all
all hooks Passed
```

`:issue:` is not a configured role in this Sphinx build (no `extlinks` in `conf.py`), so the new references use the explicit-link form already used elsewhere in `docs/source`.

Refs #4070, #4081

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
