### PR TITLE
test(feature): revive LoFTR's two accuracy tests on CPU

### DIFF
--- a/tests/feature/test_loftr.py
+++ b/tests/feature/test_loftr.py
@@ -20,7 +20,6 @@ import sys
 import pytest
 import torch
 
-from kornia.core._compat import torch_version_ge
 from kornia.feature import LoFTR
 from kornia.geometry import resize
 
@@ -40,10 +39,16 @@ class TestLoFTR(BaseTester):
         assert loftr is not None
 
     @pytest.mark.slow
-    @pytest.mark.skipif(torch_version_ge(1, 10), reason="RuntimeError: CUDA out of memory with pytorch>=1.10")
     @pytest.mark.skipif(sys.platform == "win32", reason="this test takes so much memory in the CI with Windows")
     @pytest.mark.parametrize("data", ["loftr_fund"], indirect=True)
     def test_pretrained_indoor(self, device, dtype, data):
+        if device.type == "cuda":
+            # The stored expectations were generated on CPU. The CUDA matcher
+            # selects a different set of correspondences (~37% of coordinates
+            # differ, and the match count itself changes), so this comparison
+            # cannot hold on CUDA until the expectations are regenerated
+            # per-device. See https://github.com/kornia/kornia/issues/4092.
+            pytest.skip("stored keypoint expectations are CPU-specific")
         loftr = LoFTR("indoor").to(device, dtype)
         data_dev = dict_to(data, device, dtype)
         with torch.no_grad():
@@ -52,10 +57,16 @@ class TestLoFTR(BaseTester):
         self.assert_close(out["keypoints1"], data_dev["loftr_indoor_tentatives1"])
 
     @pytest.mark.slow
-    @pytest.mark.skipif(torch_version_ge(1, 10), reason="RuntimeError: CUDA out of memory with pytorch>=1.10")
     @pytest.mark.skipif(sys.platform == "win32", reason="this test takes so much memory in the CI with Windows")
     @pytest.mark.parametrize("data", ["loftr_homo"], indirect=True)
     def test_pretrained_outdoor(self, device, dtype, data):
+        if device.type == "cuda":
+            # The stored expectations were generated on CPU. The CUDA matcher
+            # selects a different set of correspondences (~37% of coordinates
+            # differ, and the match count itself changes), so this comparison
+            # cannot hold on CUDA until the expectations are regenerated
+            # per-device. See https://github.com/kornia/kornia/issues/4092.
+            pytest.skip("stored keypoint expectations are CPU-specific")
         loftr = LoFTR("outdoor").to(device, dtype)
         data_dev = dict_to(data, device, dtype)
         with torch.no_grad():


### PR DESCRIPTION
Fixes #4092

## Problem

`tests/feature/test_loftr.py` guards its only two numerical tests with

```python
@pytest.mark.skipif(torch_version_ge(1, 10),
                    reason="RuntimeError: CUDA out of memory with pytorch>=1.10")
```

`pyproject.toml` requires `torch>=2.0.0`, so the predicate is unconditionally true.
`test_pretrained_indoor` and `test_pretrained_outdoor` have therefore been skipped on every
supported torch, on every device, with or without `--runslow`. They are the only tests that
exercise the matcher end-to-end against stored expectations; `kornia/feature/loftr/` sits at
21% statement coverage as a result.

Confirmed on torch 2.13.0 — `torch_version_ge(1, 10)` is `True`, and the two tests report
`2 skipped`.

## Change

Remove the dead guard so both tests run. On CPU they pass:

```
tests/feature/test_loftr.py  6 passed, 1 skipped
```

The remaining skip is the pre-existing `win32` memory guard. CI runs
`KORNIA_TEST_DEVICE: cpu`, so these two now execute on every PR.

The now-unused `torch_version_ge` import is removed with it.

## Why CUDA is skipped explicitly

The tests do **not** pass on CUDA — but not for the recorded reason. Running them on an
RTX 4050 (6 GB, torch 2.13.0+cu130) produces no out-of-memory error at any point. The
failures are numerical:

```
test_pretrained_indoor
  Mismatched elements: 476 / 1278 (37.2%)
  Greatest absolute difference: 416.0 at index (80, 0) (up to 1e-05 allowed)

test_pretrained_outdoor
  The values for attribute 'shape' do not match:
  torch.Size([1720, 2]) != torch.Size([1719, 2])
```

The stored expectations were generated on CPU and the CUDA matcher selects a different set
of correspondences — the match *count* differs, so this is not a tolerance question, and a
416-pixel difference is a different keypoint rather than a rounding artifact.

So CUDA is skipped with that reason recorded in place of the OOM one, using the `device.type`
skip convention already used throughout the suite (60 sites, including CUDA-specific ones in
`tests/geometry/transform/test_affine.py` and `tests/geometry/test_grid.py`).

This is a deliberate scope limit: the CPU/CUDA divergence is a much larger question
(regenerate expectations per device? is the matcher nondeterministic on CUDA? is it a genuine
bug?) and is currently invisible because kornia has no GPU CI. I have described it on #4092
and am happy to file it separately if you would like it tracked.

## Not included

#4092 also lists other dead version predicates (`torch_version_le(1, 9, 1)` in
`test_integrated.py`, `test_matching.py`, `test_planar_tracking.py`). Those are harmless
no-ops — they evaluate false on `torch>=2.0.0`, so their tests do run — and I have left them
out to keep this reviewable. Happy to follow up.

## Verification

- CPU: `pytest tests/feature/test_loftr.py --runslow` -> 6 passed, 1 skipped
- CUDA: `pytest tests/feature/test_loftr.py --runslow --device cuda` -> 4 passed, 3 skipped
- `ruff check` and `ruff format --check` clean

## AI assistance disclosure

This change was developed with AI assistance (Claude). The diagnosis, the patch and this
description were AI-drafted; the CPU and CUDA runs above were executed on my machine and the
numbers are from those runs.
