### PR TITLE
fix(feature): return isolated SIFT kernel copies

### DIFF
--- a/kornia/feature/siftdesc.py
+++ b/kornia/feature/siftdesc.py
@@ -184,17 +184,17 @@ class SIFTDescriptor(nn.Module):
         """Return the spatial pooling kernel used for histogram accumulation.
 
         Returns:
-            Detached convolution kernel tensor from the pooling layer.
+            Detached copy of the convolution kernel tensor from the pooling layer.
         """
-        return self.pk.weight.detach()
+        return self.pk.weight.detach().clone()
 
     def get_weighting_kernel(self) -> torch.Tensor:
         """Return the Gaussian weighting kernel used before orientation pooling.
 
         Returns:
-            Detached Gaussian kernel tensor.
+            Detached copy of the Gaussian kernel tensor.
         """
-        return self.gk.detach()
+        return self.gk.detach().clone()
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         r"""Compute SIFT descriptors for square grayscale patches.
@@ -360,17 +360,13 @@ class DenseSIFTDescriptor(nn.Module):
         PoolingConv.weight.data.copy_(self._poolingconv_weight)
         self.PoolingConv = PoolingConv
 
-        # Cache pooling kernel torch.Tensor for fast return in get_pooling_kernel
-        self._pooling_kernel = self._bin_pooling_kernel_weight.detach()
-
     def get_pooling_kernel(self) -> torch.Tensor:
-        """Return the cached pooling kernel for dense SIFT binning.
+        """Return the pooling kernel for dense SIFT binning.
 
         Returns:
-            Detached tensor containing pooling weights.
+            Detached copy of the pooling weights.
         """
-        # Return the cached detached pooling kernel directly for optimal speed
-        return self._pooling_kernel
+        return self.bin_pooling_kernel.weight.detach().clone()
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """Compute dense SIFT descriptors over a full image grid.

--- a/tests/feature/test_siftdesc.py
+++ b/tests/feature/test_siftdesc.py
@@ -108,6 +108,22 @@ class TestSIFTDescriptorKernelBuffer(BaseTester):
         mod(torch.rand(2, 1, 32, 32, dtype=torch.float64))
         assert (mod.gk.dtype, mod.gk.device) == before
 
+    def test_kernel_accessors_return_copies(self, device):
+        """Accessor writes must not mutate SIFT's pooling parameter or weighting buffer (#4083)."""
+        mod = SIFTDescriptor(32).to(device)
+        pooling = mod.get_pooling_kernel()
+        weighting = mod.get_weighting_kernel()
+        expected_pooling = pooling.clone()
+        expected_weighting = weighting.clone()
+        assert not pooling.requires_grad
+        assert not weighting.requires_grad
+
+        pooling.zero_()
+        weighting.zero_()
+
+        self.assert_close(mod.pk.weight, expected_pooling)
+        self.assert_close(mod.gk, expected_weighting)
+
 
 class TestSIFTConstantPatchIsFinite(BaseTester):
     """A constant patch has a zero-norm descriptor; normalising it must not give NaN.
@@ -238,6 +254,28 @@ class TestDenseSIFTDescriptor(BaseTester):
     def test_print(self, device):
         sift = DenseSIFTDescriptor()
         sift.__repr__()
+
+    def test_pooling_kernel_accessor_is_isolated_and_tracks_to(self, device):
+        """Dense SIFT's accessor must return a copy of the kernel used in forward (#4083)."""
+        mod = DenseSIFTDescriptor()
+        expected = mod.bin_pooling_kernel.weight.detach().clone()
+        mod.get_pooling_kernel().zero_()
+        self.assert_close(mod.bin_pooling_kernel.weight, expected)
+
+        target_dtype = torch.float32 if device.type == "mps" else torch.float64
+        mod.to(device, target_dtype)
+        kernel = mod.get_pooling_kernel()
+        assert not kernel.requires_grad
+        assert kernel.dtype == target_dtype
+        assert kernel.device == device
+
+        if device.type != "mps":
+            mod = DenseSIFTDescriptor()
+            mod(torch.rand(1, 1, 8, 8, device=device, dtype=torch.float64))
+            kernel = mod.get_pooling_kernel()
+            assert kernel.dtype == torch.float64
+            assert kernel.device == device
+            self.assert_close(kernel, mod.bin_pooling_kernel.weight)
 
     def test_instances_do_not_share_buffer_storage(self, device):
         """Instances must not share storage for `_poolingconv_weight` (see #4068).


### PR DESCRIPTION
## What does this pull request do?

`DenseSIFTDescriptor.get_pooling_kernel()` cached a detached alias during construction. The returned tensor could mutate internal state and remained on the old dtype/device after module migration. The accessor now returns a detached clone of the convolution weight actually used by `forward`. The two equivalent `SIFTDescriptor` kernel accessors also return detached clones so callers cannot mutate the module through them.

Regression tests cover mutation isolation, detached autograd semantics, explicit dtype/device migration, forward-triggered migration, and MPS device migration.

## Related issue or discussion

Fixes #4083.

## What did you check?

- Unmodified baseline with the retained regression tests: 2 failed.
- Fixed focused regression tests on CPU: 2 passed.
- Fixed focused regression tests on MPS float32: 2 passed.
- Complete `tests/feature/test_siftdesc.py` on CPU float32/float64 with inductor enabled: 57 passed, 2 existing JIT skips.
- `pixi run pre-commit-all`: all hooks passed.
- `pixi run typecheck`: exit 0; one pre-existing deprecation diagnostic in unmodified `kornia/feature/lightglue.py`.
- `git diff --check`: passed.

## How did AI help?

OpenAI Codex coordinated the reproduction, implementation, test execution, and final review. Terra subagents inspected the call chain and performed an adversarial review. I independently reviewed the final diff, reproduced the failure with the production fix removed, reran the tests and quality gates, and addressed review findings about the Dense source of truth, detached semantics, and MPS coverage.