### PR TITLE
chore(coverage): measure public feature exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,10 @@ omit = [
   "kornia/models/vit.py",
   "kornia/models/vit_mobile.py",
   "kornia/models/tiny_vit.py",
-  # Feature model building blocks (vendored architectures)
-  "kornia/feature/adalam/*",
+  # Feature internals (limited-coverage vendored/adapted code; public entry points stay measured)
+  "kornia/feature/adalam/core.py",
+  "kornia/feature/adalam/ransac.py",
+  "kornia/feature/adalam/utils.py",
   "kornia/feature/dedode/transformer/*",
   "kornia/feature/dedode/dedode_models.py",
   "kornia/feature/dedode/vgg.py",
@@ -122,12 +124,9 @@ omit = [
   "kornia/feature/loftr/backbone/*",
   "kornia/feature/loftr/utils/*",
   "kornia/feature/sold2/backbones.py",
-  "kornia/feature/sold2/sold2_detector.py",
-  "kornia/feature/lightglue.py",
-  "kornia/feature/lightglue_onnx/*",
+  "kornia/feature/lightglue_onnx/utils/*",
   "kornia/feature/aliked/deform_conv2d.py",
   "kornia/feature/disk/_unets/*",
-  "kornia/feature/defmo.py",
   # DexiNed vendored architecture (building blocks only; high-level API in kornia/contrib/edge_detection.py is kept)
   "kornia/filters/dexined.py",
   "kornia/models/dexined.py",


### PR DESCRIPTION
## What does this pull request do?

Fixes #4097.

The coverage omit list currently excludes whole feature subpackages under a `Feature model building blocks (vendored architectures)` comment. That hides five public implementations which are exported from `kornia.feature` and documented as API:

- `LightGlue`
- `OnnxLightGlue`
- `DeFMO`
- `SOLD2_detector`
- `match_adalam`

This narrows the exclusions to the limited-coverage internal files while measuring those five public implementation modules. The change only affects coverage accounting; runtime behavior and test behavior are unchanged.

## Related issue or discussion

Fixes #4097

## What did you check?

- `pixi run toml-fmt-check`
- `pixi run pre-commit-all`
- `pixi run typecheck` (passes; reports the existing `torch.cuda.amp.custom_fwd` deprecation diagnostic)
- CPU feature tests with float32: 626 passed, 81 skipped, 1 warning
- Slow CPU feature tests with float32 and float64: 45 passed and 9 skipped for each dtype
- CPU feature dynamo tests with the inductor optimizer: 6 passed
- A focused run matching the coverage workflow measured the seven newly included files at 82% combined coverage: `LightGlue` 81%, `OnnxLightGlue` 84%, `DeFMO` 84%, `SOLD2_detector` 83%, and `match_adalam` 75% (the two package `__init__.py` files are fully covered)
- Combining that result with the current `main` coverage report projects overall coverage at approximately 86.8%, above the repository `fail_under = 84` threshold
- With a cold weights cache, the weights-backed slow tests may skip and the pessimistic projection is approximately 84.3%; the coverage gate still remains above its threshold

## How did AI help?

OpenAI Codex assisted with reviewing the issue and repository policy, analyzing the coverage data, and running the verification commands. The resulting one-file diff was checked against the issue and the repository's contribution guidance.
