### PR TITLE
docs(feature): make the DescriptorMatcherWithSteerer example a small CPU one (kornia#4041)

### DIFF
--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -394,27 +394,35 @@ class DescriptorMatcherWithSteerer(nn.Module):
         th: threshold on distance ratio, or other quality measure.
 
     Example:
+        The example below is deliberately small so that it runs anywhere. A real workload uses
+        full-resolution images and many more keypoints, and is worth moving onto an accelerator --
+        uncomment the ``device`` lines to do that.
+
         >>> import kornia as K
         >>> import kornia.feature as KF
-        >>> device = K.core.utils.get_cuda_or_mps_device_if_available()
-        >>> img1 = torch.randn([1, 3, 768, 768], device=device)
-        >>> img2 = torch.randn([1, 3, 768, 768], device=device)
-        >>> dedode = KF.DeDoDe.from_pretrained(detector_weights="L-C4-v2", descriptor_weights="B-SO2").to(device)
+        >>> # device = K.core.utils.get_cuda_or_mps_device_if_available()
+        >>> img1 = torch.randn([1, 3, 128, 128])
+        >>> img2 = torch.randn([1, 3, 128, 128])
+        >>> # img1, img2 = img1.to(device), img2.to(device)
+        >>> dedode = KF.DeDoDe.from_pretrained(detector_weights="L-C4-v2", descriptor_weights="B-SO2")
+        >>> # dedode = dedode.to(device)
         >>> steerer_order = 8  # discretisation order of rotation angles
         >>> steerer = KF.steerers.DiscreteSteerer.create_dedode_default(
         ... generator_type="SO2", steerer_order=steerer_order
         ... )
-        >>> steerer = steerer.to(device)
+        >>> # steerer = steerer.to(device)
         >>> matcher = KF.matching.DescriptorMatcherWithSteerer(
         ... steerer=steerer, steerer_order=steerer_order, steer_mode="global", match_mode="smnn", th=0.98
         ... )
         >>> with torch.inference_mode():
-        ...     kps1, scores1, descs1 = dedode(img1, n=20_000)
-        ...     kps2, scores2, descs2 = dedode(img2, n=20_000)
+        ...     kps1, scores1, descs1 = dedode(img1, n=1_000)
+        ...     kps2, scores2, descs2 = dedode(img2, n=1_000)
         ...     kps1, kps2, descs1, descs2 = kps1[0], kps2[0], descs1[0], descs2[0]
         ...     dists, idxs, num_rot = matcher(
-        ...         descs1, descs2, normalize=True, subset_size=1000,
+        ...         descs1, descs2, normalize=True, subset_size=500,
         ...     )
+        >>> idxs.shape[1], 0 <= num_rot < steerer_order
+        (2, True)
         >>> # print(f"{idxs.shape[0]} tentative matches with steered DeDoDe")
         >>> # print(f"at rotation of {num_rot * 360 / steerer_order} degrees")
 

--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -398,8 +398,8 @@ class DescriptorMatcherWithSteerer(nn.Module):
         full-resolution images and many more keypoints, and is worth moving onto an accelerator --
         uncomment the ``device`` lines to do that.
 
-        >>> import kornia as K
         >>> import kornia.feature as KF
+        >>> # import kornia as K
         >>> # device = K.core.utils.get_cuda_or_mps_device_if_available()
         >>> img1 = torch.randn([1, 3, 128, 128])
         >>> img2 = torch.randn([1, 3, 128, 128])
@@ -421,8 +421,10 @@ class DescriptorMatcherWithSteerer(nn.Module):
         ...     dists, idxs, num_rot = matcher(
         ...         descs1, descs2, normalize=True, subset_size=500,
         ...     )
-        >>> idxs.shape[1], 0 <= num_rot < steerer_order
-        (2, True)
+        >>> idxs.shape == (dists.shape[0], 2), 0 <= num_rot < steerer_order
+        (True, True)
+        >>> bool((idxs[:, 0] < len(kps1)).all()), bool((idxs[:, 1] < len(kps2)).all())
+        (True, True)
         >>> # print(f"{idxs.shape[0]} tentative matches with steered DeDoDe")
         >>> # print(f"at rotation of {num_rot * 360 / steerer_order} degrees")
 


### PR DESCRIPTION
## What

Fixes #4041. `DescriptorMatcherWithSteerer` held the only docstring example in `kornia/` that moved itself onto an accelerator, and what it moved there was an integration-test workload: two 768×768 images through a DeDoDe asking for **20,000 keypoints each**. That made the outcome of `pixi run doctest` depend on how much GPU memory the machine happened to have free.

On an Apple Silicon machine with other GPU load present it dies on a **78 KiB** allocation in `match_snn` — after the example has already filled the device — which is a resource-exhaustion artifact, not a defect in the code being documented. A CPU-only runner silently falls back to CPU and passes, which is why CI never saw it.

## The change

The live example is now small and on CPU, with the device selection kept as commented-out lines so a reader still sees how to run the real thing:

```python
>>> import kornia.feature as KF
>>> # import kornia as K
>>> # device = K.core.utils.get_cuda_or_mps_device_if_available()
>>> img1 = torch.randn([1, 3, 128, 128])
>>> img2 = torch.randn([1, 3, 128, 128])
>>> # img1, img2 = img1.to(device), img2.to(device)
>>> dedode = KF.DeDoDe.from_pretrained(detector_weights="L-C4-v2", descriptor_weights="B-SO2")
>>> # dedode = dedode.to(device)
```

- 768² → 128² images, `n=20_000` → `n=1_000`, `subset_size=1000` → `500`
- a line above the block says the example is deliberately small and that a real workload uses full resolution and an accelerator
- `import kornia as K` is commented out alongside the `device` line, its only user, so the two uncomment together
- the two `print(...)` lines were already commented out, so nothing is lost; two checks replace them, so the example verifies its own call sequence without pinning any float:

```python
>>> idxs.shape == (dists.shape[0], 2), 0 <= num_rot < steerer_order
(True, True)
>>> bool((idxs[:, 0] < len(kps1)).all()), bool((idxs[:, 1] < len(kps2)).all())
(True, True)
```

  These tie output to input rather than restating the call's signature: the first catches a matcher returning mismatched distances and indices, the second an index outside the keypoint set it indexes into. Both use `(x < n).all()` instead of `.max()` so they stay valid on an empty match set rather than raising. Measured over 5 random inputs: 164-191 matches, max index 993-999 against 1000 keypoints, `num_rot = 0` throughout.

The full-size version is not moved into `tests/` because the class already has real coverage there — `tests/feature/test_matching.py` exercises `global`/`local` steer modes and `mnn`/`smnn` matching (37 tests).

## Verification

```console
$ pytest --doctest-modules "kornia/feature/matching.py::kornia.feature.matching.DescriptorMatcherWithSteerer"
1 passed in 5.26s                  # was two 768x768 forward passes at 20k keypoints

$ pytest --doctest-modules kornia/
657 passed, 2 skipped in 48.52s

$ pytest tests/feature/test_matching.py -k "steer or Steer"
37 passed, 63 deselected in 0.52s

$ pre-commit run --files kornia/feature/matching.py
all hooks Passed
```

Run on macOS/arm64, torch 2.9.1, python 3.11.14, with the DeDoDe checkpoints cached. Docstring-only change; no library behavior is touched. After it, `grep -rn ">>> .*get_cuda_or_mps_device_if_available" kornia/` matches only the commented-out line, so no docstring example selects a device any more.

Closes #4041

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
