### PR TITLE
Fix empty NMS output device

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -590,4 +590,4 @@ def nms(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torc
     if len(keep) > 0:
         return torch.stack(keep)
 
-    return torch.tensor(keep)
+    return boxes.new_empty((0,), dtype=torch.long)

--- a/tests/geometry/test_bbox.py
+++ b/tests/geometry/test_bbox.py
@@ -289,6 +289,14 @@ class TestBbox3D(BaseTester):
 
 
 class TestNMS(BaseTester):
+    def test_empty(self, device):
+        boxes = torch.empty((0, 4), device=device)
+        scores = torch.empty((0,), device=device)
+        actual = nms(boxes, scores, iou_threshold=0.8)
+        assert actual.shape == (0,)
+        assert actual.dtype == torch.long
+        assert actual.device == boxes.device
+
     def test_smoke(self, device, dtype):
         boxes = torch.tensor(
             [


### PR DESCRIPTION
Return empty NMS indices with the input device and dtype. Fixes #4059.