### PR TITLE
fix(feature): batch patch extraction and keep CPU half off a broken grid_sample kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* Make `load_pointcloud_ply` and `load_pointcloud_ply_binary` parse the PLY header instead of skipping a fixed
+* Keep `extract_patches_simple` and `extract_patches_from_pyramid` off a broken reduced-precision CPU kernel: for a
+  `float16`/`bfloat16` CPU image, the `grid_sample` kernels in torch <= 2.9 read out of bounds when a rotated patch
+  straddles the image border and return NaN or garbage values far outside the image's range, so both extractors now
+  sample reduced-precision CPU images in `float32` and cast the patches back. Half-precision CPU patches change as a
+  result (they are computed with `float32` sampling coordinates, which is also more accurate for large images);
+  `float32`, `float64`, CUDA, and MPS results are byte-for-byte unchanged. Both extractors also replace their
+  per-image Python loop with one batched `grid_sample` call over a `(B, N*PS, PS, 2)` grid, so they trace as a
+  single `fullgraph=True` graph; measured throughput is unchanged on CPU and MPS, where `grid_sample` dominates.
   number of lines. Both loaders skipped `header_size=8` lines and read everything after them as `x y z` triples, so a
   minimal PLY file (seven header lines, no `comment`) lost its first point to a header line -- the binary reader
   returned header bytes decoded as doubles -- and any file with extra vertex properties (normals, colours) or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sample reduced-precision CPU images in `float32` and cast the patches back. Half-precision CPU patches change as a
   result (they are computed with `float32` sampling coordinates, which is also more accurate for large images);
   `float32`, `float64`, CUDA, and MPS results are byte-for-byte unchanged. Both extractors also replace their
-  per-image Python loop with one batched `grid_sample` call over a `(B, N*PS, PS, 2)` grid, so they trace as a
-  single `fullgraph=True` graph; measured throughput is unchanged on CPU and MPS, where `grid_sample` dominates.
+  per-image Python loop with one batched `grid_sample` call over a `(B, N*PS, PS, 2)` grid. Both forms compile
+  under `fullgraph=True`, but the loop was unrolled at trace time into one `grid_sample` per batch element, so the
+  graph grew with the batch and was recompiled for every new batch size: tracing `extract_patches_simple` over
+  batches of 2, 3, 5 and 7 built four graphs of 2/3/5/7 `grid_sample` nodes before and builds two graphs of one
+  node now. Measured eager throughput is unchanged on CPU and MPS, where `grid_sample` dominates.
+
+* Make `load_pointcloud_ply` and `load_pointcloud_ply_binary` parse the PLY header instead of skipping a fixed
   number of lines. Both loaders skipped `header_size=8` lines and read everything after them as `x y z` triples, so a
   minimal PLY file (seven header lines, no `comment`) lost its first point to a header line -- the binary reader
   returned header bytes decoded as doubles -- and any file with extra vertex properties (normals, colours) or a

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -428,6 +428,23 @@ def _clamp_grid_to_pixel_centers(grid: torch.Tensor, h: int, w: int) -> torch.Te
     return torch.stack([x, y], dim=-1)
 
 
+def _grid_sample_patches(img: torch.Tensor, grid: torch.Tensor, h: int, w: int) -> torch.Tensor:
+    r"""Run ``grid_sample`` with border padding, robust across devices and dtypes.
+
+    MPS does not implement ``padding_mode="border"``; it is emulated with a clamped grid plus
+    zero padding (see :func:`_clamp_grid_to_pixel_centers`). The float16/bfloat16 CPU kernel in
+    torch <= 2.9 reads out of bounds for coordinates at or beyond the border and returns
+    nondeterministic garbage or NaN, so reduced-precision CPU inputs are sampled in float32 and
+    cast back.
+    """
+    if img.device.type == "mps":
+        return F.grid_sample(img, _clamp_grid_to_pixel_centers(grid, h, w), padding_mode="zeros", align_corners=False)
+    if img.device.type == "cpu" and img.dtype in (torch.float16, torch.bfloat16):
+        out = F.grid_sample(img.float(), grid.float(), padding_mode="border", align_corners=False)
+        return out.to(img.dtype)
+    return F.grid_sample(img, grid, padding_mode="border", align_corners=False)
+
+
 def extract_patches_simple(
     img: torch.Tensor, laf: torch.Tensor, PS: int = 32, normalize_lafs_before_extraction: bool = True
 ) -> torch.Tensor:
@@ -452,26 +469,11 @@ def extract_patches_simple(
         nlaf = laf
     _, ch, h, w = img.size()
     B, N, _, _ = laf.size()
-    out = []
-    # for loop temporarily, to be refactored
-    for i in range(B):
-        grid = generate_patch_grid_from_normalized_LAF(img[i : i + 1], nlaf[i : i + 1], PS).to(img.device)
-        if img.device.type == "mps":
-            out.append(
-                F.grid_sample(
-                    img[i : i + 1].expand(grid.size(0), ch, h, w),
-                    _clamp_grid_to_pixel_centers(grid, h, w),
-                    padding_mode="zeros",
-                    align_corners=False,
-                )
-            )
-        else:
-            out.append(
-                F.grid_sample(
-                    img[i : i + 1].expand(grid.size(0), ch, h, w), grid, padding_mode="border", align_corners=False
-                )
-            )
-    return torch.cat(out, dim=0).view(B, N, ch, PS, PS)
+    # Fold the (B*N, PS, PS, 2) grid to (B, N*PS, PS, 2) so one grid_sample call samples every
+    # patch of every image, without a Python loop over B or a (B*N, CH, H, W) input copy.
+    grid = generate_patch_grid_from_normalized_LAF(img, nlaf, PS).view(B, N * PS, PS, 2)
+    patches = _grid_sample_patches(img, grid, h, w)
+    return patches.view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4).contiguous()
 
 
 def extract_patches_from_pyramid(
@@ -508,22 +510,12 @@ def extract_patches_from_pyramid(
     num_levels = max(1, max_level)
     for cur_pyr_level in range(num_levels):
         _, ch_l, h_l, w_l = cur_img.size()
-        for i in range(B):
-            # torch.where avoids nonzero/data-dependent shapes → fully compilable.
-            level_mask = (pyr_idx[i] == cur_pyr_level).view(N, 1, 1, 1)
-            grid = generate_patch_grid_from_normalized_LAF(cur_img[i : i + 1], nlaf[i : i + 1], PS)
-            if cur_img.device.type == "mps":
-                patches = F.grid_sample(
-                    cur_img[i : i + 1].expand(N, ch_l, h_l, w_l),
-                    _clamp_grid_to_pixel_centers(grid, h_l, w_l),
-                    padding_mode="zeros",
-                    align_corners=False,
-                )
-            else:
-                patches = F.grid_sample(
-                    cur_img[i : i + 1].expand(N, ch_l, h_l, w_l), grid, padding_mode="border", align_corners=False
-                )
-            out[i] = torch.where(level_mask, patches.to(nlaf.dtype), out[i])
+        # torch.where avoids nonzero/data-dependent shapes → fully compilable; the (B*N, PS, PS, 2)
+        # grid is folded to (B, N*PS, PS, 2) so one grid_sample call covers the whole batch.
+        level_mask = (pyr_idx == cur_pyr_level).view(B, N, 1, 1, 1)
+        grid = generate_patch_grid_from_normalized_LAF(cur_img, nlaf, PS).view(B, N * PS, PS, 2)
+        patches = _grid_sample_patches(cur_img, grid, h_l, w_l).view(B, ch_l, N, PS, PS).permute(0, 2, 1, 3, 4)
+        out = torch.where(level_mask, patches.to(nlaf.dtype), out)
         if cur_pyr_level < num_levels - 1:
             cur_img = pyrdown(cur_img)
             # Stop early if the pyramided image is too small for further levels.

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -471,7 +471,9 @@ def extract_patches_simple(
     B, N, _, _ = laf.size()
     # Fold the (B*N, PS, PS, 2) grid to (B, N*PS, PS, 2) so one grid_sample call samples every
     # patch of every image, without a Python loop over B or a (B*N, CH, H, W) input copy.
-    grid = generate_patch_grid_from_normalized_LAF(img, nlaf, PS).view(B, N * PS, PS, 2)
+    # The grid follows the LAF device, so it is moved to the image: this function has always
+    # accepted a LAF on a different device than the image and returned a patch on the image's.
+    grid = generate_patch_grid_from_normalized_LAF(img, nlaf, PS).to(img.device).view(B, N * PS, PS, 2)
     patches = _grid_sample_patches(img, grid, h, w)
     return patches.view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4).contiguous()
 

--- a/testing/base.py
+++ b/testing/base.py
@@ -194,6 +194,23 @@ def supports_replicate_padding(device: torch.device, dtype: torch.dtype) -> bool
     return _supports_kernel_probe(_replicate_padding_op, device.type, dtype)
 
 
+def _reflect_padding_op(device_type: str, dtype: torch.dtype) -> None:
+    F.pad(_probe_zeros(device_type, dtype, 1, 1, 2, 2), (1, 1, 1, 1), mode="reflect")
+
+
+def supports_reflect_padding(device: torch.device, dtype: torch.dtype) -> bool:
+    """Whether this device has a 2D ``mode="reflect"`` pad kernel for ``dtype``.
+
+    :func:`kornia.geometry.transform.pyrdown` blurs with ``border_type="reflect"`` before it
+    downsamples, so every pyramid consumer inherits the gap --
+    :func:`kornia.feature.extract_patches_from_pyramid` and the descriptor pipelines above it.
+    torch 2.5.1 has no float16 CPU ``reflection_pad2d`` (bfloat16 is fine), so a test that
+    hardcodes a half dtype rather than reading the injected one fails there on every job. Probed
+    at runtime and cached per (device type, dtype), like :func:`supports_replicate_padding`.
+    """
+    return _supports_kernel_probe(_reflect_padding_op, device.type, dtype)
+
+
 def _grid_sample_op(device_type: str, dtype: torch.dtype) -> None:
     F.grid_sample(
         _probe_zeros(device_type, dtype, 1, 1, 2, 2),

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -15,13 +15,15 @@
 # limitations under the License.
 #
 
+import math
+
 import pytest
 import torch
 
 import kornia
 import kornia.geometry.transform.imgwarp
 
-from testing.base import BaseTester
+from testing.base import BaseTester, supports_reflect_padding
 from testing.geometry.create import create_random_homography
 
 
@@ -475,6 +477,20 @@ class TestClampGridToPixelCenters(BaseTester):
         self.assert_close(actual.cpu(), expected)
 
 
+def _corner_border_laf(device, dtype, scale: float = 8.0, angle_deg: float = 15.0, center: float = 255.0):
+    """Build a rotated LAF centered on the last pixel of a 256x256 image.
+
+    Its patch straddles the image corner, so half of the sampling grid falls outside the frame and
+    is served by the border padding. ``scale`` is below the patch size used by the tests (16), so
+    ``extract_patches_from_pyramid`` routes it through pyramid level 0: at a downsampled level the
+    repeated blur turns the patch into a near-constant that hides a bad read.
+    """
+    t = math.radians(angle_deg)
+    cos, sin = scale * math.cos(t), scale * math.sin(t)
+    laf = torch.tensor([[cos, -sin, center], [sin, cos, center]], device=device, dtype=dtype)
+    return laf.view(1, 1, 2, 3).expand(1, 3, 2, 3)
+
+
 class TestExtractPatchesSimple(BaseTester):
     def test_shape(self, device):
         laf = torch.rand(5, 4, 2, 3, device=device)
@@ -524,24 +540,48 @@ class TestExtractPatchesSimple(BaseTester):
         expected = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1, 1).expand(B, N, 1, PS, PS)
         self.assert_close(patches, expected)
 
-    def test_border_patches_stay_in_range(self, device, dtype):
-        # A rotated patch straddling the frame reads border pixels; the values must never leave
-        # the image's value range. The float16/bfloat16 CPU grid_sample kernels in torch <= 2.9
-        # read out of bounds for such coordinates and return NaN or garbage.
+    @pytest.mark.parametrize("half_dtype", [torch.float16, torch.bfloat16])
+    def test_border_patches_stay_in_range(self, device, half_dtype):
+        # A patch straddling the frame reads border pixels, so every sampled value is a convex
+        # combination of image values and cannot leave the image's range. The float16/bfloat16 CPU
+        # `grid_sample` kernels in torch <= 2.9 read out of bounds for such coordinates and return
+        # zeros, values of order 1e4 or NaN depending on what the heap happens to hold, so the
+        # extractor samples reduced-precision CPU images in float32. Parametrized on the dtype
+        # rather than taking the global `dtype` fixture: CI runs the suite in float32/float64 only,
+        # where the kernel is sound and this test cannot fail.
+        if device.type == "mps":
+            pytest.skip("MPS autocast changes the effective dtype")
         torch.manual_seed(0)
-        img = torch.rand(1, 1, 256, 256, device=device, dtype=dtype)
-        laf = torch.tensor([[1.76, -90.38, -19.14], [90.38, 1.76, 268.75]], device=device, dtype=dtype)
-        laf = laf.view(1, 1, 2, 3).expand(1, 3, 2, 3)
+        img = torch.rand(1, 1, 256, 256, device=device).to(half_dtype)
+        laf = _corner_border_laf(device, half_dtype)
         patches = kornia.feature.extract_patches_simple(img, laf, 16)
+        assert patches.dtype == half_dtype
         assert bool(patches.isfinite().all())
         assert patches.min() >= img.min()
         assert patches.max() <= img.max()
 
+    def test_laf_on_another_device(self, device, dtype):
+        # The sampling grid follows the LAF, so it has to be moved to the image: this function has
+        # always accepted a LAF on a different device than the image and returned a patch on the
+        # image's device.
+        if device.type == "cpu":
+            pytest.skip("needs a second device besides the CPU")
+        img = torch.rand(1, 1, 32, 32, device=device, dtype=dtype)
+        laf = torch.tensor([[4.0, 0.0, 16.0], [0.0, 4.0, 16.0]], dtype=dtype).view(1, 1, 2, 3)
+        patches = kornia.feature.extract_patches_simple(img, laf, 8)
+        assert patches.device == img.device
+        self.assert_close(patches, kornia.feature.extract_patches_simple(img, laf.to(device), 8))
+
     def test_dynamo(self, device, dtype, torch_optimizer):
         laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
         img = torch.rand(2, 1, 40, 30, device=device, dtype=dtype)
+        expected = kornia.feature.extract_patches_simple(img, laf, 10)
         op = torch_optimizer(kornia.feature.extract_patches_simple)
-        self.assert_close(op(img, laf, 10), kornia.feature.extract_patches_simple(img, laf, 10))
+        self.assert_close(op(img, laf, 10), expected)
+        # The fixture compiles without `fullgraph`, so it would pass on a graph break too, and the
+        # extractor is meant to trace as one graph -- assert that directly.
+        torch._dynamo.reset()
+        self.assert_close(torch.compile(kornia.feature.extract_patches_simple, fullgraph=True)(img, laf, 10), expected)
 
 
 class TestExtractPatchesPyr(BaseTester):
@@ -622,24 +662,42 @@ class TestExtractPatchesPyr(BaseTester):
         expected = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1, 1).expand(B, 2, 1, PS, PS)
         self.assert_close(patches, expected)
 
-    def test_border_patches_stay_in_range(self, device, dtype):
-        # A rotated patch straddling the frame reads border pixels; the values must never leave
-        # the image's value range. The float16/bfloat16 CPU grid_sample kernels in torch <= 2.9
-        # read out of bounds for such coordinates and return NaN or garbage.
+    @pytest.mark.parametrize("half_dtype", [torch.float16, torch.bfloat16])
+    def test_border_patches_stay_in_range(self, device, half_dtype):
+        # Same border read as in `TestExtractPatchesSimple`, at pyramid level 0: `_corner_border_laf`
+        # has a scale below the patch size, so the patch comes from the undownsampled image and the
+        # level-0 result must equal the plain extractor's byte for byte. A larger LAF would be served
+        # by a blurred level whose near-constant patch stays in range even when the read is wrong.
+        if device.type == "mps":
+            pytest.skip("MPS autocast changes the effective dtype")
+        if not supports_reflect_padding(device, half_dtype):
+            # `pyrdown` blurs with border_type="reflect"; torch 2.5.1 has no float16 CPU kernel.
+            pytest.skip(f"no reflect-padding kernel for {half_dtype} on {device.type}")
         torch.manual_seed(0)
-        img = torch.rand(1, 1, 256, 256, device=device, dtype=dtype)
-        laf = torch.tensor([[1.76, -90.38, -19.14], [90.38, 1.76, 268.75]], device=device, dtype=dtype)
-        laf = laf.view(1, 1, 2, 3).expand(1, 3, 2, 3)
+        img = torch.rand(1, 1, 256, 256, device=device).to(half_dtype)
+        laf = _corner_border_laf(device, half_dtype)
         patches = kornia.feature.extract_patches_from_pyramid(img, laf, 16)
+        assert patches.dtype == half_dtype
         assert bool(patches.isfinite().all())
         assert patches.min() >= img.min()
         assert patches.max() <= img.max()
+        self.assert_close(patches, kornia.feature.extract_patches_simple(img, laf, 16))
 
-    def test_dynamo(self, device, dtype, torch_optimizer):
+    def test_dynamo(self, device, dtype, torch_optimizer, optimizer_backend):
+        if optimizer_backend == "jit":
+            # `pyrdown` -> `filter2d` closes over a `set` of valid border modes, which TorchScript
+            # cannot compile; unrelated to this extractor and to the compile path CI exercises.
+            pytest.skip("`extract_patches_from_pyramid` reaches a non-scriptable `filter2d`")
         laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
         img = torch.rand(2, 1, 40, 30, device=device, dtype=dtype)
+        expected = kornia.feature.extract_patches_from_pyramid(img, laf, 10)
         op = torch_optimizer(kornia.feature.extract_patches_from_pyramid)
-        self.assert_close(op(img, laf, 10), kornia.feature.extract_patches_from_pyramid(img, laf, 10))
+        self.assert_close(op(img, laf, 10), expected)
+        # The fixture compiles without `fullgraph`, so it would pass on a graph break too, and the
+        # extractor is meant to trace as one graph -- assert that directly.
+        torch._dynamo.reset()
+        compiled = torch.compile(kornia.feature.extract_patches_from_pyramid, fullgraph=True)
+        self.assert_close(compiled(img, laf, 10), expected)
 
 
 class TestLAFIsTouchingBoundary(BaseTester):

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -514,6 +514,35 @@ class TestExtractPatchesSimple(BaseTester):
         PS = 11
         self.gradcheck(kornia.feature.extract_patches_simple, (img, nlaf, PS, False), fast_mode=False)
 
+    def test_batch_independence(self, device, dtype):
+        # Each patch must come only from its own batch element.
+        B, N, PS = 3, 4, 8
+        img = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1).expand(B, 1, 32, 32).contiguous()
+        laf = torch.tensor([[4.0, 0.0, 16.0], [0.0, 4.0, 16.0]], device=device, dtype=dtype).view(1, 1, 2, 3)
+        patches = kornia.feature.extract_patches_simple(img, laf.expand(B, N, 2, 3), PS)
+        assert patches.shape == (B, N, 1, PS, PS)
+        expected = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1, 1).expand(B, N, 1, PS, PS)
+        self.assert_close(patches, expected)
+
+    def test_border_patches_stay_in_range(self, device, dtype):
+        # A rotated patch straddling the frame reads border pixels; the values must never leave
+        # the image's value range. The float16/bfloat16 CPU grid_sample kernels in torch <= 2.9
+        # read out of bounds for such coordinates and return NaN or garbage.
+        torch.manual_seed(0)
+        img = torch.rand(1, 1, 256, 256, device=device, dtype=dtype)
+        laf = torch.tensor([[1.76, -90.38, -19.14], [90.38, 1.76, 268.75]], device=device, dtype=dtype)
+        laf = laf.view(1, 1, 2, 3).expand(1, 3, 2, 3)
+        patches = kornia.feature.extract_patches_simple(img, laf, 16)
+        assert bool(patches.isfinite().all())
+        assert patches.min() >= img.min()
+        assert patches.max() <= img.max()
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
+        img = torch.rand(2, 1, 40, 30, device=device, dtype=dtype)
+        op = torch_optimizer(kornia.feature.extract_patches_simple)
+        self.assert_close(op(img, laf, 10), kornia.feature.extract_patches_simple(img, laf, 10))
+
 
 class TestExtractPatchesPyr(BaseTester):
     def test_shape(self, device):
@@ -579,6 +608,38 @@ class TestExtractPatchesPyr(BaseTester):
             (img, nlaf, PS, False),
             nondet_tol=1e-8,
         )
+
+    def test_batch_independence(self, device, dtype):
+        # Each patch must come only from its own batch element, across pyramid levels: the two
+        # scales route the patches through level 0 and a downsampled level respectively.
+        B, PS = 3, 8
+        img = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1).expand(B, 1, 64, 64).contiguous()
+        laf_small = torch.tensor([[4.0, 0.0, 32.0], [0.0, 4.0, 32.0]], device=device, dtype=dtype).view(1, 1, 2, 3)
+        laf_large = torch.tensor([[16.0, 0.0, 32.0], [0.0, 16.0, 32.0]], device=device, dtype=dtype).view(1, 1, 2, 3)
+        laf = torch.cat([laf_small, laf_large], dim=1).expand(B, 2, 2, 3)
+        patches = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        assert patches.shape == (B, 2, 1, PS, PS)
+        expected = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1, 1).expand(B, 2, 1, PS, PS)
+        self.assert_close(patches, expected)
+
+    def test_border_patches_stay_in_range(self, device, dtype):
+        # A rotated patch straddling the frame reads border pixels; the values must never leave
+        # the image's value range. The float16/bfloat16 CPU grid_sample kernels in torch <= 2.9
+        # read out of bounds for such coordinates and return NaN or garbage.
+        torch.manual_seed(0)
+        img = torch.rand(1, 1, 256, 256, device=device, dtype=dtype)
+        laf = torch.tensor([[1.76, -90.38, -19.14], [90.38, 1.76, 268.75]], device=device, dtype=dtype)
+        laf = laf.view(1, 1, 2, 3).expand(1, 3, 2, 3)
+        patches = kornia.feature.extract_patches_from_pyramid(img, laf, 16)
+        assert bool(patches.isfinite().all())
+        assert patches.min() >= img.min()
+        assert patches.max() <= img.max()
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
+        img = torch.rand(2, 1, 40, 30, device=device, dtype=dtype)
+        op = torch_optimizer(kornia.feature.extract_patches_from_pyramid)
+        self.assert_close(op(img, laf, 10), kornia.feature.extract_patches_from_pyramid(img, laf, 10))
 
 
 class TestLAFIsTouchingBoundary(BaseTester):

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -477,6 +477,17 @@ class TestClampGridToPixelCenters(BaseTester):
         self.assert_close(actual.cpu(), expected)
 
 
+# The two half-precision border tests below are CPU-only, for two reasons. The broken kernel and
+# the float32 workaround that routes around it are CPU-specific, so no other device exercises
+# anything the rest of the suite misses; and the half dtype comes from a `half_dtype` parameter,
+# which the CUDA half-precision isolation in `conftest.py` does not see -- both
+# `_is_subprocess_isolated_test` and `skip_half_precision_on_cuda` key on the global `dtype`
+# fixture (`dtype_name`). A `--device=cuda --dtype=float32` job would therefore run half kernels
+# in the shared CUDA context with no subprocess isolation, where a device-side assert poisons
+# every later test in the process. MPS autocast changes the effective dtype as well.
+_HALF_BORDER_SKIP = "the reduced-precision `grid_sample` gap and its float32 workaround are CPU-only"
+
+
 def _corner_border_laf(device, dtype, scale: float = 8.0, angle_deg: float = 15.0, center: float = 255.0):
     """Build a rotated LAF centered on the last pixel of a 256x256 image.
 
@@ -549,8 +560,8 @@ class TestExtractPatchesSimple(BaseTester):
         # extractor samples reduced-precision CPU images in float32. Parametrized on the dtype
         # rather than taking the global `dtype` fixture: CI runs the suite in float32/float64 only,
         # where the kernel is sound and this test cannot fail.
-        if device.type == "mps":
-            pytest.skip("MPS autocast changes the effective dtype")
+        if device.type != "cpu":
+            pytest.skip(_HALF_BORDER_SKIP)
         torch.manual_seed(0)
         img = torch.rand(1, 1, 256, 256, device=device).to(half_dtype)
         laf = _corner_border_laf(device, half_dtype)
@@ -668,8 +679,8 @@ class TestExtractPatchesPyr(BaseTester):
         # has a scale below the patch size, so the patch comes from the undownsampled image and the
         # level-0 result must equal the plain extractor's byte for byte. A larger LAF would be served
         # by a blurred level whose near-constant patch stays in range even when the read is wrong.
-        if device.type == "mps":
-            pytest.skip("MPS autocast changes the effective dtype")
+        if device.type != "cpu":
+            pytest.skip(_HALF_BORDER_SKIP)
         if not supports_reflect_padding(device, half_dtype):
             # `pyrdown` blurs with border_type="reflect"; torch 2.5.1 has no float16 CPU kernel.
             pytest.skip(f"no reflect-padding kernel for {half_dtype} on {device.type}")


### PR DESCRIPTION
Phase (c) of the `kornia.feature` audit, first code change. The gap ledger named the per-batch Python loops in `extract_patches_simple` / `extract_patches_from_pyramid` (`laf.py`) as the obvious CORE starting point. The loop removal itself turned out to be **perf-neutral** — but it surfaced a live correctness bug in half-precision CPU extraction, which this PR fixes.

## The bug

The float16/bfloat16 CPU `grid_sample` kernels in torch ≤ 2.9 read out of bounds when a rotated patch straddles the image border, returning NaN or nondeterministic garbage (values like 52672 from a [0,1) image; run-to-run variation with identical inputs). torch 2.12 is clean. **This hits `main` today** through the public API:

```python
img = torch.rand(1, 1, 256, 256, dtype=torch.float16)
laf = torch.tensor([[1.76, -90.38, -19.14], [90.38, 1.76, 268.75]], dtype=torch.float16).view(1, 1, 2, 3)
KF.extract_patches_simple(img, laf.expand(1, 3, 2, 3), 16)   # main: NaN/out-of-range elements, count varies run to run
```

Fix: reduced-precision CPU images are sampled in float32 and cast back, in a `_grid_sample_patches` helper shared by both extractors (which also carries the existing MPS clamp-emulation from #4073). Same pattern as the fp32-internal `sqrt`/`atan2` accepted for fp16 SIFT in #4098.

## The rewrite

Both extractors looped over the batch in Python. The `(B*N, PS, PS, 2)` grid is now folded to `(B, N*PS, PS, 2)` so one `grid_sample` call covers the whole batch — no `(B*N, CH, H, W)` input copy. Both the old and the new form compile under `torch.compile(fullgraph=True)`; what changes is the *size* of the graph. Dynamo unrolled the loop into one `grid_sample` per batch element and had to recompile for every new batch size: tracing `extract_patches_simple` over batches of 2, 3, 5 and 7 built four graphs of 2/3/5/7 `grid_sample` nodes (61→211 FX nodes from B=2 to B=8), against two graphs of a single node now. New `test_dynamo` for both extractors, with a direct `fullgraph=True` assertion beside the `torch_optimizer` fixture, which compiles without it.

## Verification

- **Byte-identity vs `main`**: 100 cases (5 shape configs × {fp32, fp64, fp16} × {simple, pyramid} × {normalize on/off} × {cpu, mps}). All fp32/fp64/MPS outputs `torch.equal` bitwise. Only CPU fp16 changes — always finite and in-range, where main garbles the straddling-rotated cases. CUDA unavailable on this box: the fold is layout-only and CUDA keeps the native-dtype path, but CUDA byte-identity is unverified here.
- **Benchmarks** (back-to-back A/B, same script, Apple Silicon, torch 2.9.1, `benchmarks/feature/laf_ops.py` from #4119): every cell equal within noise on CPU and MPS, eager and compiled, at B∈{1,8}, N∈{2000, 20000} — `grid_sample` dominates, and dynamo unrolled the old loop fine. The claim of this PR is correctness + simplification, not speed.
- **Tests**: `tests/feature/test_laf.py` on float32/float64/float16/bfloat16 — the only failures are the 18 pre-existing bf16 `linalg.inv` ones, node-for-node identical to `main`. Full `tests/feature` float32: 626 passed. New tests: `test_batch_independence` (pins the fold: each patch reads only its own batch element, across pyramid levels), `test_border_patches_stay_in_range` (parametrized on float16/bfloat16, so it runs in the ordinary float32 CI legs; fails on `main` for both extractors in both half dtypes, passes here), `test_laf_on_another_device`, `test_dynamo` (both ops). Gradchecks unchanged and passing. Also verified against torch 2.5.1 on CPU.
- `pixi run pre-commit-all` clean; CHANGELOG entry under Bug fixes.

## Review round 1 (`27747b85`)

Addresses the three items in the review above, plus one correction found while checking the third.

1. **Mixed-device extraction restored.** `extract_patches_simple` lost the `.to(img.device)` the loop used to apply, so an MPS image with a CPU LAF raised `RuntimeError: expected input and grid to be on same device` instead of returning an MPS patch. Restored, and pinned by `test_laf_on_another_device` (skips on a CPU-only run). `extract_patches_from_pyramid` never had the transfer and raises on `main` too, so it is left alone rather than silently gaining a new contract in a perf PR.
2. **CHANGELOG bullet restored.** The `load_pointcloud_ply*` item is a separate `*` entry again.
3. **Half-precision regression tests now run in ordinary CI.** `test_border_patches_stay_in_range` is parametrized on `float16`/`bfloat16` instead of reading the global `dtype` fixture, which CI only fills with float32/float64. The LAF is now a rotated **level-0** frame (scale 8 < PS 16, 15°, centered on the last pixel of a 256×256 image) built by a shared `_corner_border_laf` helper: on `main` it fails 5/5 seeds in both half dtypes for **both** extractors (NaN, all-zero patches, values around −2e4 and 3e15), and the pyramid case additionally asserts the level-0 result equals `extract_patches_simple` byte for byte, which is what keeps it anchored at level 0. The previous high-scale LAF was served by a blurred pyramid level whose near-constant patch stayed in range on `main`, exactly as the review said. `pyrdown` blurs with `border_type="reflect"` and torch 2.5.1 has no float16 CPU `reflection_pad2d`, so the pyramid case is gated by a new `supports_reflect_padding` probe in `testing/base.py`, following the existing probes from #4117; bfloat16 still runs there. Verified: the four new cases fail on a `main` worktree and pass here, on torch 2.9.1 and 2.5.1.
4. **Corrected an inaccurate claim of my own** (from the Copilot thread about `fullgraph`): the PR previously said the rewrite is what makes the extractors trace as a single `fullgraph=True` graph. That is wrong — `main` compiles fullgraph too, on CPU and MPS, by unrolling the loop. The real difference is graph size and recompilation, measured with a counting backend and now stated that way in the CHANGELOG and above.

Byte-identity vs `main` re-confirmed after the device fix: float32/float64 CPU and float32 MPS outputs are `torch.equal` for both extractors. `pixi run pre-commit-all` and `pixi run typecheck` clean.

## Review round 2 (`88be45b5`)

**[P2] The half-precision border tests are CPU-only now.** They carry their dtype in a `half_dtype` parameter, and kornia's CUDA half-precision isolation reads only the global `dtype` fixture — `_is_subprocess_isolated_test` requires `callspec.params["dtype_name"]` to be half, and `skip_half_precision_on_cuda` returns early when the test does not request `dtype`. So they collected as `cuda-half_dtype0/1` even under `--device=cuda --dtype=float32` and would have run half kernels in the shared CUDA context. Both tests now skip every non-CPU device rather than only MPS, as the first statement in the body, so no kernel launches; the broken kernel and its float32 workaround are CPU-only, so nothing is lost.

The same gap covers **49 other test ids across 8 files** that use the same `@parametrize("half_dtype", ...)` convention (18 in `test_siftdesc.py` alone). That is a harness fix, not a patch-extraction fix, so it is filed as #4126 rather than done here.

Posted on behalf of @ducha-aiki by Claude (Fable 5, Opus 5).
