### PR TITLE
test: speed up VisualPrompter and SAM3 coverage

### DIFF
--- a/tests/contrib/test_visual_prompter.py
+++ b/tests/contrib/test_visual_prompter.py
@@ -19,17 +19,40 @@ import pytest
 import torch
 
 from kornia.contrib.visual_prompter import VisualPrompter
+from kornia.models.sam import Sam, SamConfig
 
 from testing.base import BaseTester
 
 
 class TestVisualPrompter(BaseTester):
+    def test_default_config(self, monkeypatch):
+        captured_configs = []
+
+        class FakeSam:
+            image_encoder = type("ImageEncoder", (), {"img_size": 1024})()
+
+            def to(self, **kwargs):
+                return self
+
+        def fake_from_config(config):
+            captured_configs.append(config)
+            return FakeSam()
+
+        monkeypatch.setattr(Sam, "from_config", staticmethod(fake_from_config))
+
+        prompter = VisualPrompter()
+
+        assert prompter is not None
+        assert len(captured_configs) == 1
+        assert captured_configs[0].model_type == "vit_h"
+        assert captured_configs[0].pretrained is True
+
     @pytest.mark.slow
     def test_smoke(self, device, dtype):
         if dtype not in (torch.float32, torch.float16):
             pytest.skip("VisualPrompter (SAM) primarily supports float32 and float16")
 
-        prompter = VisualPrompter(device=device, dtype=dtype)
+        prompter = VisualPrompter(SamConfig("mobile_sam"), device=device, dtype=dtype)
         assert prompter is not None
         assert not prompter.is_image_set
 
@@ -37,7 +60,7 @@ class TestVisualPrompter(BaseTester):
     def test_batching_pipeline(self, device, dtype):
         if dtype not in (torch.float32, torch.float16):
             pytest.skip("VisualPrompter (SAM) primarily supports float32 and float16")
-        prompter = VisualPrompter(device=device, dtype=dtype)
+        prompter = VisualPrompter(SamConfig("mobile_sam"), device=device, dtype=dtype)
 
         batch_size = 2
         image = torch.rand(batch_size, 3, 256, 256).to(device=device, dtype=dtype)
@@ -55,14 +78,6 @@ class TestVisualPrompter(BaseTester):
         results = prompter.predict(boxes=boxes_tensor)
 
         assert results.logits.shape == (batch_size, 3, 256, 256)
-
-    def test_exception(self, device, dtype):
-
-        prompter = VisualPrompter(device=device, dtype=dtype)
-
-        image = torch.rand(1, 2, 3, 256, 256).to(device=device, dtype=dtype)
-        with pytest.raises(Exception):
-            prompter.set_image(image)
 
     def test_gradcheck(self, device):
         pytest.skip("Gradcheck is not currently applicable for VisualPrompter inference.")

--- a/tests/contrib/test_visual_prompter.py
+++ b/tests/contrib/test_visual_prompter.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -29,7 +31,7 @@ class TestVisualPrompter(BaseTester):
         captured_configs = []
 
         class FakeSam:
-            image_encoder = type("ImageEncoder", (), {"img_size": 1024})()
+            image_encoder = SimpleNamespace(img_size=1024)
 
             def to(self, **kwargs):
                 return self
@@ -42,12 +44,11 @@ class TestVisualPrompter(BaseTester):
 
         prompter = VisualPrompter()
 
-        assert prompter is not None
+        assert prompter.model.image_encoder.img_size == 1024
         assert len(captured_configs) == 1
         assert captured_configs[0].model_type == "vit_h"
         assert captured_configs[0].pretrained is True
 
-    @pytest.mark.slow
     def test_smoke(self, device, dtype):
         if dtype not in (torch.float32, torch.float16):
             pytest.skip("VisualPrompter (SAM) primarily supports float32 and float16")

--- a/tests/models/sam3/test_sam3_architecture.py
+++ b/tests/models/sam3/test_sam3_architecture.py
@@ -67,7 +67,7 @@ class TestSam3Common(BaseTester):
 class TestImageEncoderHiera(BaseTester):
     """Test ImageEncoderHiera architecture."""
 
-    @pytest.mark.parametrize("img_size,embed_dim", [(512, 128), (1024, 256)])
+    @pytest.mark.parametrize("img_size,embed_dim", [(256, 128), (512, 256)])
     def test_image_encoder_hiera_smoke(self, device: str, img_size: int, embed_dim: int) -> None:
         """Test ImageEncoderHiera basic functionality with different configs."""
         patch_size = 16
@@ -91,16 +91,16 @@ class TestImageEncoderHiera(BaseTester):
     def test_image_encoder_hiera_cardinality(self, device: str, batch_size: int) -> None:
         """Test ImageEncoderHiera output cardinality with different batch sizes."""
         encoder = ImageEncoderHiera(
-            img_size=512,
+            img_size=256,
             patch_size=16,
-            embed_dim=256,
+            embed_dim=128,
             depth=2,
-            num_heads=8,
+            num_heads=4,
         ).to(device)
 
-        x = torch.randn(batch_size, 3, 512, 512, device=device)
+        x = torch.randn(batch_size, 3, 256, 256, device=device)
         features = encoder(x)
-        assert features.shape == (batch_size, (512 // 16) ** 2, 256)
+        assert features.shape == (batch_size, (256 // 16) ** 2, 128)
 
     def test_image_encoder_hiera_output_shape(self) -> None:
         """Test output shape computation method."""


### PR DESCRIPTION
## Summary

- replace pretrained ViT-H construction in `VisualPrompter` coverage with an explicit untrained MobileSAM configuration
- remove the duplicate contrib invalid-shape test; the broader validation test remains in `tests/models/test_prompter.py`
- preserve fast coverage of the public `VisualPrompter()` default with a mocked test that verifies pretrained ViT-H is still requested without building or downloading it
- keep the inexpensive MobileSAM construction smoke test in the default device-parametrized suite, while the batching pipeline remains slow-marked
- reduce the SAM3 forward-test image sizes while retaining both the explicit 1024-by-1024 output-shape contract test and the 1024 forward doctest

No production default or runtime behavior changes.

## Why

In PR #4160's hosted MPS run, `tests/contrib/test_visual_prompter.py::TestVisualPrompter::test_exception` spent 94.62 seconds constructing the default pretrained ViT-H model before checking a malformed input that fails prior to inference. On a cold cache this also attempts to fetch the 2.39 GiB ViT-H checkpoint. This VisualPrompter saving applies broadly, including local runs.

The SAM3 tests do not load weights, but their forward cases used quadratic-attention inputs larger than needed for smoke and batch-cardinality coverage. On GitHub's virtual-M1 runner, the 1024 smoke case took 15.19 seconds and the batch-4 cardinality case took 17.40 seconds; local MPS timings are much smaller, so this part primarily targets hosted-runner wall time. The smaller cases exercise the same paths, while 1024 support remains covered as described above.

## Verification

- focused default CPU run across both files: 20 passed, 3 skipped in 0.58 seconds
- focused default MPS run across both files: 17 passed, 6 skipped in 1.36 seconds
- focused CPU run with slow `VisualPrompter` coverage: 3 passed, 2 skipped in 2.11 seconds
- `pre-commit run --all-files`: passed
- independent review: no blocking findings

The slow MobileSAM batching path also exposes the pre-existing augmentation device mismatch tracked in #4151 (`torch.where` receives an MPS input and a CPU selection tensor). The fix is being handled separately in #4164. This test-only PR intentionally does not alter that production path; CPU pipeline coverage passes, and the normal MPS PR leg skips slow tests.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (gpt-5.6-sol).
