### PR TITLE
Avoid CPU autocast warning in DeDoDe

### DIFF
--- a/kornia/feature/dedode/decoder.py
+++ b/kornia/feature/dedode/decoder.py
@@ -165,10 +165,8 @@ class ConvRefiner(nn.Module):
             surrounding class.
         """
         _b, _c, _hs, _ws = feats.shape
-        # AMP is intentionally scoped to "cuda" only: float16 autocast on CPU is not
-        # supported by PyTorch and a no-op on MPS. Use amp_dtype=torch.float32 on
-        # non-CUDA devices to disable AMP entirely.
-        with torch.autocast("cuda", enabled=self.amp, dtype=self.amp_dtype):
+        # AMP runs only for CUDA tensors.
+        with torch.autocast("cuda", enabled=self.amp and feats.is_cuda, dtype=self.amp_dtype):
             x0 = self.block1(feats)
             x = self.hidden_blocks(x0)
             if self.residual:

--- a/kornia/feature/dedode/encoder.py
+++ b/kornia/feature/dedode/encoder.py
@@ -48,9 +48,7 @@ class VGG19(nn.Module):
         self.amp_dtype = amp_dtype
 
     def forward(self, x: torch.Tensor, **kwargs):  # type: ignore[no-untyped-def]
-        # AMP is intentionally scoped to "cuda" only: float16 autocast on CPU is not
-        # supported by PyTorch and a no-op on MPS. Use amp_dtype=torch.float32 on
-        # non-CUDA devices to disable AMP entirely.
+        # AMP runs only for CUDA tensors.
         """Run this DeDoDe module forward.
 
         Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
@@ -66,7 +64,7 @@ class VGG19(nn.Module):
             Output tensor or dictionary produced by the module while preserving the shape contract documented by the
             surrounding class.
         """
-        with torch.autocast("cuda", enabled=self.amp, dtype=self.amp_dtype):
+        with torch.autocast("cuda", enabled=self.amp and x.is_cuda, dtype=self.amp_dtype):
             feats = []
             sizes = []
             for layer in self.layers:

--- a/kornia/feature/dedode/encoder.py
+++ b/kornia/feature/dedode/encoder.py
@@ -48,7 +48,6 @@ class VGG19(nn.Module):
         self.amp_dtype = amp_dtype
 
     def forward(self, x: torch.Tensor, **kwargs):  # type: ignore[no-untyped-def]
-        # AMP runs only for CUDA tensors.
         """Run this DeDoDe module forward.
 
         Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
@@ -64,6 +63,7 @@ class VGG19(nn.Module):
             Output tensor or dictionary produced by the module while preserving the shape contract documented by the
             surrounding class.
         """
+        # AMP runs only for CUDA tensors.
         with torch.autocast("cuda", enabled=self.amp and x.is_cuda, dtype=self.amp_dtype):
             feats = []
             sizes = []

--- a/tests/feature/test_dedode.py
+++ b/tests/feature/test_dedode.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import warnings
+
 import pytest
 import torch
 
@@ -32,9 +34,12 @@ class TestConvRefiner(BaseTester):
             lambda _module, _inputs: autocast_enabled.append(torch.is_autocast_enabled("cuda"))
         )
 
-        refiner(torch.rand(1, 4, 8, 8, device=device))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            refiner(torch.rand(1, 4, 8, 8, device=device))
 
         assert autocast_enabled == [device.type == "cuda"]
+        assert not any("device_type of 'cuda'" in str(w.message) for w in caught)
 
 
 @pytest.mark.skip(reason="DeDoDe is ummaintained")

--- a/tests/feature/test_dedode.py
+++ b/tests/feature/test_dedode.py
@@ -20,6 +20,7 @@ import torch
 
 from kornia.feature.dedode import DeDoDe
 from kornia.feature.dedode.decoder import ConvRefiner
+
 from testing.base import BaseTester
 
 

--- a/tests/feature/test_dedode.py
+++ b/tests/feature/test_dedode.py
@@ -19,6 +19,21 @@ import pytest
 import torch
 
 from kornia.feature.dedode import DeDoDe
+from kornia.feature.dedode.decoder import ConvRefiner
+from testing.base import BaseTester
+
+
+class TestConvRefiner(BaseTester):
+    def test_amp_matches_input_device(self, device):
+        refiner = ConvRefiner(in_dim=4, hidden_dim=4, out_dim=4)
+        autocast_enabled = []
+        refiner.block1.register_forward_pre_hook(
+            lambda _module, _inputs: autocast_enabled.append(torch.is_autocast_enabled("cuda"))
+        )
+
+        refiner(torch.rand(1, 4, 8, 8, device=device))
+
+        assert autocast_enabled == [device.type == "cuda"]
 
 
 @pytest.mark.skip(reason="DeDoDe is ummaintained")

--- a/tests/feature/test_dedode.py
+++ b/tests/feature/test_dedode.py
@@ -26,7 +26,7 @@ from testing.base import BaseTester
 
 class TestConvRefiner(BaseTester):
     def test_amp_matches_input_device(self, device):
-        refiner = ConvRefiner(in_dim=4, hidden_dim=4, out_dim=4)
+        refiner = ConvRefiner(in_dim=4, hidden_dim=4, out_dim=4).to(device)
         autocast_enabled = []
         refiner.block1.register_forward_pre_hook(
             lambda _module, _inputs: autocast_enabled.append(torch.is_autocast_enabled("cuda"))


### PR DESCRIPTION
Skip CUDA autocast when DeDoDe runs on CPU. Fixes #4094.

The regression test now moves `ConvRefiner` to the parametrized device before checking autocast state.

AI assistance helped inspect the issue and draft the patch; I reviewed the changed lines.
