### PR TITLE
test: make half precision references backend-safe

### DIFF
--- a/tests/feature/test_laf.py
+++ b/tests/feature/test_laf.py
@@ -1528,20 +1528,54 @@ class TestTransformLAFs(BaseTester):
     @pytest.mark.parametrize("batch_size", [1, 2, 5])
     @pytest.mark.parametrize("num_points", [2, 3, 5])
     def test_transform_points(self, batch_size, num_points, device, dtype):
-        # generate input data
-        eye_size = 3
-        lafs_src = torch.rand(batch_size, num_points, 2, 3, device=device, dtype=dtype)
+        laf_bank = torch.tensor(
+            [[[0.4, 0.1, 1.0], [-0.2, 0.3, 2.0]], [[-0.3, 0.2, -1.0], [0.1, 0.5, 0.5]]],
+            device=device,
+            dtype=dtype,
+        )
+        homography_bank = torch.tensor(
+            [
+                [[1.2, 0.1, 0.5], [-0.2, 0.9, 0.3], [0.02, -0.01, 1.0]],
+                [[0.8, -0.15, -0.2], [0.05, 1.1, 0.4], [-0.015, 0.025, 1.0]],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        # Closed-form projection of the two LAFs by the two homographies, generated in float64:
+        # p' = (H[:2, :2] @ p + H[:2, 2]) / (H[2, :2] @ p + H[2, 2]).
+        expected_bank = torch.tensor(
+            [
+                [
+                    [[0.4366336634, 0.1520520521, 1.9], [-0.2762376238, 0.2521521522, 1.9]],
+                    [
+                        [-0.3663911846, 0.2970568104, -0.6666666667],
+                        [0.1620046620, 0.4219449271, 0.9743589744],
+                    ],
+                ],
+                [
+                    [
+                        [0.3449105525, 0.0319508833, 0.2898550725],
+                        [-0.1678083484, 0.3070486851, 2.5603864734],
+                    ],
+                    [
+                        [-0.2394165288, 0.0915517577, -1.0462287105],
+                        [0.0859048943, 0.5319950165, 0.8759124088],
+                    ],
+                ],
+            ],
+            device=device,
+            dtype=dtype,
+        )
+        batch_indices = torch.arange(batch_size, device=device) % len(homography_bank)
+        point_indices = torch.arange(num_points, device=device) % len(laf_bank)
+        lafs_src = laf_bank[point_indices].unsqueeze(0).expand(batch_size, -1, -1, -1)
+        dst_homo_src = homography_bank[batch_indices]
+        expected = expected_bank[batch_indices[:, None], point_indices[None, :]]
 
-        dst_homo_src = create_random_homography(lafs_src, eye_size)
-        # transform the points from dst to ref
-        lafs_dst = kornia.feature.perspective_transform_lafs(dst_homo_src, lafs_src)
+        actual = kornia.feature.perspective_transform_lafs(dst_homo_src, lafs_src)
 
-        # transform the points from ref to dst
-        src_homo_dst = torch.inverse(dst_homo_src)
-        lafs_dst_to_src = kornia.feature.perspective_transform_lafs(src_homo_dst, lafs_dst)
-
-        # projected should be equal as initial
-        self.assert_close(lafs_src, lafs_dst_to_src)
+        half_tolerance = 3 * torch.finfo(dtype).eps if dtype in (torch.float16, torch.bfloat16) else None
+        self.assert_close(actual, expected, atol=half_tolerance, rtol=half_tolerance)
 
     def test_gradcheck(self, device):
         # generate input data

--- a/tests/filters/test_bilateral.py
+++ b/tests/filters/test_bilateral.py
@@ -31,15 +31,15 @@ class TestBilateralBlur(BaseTester):
         inp = torch.zeros(shape, device=device, dtype=dtype)
 
         # tensor sigmas -> with batch dim
-        sigma_color = torch.rand(shape[0], device=device, dtype=dtype)
-        sigma_space = torch.rand(shape[0], 2, device=device, dtype=dtype)
+        sigma_color = torch.linspace(0.5, 1.0, shape[0], device=device, dtype=dtype)
+        sigma_space = torch.stack((sigma_color + 0.5, sigma_color + 1.0), dim=-1)
         actual_A = bilateral_blur(inp, kernel_size, sigma_color, sigma_space, "reflect", color_distance_type)
         assert isinstance(actual_A, torch.Tensor)
         assert actual_A.shape == shape
 
         # float and tuple sigmas -> same sigmas across batch
         sigma_color_ = sigma_color[0].item()
-        sigma_space_ = tuple(sigma_space[0].cpu().numpy())
+        sigma_space_ = tuple(sigma_space[0].tolist())
         actual_B = bilateral_blur(inp, kernel_size, sigma_color_, sigma_space_, "reflect", color_distance_type)
         assert isinstance(actual_B, torch.Tensor)
         assert actual_B.shape == shape

--- a/tests/filters/test_gaussian.py
+++ b/tests/filters/test_gaussian.py
@@ -219,13 +219,13 @@ class TestGaussianBlur2d(BaseTester):
     def test_smoke(self, shape, kernel_size, separable, device, dtype):
         B, C, H, W = shape
         data = torch.rand(B, C, H, W, device=device, dtype=dtype)
-        sigma_tensor = torch.rand(B, 2, device=device, dtype=dtype)
+        sigma_tensor = torch.rand(B, 2, device=device, dtype=dtype) + 0.1
 
         actual_A = gaussian_blur2d(data, kernel_size, sigma_tensor, "reflect", separable)
         assert isinstance(actual_A, torch.Tensor)
         assert actual_A.shape == shape
 
-        sigma = tuple(sigma_tensor[0, ...].cpu().numpy().tolist())
+        sigma = tuple(sigma_tensor[0, ...].tolist())
         actual_B = gaussian_blur2d(data, kernel_size, sigma, "reflect", separable)
         assert isinstance(actual_B, torch.Tensor)
         assert actual_B.shape == shape

--- a/tests/geometry/liegroup/test_se3.py
+++ b/tests/geometry/liegroup/test_se3.py
@@ -292,12 +292,17 @@ class TestSe3(BaseTester):
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_adjoint(self, device, dtype, batch_size):
-        x_data = self._make_rand_data(device, dtype, batch_size, dims=6)
-        y_data = self._make_rand_data(device, dtype, batch_size, dims=6)
+        shape = (6,) if batch_size is None else (batch_size, 6)
+        x_data = torch.tensor([0.1, -0.2, 0.3, 0.2, -0.1, 0.1], device=device, dtype=dtype).expand(shape)
+        y_data = torch.tensor([-0.2, 0.1, 0.2, -0.1, 0.2, 0.1], device=device, dtype=dtype).expand(shape)
         x = Se3.exp(x_data)
         y = Se3.exp(y_data)
-        self.assert_close(x.inverse().adjoint(), x.adjoint().inverse())
-        self.assert_close((x * y).adjoint(), x.adjoint() @ y.adjoint())
+        adjoint = x.adjoint()
+        inverse_adjoint = x.inverse().adjoint()
+        identity = torch.eye(adjoint.shape[-1], device=device, dtype=dtype).expand_as(adjoint)
+        half_tolerance = torch.finfo(dtype).eps if dtype in (torch.float16, torch.bfloat16) else None
+        self.assert_close(adjoint @ inverse_adjoint, identity, rtol=half_tolerance, atol=half_tolerance)
+        self.assert_close((x * y).adjoint(), adjoint @ y.adjoint(), rtol=half_tolerance, atol=half_tolerance)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_random(self, device, dtype, batch_size):

--- a/tests/geometry/liegroup/test_so3.py
+++ b/tests/geometry/liegroup/test_so3.py
@@ -248,12 +248,15 @@ class TestSo3(BaseTester):
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_adjoint(self, device, dtype, batch_size):
-        q1 = Quaternion.random(batch_size, device, dtype)
-        q2 = Quaternion.random(batch_size, device, dtype)
-        x = So3(q1)
-        y = So3(q2)
-        self.assert_close(x.inverse().adjoint(), x.adjoint().inverse())
-        self.assert_close((x * y).adjoint(), x.adjoint() @ y.adjoint())
+        shape = (3,) if batch_size is None else (batch_size, 3)
+        x = So3.exp(torch.tensor([0.1, -0.2, 0.3], device=device, dtype=dtype).expand(shape))
+        y = So3.exp(torch.tensor([-0.3, 0.1, 0.2], device=device, dtype=dtype).expand(shape))
+        adjoint = x.adjoint()
+        inverse_adjoint = x.inverse().adjoint()
+        identity = torch.eye(adjoint.shape[-1], device=device, dtype=dtype).expand_as(adjoint)
+        half_tolerance = torch.finfo(dtype).eps if dtype in (torch.float16, torch.bfloat16) else None
+        self.assert_close(adjoint @ inverse_adjoint, identity, rtol=half_tolerance, atol=half_tolerance)
+        self.assert_close((x * y).adjoint(), adjoint @ y.adjoint(), rtol=half_tolerance, atol=half_tolerance)
 
     @pytest.mark.parametrize("batch_size", (None, 1, 2, 5))
     def test_random(self, device, dtype, batch_size):

--- a/tests/geometry/test_grid.py
+++ b/tests/geometry/test_grid.py
@@ -41,14 +41,16 @@ def test_create_meshgrid(device, dtype):
     assert grid.shape == (1, height, width, 2)
 
     # check grid corner values
-    assert tuple(grid[0, 0, 0].cpu().numpy()) == (0.0, 0.0)
-    assert tuple(grid[0, height - 1, width - 1].cpu().numpy()) == (width - 1, height - 1)
+    assert_close(grid[0, 0, 0], torch.tensor((0.0, 0.0), device=device, dtype=dtype), atol=0.0, rtol=0.0)
+    assert_close(
+        grid[0, height - 1, width - 1],
+        torch.tensor((width - 1, height - 1), device=device, dtype=dtype),
+        atol=0.0,
+        rtol=0.0,
+    )
 
 
 def test_normalize_pixel_grid(device, dtype):
-    if device.type == "cuda" and dtype == torch.float16:
-        pytest.skip('"inverse_cuda" not implemented for "Half"')
-
     # generate input data
     height, width = 2, 4
 
@@ -69,7 +71,7 @@ def test_normalize_pixel_grid(device, dtype):
     norm_trans_pix = kornia.geometry.conversions.normal_transform_pixel(
         height, width, device=device, dtype=dtype
     )  # 1x3x3
-    pix_trans_norm = torch.inverse(norm_trans_pix)  # 1x3x3
+    pix_trans_norm = torch.tensor([[[1.5, 0.0, 1.5], [0.0, 0.5, 0.5], [0.0, 0.0, 1.0]]], device=device, dtype=dtype)
     # transform grids
     grid_pix_to_norm = kornia.geometry.linalg.transform_points(norm_trans_pix, grid_pix)
     grid_norm_to_pix = kornia.geometry.linalg.transform_points(pix_trans_norm, grid_norm)
@@ -307,8 +309,13 @@ def test_create_meshgrid3d(device, dtype):
     assert grid.shape == (1, depth, height, width, 3)
 
     # check grid corner values
-    assert tuple(grid[0, 0, 0, 0].cpu().numpy()) == (0.0, 0.0, 0.0)
-    assert tuple(grid[0, depth - 1, height - 1, width - 1].cpu().numpy()) == (depth - 1, width - 1, height - 1)
+    assert_close(grid[0, 0, 0, 0], torch.tensor((0.0, 0.0, 0.0), device=device, dtype=dtype), atol=0.0, rtol=0.0)
+    assert_close(
+        grid[0, depth - 1, height - 1, width - 1],
+        torch.tensor((depth - 1, width - 1, height - 1), device=device, dtype=dtype),
+        atol=0.0,
+        rtol=0.0,
+    )
 
 
 @pytest.mark.parametrize(("depth", "height", "width", "axis"), [(1, 4, 6, 0), (5, 1, 6, 2), (5, 4, 1, 1)])

--- a/tests/geometry/test_linalg.py
+++ b/tests/geometry/test_linalg.py
@@ -32,23 +32,26 @@ class TestTransformPoints(BaseTester):
     @pytest.mark.parametrize("num_points", [2, 3, 5])
     @pytest.mark.parametrize("num_dims", [2, 3])
     def test_transform_points(self, batch_size, num_points, num_dims, device, dtype):
-        # generate input data
-        eye_size = num_dims + 1
-        points_src = torch.rand(batch_size, num_points, num_dims, device=device, dtype=dtype)
+        points_src = (
+            torch.arange(batch_size * num_points * num_dims, device=device)
+            .remainder(5)
+            .to(dtype)
+            .reshape(batch_size, num_points, num_dims)
+            - 2
+        ) / 2
+        scale = torch.arange(2, num_dims + 2, device=device).to(dtype)
+        translation = torch.arange(-1, num_dims - 1, device=device).to(dtype)
+        dst_homo_src = torch.eye(num_dims + 1, device=device, dtype=dtype).expand(batch_size, -1, -1).clone()
+        dst_homo_src[:, :num_dims, :num_dims] = torch.diag(scale)
+        dst_homo_src[:, :num_dims, -1] = translation
+        perspective = torch.arange(1, batch_size + 1, device=device).to(dtype) * 0.1
+        dst_homo_src[:, -1, 0] = perspective
+        denominator = 1 + points_src[..., 0] * perspective[:, None]
+        expected = (points_src * scale + translation) / denominator.unsqueeze(-1)
 
-        dst_homo_src = create_random_homography(points_src, eye_size)
-        dst_homo_src = dst_homo_src.to(device)
+        actual = kgl.transform_points(dst_homo_src, points_src)
 
-        # transform the points from dst to ref
-        points_dst = kgl.transform_points(dst_homo_src, points_src)
-
-        # transform the points from ref to dst
-        src_homo_dst = torch.inverse(dst_homo_src)
-        points_dst_to_src = kgl.transform_points(src_homo_dst, points_dst)
-
-        # projected should be equal as initial
-        atol = 1e-3 if (device.type == "cuda" and dtype == torch.float32) else 1e-4
-        self.assert_close(points_src, points_dst_to_src, atol=atol, rtol=1e-4)
+        self.assert_close(actual, expected)
 
     @pytest.mark.parametrize("num_dims", [2, 3])
     def test_transform_points_empty(self, num_dims, device, dtype):

--- a/tests/geometry/test_ransac.py
+++ b/tests/geometry/test_ransac.py
@@ -423,9 +423,11 @@ class TestRANSACEssential(BaseTester):
         torch.random.manual_seed(0)
         M = torch.rand(4, 3, 3, device=device, dtype=dtype)
         E = project_to_essential(M)
-        sv = torch.linalg.svdvals(E)
+        svd_input = E.float() if E.dtype in (torch.float16, torch.bfloat16) else E
+        sv = torch.linalg.svdvals(svd_input)
         assert torch.all((sv[..., 0] / sv[..., 1] - 1.0).abs() < 1e-2)
-        assert torch.all((sv[..., 2] / sv[..., 0]).abs() < 1e-4)
+        zero_tolerance = max(1e-4, torch.finfo(E.dtype).eps)
+        assert torch.all((sv[..., 2] / sv[..., 0]).abs() < zero_tolerance)
 
     @pytest.mark.skip(reason="try except block in python version")
     def test_jit(self, device, dtype):


### PR DESCRIPTION
## Summary

- replace test-side inverse operations with analytic projective expectations and Lie-group identities
- avoid unsupported NumPy conversions for BF16 and upcast only SVD validation where PyTorch lacks half support
- use deterministic, non-degenerate reduced-precision fixtures while preserving projective and batching coverage

Closes #4137

## Test plan

- [x] `pixi run pre-commit-all`
- [x] affected tests on CPU with float16, bfloat16, float32, and float64 (236 passed)
- [x] affected tests on CUDA with isolated float16 and bfloat16 subprocesses (118 passed)