### PR TITLE
Fix transform_bbox mutating xywh input

### DIFF
--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -512,6 +512,7 @@ def transform_bbox(
 
     # convert boxes to format xyxy
     if mode == "xywh":
+        boxes = boxes.clone()
         boxes[..., 2] = boxes[..., 0] + boxes[..., 2]  # x + w
         boxes[..., 3] = boxes[..., 1] + boxes[..., 3]  # y + h
 

--- a/tests/geometry/test_bbox.py
+++ b/tests/geometry/test_bbox.py
@@ -164,6 +164,7 @@ class TestTransformBoxes2D(BaseTester):
             device=device,
             dtype=dtype,
         )
+        boxes_before = boxes.clone()
 
         expected = torch.tensor(
             [
@@ -180,6 +181,7 @@ class TestTransformBoxes2D(BaseTester):
 
         out = transform_bbox(trans_mat, boxes, mode="xywh", restore_coordinates=True)
         self.assert_close(out, expected, atol=1e-4, rtol=1e-4)
+        assert torch.equal(boxes, boxes_before)
 
     def test_gradcheck(self, device):
         boxes = torch.tensor(


### PR DESCRIPTION
## What does this pull request do?

`transform_bbox(..., mode="xywh")` converted boxes to `xyxy` with in-place assignments, silently rewriting the caller's input tensor even though the returned boxes were correct. This change clones the input only in the `xywh` conversion branch before those internal assignments, preserving the existing output while removing the side effect.

The existing xywh numerical test now also keeps an exact copy of the argument and verifies that it remains unchanged after the call.

## Related issue or discussion

Fixes #4011.

## What did you check?

With the regression assertion kept and the production clone temporarily removed, the focused CPU test failed for both float32 and float64 at the new input-integrity assertion; the existing output assertion passed before it.

```text
$ pixi run test-module tests/geometry/test_bbox.py::TestTransformBoxes2D::test_transform_boxes_wh --device=cpu --dtype=float32,float64
2 passed

$ KORNIA_TEST_OPTIMIZER=inductor pixi run test-module tests/geometry/test_bbox.py --device=cpu --dtype=float32,float64
32 passed

$ pixi run pre-commit-all
all hooks passed

$ pixi run typecheck
exit 0; one existing deprecation diagnostic in kornia/feature/lightglue.py
```

The same full bbox test file without compile collection also passed 26 tests, and `git diff --check` passed.

## How did AI help?

OpenAI Codex, including Terra sub-agents, helped trace the call path, identify the smallest non-mutating change, and draft the regression assertion. I independently reproduced the old side effect, reviewed the final three-line diff, ran the old-code failure and fixed-code tests, and completed the repository's pre-commit and type checks.
