### PR TITLE
fix(geometry): return an empty image for a zero-sized resize output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,6 +569,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The export resolver includes implicit submodule bindings and rejects unsupported dynamic binding expressions
   as evidence of removal. Deprecation windows and release notes still apply. (#4190, #4230)
 
+* `resize` and `rescale` return an empty image for a zero-sized output instead of raising
+  `ZeroDivisionError` out of the scale-factor computation (#4115). `resize(x, (0, 4))`, `resize(x, 0)`,
+  `Resize((0, 4))`, and any `rescale` factor that takes a side to zero (`rescale(x, 0.0)`) previously died
+  in `h / size[0]`; they now return an empty tensor of the requested shape, which is the answer
+  `warp_affine`, `warp_perspective` and `center_crop` already gave for the same request. The empty result
+  stays connected to the autograd graph, the way `_empty_warp_output_2d` builds it for the warping ops, so
+  a batch element that degenerates to a zero-sized output still contributes a zero gradient rather than
+  detaching.
+
+  A degenerate *input* is a different question and is now rejected rather than divided by: resizing a
+  `(1, 3, 0, 4)` image to a positive size, or with an `int` size at all -- an `int` names one side and takes
+  the other from an aspect ratio a degenerate input does not have -- raises
+  `ValueError("Input image size must be positive. Got height=0, width=4.")`, the message the warping ops
+  already use, instead of the same bare `ZeroDivisionError`. Empty in and empty out is well defined and
+  still comes back empty. (#4140)
+
 * `validate_bbox` and `validate_bbox3d` flatten rank-4 `(B, N, 4, 2)` / `(B, N, 8, 3)` input with `reshape`
   instead of `view`, so a non-contiguous leading-dimension stride (a transpose, a slice that drops boxes, an
   `expand`) returns a boolean as documented instead of raising `RuntimeError`. (#4174)

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -636,12 +636,13 @@ def resize(
 
     original_shape = input.shape
     h, w = input.shape[-2:]
-    if h <= 0 or w <= 0:
-        # Reject a degenerate input the way the warping ops do, rather than letting the
-        # aspect-ratio division below fail with a bare ZeroDivisionError.
-        raise ValueError(f"Input image size must be positive. Got height={h}, width={w}.")
 
     if isinstance(size, int):
+        if h <= 0 or w <= 0:
+            # An int size names one side and takes the other from the aspect ratio, which a
+            # degenerate input does not have. Reject it with the message the warping ops use,
+            # rather than letting the division below fail with a bare ZeroDivisionError.
+            raise ValueError(f"Input image size must be positive. Got height={h}, width={w}.")
         aspect_ratio = w / h
         size = _side_to_image_size(size, aspect_ratio, side)
     if len(original_shape) == 2:
@@ -659,10 +660,18 @@ def resize(
 
     if size[0] == 0 or size[1] == 0:
         # An output side of zero gives an empty image, matching warp_affine,
-        # warp_perspective and center_crop. The result is built directly: the scale
-        # factors below would divide by zero, and torch.nn.functional.interpolate
-        # rejects a zero-sized output outright.
-        output = input.new_empty((*input.shape[:-2], size[0], size[1]))
+        # warp_perspective and center_crop -- including when the input is empty as well,
+        # which is why this runs ahead of the positive-size check below. The result is
+        # built directly: the scale factors would divide by zero, and
+        # torch.nn.functional.interpolate rejects a zero-sized output outright.
+        #
+        # It is routed through the input so the empty result keeps its autograd link, the
+        # way _empty_warp_output_2d does for the warping ops. sum() promotes an integer
+        # input to int64, so the accumulation dtype is pinned to the input's.
+        zero = input.reshape(-1)[:1].sum(dtype=input.dtype) * 0
+        output = zero.reshape(*([1] * input.dim())).expand(*input.shape[:-2], size[0], size[1])
+    elif h <= 0 or w <= 0:
+        raise ValueError(f"Input image size must be positive. Got height={h}, width={w}.")
     else:
         factors = (h / size[0], w / size[1])
         antialias = antialias and (max(factors) > 1)

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -636,6 +636,11 @@ def resize(
 
     original_shape = input.shape
     h, w = input.shape[-2:]
+    if h <= 0 or w <= 0:
+        # Reject a degenerate input the way the warping ops do, rather than letting the
+        # aspect-ratio division below fail with a bare ZeroDivisionError.
+        raise ValueError(f"Input image size must be positive. Got height={h}, width={w}.")
+
     if isinstance(size, int):
         aspect_ratio = w / h
         size = _side_to_image_size(size, aspect_ratio, side)
@@ -652,19 +657,26 @@ def resize(
             batch_size *= d
         input = input.reshape(batch_size, *original_shape[-3:])
 
-    factors = (h / size[0], w / size[1])
-    antialias = antialias and (max(factors) > 1)
+    if size[0] == 0 or size[1] == 0:
+        # An output side of zero gives an empty image, matching warp_affine,
+        # warp_perspective and center_crop. The result is built directly: the scale
+        # factors below would divide by zero, and torch.nn.functional.interpolate
+        # rejects a zero-sized output outright.
+        output = input.new_empty((*input.shape[:-2], size[0], size[1]))
+    else:
+        factors = (h / size[0], w / size[1])
+        antialias = antialias and (max(factors) > 1)
 
-    if antialias:
-        sigmas = (max((factors[0] - 1.0) / 2.0, 0.001), max((factors[1] - 1.0) / 2.0, 0.001))
+        if antialias:
+            sigmas = (max((factors[0] - 1.0) / 2.0, 0.001), max((factors[1] - 1.0) / 2.0, 0.001))
 
-        ks = int(max(2.0 * 2 * sigmas[0], 3)), int(max(2.0 * 2 * sigmas[1], 3))
+            ks = int(max(2.0 * 2 * sigmas[0], 3)), int(max(2.0 * 2 * sigmas[1], 3))
 
-        ks = (ks[0] if ks[0] % 2 else ks[0] + 1, ks[1] if ks[1] % 2 else ks[1] + 1)
+            ks = (ks[0] if ks[0] % 2 else ks[0] + 1, ks[1] if ks[1] % 2 else ks[1] + 1)
 
-        input = gaussian_blur2d(input, ks, sigmas)
+            input = gaussian_blur2d(input, ks, sigmas)
 
-    output = torch.nn.functional.interpolate(input, size=size, mode=interpolation, align_corners=align_corners)
+        output = torch.nn.functional.interpolate(input, size=size, mode=interpolation, align_corners=align_corners)
 
     if len(original_shape) == 2:
         output = output[0, 0]

--- a/tests/geometry/transform/test_affine.py
+++ b/tests/geometry/transform/test_affine.py
@@ -84,6 +84,44 @@ class TestResize(BaseTester):
         out = kornia.geometry.transform.resize(inp, (3, 1), align_corners=False)
         assert out.shape == (1, 2, 3, 2, 1, 3, 3, 1)
 
+    def test_zero_output_size(self, device, dtype):
+        # A zero output side gives an empty image, matching warp_affine,
+        # warp_perspective and center_crop on the same argument.
+        inp = torch.rand(1, 3, 4, 4, device=device, dtype=dtype)
+
+        assert kornia.geometry.transform.resize(inp, (0, 4)).shape == (1, 3, 0, 4)
+        assert kornia.geometry.transform.resize(inp, (4, 0)).shape == (1, 3, 4, 0)
+        assert kornia.geometry.transform.resize(inp, (0, 0)).shape == (1, 3, 0, 0)
+        assert kornia.geometry.transform.resize(inp, 0).shape == (1, 3, 0, 0)
+        assert kornia.geometry.transform.Resize((0, 4))(inp).shape == (1, 3, 0, 4)
+        assert kornia.geometry.transform.resize(inp, (0, 4), antialias=True).shape == (1, 3, 0, 4)
+
+        eye = torch.eye(2, 3, device=device, dtype=dtype)[None]
+        assert kornia.geometry.transform.warp_affine(inp, eye, (0, 4)).shape == (1, 3, 0, 4)
+
+        # 2D
+        inp_2d = torch.rand(4, 4, device=device, dtype=dtype)
+        assert kornia.geometry.transform.resize(inp_2d, (0, 4)).shape == (0, 4)
+
+        # 3D
+        inp_3d = torch.rand(3, 4, 4, device=device, dtype=dtype)
+        assert kornia.geometry.transform.resize(inp_3d, (0, 4)).shape == (3, 0, 4)
+
+        # arbitrary dim
+        inp_nd = torch.rand(2, 1, 3, 4, 4, device=device, dtype=dtype)
+        assert kornia.geometry.transform.resize(inp_nd, (0, 4)).shape == (2, 1, 3, 0, 4)
+
+    def test_zero_input_size(self, device, dtype):
+        # A degenerate input is rejected with the message the warping ops already
+        # use, instead of a bare ZeroDivisionError out of the aspect-ratio division.
+        inp = torch.rand(1, 3, 0, 4, device=device, dtype=dtype)
+
+        with pytest.raises(ValueError, match="Input image size must be positive"):
+            kornia.geometry.transform.resize(inp, (2, 2))
+
+        with pytest.raises(ValueError, match="Input image size must be positive"):
+            kornia.geometry.transform.resize(inp, 2)
+
     def test_downsizeAA(self, device, dtype):
         inp = torch.rand(1, 3, 10, 8, device=device, dtype=dtype)
         out = kornia.geometry.transform.resize(inp, (5, 3), align_corners=False, antialias=True)
@@ -256,6 +294,15 @@ class TestRescale(BaseTester):
         input = torch.rand(1, 3, 9, 8, device=device, dtype=dtype)
         output = kornia.geometry.transform.rescale(input, (1.0 / 3.0, 1.0 / 2.0), align_corners=False)
         assert output.shape == (1, 3, 3, 4)
+
+    def test_zero_factor(self, device, dtype):
+        # A zero factor asks for a zero-sized output, which gives an empty image
+        # rather than a ZeroDivisionError.
+        inp = torch.rand(1, 3, 4, 4, device=device, dtype=dtype)
+
+        assert kornia.geometry.transform.rescale(inp, 0.0).shape == (1, 3, 0, 0)
+        assert kornia.geometry.transform.rescale(inp, (0.0, 1.0)).shape == (1, 3, 0, 4)
+        assert kornia.geometry.transform.Rescale(0.0)(inp).shape == (1, 3, 0, 0)
 
     def test_downscale_values(self, device, dtype):
         inp_x = torch.arange(20, device=device, dtype=dtype) / 20.0

--- a/tests/geometry/transform/test_affine.py
+++ b/tests/geometry/transform/test_affine.py
@@ -99,6 +99,16 @@ class TestResize(BaseTester):
         eye = torch.eye(2, 3, device=device, dtype=dtype)[None]
         assert kornia.geometry.transform.warp_affine(inp, eye, (0, 4)).shape == (1, 3, 0, 4)
 
+        # The empty result stays attached to the graph, as it does for the warping ops:
+        # _empty_warp_output_2d builds a connected tensor precisely so a batch that
+        # degenerates to a zero-sized output still contributes a zero gradient.
+        grad_inp = torch.rand(1, 3, 4, 4, device=device, dtype=dtype, requires_grad=True)
+        empty = kornia.geometry.transform.resize(grad_inp, (0, 4))
+        assert empty.requires_grad
+        assert empty.dtype == grad_inp.dtype
+        empty.sum().backward()
+        assert grad_inp.grad is not None
+
         # 2D
         inp_2d = torch.rand(4, 4, device=device, dtype=dtype)
         assert kornia.geometry.transform.resize(inp_2d, (0, 4)).shape == (0, 4)
@@ -121,6 +131,15 @@ class TestResize(BaseTester):
 
         with pytest.raises(ValueError, match="Input image size must be positive"):
             kornia.geometry.transform.resize(inp, 2)
+
+        # Empty in and empty out is not undefined, so it comes back empty rather than
+        # raising -- the same answer warp_affine and center_crop give.
+        assert kornia.geometry.transform.resize(inp, (0, 4)).shape == (1, 3, 0, 4)
+        assert kornia.geometry.transform.resize(inp, (0, 2)).shape == (1, 3, 0, 2)
+
+        eye = torch.eye(2, 3, device=device, dtype=dtype)[None]
+        assert kornia.geometry.transform.warp_affine(inp, eye, (0, 4)).shape == (1, 3, 0, 4)
+        assert kornia.geometry.transform.center_crop(inp, (0, 4)).shape == (1, 3, 0, 4)
 
     def test_downsizeAA(self, device, dtype):
         inp = torch.rand(1, 3, 10, 8, device=device, dtype=dtype)


### PR DESCRIPTION
## What does this pull request do?

`resize`, `rescale`, `Resize` and `Rescale` raised a bare `ZeroDivisionError` when the requested output size had a zero side, while `warp_affine`, `warp_perspective` and `center_crop` return a correspondingly empty image for that same argument.

The zero-sized output is now short-circuited and the empty result built directly. It cannot come out of the normal path: the antialias scale factors divide by the requested side, and `torch.nn.functional.interpolate` rejects a zero-sized output outright with `RuntimeError: Input and output sizes should be greater than 0`.

The same function had a second gap on the other side of the argument. A zero-sized *input* leaked a `ZeroDivisionError` out of `aspect_ratio = w / h`, or a `RuntimeError` out of `interpolate`, where `warp_affine` and `center_crop` raise `ValueError: Input image size must be positive.`. `resize` now raises that same error up front. This half is not in the report, so it is easy to drop if you would rather keep the PR to exactly the reported case — it is the `h <= 0 or w <= 0` guard and `TestResize::test_zero_input_size`.

`rescale`, `Resize` and `Rescale` all delegate to `resize`, so the one change covers the six call paths in the issue.

This follows the convention @ducha-aiki stated in #4056 — *empty in → empty out, with validation parity* — so a zero output side returns an empty image rather than raising, and the input side is validated rather than left to a downstream error.

## Related issue or discussion

Fixes #4115

## What did you check?

Behaviour on `torch.rand(1, 3, 4, 4)`, measured before and after:

| call | before | after | reference op, same argument |
|---|---|---|---|
| `resize(img, (0, 4))` | `ZeroDivisionError` | `(1, 3, 0, 4)` | `warp_affine(img, eye, (0, 4))` → `(1, 3, 0, 4)` |
| `resize(img, (4, 0))` | `ZeroDivisionError` | `(1, 3, 4, 0)` | |
| `resize(img, (0, 0))` | `ZeroDivisionError` | `(1, 3, 0, 0)` | |
| `resize(img, 0)` | `ZeroDivisionError` | `(1, 3, 0, 0)` | |
| `rescale(img, 0.0)` | `ZeroDivisionError` | `(1, 3, 0, 0)` | |
| `Resize((0, 4))(img)` | `ZeroDivisionError` | `(1, 3, 0, 4)` | |
| `Rescale(0.0)(img)` | `ZeroDivisionError` | `(1, 3, 0, 0)` | |
| `resize(empty_hw, (2, 2))` | `RuntimeError` from `interpolate` | `ValueError: Input image size must be positive.` | `warp_affine` raises the same |
| `resize(empty_hw, 2)` | `ZeroDivisionError` | `ValueError: Input image size must be positive.` | `center_crop` raises the same |

Leading dimensions are preserved: `(4, 4)` → `(0, 4)`, `(3, 4, 4)` → `(3, 0, 4)`, `(2, 1, 3, 4, 4)` → `(2, 1, 3, 0, 4)`.

Valid inputs are untouched. A/B sweep of `resize` and `rescale` over 4 input shapes × float32/float64 × 6 output sizes × antialias on/off × 4 interpolation modes, plus the integer-`size` form over all four `side` values — comparing output shape and sum against this branch's base revision:

```text
combinations (float32 + float64): 512   differing: 0
```

Both halves of that sweep ran from the repository root as stdin and printed `kornia.__file__` (`/root/kornia/kornia/__init__.py`) to confirm each half measured the tree it was meant to.

```text
$ pytest tests/geometry/transform/test_affine.py --dtype=float32,float64
97 passed, 10 skipped

$ pytest tests/geometry/transform/
520 passed, 15 skipped, 1 xfailed

$ ruff check kornia/geometry/transform/affwarp.py tests/geometry/transform/test_affine.py
All checks passed!
$ ruff format --check <same files>
2 files already formatted
```

New tests: `TestResize::test_zero_output_size`, `TestResize::test_zero_input_size`, `TestRescale::test_zero_factor`. The first asserts against `warp_affine` on the same argument, so the two stay pinned together.

`grep -rnE "#4115|issues/4115" kornia/ tests/` returns nothing, so there is no inline defect note to retire with this change.

I did not run `pixi run pre-commit-all` or `pixi run typecheck` — I worked in a plain venv rather than a Pixi environment, so those two are worth a look in CI.

## How did AI help?

AI (Claude Code) wrote the patch and the tests, ran the A/B sweep, and drafted this description. I reviewed every line, and the measurements above are from runs on my own machine. The one judgement call I would flag for you rather than claim as settled is the zero-sized-input half described above, since the issue only asks for the output half.
