### PR TITLE
fix(feature): avoid half-precision underflow in patch affine shape estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Compute `PatchAffineShapeEstimator` moments and normalization in float32 for float16 and bfloat16
+  inputs, then cast the result back to the input dtype (#4123). Weighted gradients could underflow
+  when squared in float16, producing NaNs or replacing an anisotropic patch with a circular shape.
+  Float32 and float64 inputs keep their existing computation.
+
 * Make `load_pointcloud_ply` and `load_pointcloud_ply_binary` parse the PLY header instead of skipping a fixed
   number of lines. Both loaders skipped `header_size=8` lines and read everything after them as `x y z` triples, so a
   minimal PLY file (seven header lines, no `comment`) lost its first point to a header line -- the binary reader

--- a/kornia/feature/affine_shape.py
+++ b/kornia/feature/affine_shape.py
@@ -48,6 +48,9 @@ class PatchAffineShapeEstimator(nn.Module):
 
     The method determines the affine shape of the local feature as in :cite:`baumberg2000`.
 
+    For float16 and bfloat16 inputs, the moments and normalization are computed in float32.
+    The output keeps the input dtype.
+
     Args:
         patch_size: the input image patch size.
         eps: for safe division.
@@ -81,6 +84,10 @@ class PatchAffineShapeEstimator(nn.Module):
 
         """
         KORNIA_CHECK_SHAPE(patch, ["B", "1", "H", "W"])
+        dtype = patch.dtype
+        # Squared weighted gradients and the degeneracy threshold can underflow in half precision.
+        if dtype in (torch.float16, torch.bfloat16):
+            patch = patch.float()
         # cast into a local; rebinding `self.weighting` would make the module's dtype/device depend
         # on whichever tensor was passed last.
         weighting = self.weighting.to(patch.dtype).to(patch.device)
@@ -105,7 +112,7 @@ class PatchAffineShapeEstimator(nn.Module):
         ellipse_shape = ellipse_shape * (1.0 - bad_mask) + circular_shape * bad_mask
         # normalization
         ellipse_shape = ellipse_shape / ellipse_shape.max(dim=2, keepdim=True)[0]
-        return ellipse_shape
+        return ellipse_shape.to(dtype)
 
 
 class LAFAffineShapeEstimator(nn.Module):

--- a/tests/feature/test_affine_shape_estimator.py
+++ b/tests/feature/test_affine_shape_estimator.py
@@ -54,6 +54,56 @@ class TestPatchAffineShapeEstimator(BaseTester):
         patches = torch.rand(batch_size, channels, height, width, device=device, dtype=torch.float64)
         self.gradcheck(ori, (patches,), nondet_tol=1e-4)
 
+    @pytest.mark.parametrize("patch_size", [19, 32])
+    @pytest.mark.parametrize("batch_size", [1, 3])
+    def test_precision(self, device, dtype, patch_size, batch_size):
+        """Flat and anisotropic patches retain their shape and finite input gradients."""
+        patches = torch.zeros(batch_size, 1, patch_size, patch_size, device=device, dtype=dtype)
+        middle = patch_size // 2
+        patches[:, :, middle - 1 : middle + 1, 2:-2] = 1
+        if batch_size == 3:
+            patches[0].zero_()
+            patches[2] = patches[1].transpose(-2, -1)
+
+        expected = PatchAffineShapeEstimator(patch_size).to(device)(patches.float()).to(dtype)
+        module = PatchAffineShapeEstimator(patch_size).to(device, dtype)
+        weighting = module.weighting.clone()
+        patches.requires_grad_()
+
+        actual = module(patches)
+
+        assert actual.shape == (batch_size, 1, 3)
+        assert actual.dtype == dtype
+        assert actual.device == device
+        self.assert_close(actual, expected)
+        self.assert_close(module.weighting, weighting, atol=0, rtol=0)
+        actual.sum().backward()
+        assert patches.grad is not None and torch.isfinite(patches.grad).all()
+        if batch_size == 3:
+            assert (patches.grad[0] == 0).all()
+
+    @pytest.mark.parametrize("half_dtype", [torch.float16, torch.bfloat16])
+    def test_half_precision_cpu(self, device, half_dtype):
+        """Keep the half-precision regression covered in ordinary CPU CI jobs."""
+        if device.type != "cpu":
+            pytest.skip("Explicit half-precision CI guard is CPU-only. Other devices use the dtype fixture.")
+        patches = torch.zeros(2, 1, 32, 32, device=device, dtype=half_dtype)
+        patches[1, :, 15:17, 9:23] = 1
+        actual = PatchAffineShapeEstimator(32).to(device, half_dtype)(patches)
+        # The anisotropic value is the float32 result for the rectangle in #4123.
+        expected = torch.tensor([[[1.0, 0.0, 1.0]], [[0.0883344, 0.0, 1.0]]], device=device, dtype=half_dtype)
+        assert actual.dtype == half_dtype
+        self.assert_close(actual, expected)
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        """Compilation preserves the public result and output dtype."""
+        module = PatchAffineShapeEstimator(32).to(device, dtype)
+        patches = torch.zeros(2, 1, 32, 32, device=device, dtype=dtype)
+        patches[1, :, 15:17, 9:23] = 1
+        actual = torch_optimizer(module)(patches)
+        assert actual.dtype == dtype
+        self.assert_close(actual, module(patches))
+
 
 class TestAffineShapeKernelBuffer(BaseTester):
     """`weighting` must be a real buffer so `.to()` moves it, and `forward` must not rebind it (#4069)."""


### PR DESCRIPTION
## What does this pull request do?

I reproduced the rectangle from #4123 on CPU and MPS. On CPU, `PatchAffineShapeEstimator` returns NaNs in float16. On MPS, the same patch produces a finite circular shape instead of the expected anisotropic one. Checking only for finite output would miss that second case.

This promotes float16 and bfloat16 patches to float32 before gradient evaluation, keeps the moments and normalization in float32, then returns the result in the input dtype. The existing `eps` is unchanged. Increasing it alone would turn valid patches into circles without recovering their shape.

The float32 and float64 computation stays unchanged, as does the registered weighting buffer. The change includes a short docstring note and changelog entry.

## Related issue or discussion

Fixes #4123, reported by @ducha-aiki.

This addresses the patch estimator root cause discussed in #4122. Its latest head, `d2e53c8`, adds a downstream finite-output fallback, but the patch estimator itself still underflows. That fallback also cannot recover a finite but incorrect shape. This PR does not change `ellipse_to_laf` or include the inverse implementation.

## What did you check?

The main comparison used Python 3.11.7 and PyTorch 2.9.1 on Apple Silicon, against `cec6d3dbae7f2f99f83694db24cc8c137866eb57`. Base and fix ran from separate worktrees with the imported source path checked.

The issue reproduction is enough to see the change. Set `device` to `"mps"` to check the other backend.

```python
import torch
from kornia.feature import PatchAffineShapeEstimator

device = "cpu"
patch = torch.zeros(1, 1, 32, 32, device=device, dtype=torch.float16)
patch[:, :, 15:17, 9:23] = 1
print(PatchAffineShapeEstimator(32).to(device, patch.dtype)(patch))
```

```text
CPU before: [nan, nan, nan]
MPS before: [1.0, 0.0, 1.0]
Both after: [0.08831787109375, 0.0, 1.0]
Float32 reference: [0.0883344, 0.0, 1.0]
```

The new tests cover flat patches, both rectangle orientations, patch sizes 19 and 32, batches of 1 and 3, output dtype/device and finite input gradients. They use the existing dtype tolerances. There is also an explicit CPU float16/bfloat16 case, so the regression is exercised by ordinary CI jobs even when their dtype selection is float32 or float64.

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest \
  tests/feature/test_affine_shape_estimator.py \
  -k 'test_precision or test_half_precision_cpu' \
  --device=cpu --dtype=float16,bfloat16,float32,float64 -q -o addopts=''
```

Those cases went from 5 failed and 13 passed to 18 passed on CPU. On MPS, using `--dtype=float16,bfloat16,float32`, they went from 4 failed and 8 passed to 12 passed, with the 2 CPU-only cases skipped.

The broader CPU run covered affine shape estimation, LAFs, scale-space detection, orientation and SIFT in float32/float64. It went from 350 passed to 360 passed, with the same 16 skips. On PyTorch 2.5.1 it went from 335 to 345 passed, with the same 31 skips. The pretrained AffNet and OriNet classes were excluded from these runs. The patch estimator and buffer tests also passed across all four CPU dtypes on both versions. Inductor passed all 4 CPU and 3 MPS dtype cases. Six autocast probes had finite outputs and gradients after the fix. A separate comparison found bit-identical float32/float64 outputs and input gradients in 16 cases.

I also checked the fix on top of #4122, then repeated the integration checks when its head advanced to `d2e53c8`. All 12 configurations of flat and anisotropic patches match the float32 reference within dtype tolerances after the fix, compared with 8 before. The 36 rotated LAF cases cover 0, 37 and 90 degrees with orientation preservation enabled and disabled. The maximum float16 matrix-relative error falls from `1.26` to `8.93e-4`.

The new fallback regression in that PR still passes. Its ramp also exposed NaN gradients before this fix in 8 of 24 CPU configurations covering three dtypes, single and mixed batches, two rotations and both orientation settings. Afterward all 24 have finite image and LAF gradients. This only checks the default patch estimator, not arbitrary custom estimators. MPS pipeline backward could not be checked because PyTorch lacks `grid_sampler_2d_backward` there.

There are boundaries to that result. On current main, the full half precision LAF path still hits the inverse limitation addressed by #4122. On the combined tree, the existing LAF toy tests still fail their fixed `1e-4` comparisons. The affine test file gives 28 passed, 8 failed and 4 skipped both before and after, excluding AffNet. Those assertions are unchanged here. The broader MPS run also retains the same two SIFT failures that request unsupported float64 tensors. I compared the failing test IDs against the respective bases.

All repository pre-commit hooks passed. Feature doctests gave 28 passed and 9 skipped. `ty 0.0.9` reports the same pre-existing deprecation in `lightglue.py` on both trees. TorchScript still fails in the unchanged Sobel kernel signature on both trees. CUDA was not available. Pixi was not installed locally, so these checks used isolated environments and the underlying pytest, pre-commit and ty commands.

## How did AI help?

AI helped with the analysis and acted as a coding copilot.
