### PR TITLE
docs: stop three doctests pinning float reprs at a representation boundary (kornia#4040)

### DIFF
--- a/kornia/filters/kernels.py
+++ b/kornia/filters/kernels.py
@@ -644,8 +644,8 @@ def get_gaussian_erf_kernel1d(
         1D tensor with gaussian filter coefficients. Shape :math:`(B, \text{kernel_size})`
 
     Examples:
-        >>> get_gaussian_erf_kernel1d(3, 2.5)
-        tensor([[0.3245, 0.3511, 0.3245]])
+        >>> get_gaussian_erf_kernel1d(3, 2.0)
+        tensor([[0.3195, 0.3611, 0.3195]])
         >>> get_gaussian_erf_kernel1d(5, 1.5)
         tensor([[0.1226, 0.2331, 0.2887, 0.2331, 0.1226]])
         >>> get_gaussian_erf_kernel1d(5, torch.tensor([[1.5], [2.1]]))
@@ -751,8 +751,8 @@ def get_gaussian_kernel3d(
                  [[0.0292, 0.0364, 0.0292],
                   [0.0364, 0.0455, 0.0364],
                   [0.0292, 0.0364, 0.0292]]]])
-        >>> get_gaussian_kernel3d((3, 3, 3), (1.5, 1.5, 1.5)).sum()
-        tensor(1.)
+        >>> torch.allclose(get_gaussian_kernel3d((3, 3, 3), (1.5, 1.5, 1.5)).sum(), torch.tensor(1.0))
+        True
         >>> get_gaussian_kernel3d((3, 3, 3), (1.5, 1.5, 1.5)).shape
         torch.Size([1, 3, 3, 3])
         >>> get_gaussian_kernel3d((3, 7, 5), torch.tensor([[1.5, 1.5, 1.5]])).shape

--- a/kornia/geometry/liegroup/se2.py
+++ b/kornia/geometry/liegroup/se2.py
@@ -200,8 +200,10 @@ class Se2(nn.Module):
         Example:
             >>> v = torch.ones((1, 3))
             >>> s = Se2.exp(v).log()
-            >>> s
-            tensor([[1.0000, 1.0000, 1.0000]], grad_fn=<StackBackward0>)
+            >>> s.shape
+            torch.Size([1, 3])
+            >>> torch.allclose(s, v)
+            True
 
         """
         theta = self.so2.log()

--- a/kornia/geometry/liegroup/se2.py
+++ b/kornia/geometry/liegroup/se2.py
@@ -204,6 +204,8 @@ class Se2(nn.Module):
             torch.Size([1, 3])
             >>> torch.allclose(s, v)
             True
+            >>> s.requires_grad
+            True
 
         """
         theta = self.so2.log()


### PR DESCRIPTION
## What

Fixes the three doctests in #4040 that pin an exact `torch.Tensor` repr whose printed form sits on a **representation boundary** — which side it lands on is decided by platform float accumulation, not by anything the example demonstrates. All three fail on macOS/arm64 with torch 2.9.1 on a warm weights cache while passing in CI.

## The three cases

**1. `get_gaussian_erf_kernel1d(3, 2.5)` — decimal rounding boundary**

The computed coefficient is `0.3244499862`; printing `0.3245` requires `>= 0.32445`. That is **0.5 ULP** from the boundary, so the fourth decimal is decided by the last bit of the accumulation. The example is fragile by construction, not merely mis-specified.

Changed to `sigma=2.0`, whose coefficients are ~500 ULP from any 4-decimal boundary:

```python
>>> get_gaussian_erf_kernel1d(3, 2.0)
tensor([[0.3195, 0.3611, 0.3195]])
```

It still shows what the old one showed — a large sigma relative to the kernel size gives a near-flat kernel. Margins measured on this machine:

| args | min distance to a 4-decimal boundary |
|---|---:|
| `(3, 2.5)` *(old)* | **1.4e-08** (~0.5 ULP) |
| `(3, 2.0)` *(new)* | 1.6e-05 (~500 ULP) |
| `(5, 1.5)` *(untouched)* | 1.2e-05 |

**2. `get_gaussian_kernel3d(...).sum()` → `tensor(1.)`**

torch prints the integral form only when every element is exactly integral, so this silently asserted that the kernel sums to **exactly** 1.0 in float32. The sum is `1.0000001192092896`. Now asserts the property:

```python
>>> torch.allclose(get_gaussian_kernel3d((3, 3, 3), (1.5, 1.5, 1.5)).sum(), torch.tensor(1.0))
True
```

**3. `Se2.exp(v).log()` → `tensor([[1.0000, 1.0000, 1.0000]], ...)`**

The same mechanism with the opposite sign: here the round trip is exact, so torch uses the integral form, while the docstring pinned the *fractional* one — i.e. it asserted the round trip is **inexact**, and a more accurate result fails the doctest. Cases 2 and 3 asserted opposite exactness properties of each other by accident. Now:

```python
>>> s.shape
torch.Size([1, 3])
>>> torch.allclose(s, v)
True
>>> s.requires_grad
True
```

The `requires_grad` line replaces what the old `grad_fn=<StackBackward0>` in the expected output carried: the docstring's one demonstration that the round trip is differentiable. It is a bool, so it is not repr-fragile.

## Audit of the rest of the doctests

The issue asks for the same audit on any other doctest printing derived floats, so I ran one: patch `torch.Tensor.__repr__` for the duration of `pytest --doctest-modules kornia/` and measure every printed value's distance to a 4-decimal rounding boundary and to an integer. **Nothing else currently fails**, and I have not changed anything else, but the run surfaces a latent tail worth recording:

- `enhance/zca.py::zca_whiten` — `-0.5773` is **9.7 ULP** below the `0.57735` boundary and comes out of an eigendecomposition, so a different LAPACK could print `-0.5774`. The likeliest of the tail to break somewhere.
- integral-vs-fractional flips 1 ULP from exact (the case 2/3 mechanism): `crop_by_boxes` (`5.0000005`), `center_crop3d` and `crop_and_resize3d` (`20.999998`), `spatial_soft_argmax2d` (`0.99999994`), `psnr` / `psnr_loss` (`±19.999998`), `ARKitQTVecs_to_ColmapQTVecs`.
- `project_points` / `PinholeCamera.project` (2 ULP) and `Se2.hat` / `So2.hat` (`1.5707`) are false alarms — an elementwise IEEE-exact chain and a `3.1415/2` literal respectively, so both are bit-identical on every platform.

Rewriting those live examples into `allclose` checks costs real documentation value for a risk that has not materialised, so they are left as they are. Since merging this closes #4040, that tail is now recorded in **#4086** with the per-case ULP figures and the audit method, so it does not die with this PR description; if one of them ever fails on a new platform, that issue is the place to start.

## Verification

```console
$ pytest --doctest-modules kornia/
656 passed, 1 failed, 2 skipped     # the failure is #4041, fixed by #4085; 657 pass with both applied
                                    # the 2 skips are uncached-weight examples

$ pytest --doctest-modules kornia/filters/kernels.py kornia/geometry/liegroup/se2.py
22 passed

$ pre-commit run --all-files
all hooks Passed
```

Docstring-only change; no library behavior is touched.

Closes #4040

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
