### PR TITLE
perf(feature): sample pyramid patches from an atlas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
+* `extract_patches_from_pyramid` now samples ordinary-sized inputs once from a packed pyramid atlas instead of
+  sampling every LAF at every pyramid level. A statically selected levelwise fallback keeps atlases larger than
+  128 MiB from becoming a memory hazard. LAFs whose nominal level is coarser than the last usable pyramid level now
+  sample that actual coarsest level; they previously returned an all-zero patch. Atlas coordinate arithmetic also
+  runs in `float32` for `float16` and `bfloat16` inputs, avoiding the normalized-coordinate precision loss caused by
+  the wider atlas. Floating-point results are therefore not byte-identical to the former levelwise implementation.
+
 * The shape guards of `normalize_homography` and `denormalize_homography` now reject everything but a
   `(3, 3)`/`(B, 3, 3)` matrix, and `normalize_homography3d`'s everything but a `(4, 4)`/`(B, 4, 4)` one (#3999).
   A rank-4 input used to pass the guard and come back with its rank unchanged —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `extract_patches_from_pyramid` now samples ordinary-sized inputs once from a packed pyramid atlas instead of
   sampling every LAF at every pyramid level. A statically selected levelwise fallback keeps atlases larger than
   128 MiB from becoming a memory hazard. LAFs whose nominal level is coarser than the last usable pyramid level now
-  sample that actual coarsest level; they previously returned an all-zero patch. Atlas coordinate arithmetic also
-  runs in `float32` for `float16` and `bfloat16` inputs, avoiding the normalized-coordinate precision loss caused by
-  the wider atlas, and `extract_patches_simple` computes its sampling grid in `float32` for reduced-precision inputs
-  on every device for the same reason -- its output matches the pyramid extractor's level-0 output again, and
-  half-precision patches therefore change on CUDA and MPS as well as the CPU (superseding the device scope of the
-  reduced-precision entry under **Bug fixes**). Floating-point results are not byte-identical to the former
-  levelwise implementation. Both extractors chunk their sampling along N, in the spirit of `batched_forward`, so
+  sample that actual coarsest level; they previously returned an all-zero patch. For `float16` and `bfloat16` inputs
+  the whole pyramid -- padding, `pyrdown`, coordinate arithmetic and sampling -- runs in `float32` and the patches
+  are cast back, on every device: this avoids the normalized-coordinate precision loss caused by the wider atlas,
+  keeps the extraction off `replication_pad2d`/`grid_sampler_2d` kernels that old torch builds lack for half dtypes
+  on the CPU (torch <= 2.5.1 would otherwise crash), and avoids recasting the full atlas on every sampling chunk.
+  `extract_patches_simple` computes its sampling grid in `float32` for reduced-precision inputs on every device for
+  the same reason -- its output matches the pyramid extractor's level-0 output again. Half-precision patches
+  therefore change on CUDA and MPS as well as the CPU (superseding the device scope of the reduced-precision entry
+  under **Bug fixes**), and floating-point results are not byte-identical to the former levelwise implementation.
+  Both extractors now also reject an image/LAF batch-size or dtype mismatch at the boundary with a clear error:
+  former releases raised an internal `grid_sample` error for most of these mixes, except `extract_patches_simple`
+  with a smaller LAF batch, which silently returned patches for only the first `min(B_img, B_laf)` images. Both extractors chunk their sampling along N, in the spirit of `batched_forward`, so
   the folded `(B, N*PS, PS, 2)` grid and its remap intermediates stay within a fixed 64 MiB budget: batched high-N
   extraction now peaks below even the pre-batching per-image loop (468 MiB against 495 MiB on `main` for B=8,
   N=4000, PS=32 on a 512x512 float32 image, where the unchunked atlas peaked at 1.24 GiB), eager throughput stays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   128 MiB from becoming a memory hazard. LAFs whose nominal level is coarser than the last usable pyramid level now
   sample that actual coarsest level; they previously returned an all-zero patch. Atlas coordinate arithmetic also
   runs in `float32` for `float16` and `bfloat16` inputs, avoiding the normalized-coordinate precision loss caused by
-  the wider atlas. Floating-point results are therefore not byte-identical to the former levelwise implementation.
+  the wider atlas, and `extract_patches_simple` computes its sampling grid in `float32` for reduced-precision inputs
+  on every device for the same reason -- its output matches the pyramid extractor's level-0 output again, and
+  half-precision patches therefore change on CUDA and MPS as well as the CPU (superseding the device scope of the
+  reduced-precision entry under **Bug fixes**). Floating-point results are not byte-identical to the former
+  levelwise implementation. Both extractors chunk their sampling along N, in the spirit of `batched_forward`, so
+  the folded `(B, N*PS, PS, 2)` grid and its remap intermediates stay within a fixed 64 MiB budget: batched high-N
+  extraction now peaks below even the pre-batching per-image loop (468 MiB against 495 MiB on `main` for B=8,
+  N=4000, PS=32 on a 512x512 float32 image, where the unchunked atlas peaked at 1.24 GiB), eager throughput stays
+  within ~5% of the unchunked atlas, and float32/float64 patches are bitwise identical to it; a `torch.compile`d
+  call whose grid exceeds the budget splits into several `grid_sample` calls (~1.5x the unbounded atlas latency at
+  B=8, N=2000 on CPU inductor, still ~10x faster than the per-level loop it replaces). Both extractors return an
+  empty `(B, N, CH, PS, PS)` tensor for `B == 0` or `N == 0` instead of raising from inside `affine_grid` --
+  `extract_patches_from_pyramid` with `B == 0` returned the empty result before the batched rewrite below
+  regressed it; every other empty combination raised on all prior releases. `extract_patches_from_pyramid` now
+  also accepts a LAF on a different device than the image, as `extract_patches_simple` always has, and returns
+  patches on the image's device.
 
 * The shape guards of `normalize_homography` and `denormalize_homography` now reject everything but a
   `(3, 3)`/`(B, 3, 3)` matrix, and `normalize_homography3d`'s everything but a `(4, 4)`/`(B, 4, 4)` one (#3999).

--- a/benchmarks/feature/scale_space_detector.py
+++ b/benchmarks/feature/scale_space_detector.py
@@ -281,9 +281,10 @@ class KeyNetExtractor(nn.Module):
             # model and nms run at 6 different image sizes → dynamic=True avoids recompilation
             det.model = torch.compile(det.model, dynamic=True)
             det.nms = torch.compile(det.nms, dynamic=True)
-            # aff/ori/descriptor NOT compiled: extract_patches_from_pyramid (laf.py) contains
-            # an .item() call inside a while-loop that creates graph breaks, causing extra
-            # sub-graphs that need additional warmup and show as a spike on the first eval pair.
+            # aff/ori/descriptor NOT compiled: extract_patches_from_pyramid traces as one graph
+            # now, but each (num-LAF, patch-size) pair it is called with would still specialize
+            # into its own graph, needing additional warmup that shows as a spike on the first
+            # eval pair.
 
     @torch.no_grad()
     def forward(self, img: torch.Tensor):

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -21,7 +21,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torch.nn.functional as F
 
-from kornia.core.check import KORNIA_CHECK_LAF, KORNIA_CHECK_SHAPE
+from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_LAF, KORNIA_CHECK_SHAPE
 from kornia.geometry.conversions import angle_to_rotation_matrix, convert_points_from_homogeneous
 from kornia.geometry.linalg import transform_points
 from kornia.geometry.transform import pyrdown
@@ -416,13 +416,14 @@ def _clamp_grid_to_pixel_centers(grid: torch.Tensor, h: int, w: int) -> torch.Te
     exactly.
 
     Args:
-        grid: sampling grid :math:`(B, PS, PS, 2)`, last dimension ordered ``(x, y)``. Only the 2-D form is
-            handled; a 3-D grid would need a third bound from the depth of the sampled volume.
+        grid: sampling grid :math:`(..., 2)` with any leading batch dimensions, last dimension ordered
+            ``(x, y)``. Only 2-D sampling is handled; a 3-D grid would need a third bound from the
+            depth of the sampled volume.
         h: height of the sampled image.
         w: width of the sampled image.
 
     Returns:
-        the clamped grid :math:`(B, PS, PS, 2)`.
+        the clamped grid, same shape as ``grid``.
 
     """
     x = grid[..., 0].clamp(-1.0 + 1.0 / float(w), 1.0 - 1.0 / float(w))
@@ -431,40 +432,36 @@ def _clamp_grid_to_pixel_centers(grid: torch.Tensor, h: int, w: int) -> torch.Te
 
 
 def _grid_sample_patches(img: torch.Tensor, grid: torch.Tensor, h: int, w: int) -> torch.Tensor:
-    r"""Run ``grid_sample`` with border padding, robust across devices and dtypes.
+    r"""Run ``grid_sample`` with border padding, robust across devices.
 
     MPS does not implement ``padding_mode="border"``; it is emulated with a clamped grid plus
-    zero padding (see :func:`_clamp_grid_to_pixel_centers`). The float16/bfloat16 CPU kernel in
-    torch <= 2.9 reads out of bounds for coordinates at or beyond the border and returns
-    nondeterministic garbage or NaN, so reduced-precision CPU inputs are sampled in float32 and
-    cast back.
+    zero padding (see :func:`_clamp_grid_to_pixel_centers`). ``img`` and ``grid`` share a dtype:
+    the extractors upcast reduced-precision inputs to float32 once, before their chunk loops.
+    That upcast is deliberate on every torch version, not only the torch <= 2.9 builds whose
+    float16/bfloat16 CPU kernel reads out of bounds at the border — half-precision sampling
+    coordinates also quantize to whole pixels on large images.
     """
     if img.device.type == "mps":
-        sample_img = img.to(grid.dtype) if img.dtype != grid.dtype else img
-        out = F.grid_sample(
-            sample_img, _clamp_grid_to_pixel_centers(grid, h, w), padding_mode="zeros", align_corners=False
-        )
-        return out.to(img.dtype)
-    if img.device.type == "cpu" and img.dtype in (torch.float16, torch.bfloat16):
-        out = F.grid_sample(img.float(), grid.float(), padding_mode="border", align_corners=False)
-        return out.to(img.dtype)
-    if img.dtype != grid.dtype:
-        out = F.grid_sample(img.to(grid.dtype), grid, padding_mode="border", align_corners=False)
-        return out.to(img.dtype)
+        return F.grid_sample(img, _clamp_grid_to_pixel_centers(grid, h, w), padding_mode="zeros", align_corners=False)
     return F.grid_sample(img, grid, padding_mode="border", align_corners=False)
 
 
-def _grid_chunk_lafs(B: int, N: int, PS: int, elem_size: int) -> int:
+def _grid_elem_bytes(dtype: torch.dtype) -> int:
+    """Bytes per element of a sampling-grid dtype (float64, or float32 after the half upcast)."""
+    return 8 if dtype == torch.float64 else 4
+
+
+def _grid_chunk_lafs(B: int, N: int, PS: int, elem_size: int, budget: int = 64 * 1024 * 1024) -> int:
     r"""Largest LAF count per sampling call whose folded grid stays within the chunk byte budget.
 
     The sampling grid and its pointwise intermediates scale with :math:`B \cdot N \cdot PS^2`,
     so extraction is chunked along N to bound peak memory, in the spirit of
     :func:`kornia.core.utils.batched_forward`. At least one LAF per chunk; when every grid fits
-    the budget the loop degenerates to the single-call fast path. The budget is a local literal
-    rather than a module constant because TorchScript cannot close over module-level ints; tests
-    monkeypatch this function to force multi-chunk sampling on small inputs.
+    the budget the loop degenerates to the single-call fast path. The default budget is a
+    defaulted argument rather than a module constant because TorchScript cannot close over
+    module-level ints; tests monkeypatch this function to force multi-chunk sampling on small
+    inputs.
     """
-    budget = 64 * 1024 * 1024
     per_laf = B * PS * PS * 2 * elem_size
     return min(N, max(1, budget // per_laf))
 
@@ -495,13 +492,19 @@ def _extract_patches_from_pyramid_levelwise(
     widths: List[int],
     PS: int,
 ) -> torch.Tensor:
-    """Sample each pyramid level separately when a single atlas would be too large."""
+    """Sample each pyramid level separately when a single atlas would be too large.
+
+    Patches accumulate on the image's device and dtype, like the atlas path: the grid follows the
+    LAF and is moved inside `_sample_patches`, and reduced-precision levels are upcast once,
+    before the loops, so no full level is re-cast per chunk.
+    """
     B, N = nlaf.shape[:2]
     ch = img.shape[1]
-    out = torch.zeros(B, N, ch, PS, PS, dtype=nlaf.dtype, device=nlaf.device)
     grid_laf = nlaf.float() if nlaf.dtype in (torch.float16, torch.bfloat16) else nlaf
-    chunk = _grid_chunk_lafs(B, N, PS, 8 if grid_laf.dtype == torch.float64 else 4)
-    cur_img = img
+    out = torch.zeros(B, N, ch, PS, PS, dtype=img.dtype, device=img.device)
+    level_idx_of_laf = pyr_idx.to(img.device)
+    chunk = _grid_chunk_lafs(B, N, PS, _grid_elem_bytes(grid_laf.dtype))
+    cur_img = img.to(grid_laf.dtype) if img.dtype != grid_laf.dtype else img
     for level_idx, (h_l, w_l) in enumerate(zip(heights, widths)):
         if level_idx > 0:
             cur_img = pyrdown(cur_img)
@@ -509,8 +512,8 @@ def _extract_patches_from_pyramid_levelwise(
             en = min(st + chunk, N)
             grid = generate_patch_grid_from_normalized_LAF(cur_img, grid_laf[:, st:en], PS).view(B, en - st, PS, PS, 2)
             grid = _clamp_grid_to_pixel_centers(grid, h_l, w_l)
-            patches = _sample_patches(cur_img, grid, h_l, w_l).to(nlaf.dtype)
-            mask = (pyr_idx[:, st:en] == level_idx).view(B, en - st, 1, 1, 1)
+            patches = _sample_patches(cur_img, grid, h_l, w_l).to(img.dtype)
+            mask = (level_idx_of_laf[:, st:en] == level_idx).view(B, en - st, 1, 1, 1)
             out[:, st:en] = torch.where(mask, patches, out[:, st:en])
     return out
 
@@ -533,6 +536,8 @@ def extract_patches_simple(
 
     """
     KORNIA_CHECK_LAF(laf)
+    KORNIA_CHECK(img.size(0) == laf.size(0), "img and laf must have the same batch size")
+    KORNIA_CHECK(img.dtype == laf.dtype, "img and laf must have the same dtype")
     if normalize_lafs_before_extraction:
         nlaf = normalize_laf(laf, img)
     else:
@@ -543,15 +548,17 @@ def extract_patches_simple(
         return torch.zeros(B, N, ch, PS, PS, device=img.device, dtype=img.dtype)
     if nlaf.dtype in (torch.float16, torch.bfloat16):
         # Reduced-precision sampling coordinates quantize to whole pixels on large images (the
-        # float16 ulp near the +-1 frame corners is 2^-11), so the grid is computed in float32;
-        # `_grid_sample_patches` keeps the output in the image dtype.
+        # float16 ulp near the +-1 frame corners is 2^-11), so the grid is computed in float32.
         nlaf = nlaf.float()
+    # The image is upcast to the grid's dtype once, before the chunk loop: `_grid_sample_patches`
+    # samples in one dtype, and re-casting the full image per chunk would defeat the chunk budget.
+    sample_img = img.to(nlaf.dtype) if img.dtype != nlaf.dtype else img
     out = torch.empty(B, N, ch, PS, PS, device=img.device, dtype=img.dtype)
-    chunk = _grid_chunk_lafs(B, N, PS, 8 if nlaf.dtype == torch.float64 else 4)
+    chunk = _grid_chunk_lafs(B, N, PS, _grid_elem_bytes(nlaf.dtype))
     for st in range(0, N, chunk):
         en = min(st + chunk, N)
         grid = generate_patch_grid_from_normalized_LAF(img, nlaf[:, st:en], PS).view(B, en - st, PS, PS, 2)
-        out[:, st:en] = _sample_patches(img, grid, h, w)
+        out[:, st:en] = _sample_patches(sample_img, grid, h, w)
     return out
 
 
@@ -574,6 +581,8 @@ def extract_patches_from_pyramid(
 
     """
     KORNIA_CHECK_LAF(laf)
+    KORNIA_CHECK(img.size(0) == laf.size(0), "img and laf must have the same batch size")
+    KORNIA_CHECK(img.dtype == laf.dtype, "img and laf must have the same dtype")
     if normalize_lafs_before_extraction:
         nlaf = normalize_laf(laf, img)
     else:
@@ -581,7 +590,7 @@ def extract_patches_from_pyramid(
     B, N, _, _ = laf.size()
     _, ch, h, w = img.size()
     if B == 0 or N == 0:
-        return torch.zeros(B, N, ch, PS, PS, device=img.device, dtype=laf.dtype)
+        return torch.zeros(B, N, ch, PS, PS, device=img.device, dtype=img.dtype)
     scale = 2.0 * get_laf_scale(denormalize_laf(nlaf, img)) / float(PS)
     # max_level is a compile-time constant for static image shapes.
     max_level = min(h, w) // PS
@@ -610,16 +619,21 @@ def extract_patches_from_pyramid(
     grid_dtype = torch.float32 if nlaf.dtype in (torch.float16, torch.bfloat16) else nlaf.dtype
     # A full-height atlas is counterproductive for very large or heavily batched images. Keep
     # its storage bounded; the static shape guard disappears under torch.compile, and the
-    # levelwise path preserves the same clamping and reduced-precision grid semantics.
+    # levelwise path preserves the same clamping and reduced-precision grid semantics. The atlas
+    # is built in the grid's dtype -- reduced-precision inputs are upcast once, so the replicate
+    # pad, `pyrdown` and every chunk's `grid_sample` run on kernels every torch build has, and no
+    # full-atlas recast is paid per chunk. A 1-pixel image axis would make the level constants'
+    # Python `w_l - 1` division below raise; the levelwise sampler's tensor arithmetic degrades
+    # the way the pre-atlas code did instead.
     atlas_elements = B * ch * atlas_h * atlas_w
-    atlas_bytes = atlas_elements * img.element_size()
+    atlas_bytes = atlas_elements * _grid_elem_bytes(grid_dtype)
     if img.dtype != grid_dtype:
-        grid_element_size = 8 if grid_dtype == torch.float64 else 4 if grid_dtype == torch.float32 else 2
-        atlas_bytes += atlas_elements * grid_element_size
-    if atlas_bytes > _PYRAMID_ATLAS_MAX_BYTES:
+        atlas_bytes += B * ch * h * w * _grid_elem_bytes(grid_dtype)  # the one-time upcast copy
+    if min(h, w) < 2 or atlas_bytes > _PYRAMID_ATLAS_MAX_BYTES:
         return _extract_patches_from_pyramid_levelwise(img, nlaf, pyr_idx, heights, widths, PS)
-    atlas = img.new_zeros(B, ch, atlas_h, atlas_w)
-    cur_img = img
+    sample_img = img.to(grid_dtype) if img.dtype != grid_dtype else img
+    atlas = sample_img.new_zeros(B, ch, atlas_h, atlas_w)
+    cur_img = sample_img
     xoff = 0
     for level_idx, (h_l, w_l) in enumerate(zip(heights, widths)):
         if level_idx > 0:
@@ -661,8 +675,8 @@ def extract_patches_from_pyramid(
     # The folded grid and its remap intermediates scale with B*N*PS^2, so sampling is chunked
     # along N to bound peak memory; each chunk repeats exactly the single-call arithmetic, and
     # for small workloads the loop is a single iteration.
-    out = torch.empty(B, N, ch, PS, PS, device=img.device, dtype=nlaf.dtype)
-    chunk = _grid_chunk_lafs(B, N, PS, 8 if grid_dtype == torch.float64 else 4)
+    out = torch.empty(B, N, ch, PS, PS, device=img.device, dtype=img.dtype)
+    chunk = _grid_chunk_lafs(B, N, PS, _grid_elem_bytes(grid_dtype))
     for st in range(0, N, chunk):
         en = min(st + chunk, N)
         nc = en - st

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -454,16 +454,37 @@ def _grid_sample_patches(img: torch.Tensor, grid: torch.Tensor, h: int, w: int) 
     return F.grid_sample(img, grid, padding_mode="border", align_corners=False)
 
 
-def _clamp_grid_to_level_pixel_centers(
-    x: torch.Tensor,
-    y: torch.Tensor,
-    x_lo: torch.Tensor,
-    x_hi: torch.Tensor,
-    y_lo: torch.Tensor,
-    y_hi: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Clamp each patch grid axis to the pixel centers of its selected pyramid level."""
-    return x.maximum(x_lo).minimum(x_hi), y.maximum(y_lo).minimum(y_hi)
+def _grid_chunk_lafs(B: int, N: int, PS: int, elem_size: int) -> int:
+    r"""Largest LAF count per sampling call whose folded grid stays within the chunk byte budget.
+
+    The sampling grid and its pointwise intermediates scale with :math:`B \cdot N \cdot PS^2`,
+    so extraction is chunked along N to bound peak memory, in the spirit of
+    :func:`kornia.core.utils.batched_forward`. At least one LAF per chunk; when every grid fits
+    the budget the loop degenerates to the single-call fast path. The budget is a local literal
+    rather than a module constant because TorchScript cannot close over module-level ints; tests
+    monkeypatch this function to force multi-chunk sampling on small inputs.
+    """
+    budget = 64 * 1024 * 1024
+    per_laf = B * PS * PS * 2 * elem_size
+    return min(N, max(1, budget // per_laf))
+
+
+def _sample_patches(img: torch.Tensor, grid: torch.Tensor, h: int, w: int) -> torch.Tensor:
+    r"""Sample one patch per LAF with a single ``grid_sample`` call.
+
+    The per-LAF grids :math:`(B, N, PS, PS, 2)` are folded to :math:`(B, N \cdot PS, PS, 2)` so
+    one call covers the whole batch, without a Python loop over B or a ``(B*N, CH, H, W)`` input
+    copy. The grid follows the LAF device and is moved to the image's: the extractors have always
+    accepted a LAF on a different device than the image and returned patches on the image's device.
+
+    Returns:
+        patches :math:`(B, N, CH, PS, PS)` as a permuted view; assigning it or calling
+        ``.contiguous()`` makes the copy.
+    """
+    B, N, PS = grid.size(0), grid.size(1), grid.size(2)
+    ch = img.size(1)
+    folded = grid.to(img.device).view(B, N * PS, PS, 2)
+    return _grid_sample_patches(img, folded, h, w).view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4)
 
 
 def _extract_patches_from_pyramid_levelwise(
@@ -479,15 +500,18 @@ def _extract_patches_from_pyramid_levelwise(
     ch = img.shape[1]
     out = torch.zeros(B, N, ch, PS, PS, dtype=nlaf.dtype, device=nlaf.device)
     grid_laf = nlaf.float() if nlaf.dtype in (torch.float16, torch.bfloat16) else nlaf
+    chunk = _grid_chunk_lafs(B, N, PS, 8 if grid_laf.dtype == torch.float64 else 4)
     cur_img = img
     for level_idx, (h_l, w_l) in enumerate(zip(heights, widths)):
         if level_idx > 0:
             cur_img = pyrdown(cur_img)
-        grid = generate_patch_grid_from_normalized_LAF(cur_img, grid_laf, PS).view(B, N * PS, PS, 2)
-        grid = _clamp_grid_to_pixel_centers(grid, h_l, w_l)
-        patches = _grid_sample_patches(cur_img, grid, h_l, w_l)
-        patches = patches.view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4).to(nlaf.dtype)
-        out = torch.where((pyr_idx == level_idx).view(B, N, 1, 1, 1), patches, out)
+        for st in range(0, N, chunk):
+            en = min(st + chunk, N)
+            grid = generate_patch_grid_from_normalized_LAF(cur_img, grid_laf[:, st:en], PS).view(B, en - st, PS, PS, 2)
+            grid = _clamp_grid_to_pixel_centers(grid, h_l, w_l)
+            patches = _sample_patches(cur_img, grid, h_l, w_l).to(nlaf.dtype)
+            mask = (pyr_idx[:, st:en] == level_idx).view(B, en - st, 1, 1, 1)
+            out[:, st:en] = torch.where(mask, patches, out[:, st:en])
     return out
 
 
@@ -515,13 +539,20 @@ def extract_patches_simple(
         nlaf = laf
     _, ch, h, w = img.size()
     B, N, _, _ = laf.size()
-    # Fold the (B*N, PS, PS, 2) grid to (B, N*PS, PS, 2) so one grid_sample call samples every
-    # patch of every image, without a Python loop over B or a (B*N, CH, H, W) input copy.
-    # The grid follows the LAF device, so it is moved to the image: this function has always
-    # accepted a LAF on a different device than the image and returned a patch on the image's.
-    grid = generate_patch_grid_from_normalized_LAF(img, nlaf, PS).to(img.device).view(B, N * PS, PS, 2)
-    patches = _grid_sample_patches(img, grid, h, w)
-    return patches.view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4).contiguous()
+    if B == 0 or N == 0:
+        return torch.zeros(B, N, ch, PS, PS, device=img.device, dtype=img.dtype)
+    if nlaf.dtype in (torch.float16, torch.bfloat16):
+        # Reduced-precision sampling coordinates quantize to whole pixels on large images (the
+        # float16 ulp near the +-1 frame corners is 2^-11), so the grid is computed in float32;
+        # `_grid_sample_patches` keeps the output in the image dtype.
+        nlaf = nlaf.float()
+    out = torch.empty(B, N, ch, PS, PS, device=img.device, dtype=img.dtype)
+    chunk = _grid_chunk_lafs(B, N, PS, 8 if nlaf.dtype == torch.float64 else 4)
+    for st in range(0, N, chunk):
+        en = min(st + chunk, N)
+        grid = generate_patch_grid_from_normalized_LAF(img, nlaf[:, st:en], PS).view(B, en - st, PS, PS, 2)
+        out[:, st:en] = _sample_patches(img, grid, h, w)
+    return out
 
 
 def extract_patches_from_pyramid(
@@ -549,6 +580,8 @@ def extract_patches_from_pyramid(
         nlaf = laf
     B, N, _, _ = laf.size()
     _, ch, h, w = img.size()
+    if B == 0 or N == 0:
+        return torch.zeros(B, N, ch, PS, PS, device=img.device, dtype=laf.dtype)
     scale = 2.0 * get_laf_scale(denormalize_laf(nlaf, img)) / float(PS)
     # max_level is a compile-time constant for static image shapes.
     max_level = min(h, w) // PS
@@ -594,47 +627,56 @@ def extract_patches_from_pyramid(
         atlas[:, :, : h_l + 2, xoff : xoff + w_l + 2] = F.pad(cur_img, (1, 1, 1, 1), mode="replicate")
         xoff += w_l + 2
 
-    # A patch grid's linear part is level-independent. Generate Px/Py once from normalized LAF
-    # A with zero translation; reduced-precision inputs need float32 grid arithmetic because the
-    # atlas is wider than the original image.
+    # A patch grid's linear part is level-independent: it is generated from normalized LAF A with
+    # zero translation; reduced-precision inputs need float32 grid arithmetic because the atlas is
+    # wider than the original image.
     laf_a = nlaf[..., :2].to(grid_dtype)
-    zeros = torch.zeros(B, N, 2, 1, dtype=grid_dtype, device=nlaf.device)
-    grid = F.affine_grid(
-        torch.cat([laf_a, zeros], dim=-1).view(B * N, 2, 3), [B * N, ch, PS, PS], align_corners=False
-    ).view(B, N, PS, PS, 2)
+    t = 2.0 * nlaf[..., :, 2].to(grid_dtype) - 1.0
 
-    # Gather all level-dependent conversion constants per patch. A giant LAF that nominally
-    # selects an unbuilt level is sampled from the actual coarsest pyramid image.
+    # Gather all level-dependent conversion constants per patch, packed as (x, y) pairs so the
+    # remap below runs on the whole grid tensor step by step, never holding split-axis copies. A
+    # giant LAF that nominally selects an unbuilt level is sampled from the actual coarsest
+    # pyramid image.
     xoff = 0
     constants = []
     for h_l, w_l in zip(heights, widths):
         min_l = float(min(h_l - 1, w_l - 1))
         constants.append(
             (
-                2.0 * min_l / float(w_l - 1),
+                2.0 * min_l / float(w_l - 1),  # k: LAF frame -> level-normalized units
                 2.0 * min_l / float(h_l - 1),
-                -1.0 + 1.0 / float(w_l),
-                1.0 - 1.0 / float(w_l),
+                -1.0 + 1.0 / float(w_l),  # lo/hi: the level's outermost pixel centers
                 -1.0 + 1.0 / float(h_l),
+                1.0 - 1.0 / float(w_l),
                 1.0 - 1.0 / float(h_l),
-                float(w_l) / float(atlas_w),
-                (float(w_l) + 2.0 * float(xoff + 1)) / float(atlas_w) - 1.0,
+                float(w_l) / float(atlas_w),  # scale/offset: level frame -> atlas frame
                 float(h_l) / float(atlas_h),
+                (float(w_l) + 2.0 * float(xoff + 1)) / float(atlas_w) - 1.0,
                 (float(h_l) + 2.0) / float(atlas_h) - 1.0,
             )
         )
         xoff += w_l + 2
-    level_constants = torch.tensor(constants, dtype=grid_dtype, device=nlaf.device)
-    gathered = level_constants[pyr_idx].unsqueeze(-2).unsqueeze(-2)
-    kx, ky, x_lo, x_hi, y_lo, y_hi, x_scale, x_offset, y_scale, y_offset = gathered.unbind(dim=-1)
+    level_constants = torch.tensor(constants, dtype=grid_dtype, device=nlaf.device).view(-1, 5, 2)
 
-    x = grid[..., 0] * kx + (2.0 * nlaf[..., 0, 2].to(grid_dtype).unsqueeze(-1).unsqueeze(-1) - 1.0)
-    y = grid[..., 1] * ky + (2.0 * nlaf[..., 1, 2].to(grid_dtype).unsqueeze(-1).unsqueeze(-1) - 1.0)
-    x, y = _clamp_grid_to_level_pixel_centers(x, y, x_lo, x_hi, y_lo, y_hi)
-    grid = torch.stack([x * x_scale + x_offset, y * y_scale + y_offset], dim=-1)
-
-    patches = _grid_sample_patches(atlas, grid.view(B, N * PS, PS, 2), atlas_h, atlas_w)
-    return patches.view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4).contiguous().to(nlaf.dtype)
+    # The folded grid and its remap intermediates scale with B*N*PS^2, so sampling is chunked
+    # along N to bound peak memory; each chunk repeats exactly the single-call arithmetic, and
+    # for small workloads the loop is a single iteration.
+    out = torch.empty(B, N, ch, PS, PS, device=img.device, dtype=nlaf.dtype)
+    chunk = _grid_chunk_lafs(B, N, PS, 8 if grid_dtype == torch.float64 else 4)
+    for st in range(0, N, chunk):
+        en = min(st + chunk, N)
+        nc = en - st
+        theta = torch.cat([laf_a[:, st:en], torch.zeros(B, nc, 2, 1, dtype=grid_dtype, device=nlaf.device)], dim=-1)
+        grid = F.affine_grid(theta.view(B * nc, 2, 3), [B * nc, ch, PS, PS], align_corners=False).view(B, nc, PS, PS, 2)
+        k, lo, hi, level_scale, level_offset = level_constants[pyr_idx[:, st:en]].view(B, nc, 1, 1, 5, 2).unbind(-2)
+        grid = grid * k
+        grid = grid + t[:, st:en].view(B, nc, 1, 1, 2)
+        grid = grid.maximum(lo)
+        grid = grid.minimum(hi)
+        grid = grid * level_scale
+        grid = grid + level_offset
+        out[:, st:en] = _sample_patches(atlas, grid, atlas_h, atlas_w)
+    return out
 
 
 def laf_is_inside_image(laf: torch.Tensor, images: torch.Tensor, border: int = 0) -> torch.Tensor:

--- a/kornia/feature/laf.py
+++ b/kornia/feature/laf.py
@@ -26,6 +26,8 @@ from kornia.geometry.conversions import angle_to_rotation_matrix, convert_points
 from kornia.geometry.linalg import transform_points
 from kornia.geometry.transform import pyrdown
 
+_PYRAMID_ATLAS_MAX_BYTES = 128 * 1024 * 1024
+
 
 def get_laf_scale(LAF: torch.Tensor) -> torch.Tensor:
     """Return a scale of the LAFs.
@@ -438,11 +440,55 @@ def _grid_sample_patches(img: torch.Tensor, grid: torch.Tensor, h: int, w: int) 
     cast back.
     """
     if img.device.type == "mps":
-        return F.grid_sample(img, _clamp_grid_to_pixel_centers(grid, h, w), padding_mode="zeros", align_corners=False)
+        sample_img = img.to(grid.dtype) if img.dtype != grid.dtype else img
+        out = F.grid_sample(
+            sample_img, _clamp_grid_to_pixel_centers(grid, h, w), padding_mode="zeros", align_corners=False
+        )
+        return out.to(img.dtype)
     if img.device.type == "cpu" and img.dtype in (torch.float16, torch.bfloat16):
         out = F.grid_sample(img.float(), grid.float(), padding_mode="border", align_corners=False)
         return out.to(img.dtype)
+    if img.dtype != grid.dtype:
+        out = F.grid_sample(img.to(grid.dtype), grid, padding_mode="border", align_corners=False)
+        return out.to(img.dtype)
     return F.grid_sample(img, grid, padding_mode="border", align_corners=False)
+
+
+def _clamp_grid_to_level_pixel_centers(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    x_lo: torch.Tensor,
+    x_hi: torch.Tensor,
+    y_lo: torch.Tensor,
+    y_hi: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Clamp each patch grid axis to the pixel centers of its selected pyramid level."""
+    return x.maximum(x_lo).minimum(x_hi), y.maximum(y_lo).minimum(y_hi)
+
+
+def _extract_patches_from_pyramid_levelwise(
+    img: torch.Tensor,
+    nlaf: torch.Tensor,
+    pyr_idx: torch.Tensor,
+    heights: List[int],
+    widths: List[int],
+    PS: int,
+) -> torch.Tensor:
+    """Sample each pyramid level separately when a single atlas would be too large."""
+    B, N = nlaf.shape[:2]
+    ch = img.shape[1]
+    out = torch.zeros(B, N, ch, PS, PS, dtype=nlaf.dtype, device=nlaf.device)
+    grid_laf = nlaf.float() if nlaf.dtype in (torch.float16, torch.bfloat16) else nlaf
+    cur_img = img
+    for level_idx, (h_l, w_l) in enumerate(zip(heights, widths)):
+        if level_idx > 0:
+            cur_img = pyrdown(cur_img)
+        grid = generate_patch_grid_from_normalized_LAF(cur_img, grid_laf, PS).view(B, N * PS, PS, 2)
+        grid = _clamp_grid_to_pixel_centers(grid, h_l, w_l)
+        patches = _grid_sample_patches(cur_img, grid, h_l, w_l)
+        patches = patches.view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4).to(nlaf.dtype)
+        out = torch.where((pyr_idx == level_idx).view(B, N, 1, 1, 1), patches, out)
+    return out
 
 
 def extract_patches_simple(
@@ -483,7 +529,8 @@ def extract_patches_from_pyramid(
 ) -> torch.Tensor:
     """Extract patches defined by LAFs from image torch.Tensor.
 
-    Patches are extracted from appropriate pyramid level.
+    Patches are extracted from the appropriate pyramid level. A LAF whose scale selects a level
+    smaller than ``PS`` is sampled from the coarsest level that can still provide a full patch.
 
     Args:
         img: images, LAFs are detected in  :math:`(B, CH, H, W)`.
@@ -505,25 +552,89 @@ def extract_patches_from_pyramid(
     scale = 2.0 * get_laf_scale(denormalize_laf(nlaf, img)) / float(PS)
     # max_level is a compile-time constant for static image shapes.
     max_level = min(h, w) // PS
-    pyr_idx = scale.log2().clamp(min=0.0, max=max(0, max_level - 1)).long()  # (B, N, 1, 1)
-    out = torch.zeros(B, N, ch, PS, PS, dtype=nlaf.dtype, device=nlaf.device)
+    pyr_idx = scale.log2().clamp(min=0.0, max=max(0, max_level - 1)).long().squeeze(-1).squeeze(-1)
+
+    # Build exactly the pyramid that can provide a PS-sized patch. ``pyrdown`` defines its output
+    # size as floor(side / 2), including for odd inputs, so the atlas can be allocated before the
+    # levels are materialized and each level can be released after it is copied.
+    heights = [h]
+    widths = [w]
+    for _ in range(1, max(1, max_level)):
+        h_l = heights[-1] // 2
+        w_l = widths[-1] // 2
+        if min(h_l, w_l) < PS:
+            break
+        heights.append(h_l)
+        widths.append(w_l)
+
+    # Place every level side-by-side with a one-pixel replicated guard. The guard absorbs
+    # floating-point remapping error at an outer pixel center and preserves both the border value
+    # and its zero outward gradient instead of leaking into the neighbouring level.
+    atlas_h = h + 2
+    packed_widths = [w_l + 2 for w_l in widths]
+    atlas_w = sum(packed_widths)
+    pyr_idx = pyr_idx.clamp(max=len(heights) - 1)
+    grid_dtype = torch.float32 if nlaf.dtype in (torch.float16, torch.bfloat16) else nlaf.dtype
+    # A full-height atlas is counterproductive for very large or heavily batched images. Keep
+    # its storage bounded; the static shape guard disappears under torch.compile, and the
+    # levelwise path preserves the same clamping and reduced-precision grid semantics.
+    atlas_elements = B * ch * atlas_h * atlas_w
+    atlas_bytes = atlas_elements * img.element_size()
+    if img.dtype != grid_dtype:
+        grid_element_size = 8 if grid_dtype == torch.float64 else 4 if grid_dtype == torch.float32 else 2
+        atlas_bytes += atlas_elements * grid_element_size
+    if atlas_bytes > _PYRAMID_ATLAS_MAX_BYTES:
+        return _extract_patches_from_pyramid_levelwise(img, nlaf, pyr_idx, heights, widths, PS)
+    atlas = img.new_zeros(B, ch, atlas_h, atlas_w)
     cur_img = img
-    # Always run at least level 0; max_level is a compile-time constant for static shapes.
-    num_levels = max(1, max_level)
-    for cur_pyr_level in range(num_levels):
-        _, ch_l, h_l, w_l = cur_img.size()
-        # torch.where avoids nonzero/data-dependent shapes → fully compilable; the (B*N, PS, PS, 2)
-        # grid is folded to (B, N*PS, PS, 2) so one grid_sample call covers the whole batch.
-        level_mask = (pyr_idx == cur_pyr_level).view(B, N, 1, 1, 1)
-        grid = generate_patch_grid_from_normalized_LAF(cur_img, nlaf, PS).view(B, N * PS, PS, 2)
-        patches = _grid_sample_patches(cur_img, grid, h_l, w_l).view(B, ch_l, N, PS, PS).permute(0, 2, 1, 3, 4)
-        out = torch.where(level_mask, patches.to(nlaf.dtype), out)
-        if cur_pyr_level < num_levels - 1:
+    xoff = 0
+    for level_idx, (h_l, w_l) in enumerate(zip(heights, widths)):
+        if level_idx > 0:
             cur_img = pyrdown(cur_img)
-            # Stop early if the pyramided image is too small for further levels.
-            if min(cur_img.size(2), cur_img.size(3)) < PS:
-                break
-    return out
+        atlas[:, :, : h_l + 2, xoff : xoff + w_l + 2] = F.pad(cur_img, (1, 1, 1, 1), mode="replicate")
+        xoff += w_l + 2
+
+    # A patch grid's linear part is level-independent. Generate Px/Py once from normalized LAF
+    # A with zero translation; reduced-precision inputs need float32 grid arithmetic because the
+    # atlas is wider than the original image.
+    laf_a = nlaf[..., :2].to(grid_dtype)
+    zeros = torch.zeros(B, N, 2, 1, dtype=grid_dtype, device=nlaf.device)
+    grid = F.affine_grid(
+        torch.cat([laf_a, zeros], dim=-1).view(B * N, 2, 3), [B * N, ch, PS, PS], align_corners=False
+    ).view(B, N, PS, PS, 2)
+
+    # Gather all level-dependent conversion constants per patch. A giant LAF that nominally
+    # selects an unbuilt level is sampled from the actual coarsest pyramid image.
+    xoff = 0
+    constants = []
+    for h_l, w_l in zip(heights, widths):
+        min_l = float(min(h_l - 1, w_l - 1))
+        constants.append(
+            (
+                2.0 * min_l / float(w_l - 1),
+                2.0 * min_l / float(h_l - 1),
+                -1.0 + 1.0 / float(w_l),
+                1.0 - 1.0 / float(w_l),
+                -1.0 + 1.0 / float(h_l),
+                1.0 - 1.0 / float(h_l),
+                float(w_l) / float(atlas_w),
+                (float(w_l) + 2.0 * float(xoff + 1)) / float(atlas_w) - 1.0,
+                float(h_l) / float(atlas_h),
+                (float(h_l) + 2.0) / float(atlas_h) - 1.0,
+            )
+        )
+        xoff += w_l + 2
+    level_constants = torch.tensor(constants, dtype=grid_dtype, device=nlaf.device)
+    gathered = level_constants[pyr_idx].unsqueeze(-2).unsqueeze(-2)
+    kx, ky, x_lo, x_hi, y_lo, y_hi, x_scale, x_offset, y_scale, y_offset = gathered.unbind(dim=-1)
+
+    x = grid[..., 0] * kx + (2.0 * nlaf[..., 0, 2].to(grid_dtype).unsqueeze(-1).unsqueeze(-1) - 1.0)
+    y = grid[..., 1] * ky + (2.0 * nlaf[..., 1, 2].to(grid_dtype).unsqueeze(-1).unsqueeze(-1) - 1.0)
+    x, y = _clamp_grid_to_level_pixel_centers(x, y, x_lo, x_hi, y_lo, y_hi)
+    grid = torch.stack([x * x_scale + x_offset, y * y_scale + y_offset], dim=-1)
+
+    patches = _grid_sample_patches(atlas, grid.view(B, N * PS, PS, 2), atlas_h, atlas_w)
+    return patches.view(B, ch, N, PS, PS).permute(0, 2, 1, 3, 4).contiguous().to(nlaf.dtype)
 
 
 def laf_is_inside_image(laf: torch.Tensor, images: torch.Tensor, border: int = 0) -> torch.Tensor:

--- a/testing/base.py
+++ b/testing/base.py
@@ -222,11 +222,13 @@ def _grid_sample_op(device_type: str, dtype: torch.dtype) -> None:
 def supports_grid_sample(device: torch.device, dtype: torch.dtype) -> bool:
     """Whether this device has a 2D ``grid_sample`` kernel for ``dtype``.
 
-    Patch extraction (:func:`kornia.feature.extract_patches_from_pyramid`, and so every LAF
-    orienter, affine-shape estimator and descriptor pipeline built on it) samples that way.
-    torch 2.5.1 has no float16 or bfloat16 CPU ``grid_sampler_2d``, so a test that hardcodes a
-    half dtype rather than reading the injected one fails there on every job. Probed at runtime
-    and cached per (device type, dtype), like :func:`supports_replicate_padding`.
+    For tests that call ``grid_sample`` (or an op built on it) at its native dtype. The LAF patch
+    extractors are NOT such consumers: :func:`kornia.feature.extract_patches_simple` and
+    :func:`kornia.feature.extract_patches_from_pyramid` sample reduced-precision inputs in
+    float32, so a test routed through them must not gate on this probe -- it would skip where the
+    extraction works. torch 2.5.1 has no float16 or bfloat16 CPU ``grid_sampler_2d``, so a test
+    that hardcodes a half dtype rather than reading the injected one fails there on every job.
+    Probed at runtime and cached per (device type, dtype), like :func:`supports_replicate_padding`.
     """
     return _supports_kernel_probe(_grid_sample_op, device.type, dtype)
 

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -23,7 +23,7 @@ import torch
 import kornia
 import kornia.geometry.transform.imgwarp
 
-from testing.base import BaseTester, supports_reflect_padding
+from testing.base import BaseTester
 from testing.geometry.create import create_random_homography
 
 
@@ -520,6 +520,16 @@ class TestExtractPatchesSimple(BaseTester):
         assert patches.mean().item() > 0.01
         assert patches.shape == (1, 1, 1, PS, PS)
 
+    def test_exception(self, device, dtype):
+        # Batch or dtype disagreement between the image and the LAFs is rejected at the boundary
+        # with a clear message instead of an internal `grid_sample` error.
+        img = torch.rand(3, 1, 32, 32, device=device, dtype=dtype)
+        with pytest.raises(Exception, match="same batch size"):
+            kornia.feature.extract_patches_simple(img, torch.rand(1, 2, 2, 3, device=device, dtype=dtype), 8)
+        other = torch.float16 if dtype != torch.float16 else torch.float32
+        with pytest.raises(Exception, match="same dtype"):
+            kornia.feature.extract_patches_simple(img, torch.rand(3, 2, 2, 3, device=device, dtype=other), 8)
+
     def test_same_odd(self, device, dtype):
         img = torch.arange(5)[None].repeat(5, 1)[None, None].to(device, dtype)
         laf = torch.tensor([[2.0, 0, 2.0], [0, 2.0, 2.0]]).reshape(1, 1, 2, 3).to(device, dtype)
@@ -680,6 +690,27 @@ class TestExtractPatchesPyr(BaseTester):
         assert patches.shape == (1, 1, 1, PS, PS)
         assert patches.abs().sum().item() > 0
 
+    def test_exception(self, device, dtype):
+        # Batch or dtype disagreement between the image and the LAFs is rejected at the boundary
+        # with a clear message instead of an internal broadcasting error.
+        img = torch.rand(3, 1, 32, 32, device=device, dtype=dtype)
+        with pytest.raises(Exception, match="same batch size"):
+            kornia.feature.extract_patches_from_pyramid(img, torch.rand(1, 2, 2, 3, device=device, dtype=dtype), 8)
+        other = torch.float16 if dtype != torch.float16 else torch.float32
+        with pytest.raises(Exception, match="same dtype"):
+            kornia.feature.extract_patches_from_pyramid(img, torch.rand(3, 2, 2, 3, device=device, dtype=other), 8)
+
+    def test_one_pixel_axis_does_not_raise(self, device, dtype):
+        # A 1-pixel image axis makes the sampling arithmetic divide by `size - 1 == 0`. The
+        # pre-atlas code degraded to non-finite coordinates through tensor division; the atlas
+        # constants are Python floats, so such images route through the levelwise sampler, whose
+        # divisions are tensor ops, instead of raising ZeroDivisionError.
+        for shape in ((1, 1, 5, 1), (1, 1, 1, 5)):
+            img = torch.rand(shape, device=device, dtype=dtype)
+            laf = torch.rand(1, 1, 2, 3, device=device, dtype=dtype)
+            patches = kornia.feature.extract_patches_from_pyramid(img, laf, 4, False)
+            assert patches.shape == (1, 1, 1, 4, 4)
+
     def test_giant_laf_uses_actual_coarsest_level(self, device, dtype):
         # The nominal level for this LAF is beyond the levels that can provide a PS-sized
         # patch. It must sample the actual coarsest level rather than becoming zero padding.
@@ -689,10 +720,12 @@ class TestExtractPatchesPyr(BaseTester):
 
         actual = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
         nlaf = kornia.feature.normalize_laf(laf, img)
-        coarsest = img
+        # Build the reference pyramid the way the extractor does for half dtypes -- in float32 --
+        # so the reference itself does not hit the missing half reflect-pad kernel on old torch.
+        coarsest = img.float() if dtype in (torch.float16, torch.bfloat16) else img
         for _ in range(3):
             coarsest = kornia.geometry.transform.pyrdown(coarsest)
-        expected = kornia.feature.extract_patches_simple(coarsest, nlaf, PS, False)
+        expected = kornia.feature.extract_patches_simple(coarsest.to(dtype), nlaf, PS, False)
 
         self.assert_close(actual, expected)
         assert actual.abs().sum().item() > 0
@@ -715,15 +748,23 @@ class TestExtractPatchesPyr(BaseTester):
 
         self.assert_close(fallback, atlas)
 
-    def test_atlas_guards_preserve_level_border_value_and_gradient(self, monkeypatch):
+    def test_atlas_guards_preserve_level_border_value_and_gradient(self, device, dtype, monkeypatch):
         import kornia.feature.laf as laf_module
+
+        if dtype in (torch.float16, torch.bfloat16):
+            pytest.skip("the coordinate-rounding leak this test pins is below half-precision resolution")
 
         def sample(limit, size, patch_size):
             monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", limit)
-            img = torch.zeros(1, 1, size, size)
+            img = torch.zeros(1, 1, size, size, device=device, dtype=dtype)
             img[:, :, :, -1] = 1.0
-            center_x = 1.0 - 1.0 / (2.0 * size)
-            nlaf = torch.tensor([[[[0.0, 0.0, center_x], [0.0, 0.0, 0.5]]]], requires_grad=True)
+            # A quarter pixel OUTSIDE the outermost pixel center, so the clamp engages strictly on
+            # every backend: probing exactly at the center can round onto the clamp bound, where
+            # the subgradient convention differs between CPU and MPS.
+            center_x = 1.0 - 1.0 / (4.0 * size)
+            nlaf = torch.tensor(
+                [[[[0.0, 0.0, center_x], [0.0, 0.0, 0.5]]]], device=device, dtype=dtype, requires_grad=True
+            )
             patch = kornia.feature.extract_patches_from_pyramid(img, nlaf, patch_size, False)
             value = patch[0, 0, 0, patch_size // 2, patch_size // 2]
             grad = torch.autograd.grad(value, nlaf)[0][0, 0, 0, 2]
@@ -731,10 +772,20 @@ class TestExtractPatchesPyr(BaseTester):
 
         # 2495 exposes a forward-coordinate rounding leak without guards; 32 exposes the
         # non-zero outward center gradient even when the rounded forward value happens to match.
+        # The discriminating pin is the patch CENTER: its sampling coordinate is clamped to the
+        # border-pixel center, so with the guard both bilinear partners are exactly the border
+        # value and the sample stays within a couple of float32 ulp of 1.0, while a missing guard
+        # blends in the neighbouring level at the coordinate-rounding scale (~5e-5 in float32 at
+        # size 2495, measured). Interior pixels legitimately differ between the atlas and
+        # levelwise paths at that same rounding scale -- and across platforms -- so the
+        # whole-patch comparison uses the standard tolerances instead of `torch.equal`.
         for size, patch_size in ((2495, 8), (32, 5)):
             fallback, fallback_grad = sample(0, size, patch_size)
             atlas, atlas_grad = sample(1 << 60, size, patch_size)
-            assert torch.equal(atlas, fallback)
+            self.assert_close(atlas, fallback)
+            center = patch_size // 2
+            assert abs(atlas[0, 0, 0, center, center].item() - 1.0) < 1e-5
+            assert abs(fallback[0, 0, 0, center, center].item() - 1.0) < 1e-5
             assert atlas_grad == fallback_grad == 0.0
 
     def test_multi_level_uses_correct_pyramid_level(self, device, dtype):
@@ -851,11 +902,10 @@ class TestExtractPatchesPyr(BaseTester):
         # has a scale below the patch size, so the patch comes from the undownsampled image and the
         # level-0 result must equal the plain extractor's byte for byte. A larger LAF would be served
         # by a blurred level whose near-constant patch stays in range even when the read is wrong.
+        # The whole pyramid (pad, `pyrdown`, sampling) runs in float32 for half inputs, so no
+        # reduced-precision pad or `grid_sample` kernel gate is needed on any torch version.
         if device.type != "cpu":
             pytest.skip(_HALF_BORDER_SKIP)
-        if not supports_reflect_padding(device, half_dtype):
-            # `pyrdown` blurs with border_type="reflect"; torch 2.5.1 has no float16 CPU kernel.
-            pytest.skip(f"no reflect-padding kernel for {half_dtype} on {device.type}")
         torch.manual_seed(0)
         img = torch.rand(1, 1, 256, 256, device=device).to(half_dtype)
         laf = _corner_border_laf(device, half_dtype)
@@ -866,10 +916,13 @@ class TestExtractPatchesPyr(BaseTester):
         assert patches.max() <= img.max()
         self.assert_close(patches, kornia.feature.extract_patches_simple(img, laf, 16))
 
-    def test_laf_on_another_device(self, device, dtype):
+    def test_laf_on_another_device(self, device, dtype, monkeypatch):
         # The sampling grid follows the LAF and is moved to the image inside `_sample_patches`,
         # so the pyramid extractor accepts a LAF on a different device than the image, matching
-        # `extract_patches_simple`.
+        # `extract_patches_simple` -- on the atlas path AND on the levelwise fallback, which a
+        # 64x64 image never reaches on its own (the contract must not flip with the image size).
+        import kornia.feature.laf as laf_module
+
         if device.type == "cpu":
             pytest.skip("needs a second device besides the CPU")
         img = torch.rand(1, 1, 64, 64, device=device, dtype=dtype)
@@ -877,6 +930,10 @@ class TestExtractPatchesPyr(BaseTester):
         patches = kornia.feature.extract_patches_from_pyramid(img, laf, 8)
         assert patches.device == img.device
         self.assert_close(patches, kornia.feature.extract_patches_from_pyramid(img, laf.to(device), 8))
+        monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 0)
+        fallback = kornia.feature.extract_patches_from_pyramid(img, laf, 8)
+        assert fallback.device == img.device
+        self.assert_close(fallback, kornia.feature.extract_patches_from_pyramid(img, laf.to(device), 8))
 
     def test_dynamo(self, device, dtype, torch_optimizer, optimizer_backend):
         if optimizer_backend == "jit":
@@ -894,20 +951,28 @@ class TestExtractPatchesPyr(BaseTester):
         compiled = torch.compile(kornia.feature.extract_patches_from_pyramid, fullgraph=True)
         self.assert_close(compiled(img, laf, 10), expected)
 
-    def test_dynamo_levelwise_fallback(self, device, dtype, torch_optimizer, monkeypatch):
+    def test_dynamo_levelwise_fallback(self, device, dtype, torch_optimizer, optimizer_backend, monkeypatch):
         import kornia.feature.laf as laf_module
 
+        if optimizer_backend == "jit":
+            # Same TorchScript incompatibility `test_dynamo` skips -- and a scripted function
+            # would not see the monkeypatched module global anyway.
+            pytest.skip("`extract_patches_from_pyramid` reaches a non-scriptable `filter2d`")
         monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 0)
         laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
         img = torch.rand(2, 1, 65, 97, device=device, dtype=dtype)
         op = torch_optimizer(kornia.feature.extract_patches_from_pyramid)
         self.assert_close(op(img, laf, 16), kornia.feature.extract_patches_from_pyramid(img, laf, 16))
 
-    def test_dynamo_chunked(self, device, dtype, torch_optimizer, monkeypatch):
+    def test_dynamo_chunked(self, device, dtype, torch_optimizer, optimizer_backend, monkeypatch):
         # The chunk loop unrolls at trace time for static shapes; forcing one LAF per chunk
         # exercises it.
         import kornia.feature.laf as laf_module
 
+        if optimizer_backend == "jit":
+            # Same TorchScript incompatibility `test_dynamo` skips -- and a scripted function
+            # would not see the monkeypatched module global anyway.
+            pytest.skip("`extract_patches_from_pyramid` reaches a non-scriptable `filter2d`")
         monkeypatch.setattr(laf_module, "_grid_chunk_lafs", lambda *args: 1)
         laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
         img = torch.rand(2, 1, 65, 97, device=device, dtype=dtype)

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -551,6 +551,49 @@ class TestExtractPatchesSimple(BaseTester):
         expected = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1, 1).expand(B, N, 1, PS, PS)
         self.assert_close(patches, expected)
 
+    def test_empty(self, device, dtype):
+        # Degenerate shapes follow the empty-in -> empty-out convention instead of raising from
+        # inside `affine_grid`.
+        PS = 8
+        patches = kornia.feature.extract_patches_simple(
+            torch.rand(0, 2, 32, 32, device=device, dtype=dtype), torch.rand(0, 3, 2, 3, device=device, dtype=dtype), PS
+        )
+        assert patches.shape == (0, 3, 2, PS, PS)
+        assert patches.dtype == dtype
+        patches = kornia.feature.extract_patches_simple(
+            torch.rand(2, 1, 32, 32, device=device, dtype=dtype), torch.rand(2, 0, 2, 3, device=device, dtype=dtype), PS
+        )
+        assert patches.shape == (2, 0, 1, PS, PS)
+
+    def test_chunked_matches_single_call(self, device, dtype, monkeypatch):
+        # Forcing one LAF per chunk must reproduce the single-call result exactly, since
+        # chunking only splits the grid along N.
+        import kornia.feature.laf as laf_module
+
+        torch.manual_seed(0)
+        img = torch.rand(2, 3, 48, 64, device=device, dtype=dtype)
+        laf = torch.rand(2, 5, 2, 3, device=device, dtype=dtype)
+        expected = kornia.feature.extract_patches_simple(img, laf, 8)
+        monkeypatch.setattr(laf_module, "_grid_chunk_lafs", lambda *args: 1)
+        chunked = kornia.feature.extract_patches_simple(img, laf, 8)
+        self.assert_close(chunked, expected)
+        if device.type == "cpu":
+            assert torch.equal(chunked, expected)
+
+    def test_channel_laf_correspondence(self, device, dtype):
+        # The patch at [b, n] must equal the one extracted for that LAF alone. At ch=1 or N=1 a
+        # scrambled unfold is bit-identical to the right one (it permutes a size-1 dim), so this
+        # pins ch>1 together with N>1 and distinct LAFs.
+        B, N, ch, PS = 2, 4, 3, 8
+        torch.manual_seed(0)
+        img = torch.rand(B, ch, 48, 48, device=device, dtype=dtype)
+        laf = torch.rand(B, N, 2, 3, device=device, dtype=dtype)
+        patches = kornia.feature.extract_patches_simple(img, laf, PS)
+        for b in range(B):
+            for n in range(N):
+                single = kornia.feature.extract_patches_simple(img[b : b + 1], laf[b : b + 1, n : n + 1], PS)
+                self.assert_close(patches[b, n], single[0, 0])
+
     @pytest.mark.parametrize("half_dtype", [torch.float16, torch.bfloat16])
     def test_border_patches_stay_in_range(self, device, half_dtype):
         # A patch straddling the frame reads border pixels, so every sampled value is a convex
@@ -717,6 +760,22 @@ class TestExtractPatchesPyr(BaseTester):
             nondet_tol=1e-8,
         )
 
+    def test_gradcheck_chunked(self, device, monkeypatch):
+        # Gradients must survive the chunked sampling loop and its slice writes, on both the
+        # atlas path and the levelwise fallback.
+        import kornia.feature.laf as laf_module
+
+        monkeypatch.setattr(laf_module, "_grid_chunk_lafs", lambda *args: 1)
+        nlaf = torch.tensor(
+            [[[0.1, 0.001, 0.4], [0.0, 0.1, 0.5]], [[0.05, 0.0, 0.6], [0.0, 0.05, 0.4]]],
+            device=device,
+            dtype=torch.float64,
+        ).view(1, 2, 2, 3)
+        img = torch.rand(1, 2, 20, 30, device=device, dtype=torch.float64)
+        self.gradcheck(kornia.feature.extract_patches_from_pyramid, (img, nlaf, 7, False), nondet_tol=1e-8)
+        monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 0)
+        self.gradcheck(kornia.feature.extract_patches_from_pyramid, (img, nlaf, 7, False), nondet_tol=1e-8)
+
     def test_batch_independence(self, device, dtype):
         # Each patch must come only from its own batch element, across pyramid levels: the two
         # scales route the patches through level 0 and a downsampled level respectively.
@@ -729,6 +788,62 @@ class TestExtractPatchesPyr(BaseTester):
         assert patches.shape == (B, 2, 1, PS, PS)
         expected = torch.arange(B, device=device, dtype=dtype).view(B, 1, 1, 1, 1).expand(B, 2, 1, PS, PS)
         self.assert_close(patches, expected)
+
+    def test_empty(self, device, dtype):
+        # Degenerate shapes follow the empty-in -> empty-out convention: the batched rewrite must
+        # not call `affine_grid` on an empty batch (main returned an empty result for B=0).
+        PS = 8
+        patches = kornia.feature.extract_patches_from_pyramid(
+            torch.rand(0, 2, 32, 32, device=device, dtype=dtype), torch.rand(0, 3, 2, 3, device=device, dtype=dtype), PS
+        )
+        assert patches.shape == (0, 3, 2, PS, PS)
+        assert patches.dtype == dtype
+        patches = kornia.feature.extract_patches_from_pyramid(
+            torch.rand(2, 1, 32, 32, device=device, dtype=dtype), torch.rand(2, 0, 2, 3, device=device, dtype=dtype), PS
+        )
+        assert patches.shape == (2, 0, 1, PS, PS)
+
+    def test_chunked_matches_single_call(self, device, dtype, monkeypatch):
+        # Forcing one LAF per chunk must reproduce the single-call result on both the atlas path
+        # and the levelwise fallback, since chunking only splits the grid along N.
+        import kornia.feature.laf as laf_module
+
+        torch.manual_seed(0)
+        PS = 8
+        img = torch.rand(2, 3, 64, 64, device=device, dtype=dtype)
+        laf = torch.zeros(2, 5, 2, 3, device=device, dtype=dtype)
+        laf[..., 0, 0] = laf[..., 1, 1] = torch.tensor([2.0, 4.0, 9.0, 17.0, 33.0], device=device, dtype=dtype)
+        laf[..., :, 2] = torch.rand(2, 5, 2, device=device, dtype=dtype) * 40 + 12
+        default_chunk = laf_module._grid_chunk_lafs
+        expected = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        monkeypatch.setattr(laf_module, "_grid_chunk_lafs", lambda *args: 1)
+        chunked = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        self.assert_close(chunked, expected)
+        if device.type == "cpu":
+            assert torch.equal(chunked, expected)
+        monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 0)
+        fallback_chunked = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        monkeypatch.setattr(laf_module, "_grid_chunk_lafs", default_chunk)
+        fallback_expected = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        self.assert_close(fallback_chunked, fallback_expected)
+        if device.type == "cpu":
+            assert torch.equal(fallback_chunked, fallback_expected)
+
+    def test_channel_laf_correspondence(self, device, dtype):
+        # The patch at [b, n] must equal the one extracted for that LAF alone. At ch=1 or N=1 a
+        # scrambled unfold is bit-identical to the right one (it permutes a size-1 dim), so this
+        # pins ch>1 together with N>1, across pyramid levels.
+        B, N, ch, PS = 2, 4, 3, 8
+        torch.manual_seed(0)
+        img = torch.rand(B, ch, 64, 64, device=device, dtype=dtype)
+        laf = torch.zeros(B, N, 2, 3, device=device, dtype=dtype)
+        laf[..., 0, 0] = laf[..., 1, 1] = torch.tensor([3.0, 6.0, 17.0, 33.0], device=device, dtype=dtype)
+        laf[..., :, 2] = torch.rand(B, N, 2, device=device, dtype=dtype) * 40 + 12
+        patches = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        for b in range(B):
+            for n in range(N):
+                single = kornia.feature.extract_patches_from_pyramid(img[b : b + 1], laf[b : b + 1, n : n + 1], PS)
+                self.assert_close(patches[b, n], single[0, 0])
 
     @pytest.mark.parametrize("half_dtype", [torch.float16, torch.bfloat16])
     def test_border_patches_stay_in_range(self, device, half_dtype):
@@ -751,6 +866,18 @@ class TestExtractPatchesPyr(BaseTester):
         assert patches.max() <= img.max()
         self.assert_close(patches, kornia.feature.extract_patches_simple(img, laf, 16))
 
+    def test_laf_on_another_device(self, device, dtype):
+        # The sampling grid follows the LAF and is moved to the image inside `_sample_patches`,
+        # so the pyramid extractor accepts a LAF on a different device than the image, matching
+        # `extract_patches_simple`.
+        if device.type == "cpu":
+            pytest.skip("needs a second device besides the CPU")
+        img = torch.rand(1, 1, 64, 64, device=device, dtype=dtype)
+        laf = torch.tensor([[8.0, 0.0, 32.0], [0.0, 8.0, 32.0]], dtype=dtype).view(1, 1, 2, 3)
+        patches = kornia.feature.extract_patches_from_pyramid(img, laf, 8)
+        assert patches.device == img.device
+        self.assert_close(patches, kornia.feature.extract_patches_from_pyramid(img, laf.to(device), 8))
+
     def test_dynamo(self, device, dtype, torch_optimizer, optimizer_backend):
         if optimizer_backend == "jit":
             # `pyrdown` -> `filter2d` closes over a `set` of valid border modes, which TorchScript
@@ -771,6 +898,17 @@ class TestExtractPatchesPyr(BaseTester):
         import kornia.feature.laf as laf_module
 
         monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 0)
+        laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
+        img = torch.rand(2, 1, 65, 97, device=device, dtype=dtype)
+        op = torch_optimizer(kornia.feature.extract_patches_from_pyramid)
+        self.assert_close(op(img, laf, 16), kornia.feature.extract_patches_from_pyramid(img, laf, 16))
+
+    def test_dynamo_chunked(self, device, dtype, torch_optimizer, monkeypatch):
+        # The chunk loop unrolls at trace time for static shapes; forcing one LAF per chunk
+        # exercises it.
+        import kornia.feature.laf as laf_module
+
+        monkeypatch.setattr(laf_module, "_grid_chunk_lafs", lambda *args: 1)
         laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
         img = torch.rand(2, 1, 65, 97, device=device, dtype=dtype)
         op = torch_optimizer(kornia.feature.extract_patches_from_pyramid)

--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -637,6 +637,63 @@ class TestExtractPatchesPyr(BaseTester):
         assert patches.shape == (1, 1, 1, PS, PS)
         assert patches.abs().sum().item() > 0
 
+    def test_giant_laf_uses_actual_coarsest_level(self, device, dtype):
+        # The nominal level for this LAF is beyond the levels that can provide a PS-sized
+        # patch. It must sample the actual coarsest level rather than becoming zero padding.
+        PS = 16
+        img = torch.arange(128 * 128, device=device, dtype=dtype).reshape(1, 1, 128, 128)
+        laf = torch.tensor([[1.0e5, 0.0, 64.0], [0.0, 1.0e5, 64.0]], device=device, dtype=dtype).view(1, 1, 2, 3)
+
+        actual = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        nlaf = kornia.feature.normalize_laf(laf, img)
+        coarsest = img
+        for _ in range(3):
+            coarsest = kornia.geometry.transform.pyrdown(coarsest)
+        expected = kornia.feature.extract_patches_simple(coarsest, nlaf, PS, False)
+
+        self.assert_close(actual, expected)
+        assert actual.abs().sum().item() > 0
+
+    def test_oversized_atlas_uses_equivalent_levelwise_fallback(self, device, dtype, monkeypatch):
+        import kornia.feature.laf as laf_module
+
+        PS = 16
+        img = torch.rand(1, 1, 65, 97, device=device, dtype=dtype)
+        laf = torch.tensor(
+            [[[4.0, 0.0, 48.0], [0.0, 4.0, 32.0]], [[24.0, 0.0, 48.0], [0.0, 24.0, 32.0]]],
+            device=device,
+            dtype=dtype,
+        ).view(1, 2, 2, 3)
+
+        monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 0)
+        fallback = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+        monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 1 << 60)
+        atlas = kornia.feature.extract_patches_from_pyramid(img, laf, PS)
+
+        self.assert_close(fallback, atlas)
+
+    def test_atlas_guards_preserve_level_border_value_and_gradient(self, monkeypatch):
+        import kornia.feature.laf as laf_module
+
+        def sample(limit, size, patch_size):
+            monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", limit)
+            img = torch.zeros(1, 1, size, size)
+            img[:, :, :, -1] = 1.0
+            center_x = 1.0 - 1.0 / (2.0 * size)
+            nlaf = torch.tensor([[[[0.0, 0.0, center_x], [0.0, 0.0, 0.5]]]], requires_grad=True)
+            patch = kornia.feature.extract_patches_from_pyramid(img, nlaf, patch_size, False)
+            value = patch[0, 0, 0, patch_size // 2, patch_size // 2]
+            grad = torch.autograd.grad(value, nlaf)[0][0, 0, 0, 2]
+            return patch, grad
+
+        # 2495 exposes a forward-coordinate rounding leak without guards; 32 exposes the
+        # non-zero outward center gradient even when the rounded forward value happens to match.
+        for size, patch_size in ((2495, 8), (32, 5)):
+            fallback, fallback_grad = sample(0, size, patch_size)
+            atlas, atlas_grad = sample(1 << 60, size, patch_size)
+            assert torch.equal(atlas, fallback)
+            assert atlas_grad == fallback_grad == 0.0
+
     def test_multi_level_uses_correct_pyramid_level(self, device, dtype):
         # Two LAFs with very different scales should be extracted from different pyramid levels.
         # We verify the output shape and that the function runs without errors.
@@ -709,6 +766,15 @@ class TestExtractPatchesPyr(BaseTester):
         torch._dynamo.reset()
         compiled = torch.compile(kornia.feature.extract_patches_from_pyramid, fullgraph=True)
         self.assert_close(compiled(img, laf, 10), expected)
+
+    def test_dynamo_levelwise_fallback(self, device, dtype, torch_optimizer, monkeypatch):
+        import kornia.feature.laf as laf_module
+
+        monkeypatch.setattr(laf_module, "_PYRAMID_ATLAS_MAX_BYTES", 0)
+        laf = torch.rand(2, 4, 2, 3, device=device, dtype=dtype)
+        img = torch.rand(2, 1, 65, 97, device=device, dtype=dtype)
+        op = torch_optimizer(kornia.feature.extract_patches_from_pyramid)
+        self.assert_close(op(img, laf, 16), kornia.feature.extract_patches_from_pyramid(img, laf, 16))
 
 
 class TestLAFIsTouchingBoundary(BaseTester):

--- a/tests/feature/test_local_features_orientation.py
+++ b/tests/feature/test_local_features_orientation.py
@@ -21,7 +21,7 @@ import torch
 from kornia.feature.orientation import LAFOrienter, OriNet, PassLAF, PatchDominantGradientOrientation
 from kornia.geometry.conversions import rad2deg
 
-from testing.base import BaseTester, supports_grid_sample, supports_replicate_padding
+from testing.base import BaseTester, supports_replicate_padding
 
 
 class TestPassLAF(BaseTester):
@@ -136,10 +136,11 @@ class TestOrientationHalfPrecisionIsFinite(BaseTester):
     def test_flat_image_laf(self, device, half_dtype):
         if device.type == "mps":
             pytest.skip("MPS autocast changes the effective dtype")
-        if not (supports_replicate_padding(device, half_dtype) and supports_grid_sample(device, half_dtype)):
-            # The orienter extracts patches with `grid_sample` and differentiates them with a
-            # replicate pad; torch 2.5.1 has neither CPU kernel for float16, nor `grid_sample` for bfloat16.
-            pytest.skip(f"no half-precision patch-extraction kernels for {half_dtype} on {device.type}")
+        if not supports_replicate_padding(device, half_dtype):
+            # The orienter differentiates the extracted patches with a replicate pad, which torch
+            # 2.5.1 has no float16 CPU kernel for. Patch extraction itself samples half inputs in
+            # float32 and needs no `grid_sample` gate on any torch version.
+            pytest.skip(f"no replicate-pad kernel for {half_dtype} on {device.type}")
         img = torch.full((1, 1, 32, 32), 0.5, device=device, dtype=half_dtype)
         laf = torch.tensor([[[[5.0, 0.0, 16.0], [0.0, 5.0, 16.0]]]], device=device, dtype=half_dtype)
         out = LAFOrienter(19).to(device, half_dtype)(laf, img)


### PR DESCRIPTION
## Summary

- sample each LAF once from a guarded, packed pyramid atlas instead of sampling every LAF at every level
- use one-pixel replicated guards to preserve exact border values and outward gradients
- compute fp16/bf16 grids in float32 and keep the existing output dtype
- clamp oversized LAFs to the actual coarsest built level instead of returning an all-zero patch
- use a compile-static levelwise fallback when atlas storage plus any sampling-dtype copy would exceed 128 MiB

This PR is intentionally stacked on #4120 (`perf/extract-patches-batched`).

## Performance

Measured before implementation and again on this branch with the #4119 benchmark harness, Torch 2.9.1, Apple Silicon. Values are LAFs/s for `extract_patches_from_pyramid`, PS=32.

| device / image | config | eager base → atlas | compiled base → atlas |
|---|---:|---:|---:|
| CPU / 256² | B1 N2000 | 9,285 → 31,307 (3.37×) | 67,238 → 157,207 (2.34×) |
| CPU / 512² | B1 N2000 | 7,317 → 28,719 (3.92×) | 48,655 → 122,487 (2.52×) |
| CPU / 512² | B8 N2000 | 7,302 → 29,629 (4.06×) | 7,011 → 82,626 (11.79×) |
| MPS / 256² | B1 N2000 | 14,994 → 42,714 (2.85×) | 154,142 → 406,483 (2.64×) |
| MPS / 512² | B1 N2000 | 12,028 → 41,516 (3.45×) | 131,677 → 331,135 (2.51×) |
| MPS / 512² | B8 N2000 | 12,283 → 56,144 (4.57×) | 30,026 → 406,568 (13.54×) |

The tiny-N loss/flat case is retained explicitly: MPS 512², B1 N100 compiled was 62,012 → 61,332 LAFs/s (0.99×, within run noise). Eager improved 1.19–2.72× at N100 across the tested matrix.

### Typical inference workloads

These runs explicitly used `torch.inference_mode()`, level-spanning LAF scales, and fresh processes.

| device / image | PS / N | base → atlas latency | speedup | peak RSS base → atlas |
|---|---:|---:|---:|---:|
| CPU / 1024×768 | 32 / 2000 | 279.8 → 81.8 ms | 3.42× | 229 → 211 MiB |
| CPU / 1024×768 | 41 / 2000 | 442.8 → 119.5 ms | 3.70× | 242 → 229 MiB |
| CPU / 2048×1536 | 32 / 2000 | 407.0 → 144.9 ms | 2.81× | 435 → 366 MiB |
| CPU / 2048×1536 | 41 / 2000 | 600.9 → 182.2 ms | 3.30× | 437 → 366 MiB |
| MPS / 1024×768 | 32 / 2000 | 169.1 → 49.0 ms | 3.45× | 45 → 26 MiB RSS delta |
| MPS / 1024×768 | 41 / 2000 | 273.7 → 69.7 ms | 3.92× | 44 → 26 MiB RSS delta |
| MPS / 2048×1536 | 32 / 2000 | 206.7 → 49.2 ms | 4.20× | 51 → 27 MiB RSS delta |
| MPS / 2048×1536 | 41 / 2000 | 328.0 → 77.1 ms | 4.26× | 50 → 27 MiB RSS delta |

At N100, CPU speedups were 1.08–1.57× and MPS speedups were 1.28–1.70× for these same PS/image combinations.

I did not run 8000×6000 on MPS: it can pressure the unified allocator enough to hang this machine. CPU single-shot tests exercise the guarded fallback instead. At N2000 it peaked at about 1.58 GiB for PS32 and 4.10 GiB for PS41; the latter is output-dominated (about 4.0 GiB for the returned patches). The fallback avoids constructing the roughly gigabyte-scale atlas.

## Numerics and behavior

A 70-case branch-vs-base probe covered five even/odd/single-level shapes, normalized and pixel LAFs, CPU float32/float64/float16/bfloat16, and MPS float32/float16/bfloat16.

- float32: allclose; max absolute difference 2.94e-5, max p99 1.13e-5, max mean 1.02e-6
- float64: allclose; max absolute difference 5.82e-14
- fp16/bf16 intentionally differ from the old reduced-precision grid arithmetic; against a float32-grid levelwise reference they are allclose, with max differences 4.88e-4 and 9.77e-4 respectively
- atlas and forced fallback have exact forward and border-gradient parity in the seam regressions
- GRAF DoG/SIFT and KeyNet matching quality metrics were exactly unchanged for all evaluated pairs

## Validation

- `pixi run test-module tests/feature/test_laf.py --device=cpu --dtype=float32,float64 --color=no` — 143 passed, 12 skipped
- CPU fp16/bf16 pyramid tests passed; the full half run has the same 18 unrelated `torch.inverse` failures as the base branch
- MPS float32/fp16/bf16 pyramid tests — 27 passed, 1 skipped
- atlas and forced-fallback Dynamo/Inductor tests passed, including direct `torch.compile(fullgraph=True)` probes
- `pixi run test-module tests/feature/test_integrated.py --device=cpu --dtype=float32 --color=no` — 25 passed, 10 skipped
- `pixi run test-module tests/feature --device=cpu --dtype=float32 --color=no -q` — 634 passed, 72 skipped
- `pixi run pre-commit-all`

CUDA was unavailable on this machine.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (gpt-5.6-sol).

Posted on behalf of @ducha-aiki by Claude (Fable 5).
