### PR TITLE
docs(feature): document match_fginn's unused lafs1 argument

### DIFF
--- a/kornia/feature/matching.py
+++ b/kornia/feature/matching.py
@@ -278,7 +278,9 @@ def match_fginn(
     Args:
         desc1: Batch of descriptors of a shape :math:`(B1, D)`.
         desc2: Batch of descriptors of a shape :math:`(B2, D)`.
-        lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`.
+        lafs1: LAFs of a shape :math:`(1, B1, 2, 3)`. Accepted for API symmetry with
+          :func:`~kornia.feature.match_adalam` but not read by this function -- only
+          ``lafs2`` feeds the geometric check.
         lafs2: LAFs of a shape :math:`(1, B2, 2, 3)`.
         th: distance ratio threshold.
         spatial_th: minimal distance in pixels to 2nd nearest neighbor.


### PR DESCRIPTION
\`lafs1\` is a required positional parameter in \`match_fginn\` but the function body never reads it — only \`lafs2\` feeds the geometric check via \`get_laf_center\`. This documents that it's kept for API symmetry with \`match_adalam\`, per the second half of #4067 (the \`laf.py\` docstring issues from the same report were already fixed in #4072/#4075 — this PR closes out the remaining \`match_fginn\` part).

Fixes #4067