### PR TITLE
Raise ShapeError for empty YUV planes

### DIFF
--- a/kornia/color/yuv.py
+++ b/kornia/color/yuv.py
@@ -228,8 +228,8 @@ def yuv420_to_rgb(imagey: torch.Tensor, imageuv: torch.Tensor) -> torch.Tensor:
     if (
         len(imageuv.shape) < 2
         or len(imagey.shape) < 2
-        or imagey.shape[-2] / imageuv.shape[-2] != 2
-        or imagey.shape[-1] / imageuv.shape[-1] != 2
+        or imagey.shape[-2] != 2 * imageuv.shape[-2]
+        or imagey.shape[-1] != 2 * imageuv.shape[-1]
     ):
         raise ShapeError(
             f"Input imageuv H&W must be half the size of the luma plane. Got {imagey.shape} and {imageuv.shape}"
@@ -280,7 +280,7 @@ def yuv422_to_rgb(imagey: torch.Tensor, imageuv: torch.Tensor) -> torch.Tensor:
         len(imageuv.shape) < 2
         or len(imagey.shape) < 2
         or imagey.shape[-2] != imageuv.shape[-2]
-        or imagey.shape[-1] / imageuv.shape[-1] != 2
+        or imagey.shape[-1] != 2 * imageuv.shape[-1]
     ):
         raise ShapeError(
             f"Input imageuv H must match the luma plane and W must be half its size. "

--- a/tests/color/test_yuv.py
+++ b/tests/color/test_yuv.py
@@ -699,6 +699,21 @@ class TestYuv420ToRgb(BaseTester):
             imguv = torch.ones(2, 1, 1, device=device, dtype=dtype)
             kornia.color.yuv420_to_rgb(imgy, imguv)
 
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(1, 4, 4, device=device, dtype=dtype)
+            imguv = torch.empty(2, 2, 0, device=device, dtype=dtype)
+            kornia.color.yuv420_to_rgb(imgy, imguv)
+
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(1, 4, 4, device=device, dtype=dtype)
+            imguv = torch.empty(2, 0, 2, device=device, dtype=dtype)
+            kornia.color.yuv420_to_rgb(imgy, imguv)
+
+    def test_empty_input(self, device, dtype):
+        imgy = torch.empty(1, 0, 0, device=device, dtype=dtype)
+        imguv = torch.empty(2, 0, 0, device=device, dtype=dtype)
+        assert kornia.color.yuv420_to_rgb(imgy, imguv).shape == (3, 0, 0)
+
     @pytest.mark.parametrize("name", list(_REFERENCE_COLORS))
     def test_unit(self, device, dtype, name):
         rgb_values, yuv_values = _REFERENCE_COLORS[name]
@@ -826,6 +841,16 @@ class TestYuv422ToRgb(BaseTester):
             imgy = torch.ones(1, 2, 2, device=device, dtype=dtype)
             imguv = torch.ones(2, 1, 1, device=device, dtype=dtype)
             kornia.color.yuv422_to_rgb(imgy, imguv)
+
+        with pytest.raises(ShapeError):
+            imgy = torch.ones(1, 4, 4, device=device, dtype=dtype)
+            imguv = torch.empty(2, 4, 0, device=device, dtype=dtype)
+            kornia.color.yuv422_to_rgb(imgy, imguv)
+
+    def test_empty_input(self, device, dtype):
+        imgy = torch.empty(1, 4, 0, device=device, dtype=dtype)
+        imguv = torch.empty(2, 4, 0, device=device, dtype=dtype)
+        assert kornia.color.yuv422_to_rgb(imgy, imguv).shape == (3, 4, 0)
 
     @pytest.mark.parametrize("name", list(_REFERENCE_COLORS))
     def test_unit(self, device, dtype, name):


### PR DESCRIPTION
Report zero-sized chroma planes as `ShapeError`. Empty matching planes return empty RGB. Fixes #4056.

Tests: `tests/color/test_yuv.py` covers zero-sized chroma errors and intentional empty-image outputs. Kornia CI passed.

AI assistance helped inspect the issue and draft the patch; I reviewed the changed lines.
