### PR TITLE
fix(filters): make guided_blur work at half precision with multi-channel guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Make `guided_blur` / `GuidedBlur` work in `float16` and `bfloat16` when the guidance has more than one channel.
+  Multi-channel guidance solves a per-pixel `C x C` system, and `torch.linalg.solve` has no half-precision LU
+  kernel, so every such call failed: on CPU with `NotImplementedError: "lu_cpu" not implemented for 'Half'`, and on
+  MPS with a hard `Only MPSDataTypeFloat32 is supported` assertion that aborted the process rather than raising.
+  The system is now solved in `float32` and cast back. Single-channel guidance never reached the solver and is
+  unaffected. `float32` and `float64` results are bit-identical to before, and the op still compiles with
+  `fullgraph=True` in one graph. This takes `tests/filters/test_guided.py` from 98 failed / 67 passed to
+  165 passed under `--dtype=float16,bfloat16`.
+
 * Raise `NotImplementedError` instead of `RuntimeError` for an integral `src` on the empty-`dsize` paths of
   `warp_affine`, `warp_perspective`, `remap`, `warp_affine3d` and `warp_perspective3d`, matching what the non-empty path already raises from
   `grid_sample` (#4031). The degenerate path had its own explicit guard that fired first with a different exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Multi-channel guidance solves a per-pixel `C x C` system, and `torch.linalg.solve` has no half-precision LU
   kernel, so every such call failed: on CPU with `NotImplementedError: "lu_cpu" not implemented for 'Half'`, and on
   MPS with a hard `Only MPSDataTypeFloat32 is supported` assertion that aborted the process rather than raising.
-  The system is now solved in `float32` and cast back. Single-channel guidance never reached the solver and is
-  unaffected. `float32` and `float64` results are bit-identical to before, and the op still compiles with
+  The system is now solved in `float32` and cast back. A tensor `eps` also takes part in dtype promotion, so
+  the common `eps=torch.tensor(0.1)` (float32) widened the matrix past the right-hand side and made `solve`
+  reject the pair; both operands are now solved in one dtype. Single-channel guidance never reached the solver
+  and is unaffected. `float32` and `float64` results are bit-identical to before, and the op still compiles with
   `fullgraph=True` in one graph. This takes `tests/filters/test_guided.py` from 98 failed / 67 passed to
-  165 passed under `--dtype=float16,bfloat16`.
+  169 passed under `--dtype=float16,bfloat16`.
 
 * Raise `NotImplementedError` instead of `RuntimeError` for an integral `src` on the empty-`dsize` paths of
   `warp_affine`, `warp_perspective`, `remap`, `warp_affine3d` and `warp_perspective3d`, matching what the non-empty path already raises from

--- a/kornia/filters/guided.py
+++ b/kornia/filters/guided.py
@@ -113,16 +113,21 @@ def _guided_blur_multichannel_guidance(
         _eps = torch.eye(C, device=guidance.device, dtype=guidance.dtype).view(1, 1, 1, C, C) * eps.view(-1, 1, 1, 1, 1)
     else:
         _eps = guidance.new_full((C,), eps).diag().view(1, 1, 1, C, C)
-    # ``torch.linalg.solve`` has no half-precision LU kernel, so a float16/bfloat16 guidance dies
-    # here with ``NotImplementedError: "lu_cpu" not implemented for 'Half'``. Solve the tiny C x C
-    # systems in float32 and cast back. Deliberately not ``_torch_solve_cast``: that promotes
-    # float32 to float64, which would change the results of the default path and pay for a float64
-    # solve at every pixel.
+    # ``torch.linalg.solve`` needs both operands in one dtype, and it has no half-precision LU
+    # kernel: a float16/bfloat16 guidance dies here with ``NotImplementedError: "lu_cpu" not
+    # implemented for 'Half'``, and on MPS it aborts the process instead of raising. A tensor
+    # ``eps`` also takes part in promotion, so ``A`` can come out wider than ``cov_Ip`` -- the
+    # common ``eps=torch.tensor(0.1)`` is float32 -- and ``solve`` rejects the mismatched pair.
+    # So pick a single dtype for both operands, lifting half to float32, and cast the solution
+    # back. Deliberately not ``_torch_solve_cast``: that promotes float32 to float64, which would
+    # change the results of the default path and pay for a float64 solve at every pixel.
+    # ``Tensor.to`` is a no-op when the dtype already matches, so an all-float32 or all-float64
+    # call takes exactly the path it took before.
     A = var_I + _eps
-    if A.dtype in (torch.float16, torch.bfloat16):
-        a = torch.linalg.solve(A.float(), cov_Ip.float()).to(A.dtype)  # B, H, W, C_guidance, C_input
-    else:
-        a = torch.linalg.solve(A, cov_Ip)  # B, H, W, C_guidance, C_input
+    solve_dtype = torch.promote_types(A.dtype, cov_Ip.dtype)
+    if solve_dtype in (torch.float16, torch.bfloat16):
+        solve_dtype = torch.float32
+    a = torch.linalg.solve(A.to(solve_dtype), cov_Ip.to(solve_dtype)).to(cov_Ip.dtype)
     b = mean_p - (mean_I.unsqueeze(-2) @ a).squeeze(-2)  # B, H, W, C_input
 
     mean_a = box_blur(a.flatten(-2).permute(0, 3, 1, 2), kernel_size, border_type, separable=separable)

--- a/kornia/filters/guided.py
+++ b/kornia/filters/guided.py
@@ -113,7 +113,16 @@ def _guided_blur_multichannel_guidance(
         _eps = torch.eye(C, device=guidance.device, dtype=guidance.dtype).view(1, 1, 1, C, C) * eps.view(-1, 1, 1, 1, 1)
     else:
         _eps = guidance.new_full((C,), eps).diag().view(1, 1, 1, C, C)
-    a = torch.linalg.solve(var_I + _eps, cov_Ip)  # B, H, W, C_guidance, C_input
+    # ``torch.linalg.solve`` has no half-precision LU kernel, so a float16/bfloat16 guidance dies
+    # here with ``NotImplementedError: "lu_cpu" not implemented for 'Half'``. Solve the tiny C x C
+    # systems in float32 and cast back. Deliberately not ``_torch_solve_cast``: that promotes
+    # float32 to float64, which would change the results of the default path and pay for a float64
+    # solve at every pixel.
+    A = var_I + _eps
+    if A.dtype in (torch.float16, torch.bfloat16):
+        a = torch.linalg.solve(A.float(), cov_Ip.float()).to(A.dtype)  # B, H, W, C_guidance, C_input
+    else:
+        a = torch.linalg.solve(A, cov_Ip)  # B, H, W, C_guidance, C_input
     b = mean_p - (mean_I.unsqueeze(-2) @ a).squeeze(-2)  # B, H, W, C_input
 
     mean_a = box_blur(a.flatten(-2).permute(0, 3, 1, 2), kernel_size, border_type, separable=separable)

--- a/tests/filters/test_guided.py
+++ b/tests/filters/test_guided.py
@@ -107,8 +107,10 @@ class TestGuidedBlur(BaseTester):
             separable=True,
         )
 
-        if dtype in (torch.float16, torch.bfloat16):
-            # The two convolution decompositions accumulate rounding errors in different orders at half precision.
+        if dtype == torch.float16:
+            # The two convolution decompositions accumulate rounding errors in different orders at
+            # half precision. Only float16 needs this: measured worst case is 1.953e-03 against the
+            # harness's 1e-03, while every bfloat16 case fits inside _DTYPE_PRECISIONS already.
             tolerance = 3 * torch.finfo(dtype).eps
             self.assert_close(actual, expected, rtol=tolerance, atol=tolerance)
         else:
@@ -200,6 +202,30 @@ class TestGuidedBlur(BaseTester):
             op_module(guide, img),
             op(guide, img, kernel_size, eps, subsample=subsample, separable=separable),
         )
+
+    @pytest.mark.parametrize("half_dtype", [torch.float16, torch.bfloat16])
+    def test_multichannel_guidance_in_half_precision(self, half_dtype, device) -> None:
+        """Multi-channel guidance must run in float16/bfloat16 rather than dying in the solver.
+
+        ``_guided_blur_multichannel_guidance`` solves a C x C system per pixel, and
+        ``torch.linalg.solve`` has no half-precision LU kernel: before the fix this raised
+        ``NotImplementedError: "lu_cpu" not implemented for 'Half'`` on CPU, and on MPS it aborted
+        the process outright with ``Only MPSDataTypeFloat32 is supported``. Single-channel guidance
+        never reached the solver, so only ``guide_dim > 1`` was affected.
+        """
+        guide = torch.rand(1, 3, 12, 16, device=device).to(half_dtype)
+        inp = torch.rand(1, 2, 12, 16, device=device).to(half_dtype)
+
+        actual = guided_blur(guide, inp, 5, eps=0.1)
+
+        assert actual.dtype == half_dtype
+        assert torch.isfinite(actual).all()
+
+        # The solve runs in float32, so the result must track the exact answer to within the
+        # accumulated error of the surrounding half-precision arithmetic, not the solver's.
+        expected = guided_blur(guide.float(), inp.float(), 5, eps=0.1)
+        tolerance = 8 * torch.finfo(half_dtype).eps
+        self.assert_close(actual.float(), expected, rtol=tolerance, atol=tolerance)
 
     @pytest.mark.skipif(
         torch_version() in {"1.9.1", "2.1.0", "2.1.1", "2.1.2"},
@@ -311,4 +337,13 @@ class TestGuidedBlur(BaseTester):
         expected = torch.tensor(expected, device=device, dtype=dtype).view(1, 3, 4, 4)
 
         out = guided_blur(guide, img, kernel_size, eps, border_type="replicate")
-        self.assert_close(out, expected)
+        if dtype == torch.bfloat16:
+            # Multi-channel guidance chains three box blurs, a 3x3 solve and an einsum, so the error
+            # is a few eps rather than one. Measured against this op's own float64 result the error
+            # is 2.95 eps for bfloat16, 1.39 for float16 and 3.27 for float32 -- i.e. bfloat16 is not
+            # an outlier, the harness's 1-eps budget is simply too tight here. bfloat16 also cannot
+            # represent the inputs to better than 3.6e-3, over half that budget, before any
+            # arithmetic runs. float16 and float32 still use the harness tolerances.
+            self.assert_close(out, expected, rtol=4 * torch.finfo(dtype).eps, atol=4 * torch.finfo(dtype).eps)
+        else:
+            self.assert_close(out, expected)

--- a/tests/filters/test_guided.py
+++ b/tests/filters/test_guided.py
@@ -203,8 +203,8 @@ class TestGuidedBlur(BaseTester):
             op(guide, img, kernel_size, eps, subsample=subsample, separable=separable),
         )
 
-    @pytest.mark.parametrize("half_dtype", [torch.float16, torch.bfloat16])
-    def test_multichannel_guidance_in_half_precision(self, half_dtype, device) -> None:
+    @pytest.mark.parametrize("tensor_eps", [False, True], ids=["float_eps", "tensor_eps"])
+    def test_multichannel_guidance_in_half_precision(self, tensor_eps, device, dtype) -> None:
         """Multi-channel guidance must run in float16/bfloat16 rather than dying in the solver.
 
         ``_guided_blur_multichannel_guidance`` solves a C x C system per pixel, and
@@ -212,19 +212,31 @@ class TestGuidedBlur(BaseTester):
         ``NotImplementedError: "lu_cpu" not implemented for 'Half'`` on CPU, and on MPS it aborted
         the process outright with ``Only MPSDataTypeFloat32 is supported``. Single-channel guidance
         never reached the solver, so only ``guide_dim > 1`` was affected.
+
+        The ``tensor_eps`` case is the second half of the same bug: ``torch.tensor(0.1)`` is float32
+        even next to a half guidance and takes part in dtype promotion, so the matrix handed to
+        ``solve`` is wider than the right-hand side.
         """
-        guide = torch.rand(1, 3, 12, 16, device=device).to(half_dtype)
-        inp = torch.rand(1, 2, 12, 16, device=device).to(half_dtype)
+        if dtype not in (torch.float16, torch.bfloat16):
+            pytest.skip("regression test for the half-precision solve path")
 
-        actual = guided_blur(guide, inp, 5, eps=0.1)
+        # ``constant`` keeps this test on the solver: the default ``reflect`` border needs a
+        # half-precision ``reflection_pad2d``, which CPU PyTorch 2.5.1 does not have for float16.
+        border_type = "constant"
+        eps = torch.tensor(0.1, device=device) if tensor_eps else 0.1
 
-        assert actual.dtype == half_dtype
+        guide = torch.rand(1, 3, 12, 16, device=device, dtype=dtype)
+        inp = torch.rand(1, 2, 12, 16, device=device, dtype=dtype)
+
+        actual = guided_blur(guide, inp, 5, eps, border_type=border_type)
+
+        assert actual.dtype == dtype
         assert torch.isfinite(actual).all()
 
         # The solve runs in float32, so the result must track the exact answer to within the
         # accumulated error of the surrounding half-precision arithmetic, not the solver's.
-        expected = guided_blur(guide.float(), inp.float(), 5, eps=0.1)
-        tolerance = 8 * torch.finfo(half_dtype).eps
+        expected = guided_blur(guide.float(), inp.float(), 5, eps, border_type=border_type)
+        tolerance = 8 * torch.finfo(dtype).eps
         self.assert_close(actual.float(), expected, rtol=tolerance, atol=tolerance)
 
     @pytest.mark.skipif(


### PR DESCRIPTION
## What does this pull request do?

Two things, both follow-ups to #3946, which merged with these notes raised but not applied.

### 1. `guided_blur` now works at half precision with multi-channel guidance

`_guided_blur_multichannel_guidance` solves a per-pixel `C x C` system with `torch.linalg.solve`, which has no half-precision LU kernel. Every `guided_blur` / `GuidedBlur` call with more than one guidance channel failed at `float16` and `bfloat16`:

```
NotImplementedError: "lu_cpu" not implemented for 'Half'
kornia/filters/guided.py:116  ->  a = torch.linalg.solve(var_I + _eps, cov_Ip)
```

On MPS it is worse than an exception — it aborts the process:

```
MPSMatrixDecompositionLU.mm:1227: failed assertion `Only MPSDataTypeFloat32 is supported.'
```

The fix solves the system in `float32` and casts back. Single-channel guidance never reached the solver and is untouched.

A tensor `eps` takes part in the same promotion, so `A = var_I + _eps` could come out wider than the right-hand side — the common `eps=torch.tensor(0.1)` is float32 next to a half guidance — and `linalg.solve` rejected the mismatched pair. Both operands are therefore solved in one dtype rather than keying on `A` alone. All 16 combinations of {`float16`, `bfloat16`, `float32`, `float64`} × {`0.1`, `torch.tensor(0.1)`, `torch.tensor([0.1])`, a `float64` tensor} now run and preserve the input dtype; a `float64` `eps` next to a `float32` guidance raised on `main` too, and works now as well.

**Deliberately not `_torch_solve_cast`.** That helper promotes `float32` to `float64`, which would change the default path's results and pay for a float64 solve at every pixel. Measured on a 512×512 image (262144 3×3 systems, 4 threads, min of 5):

| | time |
| --- | --- |
| `float32` solve | 19.12 ms |
| `float64` solve + cast back | 23.12 ms (**1.21×**) |

### 2. Two test tolerances narrowed to what is measured

`test_separable_matches_nonseparable` overrode the harness tolerance for *both* half dtypes. Only `float16` needs it. Deleting the override and re-running:

```
FAILED ...test_separable_matches_nonseparable[cpu-float16-1-5-1]
  Greatest absolute difference: 0.001953125 (up to 0.001 allowed)
1 failed, 7 passed
```

The single failure is `float16`; every `bfloat16` case passes on `_DTYPE_PRECISIONS` alone, because `assert_close`'s `atol + rtol*|expected|` already covers them. Its pin was 3× looser than necessary.

`test_opencv_rgb` gains a `bfloat16` tolerance — reachable for the first time now that the op runs there at all. Measured against **this op's own float64 result**, so the comparison is about the arithmetic and not about OpenCV:

```
float32    max_abs_err=3.9030e-07   eps=1.19e-07   err/eps=3.27
float16    max_abs_err=1.3540e-03   eps=9.77e-04   err/eps=1.39
bfloat16   max_abs_err=2.3056e-02   eps=7.81e-03   err/eps=2.95
```

`bfloat16` is not an outlier — the harness's 1-eps budget is simply too tight for a filter that chains three box blurs, a `C x C` solve and an einsum. `bfloat16` also cannot represent the inputs to better than `3.6e-3`, over half that budget, before any arithmetic runs.

## Related issue or discussion

Follow-up to #3946. Reduces the half-precision baseline that #4070's tier-2 ratchet will inherit.

## What did you check?

**`float32` / `float64` are bit-identical.** 96 configs (`guide_dim` × `kernel_size` × `subsample` × `separable` × eps-kind × dtype), SHA-256 over the raw output bytes rather than printed values, against the same script run in a `main` worktree:

```
this branch:  configs: 96  digest: 78686f4288679c930a73bd1b34499951b099d142943c8192f4871369afe15a96
main:         configs: 96  digest: 78686f4288679c930a73bd1b34499951b099d142943c8192f4871369afe15a96
```

`Tensor.to` returns `self` when the dtype already matches, so the non-half path is literally the same sequence of ops.

**`torch.compile` is unaffected.** The new branch keys on a tensor `dtype`, which Dynamo specialises, so there is no graph break:

```
float32   eps=float    fullgraph OK  graphs=1  bit-identical to eager: True
float32   eps=Tensor   fullgraph OK  graphs=1  bit-identical to eager: True
float16   eps=float    fullgraph OK  graphs=1  bit-identical to eager: True
float16   eps=Tensor   fullgraph OK  graphs=1  bit-identical to eager: True
bfloat16  eps=float    fullgraph OK  graphs=1  bit-identical to eager: True
bfloat16  eps=Tensor   fullgraph OK  graphs=1  bit-identical to eager: True
```

`torch.promote_types` operates on dtypes, which Dynamo specialises, so it constant-folds.

**Half precision is correct, not merely non-raising.** Gradients still flow (`grad dtype float16`, finite, non-zero), dtype is preserved, and MPS now returns results at all three dtypes where `main` aborts.

**The new test fails on base.** `test_multichannel_guidance_in_half_precision` run against the unpatched `guided.py`:

```
FAILED ...[cpu-float16-float_eps]   - NotImplementedError: "lu_cpu" not implemented for 'Half'
FAILED ...[cpu-float16-tensor_eps]  - RuntimeError: linalg.solve: Expected A and B to have the same
                                      dtype, but found A of type Float and B of type Half instead
FAILED ...[cpu-bfloat16-float_eps]  - NotImplementedError: "lu_cpu" not implemented for 'BFloat16'
FAILED ...[cpu-bfloat16-tensor_eps] - RuntimeError: ... A of type Float and B of type BFloat16 instead
```

It takes the standard `dtype` fixture and skips outside `float16`/`bfloat16`, so it runs in the half jobs and goes through the CUDA half-precision subprocess isolation instead of executing in every `float32`/`float64` matrix job. It pins `border_type="constant"` so the assertion is about the solver: CPU PyTorch 2.5.1 has a `bfloat16` `reflection_pad2d` but no `float16` one, which is a torch limitation this PR does not change.

**Suites:**

```
pytest tests/filters/test_guided.py --device=cpu --dtype=float32,float64   ->  165 passed, 4 skipped
pytest tests/filters/test_guided.py --device=cpu --dtype=float16,bfloat16  ->  169 passed
                                                          (main: 98 failed, 67 passed)
KORNIA_TEST_OPTIMIZER=inductor pytest tests/filters/test_guided.py         ->  92 passed, 2 skipped

pytest tests/filters --device=cpu --dtype=float32,float64    ->  1867 passed, 19 skipped
pytest tests/filters --device=cpu --dtype=float16,bfloat16   ->  124 failed  (main: 224 failed)

pixi run pre-commit-all  ->  all hooks Passed
pixi run typecheck       ->  1 diagnostic, pre-existing on main
                             (kornia/feature/lightglue.py:53 torch.cuda.amp.custom_fwd deprecation)
```

The 124 remaining `tests/filters` half failures are in other files (`test_otsu_thresholding.py` and friends) and are untouched by this change; a couple of them are flaky run-to-run. `test_guided.py` itself is deterministic and fully green.

## Notes

`kornia.filters` stays ⚠️ in the README half-precision table — this fixes one op, not the module, so no table change is included.

## How did AI help?

Claude Opus 5 found the root cause, ran every measurement above, and drafted the change and this description. I reviewed and verified the result.

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
