### PR TITLE
Fix learnable FRN epsilon dtype

### DIFF
--- a/kornia/feature/hynet.py
+++ b/kornia/feature/hynet.py
@@ -81,7 +81,7 @@ class FilterResponseNorm2d(nn.Module):
         self.weight = nn.Parameter(torch.ones(1, num_features, 1, 1), requires_grad=True)
         self.bias = nn.Parameter(torch.zeros(1, num_features, 1, 1), requires_grad=True)
         if is_eps_leanable:
-            self.eps = nn.Parameter(torch.tensor(1), requires_grad=True)
+            self.eps = nn.Parameter(torch.tensor([eps]), requires_grad=True)
         else:
             self.register_buffer("eps", torch.tensor([eps]))
         self.reset_parameters()

--- a/tests/feature/test_hynet.py
+++ b/tests/feature/test_hynet.py
@@ -18,12 +18,18 @@
 import pytest
 import torch
 
-from kornia.feature import HyNet
+from kornia.feature import FilterResponseNorm2d, HyNet
 
 from testing.base import BaseTester
 
 
 class TestHyNet(BaseTester):
+    def test_learnable_eps(self, device):
+        layer = FilterResponseNorm2d(4, is_eps_leanable=True).to(device)
+        output = layer(torch.ones(2, 4, 8, 8, device=device))
+        assert output.shape == (2, 4, 8, 8)
+        assert layer.eps.requires_grad
+
     def test_shape(self, device):
         inp = torch.ones(1, 1, 32, 32, device=device)
         hynet = HyNet().to(device)


### PR DESCRIPTION
Initialize the learnable Filter Response Normalization epsilon as a floating-point parameter so the public option can be constructed and trained.

Test: python3 -m py_compile kornia/feature/hynet.py tests/feature/test_hynet.py

AI assistance was used.