### PR TITLE
fix(geometry): validate nms box shape

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -556,7 +556,7 @@ def nms(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torc
         tensor([0, 3, 1])
 
     """
-    if len(boxes.shape) != 2 and boxes.shape[-1] != 4:
+    if boxes.ndim != 2 or boxes.shape[-1] != 4:
         raise ValueError(f"boxes expected as Nx4. Got: {boxes.shape}.")
 
     if len(scores.shape) != 1:

--- a/tests/geometry/test_bbox.py
+++ b/tests/geometry/test_bbox.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import pytest
 import torch
 
 import kornia
@@ -320,3 +321,17 @@ class TestNMS(BaseTester):
         expected = torch.tensor([0, 3, 1], device=device, dtype=torch.long)
         actual = nms(boxes, scores, iou_threshold=0.8)
         self.assert_close(actual, expected)
+
+    @pytest.mark.parametrize(
+        ("boxes_shape", "scores_shape"),
+        [
+            ((3, 5), (3,)),
+            ((2, 3, 4), (2,)),
+        ],
+    )
+    def test_invalid_boxes_shape(self, boxes_shape, scores_shape, device, dtype):
+        boxes = torch.zeros(boxes_shape, device=device, dtype=dtype)
+        scores = torch.zeros(scores_shape, device=device, dtype=dtype)
+
+        with pytest.raises(ValueError, match="boxes expected as Nx4"):
+            nms(boxes, scores, iou_threshold=0.8)


### PR DESCRIPTION
## What does this pull request do?

`kornia.geometry.bbox.nms` combined its two box-shape checks with `and`, allowing both `(N, 5)` and `(B, N, 4)` inputs past the documented `(N, 4)` contract. The former failed later with an internal unpacking error, while the latter could return meaningless indices or enter a runaway allocation path.

This changes the guard to reject either an invalid rank or an invalid final dimension. A deterministic regression test covers both malformed shapes and verifies the public `ValueError`.

## Related issue or discussion

Fixes #4019

## What did you check?

The regression was also run against the old predicate: `(N, 5)` failed with the wrong internal error and `(B, N, 4)` failed to raise. Both cases pass with this fix.

```text
$ pixi run test-module tests/geometry/test_bbox.py --dtype=float32,float64
30 passed

$ pixi run pre-commit-all
All hooks passed

$ pixi run typecheck
Completed successfully; one unrelated existing torch.cuda.amp.custom_fwd deprecation diagnostic
```

## How did AI help?

Codex was used to inspect the relevant code and policy files, make the one-line predicate correction, and draft the regression test. The resulting change was independently reviewed; that review identified that randomized malformed boxes could recreate the runaway path, so the test inputs were changed to deterministic zeros before the final validation above.
