### PR TITLE
Support scalar inputs in bbox_generator3d

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -464,19 +464,19 @@ def bbox_generator3d(
     # front
     bbox = torch.tensor(
         [[[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]], device=x_start.device, dtype=x_start.dtype
-    ).repeat(len(x_start), 1, 1)
+    ).repeat(x_start.numel(), 1, 1)
 
     bbox[:, :, 0] += x_start.view(-1, 1)
     bbox[:, :, 1] += y_start.view(-1, 1)
     bbox[:, :, 2] += z_start.view(-1, 1)
-    bbox[:, 1, 0] += width
-    bbox[:, 2, 0] += width
-    bbox[:, 2, 1] += height
-    bbox[:, 3, 1] += height
+    bbox[:, 1, 0] += width.view(-1)
+    bbox[:, 2, 0] += width.view(-1)
+    bbox[:, 2, 1] += height.view(-1)
+    bbox[:, 3, 1] += height.view(-1)
 
     # back
     bbox_back = bbox.clone()
-    bbox_back[:, :, -1] += depth.unsqueeze(dim=1).repeat(1, 4)
+    bbox_back[:, :, -1] += depth.view(-1, 1).expand(-1, 4)
     bbox = torch.cat([bbox, bbox_back], dim=1)
 
     return bbox

--- a/tests/geometry/test_bbox.py
+++ b/tests/geometry/test_bbox.py
@@ -19,6 +19,7 @@ import torch
 
 import kornia
 from kornia.geometry.bbox import (
+    bbox_generator3d,
     infer_bbox_shape,
     infer_bbox_shape3d,
     nms,
@@ -208,6 +209,13 @@ class TestTransformBoxes2D(BaseTester):
 
 
 class TestBbox3D(BaseTester):
+    def test_generator_scalar_inputs(self, device, dtype):
+        args = [torch.tensor(value, device=device, dtype=dtype) for value in (1, 2, 3, 4, 5, 6)]
+        boxes = bbox_generator3d(*args)
+        assert boxes.shape == (1, 8, 3)
+        self.assert_close(boxes[0, 0], torch.tensor([1, 2, 3], device=device, dtype=dtype))
+        self.assert_close(boxes[0, 6], torch.tensor([5, 7, 9], device=device, dtype=dtype))
+
     def test_smoke(self, device, dtype):
         # Sample two points of the 3d rect
         points = torch.rand(1, 6, device=device, dtype=dtype)


### PR DESCRIPTION
Support the documented scalar tensor inputs in bbox_generator3d. Fixes #4057.