### PR TITLE
Validate ScaleSpaceDetector channel count

### DIFF
--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -326,6 +326,7 @@ class ScaleSpaceDetector(nn.Module):
             Tuple containing detection scores and local affine frames. Local affine frames are usually shaped `(B, N, 2,
             3)`, where `N` is the selected feature count.
         """
+        KORNIA_CHECK_SHAPE(img, ["B", "1", "H", "W"])
         dev = img.device
         dtype: torch.dtype = img.dtype
         sp, sigmas, _ = self.scale_pyr(img)

--- a/tests/feature/test_scale_space_detector.py
+++ b/tests/feature/test_scale_space_detector.py
@@ -15,9 +15,11 @@
 # limitations under the License.
 #
 
+import pytest
 import torch
 
 import kornia
+from kornia.core.check import ShapeError
 from kornia.feature.scale_space_detector import (
     _MAX_ABS_SIN_12,
     MultiResolutionDetector,
@@ -30,6 +32,11 @@ from testing.base import BaseTester
 
 
 class TestScaleSpaceDetector(BaseTester):
+    def test_rejects_multichannel_input(self, device, dtype):
+        detector = ScaleSpaceDetector(2).to(device, dtype)
+        with pytest.raises(ShapeError, match="Expected shape"):
+            detector(torch.rand(1, 3, 32, 32, device=device, dtype=dtype))
+
     def test_shape(self, device, dtype):
         inp = torch.rand(1, 1, 32, 32, device=device, dtype=dtype)
         n_feats = 10


### PR DESCRIPTION
Reject multi-channel inputs before scale-space processing, which currently assumes a single channel.

Test: python3 -m py_compile kornia/feature/scale_space_detector.py tests/feature/test_scale_space_detector.py

AI assistance was used.