### PR TITLE
Fix/4096 docstrings

### DIFF
--- a/kornia/feature/aliked/aliked.py
+++ b/kornia/feature/aliked/aliked.py
@@ -459,15 +459,13 @@ class DeformableConv2d(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the module forward pass.
+        r"""Run the module forward pass.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature map with shape :math:`(B, C_{\text{in}}, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Deformable convolution output with shape :math:`(B, C_{\text{out}}, H', W')`.
         """
         h, w = x.shape[2:]
         max_offset = max(h, w) / 4.0
@@ -540,15 +538,13 @@ class ConvBlock(nn.Module):
         self.bn2 = norm_layer(out_channels)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the module forward pass.
+        r"""Run the module forward pass.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature map with shape :math:`(B, C_{\text{in}}, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Feature map with shape :math:`(B, C_{\text{out}}, H, W)` after two gated conv-BN layers.
         """
         x = self.gate(self.bn1(self.conv1(x)))
         return self.gate(self.bn2(self.conv2(x)))
@@ -592,15 +588,14 @@ class ResBlock(nn.Module):
         self.stride = stride
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the module forward pass.
+        r"""Run the module forward pass.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature map with shape :math:`(B, C_{\text{in}}, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Feature map with shape :math:`(B, C_{\text{out}}, H', W')` after the residual block,
+            where ``H'`` and ``W'`` may differ from the input if ``stride > 1``.
         """
         identity = x
         out = self.gate(self.bn1(self.conv1(x)))

--- a/kornia/feature/dedode/decoder.py
+++ b/kornia/feature/dedode/decoder.py
@@ -40,11 +40,12 @@ class Decoder(nn.Module):
     def forward(
         self, features: torch.Tensor, context: Optional[torch.Tensor] = None, scale: Optional[int] = None
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """Run this DeDoDe module forward.
+        r"""Run this DeDoDe module forward.
 
         Args:
             features: Encoded feature map with shape :math:`(B, C, H, W)`, or concatenated with context.
-            context: Optional context feature map from previous scale, shape :math:`(B, C_{\text{ctx}}, H, W)` or ``None``.
+            context: Optional context feature map from previous scale, shape
+                :math:`(B, C_{\text{ctx}}, H, W)`, or ``None``.
             scale: String key selecting the decoder layer for this scale (e.g. ``"8"``, ``"4"``, ``"2"``, ``"1"``).
 
         Returns:

--- a/kornia/feature/dedode/decoder.py
+++ b/kornia/feature/dedode/decoder.py
@@ -42,17 +42,13 @@ class Decoder(nn.Module):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            features: Input value used by this method.
-            context: Input value used by this method.
-            scale: Input value used by this method.
+            features: Encoded feature map with shape :math:`(B, C, H, W)`, or concatenated with context.
+            context: Optional context feature map from previous scale, shape :math:`(B, C_ctx, H, W)` or ``None``.
+            scale: String key selecting the decoder layer for this scale (e.g. ``"8"``, ``"4"``, ``"2"``, ``"1"``).
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Tuple of ``(logits, context)`` tensors, each with shape :math:`(B, C_out, H, W)`.
         """
         if context is not None:
             features = torch.cat((features, context), dim=1)
@@ -123,15 +119,15 @@ class ConvRefiner(nn.Module):
         """Create one decoder block for the requested scale.
 
         Args:
-            in_dim: Input value used by this method.
-            out_dim: Input value used by this method.
-            dw: Input value used by this method.
-            kernel_size: Input value used by this method.
-            bias: Input value used by this method.
-            norm_type: Input value used by this method.
+            in_dim: Number of input channels.
+            out_dim: Number of output channels. Must be divisible by ``in_dim`` when ``dw=True``.
+            dw: Whether to use depthwise convolution.
+            kernel_size: Convolution kernel size.
+            bias: Whether to include bias in the convolution.
+            norm_type: Normalization layer class to apply after the first conv.
 
         Returns:
-            Decoder block configured for the requested input and output channel counts.
+            Decoder block (``nn.Sequential``) configured for the requested channels.
         """
         num_groups = 1 if not dw else in_dim
         if dw:
@@ -152,17 +148,13 @@ class ConvRefiner(nn.Module):
         return nn.Sequential(conv1, norm, relu, conv2)
 
     def forward(self, feats: torch.Tensor) -> torch.Tensor:
-        """Run this DeDoDe module forward.
-
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
+        r"""Run this DeDoDe module forward.
 
         Args:
-            feats: Input value used by this method.
+            feats: Input feature map with shape :math:`(B, C_{\text{in}}, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Refined feature map with shape :math:`(B, C_{\text{out}}, H, W)`.
         """
         _b, _c, _hs, _ws = feats.shape
         # AMP is intentionally scoped to "cuda" only: float16 autocast on CPU is not

--- a/kornia/feature/dedode/decoder.py
+++ b/kornia/feature/dedode/decoder.py
@@ -44,11 +44,11 @@ class Decoder(nn.Module):
 
         Args:
             features: Encoded feature map with shape :math:`(B, C, H, W)`, or concatenated with context.
-            context: Optional context feature map from previous scale, shape :math:`(B, C_ctx, H, W)` or ``None``.
+            context: Optional context feature map from previous scale, shape :math:`(B, C_{\text{ctx}}, H, W)` or ``None``.
             scale: String key selecting the decoder layer for this scale (e.g. ``"8"``, ``"4"``, ``"2"``, ``"1"``).
 
         Returns:
-            Tuple of ``(logits, context)`` tensors, each with shape :math:`(B, C_out, H, W)`.
+            Tuple of ``(logits, context)`` tensors, each with shape :math:`(B, C_{\text{out}}, H, W)`.
         """
         if context is not None:
             features = torch.cat((features, context), dim=1)

--- a/kornia/feature/dedode/descriptor.py
+++ b/kornia/feature/dedode/descriptor.py
@@ -39,15 +39,11 @@ class DeDoDeDescriptor(nn.Module):
     ) -> torch.Tensor:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            images: Input value used by this method.
+            images: Input image batch with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Dense descriptor map with shape :math:`(B, D, H, W)`.
         """
         features, sizes = self.encoder(images)
         context = None

--- a/kornia/feature/dedode/detector.py
+++ b/kornia/feature/dedode/detector.py
@@ -39,15 +39,11 @@ class DeDoDeDetector(nn.Module):
     ) -> torch.Tensor:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            images: Input value used by this method.
+            images: Input image batch with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Keypoint detection logits with shape :math:`(B, 1, H, W)`.
         """
         dtype = images.dtype
         features, sizes = self.encoder(images)

--- a/kornia/feature/dedode/encoder.py
+++ b/kornia/feature/dedode/encoder.py
@@ -53,18 +53,14 @@ class VGG19(nn.Module):
         # non-CUDA devices to disable AMP entirely.
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input image tensor with shape :math:`(B, 3, H, W)` (BGR or RGB).
             **kwargs: Additional keyword arguments accepted for compatibility with the shared encoder interface. They
                 are not used by this VGG19 batch-normalized backbone wrapper.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Tuple of ``(features, sizes)`` where ``features`` is a list of intermediate feature maps
+            captured before each max-pool, and ``sizes`` is a list of their spatial dimensions.
         """
         with torch.autocast("cuda", enabled=self.amp, dtype=self.amp_dtype):
             feats = []
@@ -104,16 +100,12 @@ class FrozenDINOv2(nn.Module):
     def forward(self, x: torch.Tensor):  # type: ignore[no-untyped-def]
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input image tensor with shape :math:`(B, 3, H, W)`. Converted to ``amp_dtype`` internally.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Tuple of ``([features_16], [(H//14, W//14)])`` where ``features_16`` has shape
+            :math:`(B, 1024, H/14, W/14)`.
         """
         B, _C, H, W = x.shape
         if self.dinov2_vitl14[0].device != x.device:
@@ -137,16 +129,11 @@ class VGG_DINOv2(nn.Module):
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, Tuple[int, int]]:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input image tensor with shape :math:`(B, 3, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Tuple of combined ``(features, sizes)`` lists from the VGG19 and DINOv2 encoders.
         """
         feats_vgg, sizes_vgg = self.vgg(x)
         feat_dinov2, size_dinov2 = self.frozen_dinov2(x)

--- a/kornia/feature/dedode/transformer/dinov2.py
+++ b/kornia/feature/dedode/transformer/dinov2.py
@@ -384,7 +384,7 @@ class DinoVisionTransformer(nn.Module):
 
         Returns:
             During training: full feature dictionary from ``forward_features``.
-            During inference: class token projection with shape :math:`(B, \text{out_dim})`.
+            During inference: class token projection with shape :math:`(B, \text{out\_dim})`.
         """
         ret = self.forward_features(*args, **kwargs)
         if is_training:

--- a/kornia/feature/dedode/transformer/dinov2.py
+++ b/kornia/feature/dedode/transformer/dinov2.py
@@ -58,16 +58,11 @@ class BlockChunk(nn.ModuleList):
     def forward(self, x):
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Token sequence or tensor passed through each transformer block in sequence.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Token sequence with the same shape as input after processing through all blocks.
         """
         for b in self:
             x = b(x)
@@ -214,13 +209,12 @@ class DinoVisionTransformer(nn.Module):
         """Interpolate positional encodings to the current patch grid.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
-            w: Input value used by this method.
-            h: Input value used by this method.
+            x: Token sequence with class token prepended, shape :math:`(B, N+1, D)`.
+            w: Image width in pixels.
+            h: Image height in pixels.
 
         Returns:
-            Positional embedding tensor resized to match the current patch grid.
+            Positional embedding tensor resized to match the current patch grid, shape :math:`(1, N'+1, D)`.
         """
         previous_dtype = x.dtype
         npatch = x.shape[1] - 1
@@ -251,12 +245,11 @@ class DinoVisionTransformer(nn.Module):
         """Prepare image patch tokens before transformer encoding.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
-            masks: Input value used by this method.
+            x: Input image tensor with shape :math:`(B, C, H, W)`.
+            masks: Optional boolean mask tensor with shape :math:`(B, N)` for masked patch tokens.
 
         Returns:
-            Token sequence prepared with class token, positional embeddings, and optional masks.
+            Token sequence with class token, positional embeddings, and optional masks, shape :math:`(B, N+1, D)`.
         """
         _B, _nc, w, h = x.shape
         x = self.patch_embed(x)
@@ -272,8 +265,8 @@ class DinoVisionTransformer(nn.Module):
         """Compute transformer features for a list of image tensors.
 
         Args:
-            x_list: Input value used by this method.
-            masks_list: Input value used by this method.
+            x_list: List of input image tensors, each with shape :math:`(B, C, H, W)`.
+            masks_list: List of optional boolean mask tensors matching each image in ``x_list``.
 
         Returns:
             List of intermediate feature dictionaries, one per input image tensor.
@@ -300,12 +293,11 @@ class DinoVisionTransformer(nn.Module):
         """Compute transformer features for one image tensor.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
-            masks: Input value used by this method.
+            x: Input image tensor with shape :math:`(B, C, H, W)`, or list of tensors.
+            masks: Optional boolean mask tensor with shape :math:`(B, N)` or ``None``.
 
         Returns:
-            Feature dictionary produced by the transformer backbone.
+            Feature dictionary with keys ``x_norm_clstoken``, ``x_norm_patchtokens``, ``x_prenorm``, and ``masks``.
         """
         if isinstance(x, list):
             return self.forward_features_list(x, masks)
@@ -360,15 +352,14 @@ class DinoVisionTransformer(nn.Module):
         """Return selected intermediate transformer layer outputs.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
-            n: Current hourglass recursion depth.
-            reshape: Input value used by this method.
-            return_class_token: Input value used by this method.
-            norm: Input value used by this method.
+            x: Input image tensor with shape :math:`(B, C, H, W)`.
+            n: Number of last transformer blocks to return, or explicit list of block indices.
+            reshape: If ``True``, reshape patch tokens from :math:`(B, N, D)` to :math:`(B, D, H_p, W_p)`.
+            return_class_token: If ``True``, return ``(patch_tokens, class_token)`` tuples.
+            norm: If ``True``, apply layer normalization to each output.
 
         Returns:
-            Tuple or list of intermediate transformer layer outputs.
+            Tuple of intermediate transformer layer outputs, optionally reshaped and with class tokens.
         """
         if self.chunked_blocks:
             outputs = self._get_intermediate_layers_chunked(x, n)
@@ -389,14 +380,11 @@ class DinoVisionTransformer(nn.Module):
         return tuple(outputs)
 
     def forward(self, *args, is_training=False, **kwargs):
-        """Run this DeDoDe module forward.
-
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
+        r"""Run this DeDoDe module forward.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            During training: full feature dictionary from ``forward_features``.
+            During inference: class token projection with shape :math:`(B, \text{out_dim})`.
         """
         ret = self.forward_features(*args, **kwargs)
         if is_training:

--- a/kornia/feature/dedode/transformer/layers/attention.py
+++ b/kornia/feature/dedode/transformer/layers/attention.py
@@ -74,16 +74,12 @@ class Attention(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input token sequence with shape :math:`(B, N, C)`, where ``B`` is batch size,
+               ``N`` is number of tokens (patches + class token), and ``C`` is the embedding dimension.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Attention output with shape :math:`(B, N, C)`.
         """
         B, N, C = x.shape
         qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
@@ -106,17 +102,12 @@ class MemEffAttention(Attention):
     def forward(self, x: Tensor, attn_bias=None) -> Tensor:  # type: ignore[no-untyped-def]
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
-            attn_bias: Input value used by this method.
+            x: Input token sequence with shape :math:`(B, N, C)`.
+            attn_bias: Optional attention bias from xFormers for nested tensor support.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Attention output with shape :math:`(B, N, C)`.
         """
         if not XFORMERS_AVAILABLE:
             if attn_bias is not None:

--- a/kornia/feature/dedode/transformer/layers/block.py
+++ b/kornia/feature/dedode/transformer/layers/block.py
@@ -121,16 +121,12 @@ class Block(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input token sequence with shape :math:`(B, N, C)`, where ``B`` is batch size,
+               ``N`` is token count, and ``C`` is embedding dimension.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output token sequence with the same shape :math:`(B, N, C)`.
         """
 
         def attn_residual_func(x: Tensor) -> Tensor:
@@ -300,15 +296,12 @@ class NestedTensorBlock(Block):
     def forward(self, x_or_x_list):
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x_or_x_list: Input value used by this method.
+            x_or_x_list: Either a single token tensor with shape :math:`(B, N, C)`, or a list of such tensors
+                for nested-tensor mode (requires xFormers).
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output token tensor(s) with the same shape(s) as the input.
         """
         if isinstance(x_or_x_list, Tensor):
             return super().forward(x_or_x_list)

--- a/kornia/feature/dedode/transformer/layers/dino_head.py
+++ b/kornia/feature/dedode/transformer/layers/dino_head.py
@@ -70,7 +70,8 @@ class DINOHead(nn.Module):
             x: Input feature tensor with shape :math:`(B, C_{\text{in}})`.
 
         Returns:
-            L2-normalized projection with shape :math:`(B, \text{out_dim})`.
+            Projection logits with shape :math:`(B, \text{out\_dim})`. The bottleneck
+            features are L2-normalized before the final weight-normalized linear layer.
         """
         x = self.mlp(x)
         eps = 1e-6 if x.dtype == torch.float16 else 1e-12

--- a/kornia/feature/dedode/transformer/layers/dino_head.py
+++ b/kornia/feature/dedode/transformer/layers/dino_head.py
@@ -64,18 +64,13 @@ class DINOHead(nn.Module):
                 nn.init.constant_(m.bias, 0)
 
     def forward(self, x):
-        """Run this DeDoDe module forward.
-
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
+        r"""Run this DeDoDe module forward.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature tensor with shape :math:`(B, C_{\text{in}})`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            L2-normalized projection with shape :math:`(B, \text{out_dim})`.
         """
         x = self.mlp(x)
         eps = 1e-6 if x.dtype == torch.float16 else 1e-12

--- a/kornia/feature/dedode/transformer/layers/drop_path.py
+++ b/kornia/feature/dedode/transformer/layers/drop_path.py
@@ -55,15 +55,12 @@ class DropPath(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input tensor of any shape. Channels are retained; only full samples are dropped.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output tensor with the same shape as ``x``. During training some samples are
+            randomly zeroed with probability ``drop_prob``; at eval time the tensor is
+            returned unchanged.
         """
         return drop_path(x, self.drop_prob, self.training)

--- a/kornia/feature/dedode/transformer/layers/layer_scale.py
+++ b/kornia/feature/dedode/transformer/layers/layer_scale.py
@@ -51,15 +51,10 @@ class LayerScale(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         """Run this DeDoDe module forward.
 
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input token tensor with shape :math:`(B, N, C)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Tensor with the same shape :math:`(B, N, C)` scaled element-wise by the learnable ``gamma`` parameter.
         """
         return x.mul_(self.gamma) if self.inplace else x * self.gamma

--- a/kornia/feature/dedode/transformer/layers/mlp.py
+++ b/kornia/feature/dedode/transformer/layers/mlp.py
@@ -60,18 +60,13 @@ class Mlp(nn.Module):
         self.drop = nn.Dropout(drop)
 
     def forward(self, x: Tensor) -> Tensor:
-        """Run this DeDoDe module forward.
-
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
+        r"""Run this DeDoDe module forward.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input token tensor with shape :math:`(B, N, C_{\text{in}})`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output tensor with shape :math:`(B, N, C_{\text{out}})` after applying the two-layer MLP.
         """
         x = self.fc1(x)
         x = self.act(x)

--- a/kornia/feature/dedode/transformer/layers/patch_embed.py
+++ b/kornia/feature/dedode/transformer/layers/patch_embed.py
@@ -85,18 +85,16 @@ class PatchEmbed(nn.Module):
         self.norm = norm_layer(embed_dim) if norm_layer else nn.Identity()
 
     def forward(self, x: Tensor) -> Tensor:
-        """Run this DeDoDe module forward.
-
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
+        r"""Run this DeDoDe module forward.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input image tensor with shape :math:`(B, C, H, W)`. ``H`` and ``W`` must be
+               multiples of the patch height and width respectively.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Patch embeddings with shape :math:`(B, N_p, D)` when ``flatten_embedding=True``,
+            or :math:`(B, H_p, W_p, D)` when ``flatten_embedding=False``, where
+            :math:`N_p = H_p \times W_p`.
         """
         _, _, H, W = x.shape
         patch_H, patch_W = self.patch_size

--- a/kornia/feature/dedode/transformer/layers/swiglu_ffn.py
+++ b/kornia/feature/dedode/transformer/layers/swiglu_ffn.py
@@ -57,18 +57,14 @@ class SwiGLUFFN(nn.Module):
         self.w3 = nn.Linear(hidden_features, out_features, bias=bias)
 
     def forward(self, x: Tensor) -> Tensor:
-        """Run this DeDoDe module forward.
-
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
+        r"""Run this DeDoDe module forward.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input token tensor with shape :math:`(B, N, C_{\text{in}})`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output tensor with shape :math:`(B, N, C_{\text{out}})` after applying
+            the SwiGLU feed-forward transformation.
         """
         x12 = self.w12(x)
         x1, x2 = x12.chunk(2, dim=-1)

--- a/kornia/feature/dedode/vgg.py
+++ b/kornia/feature/dedode/vgg.py
@@ -60,18 +60,13 @@ class VGG(nn.Module):
                     nn.init.constant_(m.bias, 0)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run this DeDoDe module forward.
-
-        Inputs are image, feature, or token tensors used by the DeDoDe detector/descriptor pipeline. `B` denotes batch
-        size, `C` channels, `H` height, `W` width, `N` token count, and `D` feature dimension where those axes appear.
+        r"""Run this DeDoDe module forward.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input image tensor with shape :math:`(B, 3, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Classification logits with shape :math:`(B, \text{num_classes})`.
         """
         x = self.features(x)
         x = self.avgpool(x)

--- a/kornia/feature/dedode/vgg.py
+++ b/kornia/feature/dedode/vgg.py
@@ -66,7 +66,7 @@ class VGG(nn.Module):
             x: Input image tensor with shape :math:`(B, 3, H, W)`.
 
         Returns:
-            Classification logits with shape :math:`(B, \text{num_classes})`.
+            Classification logits with shape :math:`(B, \text{num\_classes})`.
         """
         x = self.features(x)
         x = self.avgpool(x)

--- a/kornia/feature/disk/_unets/blocks.py
+++ b/kornia/feature/disk/_unets/blocks.py
@@ -31,15 +31,11 @@ class TrivialUpsample(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run this DISK component forward.
 
-        Feature maps use `(B, C, H, W)`, where `B` is batch size, `C` channels, and `H`/`W` are spatial dimensions.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature map with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Upsampled feature map with shape :math:`(B, C, 2H, 2W)`.
         """
         return F.interpolate(x, scale_factor=2, mode="bilinear", align_corners=False)
 
@@ -53,15 +49,11 @@ class TrivialDownsample(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run this DISK component forward.
 
-        Feature maps use `(B, C, H, W)`, where `B` is batch size, `C` channels, and `H`/`W` are spatial dimensions.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature map with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Downsampled feature map with shape :math:`(B, C, H/2, W/2)`.
         """
         return F.avg_pool2d(x, 2)
 
@@ -129,17 +121,15 @@ class ThinUnetUpBlock(nn.Module):
         self.conv = Conv(self.cat_, self.out_, size)
 
     def forward(self, bot: torch.Tensor, hor: torch.Tensor) -> torch.Tensor:
-        """Run this DISK component forward.
-
-        Feature maps use `(B, C, H, W)`, where `B` is batch size, `C` channels, and `H`/`W` are spatial dimensions.
+        r"""Run this DISK component forward.
 
         Args:
-            bot: Input value used by this method.
-            hor: Input value used by this method.
+            bot: Bottom (deeper-level) feature map with shape :math:`(B, C_{\text{bot}}, H', W')`.
+            hor: Horizontal skip-connection feature map with shape :math:`(B, C_{\text{hor}}, 2H', 2W')`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Decoded feature map with shape :math:`(B, C_{\text{out}}, 2H', 2W')` after upsampling and
+            skip-connection fusion.
         """
         bot_big = self.upsample(bot)
         combined = torch.cat([bot_big, hor], dim=1)

--- a/kornia/feature/disk/_unets/unet.py
+++ b/kornia/feature/disk/_unets/unet.py
@@ -65,16 +65,14 @@ class Unet(nn.Module):
             self.n_params += param.numel()
 
     def forward(self, inp: torch.Tensor) -> torch.Tensor:
-        """Run this DISK component forward.
-
-        Feature maps use `(B, C, H, W)`, where `B` is batch size, `C` channels, and `H`/`W` are spatial dimensions.
+        r"""Run this DISK component forward.
 
         Args:
-            inp: Input tensor passed to the module.
+            inp: Input feature map with shape :math:`(B, C_{\text{in}}, H, W)`. ``H`` and ``W`` must both be
+                divisible by :math:`2^{\text{depth}}` where depth equals ``len(self.up)``.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output feature map with shape :math:`(B, C_{\text{up}[-1]}, H, W)`.
         """
         if inp.size(1) != self.in_features:
             fmt = "Expected {} feature channels in input, got {}"

--- a/kornia/feature/hynet.py
+++ b/kornia/feature/hynet.py
@@ -278,18 +278,13 @@ class HyNet(nn.Module):
         self.eval()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the HyNet normalization or descriptor layer.
-
-        Patch tensors use `(B, C, H, W)`. For HyNet descriptors the expected input is usually grayscale `(B, 1, 32, 32)`
-        and the final descriptor has shape `(B, D)`.
+        """Compute HyNet descriptors from grayscale image patches.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input grayscale patches with shape ``(B, 1, 32, 32)``.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            HyNet descriptors with shape ``(B, D)``.
         """
         x = self.layer1(x)
         x = self.layer2(x)

--- a/kornia/feature/hynet.py
+++ b/kornia/feature/hynet.py
@@ -155,12 +155,12 @@ class TLU(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        # nn.init.zeros_(self.tau)
         """Reset learnable parameters to their initial values.
 
         Returns:
             None. The module parameters are reset in place.
         """
+        # nn.init.zeros_(self.tau)
         nn.init.constant_(self.tau, -1)
 
     def extra_repr(self) -> str:

--- a/kornia/feature/hynet.py
+++ b/kornia/feature/hynet.py
@@ -172,18 +172,13 @@ class TLU(nn.Module):
         return "num_features={num_features}".format(**self.__dict__)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the HyNet normalization or descriptor layer.
-
-        Patch tensors use `(B, C, H, W)`. For HyNet descriptors the expected input is usually grayscale `(B, 1, 32, 32)`
-        and the final descriptor has shape `(B, D)`.
+        """Apply the thresholded linear unit to the input tensor.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input tensor.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Tensor with the same shape as the input, thresholded by ``tau``.
         """
         return torch.max(x, self.tau)
 

--- a/kornia/feature/hynet.py
+++ b/kornia/feature/hynet.py
@@ -106,20 +106,15 @@ class FilterResponseNorm2d(nn.Module):
         return "num_features={num_features}, eps={init_eps}".format(**self.__dict__)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Compute the mean norm of activations per channel.
-        """Run the HyNet normalization or descriptor layer.
-
-        Patch tensors use `(B, C, H, W)`. For HyNet descriptors the expected input is usually grayscale `(B, 1, 32, 32)`
-        and the final descriptor has shape `(B, D)`.
+        """Apply filter response normalization to the input tensor.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input tensor with shape ``(B, C, H, W)``.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Normalized tensor with the same shape as the input.
         """
+        # Compute the mean norm of activations per channel.
         nu2 = x.pow(2).mean(dim=[2, 3], keepdim=True)
 
         # Perform FRN.

--- a/kornia/feature/loftr/backbone/resnet_fpn.py
+++ b/kornia/feature/loftr/backbone/resnet_fpn.py
@@ -55,18 +55,13 @@ class BasicBlock(nn.Module):
             self.downsample = nn.Sequential(conv1x1(in_planes, planes, stride=stride), nn.BatchNorm2d(planes))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run this LoFTR component forward.
-
-        The method processes coarse or fine matching tensors used by LoFTR. Shape symbols such as `B`, `C`, `H`, `W`,
-        `N`, and `D` refer to batch size, channels, height, width, token count, and feature dimension.
+        r"""Run this LoFTR component forward.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature tensor with shape :math:`(B, C_{\text{in}}, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output feature tensor with shape :math:`(B, \text{planes}, H', W')`.
         """
         y = x
         y = self.relu(self.bn1(self.conv1(y)))
@@ -136,20 +131,16 @@ class ResNetFPN_8_2(nn.Module):
         return nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
-        # ResNet Backbone
         """Run this LoFTR component forward.
 
-        The method processes coarse or fine matching tensors used by LoFTR. Shape symbols such as `B`, `C`, `H`, `W`,
-        `N`, and `D` refer to batch size, channels, height, width, token count, and feature dimension.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input grayscale image tensor with shape :math:`(B, 1, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            List containing coarse feature map with shape :math:`(B, C_c, H/8, W/8)`
+            and fine feature map with shape :math:`(B, C_f, H/2, W/2)`.
         """
+        # ResNet Backbone
         x0 = self.relu(self.bn1(self.conv1(x)))
         x1 = self.layer1(x0)  # 1/2
         x2 = self.layer2(x1)  # 1/4
@@ -229,20 +220,16 @@ class ResNetFPN_16_4(nn.Module):
         return nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
-        # ResNet Backbone
         """Run this LoFTR component forward.
 
-        The method processes coarse or fine matching tensors used by LoFTR. Shape symbols such as `B`, `C`, `H`, `W`,
-        `N`, and `D` refer to batch size, channels, height, width, token count, and feature dimension.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input grayscale image tensor with shape :math:`(B, 1, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            List containing coarse feature map with shape :math:`(B, C_c, H/16, W/16)`
+            and fine feature map with shape :math:`(B, C_f, H/4, W/4)`.
         """
+        # ResNet Backbone
         x0 = self.relu(self.bn1(self.conv1(x)))
         x1 = self.layer1(x0)  # 1/2
         x2 = self.layer2(x1)  # 1/4

--- a/kornia/feature/loftr/loftr_module/fine_preprocess.py
+++ b/kornia/feature/loftr/loftr_module/fine_preprocess.py
@@ -60,19 +60,17 @@ class FinePreprocess(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Run this LoFTR component forward.
 
-        The method processes coarse or fine matching tensors used by LoFTR. Shape symbols such as `B`, `C`, `H`, `W`,
-        `N`, and `D` refer to batch size, channels, height, width, token count, and feature dimension.
-
         Args:
-            feat_f0: Input value used by this method.
-            feat_f1: Input value used by this method.
-            feat_c0: Input value used by this method.
-            feat_c1: Input value used by this method.
-            data: Dictionary containing image features, keypoints, descriptors, and image sizes for matching.
+            feat_f0: Fine feature map of the first image with shape :math:`(B, C_f, H_f, W_f)`.
+            feat_f1: Fine feature map of the second image with shape :math:`(B, C_f, H_f, W_f)`.
+            feat_c0: Coarse feature map or transformed tokens of the first image with shape
+                :math:`(B, C_c, H_c, W_c)` or :math:`(N_c, C_c)`.
+            feat_c1: Coarse feature map or transformed tokens of the second image with shape
+                :math:`(B, C_c, H_c, W_c)` or :math:`(N_c, C_c)`.
+            data: Dictionary containing coarse match metadata and indices.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Tuple of local cropped fine feature patches ``(feat0, feat1)`` each with shape :math:`(N_m, W^2, C)`.
         """
         W = self.W
         stride = data["hw0_f"][0] // data["hw0_c"][0]

--- a/kornia/feature/loftr/utils/fine_matching.py
+++ b/kornia/feature/loftr/utils/fine_matching.py
@@ -93,11 +93,11 @@ class FineMatching(nn.Module):
         """Extract fine-level correspondences from the refined matching heatmap.
 
         Args:
-            coords_normed: Input value used by this method.
+            coords_normed: Normalized coordinate offsets with shape :math:`(M, 2)`.
             data: Dictionary containing image features, keypoints, descriptors, and image sizes for matching.
 
         Returns:
-            Dictionary updated with refined fine-level correspondences.
+            None. Updates ``data`` in place with fine-level matches.
         """
         W, _, _, scale = self.W, self.WW, self.C, self.scale
 

--- a/kornia/feature/sold2/backbones.py
+++ b/kornia/feature/sold2/backbones.py
@@ -66,16 +66,11 @@ class HourglassBackbone(nn.Module):
     def forward(self, input_images: torch.Tensor) -> torch.Tensor:
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            input_images: Input image batch with shape `(B, C, H, W)`, where `B` is batch size, `C` is channel count,
-                and `H`/`W` are spatial dimensions.
+            input_images: Input image batch with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Feature map with shape :math:`(B, 256, H/4, W/4)`.
         """
         return self.net(input_images)
 
@@ -103,16 +98,11 @@ class MultitaskHead(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature tensor with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Concatenated predictions from all heads with shape :math:`(B, 5, H, W)`.
         """
         return torch.cat([head(x) for head in self.heads], dim=1)
 
@@ -140,18 +130,13 @@ class Bottleneck2D(nn.Module):
         self.stride = stride
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run this SOLD2 backbone component forward.
-
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
+        r"""Run this SOLD2 backbone component forward.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature tensor with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Residual block output tensor with shape :math:`(B, 2 \times \text{planes}, H', W')`.
         """
         residual = x
 
@@ -227,16 +212,11 @@ class Hourglass(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature tensor with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Hourglass output feature tensor with shape :math:`(B, C, H, W)`.
         """
         return self._hour_glass_forward(self.depth, x)
 
@@ -310,16 +290,11 @@ class HourglassNet(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input image tensor with shape :math:`(B, C, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output feature map of the last stack with shape :math:`(B, 256, H/4, W/4)`.
         """
         out = []
         x = self.conv1(x)
@@ -381,15 +356,11 @@ class SuperpointDecoder(nn.Module):
     def forward(self, input_features: torch.Tensor) -> torch.Tensor:
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            input_features: Input feature map with shape `(B, C, H, W)`.
+            input_features: Input feature map with shape :math:`(B, C, H/4, W/4)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Junction heatmap prediction with shape :math:`(B, H, W)`.
         """
         feat = self.relu(self.convPa(input_features))
         semi = self.convPb(feat)
@@ -455,19 +426,15 @@ class PixelShuffleDecoder(nn.Module):
         return [256, 64, 16, 4]
 
     def forward(self, input_features: torch.Tensor) -> torch.Tensor:
-        # Iterate til output block
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            input_features: Input feature map with shape `(B, C, H, W)`.
+            input_features: Input feature map with shape :math:`(B, C, H/4, W/4)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Line heatmap prediction with shape :math:`(B, H, W)`.
         """
+        # Iterate til output block
         out = input_features
         for block in self.conv_block_lst[:-1]:
             out = block(out)
@@ -500,15 +467,11 @@ class SuperpointDescriptor(nn.Module):
     def forward(self, input_features: torch.Tensor) -> torch.Tensor:
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            input_features: Input feature map with shape `(B, C, H, W)`.
+            input_features: Input feature map with shape :math:`(B, C, H/4, W/4)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Semi-dense descriptors with shape :math:`(B, 128, H/4, W/4)`.
         """
         feat = self.relu(self.convPa(input_features))
         semi = self.convPb(feat)
@@ -552,20 +515,15 @@ class SOLD2Net(nn.Module):
             self.descriptor_decoder = SuperpointDescriptor(feat_channel)
 
     def forward(self, input_images: torch.Tensor) -> Dict[str, torch.Tensor]:
-        # The backbone
         """Run this SOLD2 backbone component forward.
 
-        This method processes image or feature tensors used by the SOLD2 line detector. Tensor layouts follow `(B, C, H,
-        W)` for feature maps unless the surrounding class documentation states otherwise.
-
         Args:
-            input_images: Input image batch with shape `(B, C, H, W)`, where `B` is batch size, `C` is channel count,
-                and `H`/`W` are spatial dimensions.
+            input_images: Input image batch with shape :math:`(B, 1, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Dictionary containing predicted junction heatmap, line heatmap, and optional descriptors.
         """
+        # The backbone
         features = self.backbone_net(input_images)
 
         # junction decoder

--- a/kornia/feature/xfeat.py
+++ b/kornia/feature/xfeat.py
@@ -75,15 +75,13 @@ class BasicLayer(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run the module forward pass.
+        r"""Run the module forward pass.
 
         Args:
-            x: Input tensor processed by this module. For image-like features this usually follows the `(B, C, H, W)`
-                layout, where `B` is batch size, `C` is channels, and `H`/`W` are height and width.
+            x: Input feature map with shape :math:`(B, C_{\text{in}}, H, W)`.
 
         Returns:
-            Output tensor or dictionary produced by the module while preserving the shape contract documented by the
-            surrounding class.
+            Output feature map with shape :math:`(B, C_{\text{out}}, H', W')`.
         """
         return self.layer(x)
 


### PR DESCRIPTION
## What type of PR is this?

/kind documentation

## What this PR does / why we need it:

Fixes #4096

This PR replaces all 44 placeholder docstrings introduced by #3737 with function-specific documentation describing the actual input/output behavior and tensor shapes.

It also fixes the incorrect `FilterResponseNorm2d.forward` docstring, which previously described HyNet descriptor output even though the layer preserves the `(B, C, H, W)` tensor shape.

Additionally, the orphaned comments identified in #4096 have been moved back to their appropriate locations below the corresponding docstrings.

### Summary

* Replaced all 44 occurrences of the placeholder docstring.
* Removed the remaining `"Input value used by this method"` placeholder.
* Corrected `FilterResponseNorm2d.forward`.
* Fixed the orphaned comments from #3737.
* Kept the `FilterResponseNorm2d.forward` bug fix in a separate commit as requested.
* Kept docstring lines within the 120-character limit.
* Used raw docstrings where appropriate for `:math:` expressions.

## Special notes for your reviewer:

The docstrings were written based on the surrounding class contracts and the actual implementations, with tensor shapes documented where they are verifiable from the code.

## Does this PR introduce a user-facing change?

No