### PR TITLE
test: speed up SigLIP2 coverage

### DIFF
--- a/tests/models/test_siglip2.py
+++ b/tests/models/test_siglip2.py
@@ -17,6 +17,8 @@
 
 """Tests for SigLip2 model."""
 
+from dataclasses import replace
+
 import pytest
 import torch
 
@@ -75,7 +77,7 @@ class TestSigLip2Model(BaseTester):
 
     def test_identity_projections(self, device, dtype, config):
         """Test the default identity projection path with a lightweight model."""
-        config.projection_dim = config.vision_config.hidden_size
+        config = replace(config, projection_dim=config.vision_config.hidden_size)
         model = SigLip2Model(config).to(device, dtype).eval()
         image_size = config.vision_config.image_size
         pixel_values = torch.randn(1, 3, image_size, image_size, device=device, dtype=dtype)
@@ -149,7 +151,7 @@ class TestSigLip2Model(BaseTester):
         assert features.shape == (batch_size, config.projection_dim)
         # Check normalization
         norms = features.norm(dim=-1)
-        self.assert_close(norms, torch.ones_like(norms), rtol=1e-5, atol=1e-5)
+        self.assert_close(norms, torch.ones_like(norms))
 
     def test_get_text_features(self, device, dtype, model, config):
         """Test get_text_features method."""
@@ -166,7 +168,7 @@ class TestSigLip2Model(BaseTester):
         assert torch.isfinite(features).all()
         # Check normalization
         norms = features.norm(dim=-1)
-        self.assert_close(norms, torch.ones_like(norms), rtol=1e-5, atol=1e-5)
+        self.assert_close(norms, torch.ones_like(norms))
 
     def test_attention_mask_handling(self, device, dtype, model, config):
         """Test attention mask handling in text encoder."""
@@ -191,8 +193,6 @@ class TestSigLip2Model(BaseTester):
 
     def test_return_loss(self, device, dtype, model, config):
         """Test forward pass with return_loss=True and verify logit_scale clamping."""
-        import math
-
         batch_size = 2
         image_size = config.vision_config.image_size
         pixel_values = torch.randn(batch_size, 3, image_size, image_size, device=device, dtype=dtype)
@@ -211,9 +211,8 @@ class TestSigLip2Model(BaseTester):
             model.logit_scale.data.fill_(100.0)
             output_max = model(pixel_values=pixel_values, input_ids=input_ids)
             assert torch.isfinite(output_max.logits_per_image).all(), "Max clamp: logits contain non-finite values"
-            assert math.isclose(output_max.logit_scale.item(), config.logit_scale_max, rel_tol=1e-5, abs_tol=1e-5), (
-                f"Max clamp failed: {output_max.logit_scale.item()} != {config.logit_scale_max}"
-            )
+            expected_max = torch.tensor(config.logit_scale_max, device=device, dtype=dtype).log().exp()
+            self.assert_close(output_max.logit_scale, expected_max)
 
             # Test min clamping
             model.logit_scale.data.fill_(-10.0)
@@ -406,15 +405,17 @@ class TestSigLip2Components(BaseTester):
         self.assert_close(output, output_without_mask, **tol)
 
     @pytest.mark.parametrize(
-        ("batch_size", "input_size", "image_size"),
+        ("batch_size", "input_size"),
         [
-            (1, (64, 64), (32, 32)),
-            (2, (48, 64), (32, 32)),
-            (4, (16, 16), (32, 32)),
+            (1, (32, 32)),
+            (1, (64, 64)),
+            (2, (48, 64)),
+            (4, (16, 16)),
         ],
     )
-    def test_image_preprocessor(self, device, dtype, batch_size, input_size, image_size):
+    def test_image_preprocessor(self, device, dtype, batch_size, input_size):
         """Test SigLip2ImagePreprocessor with different configurations."""
+        image_size = (32, 32)
         preprocessor = SigLip2ImagePreprocessor(image_size=image_size).to(device, dtype)
 
         # Test with batch of images (4D tensor)

--- a/tests/models/test_siglip2.py
+++ b/tests/models/test_siglip2.py
@@ -33,7 +33,25 @@ from testing.base import BaseTester
 @pytest.fixture
 def config():
     """Fixture for SigLip2Config."""
-    return SigLip2Config()
+    return SigLip2Config(
+        vision_config=SigLip2VisionConfig(
+            image_size=32,
+            patch_size=4,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=64,
+        ),
+        text_config=SigLip2TextConfig(
+            vocab_size=100,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=64,
+            max_position_embeddings=32,
+        ),
+        projection_dim=16,
+    )
 
 
 @pytest.fixture
@@ -55,10 +73,27 @@ class TestSigLip2Model(BaseTester):
         model = SigLip2Model(config).to(device, dtype)
         assert model is not None
 
+    def test_identity_projections(self, device, dtype, config):
+        """Test the default identity projection path with a lightweight model."""
+        config.projection_dim = config.vision_config.hidden_size
+        model = SigLip2Model(config).to(device, dtype).eval()
+        image_size = config.vision_config.image_size
+        pixel_values = torch.randn(1, 3, image_size, image_size, device=device, dtype=dtype)
+        input_ids = _create_input_ids(1, 10, config, device)
+
+        with torch.no_grad():
+            output = model(pixel_values=pixel_values, input_ids=input_ids)
+
+        assert isinstance(model.vision_projection, torch.nn.Identity)
+        assert isinstance(model.text_projection, torch.nn.Identity)
+        assert output.image_embeds.shape == (1, config.projection_dim)
+        assert output.text_embeds.shape == (1, config.projection_dim)
+
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_cardinality(self, device, dtype, model, config, batch_size):
         """Test output shapes with different inputs and batch sizes."""
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=dtype)
+        image_size = config.vision_config.image_size
+        pixel_values = torch.randn(batch_size, 3, image_size, image_size, device=device, dtype=dtype)
         seq_len = 10
         input_ids = _create_input_ids(batch_size, seq_len, config, device)
 
@@ -86,7 +121,8 @@ class TestSigLip2Model(BaseTester):
         """Test exception handling."""
         # Test invalid pixel_values shape (wrong number of dimensions)
         with pytest.raises((RuntimeError, ValueError, IndexError)):
-            invalid_pixel_values = torch.randn(3, 224, 224, device=device, dtype=dtype)  # Missing batch dimension
+            image_size = config.vision_config.image_size
+            invalid_pixel_values = torch.randn(3, image_size, image_size, device=device, dtype=dtype)
             model.get_image_features(invalid_pixel_values)
 
         # Test invalid attention mask shape
@@ -104,7 +140,8 @@ class TestSigLip2Model(BaseTester):
         """Test get_image_features method."""
 
         batch_size = 2
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=dtype)
+        image_size = config.vision_config.image_size
+        pixel_values = torch.randn(batch_size, 3, image_size, image_size, device=device, dtype=dtype)
 
         with torch.no_grad():
             features = model.get_image_features(pixel_values)
@@ -157,7 +194,8 @@ class TestSigLip2Model(BaseTester):
         import math
 
         batch_size = 2
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=dtype)
+        image_size = config.vision_config.image_size
+        pixel_values = torch.randn(batch_size, 3, image_size, image_size, device=device, dtype=dtype)
         seq_len = 10
         input_ids = _create_input_ids(batch_size, seq_len, config, device)
 
@@ -187,7 +225,10 @@ class TestSigLip2Model(BaseTester):
         # Convert model to float64 for gradcheck
         model = SigLip2Model(config).to(device, torch.float64).train()
         batch_size = 1
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=torch.float64, requires_grad=True)
+        image_size = config.vision_config.image_size
+        pixel_values = torch.randn(
+            batch_size, 3, image_size, image_size, device=device, dtype=torch.float64, requires_grad=True
+        )
         seq_len = 5
         input_ids = _create_input_ids(batch_size, seq_len, config, device).to(torch.int64)
 
@@ -201,7 +242,8 @@ class TestSigLip2Model(BaseTester):
     def test_dynamo(self, device, dtype, torch_optimizer, model, config):
         """Test torch.compile compatibility."""
         batch_size = 1
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=dtype)
+        image_size = config.vision_config.image_size
+        pixel_values = torch.randn(batch_size, 3, image_size, image_size, device=device, dtype=dtype)
         seq_len = 10
         input_ids = _create_input_ids(batch_size, seq_len, config, device)
 
@@ -220,57 +262,67 @@ class TestSigLip2Components(BaseTester):
 
     def test_vision_embeddings(self, device, dtype):
         """Test SigLip2VisionEmbeddings."""
-        config = SigLip2VisionConfig(image_size=224, patch_size=16, hidden_size=768)
+        config = SigLip2VisionConfig(image_size=32, patch_size=4, hidden_size=32)
         embeddings = SigLip2VisionEmbeddings(config).to(device, dtype)
 
         batch_size = 2
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=dtype)
+        pixel_values = torch.randn(batch_size, 3, config.image_size, config.image_size, device=device, dtype=dtype)
 
         with torch.no_grad():
             output = embeddings(pixel_values)
 
-        num_patches = (224 // 16) ** 2
+        num_patches = (config.image_size // config.patch_size) ** 2
         assert output.shape == (batch_size, num_patches, config.hidden_size)
 
     def test_vision_encoder(self, device, dtype):
         """Test SigLip2VisionEncoder."""
         config = SigLip2VisionConfig(
-            image_size=224, patch_size=16, hidden_size=768, num_hidden_layers=2, num_attention_heads=12
+            image_size=32,
+            patch_size=4,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=64,
         )
         encoder = SigLip2VisionEncoder(config).to(device, dtype)
         embeddings = SigLip2VisionEmbeddings(config).to(device, dtype)
 
         batch_size = 2
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=dtype)
+        pixel_values = torch.randn(batch_size, 3, config.image_size, config.image_size, device=device, dtype=dtype)
 
         with torch.no_grad():
             # Encoder expects embeddings, not raw pixel values
             hidden_states = embeddings(pixel_values)
             output = encoder(hidden_states)
 
-        num_patches = (224 // 16) ** 2
+        num_patches = (config.image_size // config.patch_size) ** 2
         assert output[0].shape == (batch_size, num_patches, config.hidden_size)
 
     def test_vision_model(self, device, dtype):
         """Test SigLip2VisionModel."""
         config = SigLip2VisionConfig(
-            image_size=224, patch_size=16, hidden_size=768, num_hidden_layers=2, num_attention_heads=12
+            image_size=32,
+            patch_size=4,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=64,
         )
         model = SigLip2VisionModel(config).to(device, dtype)
 
         batch_size = 2
-        pixel_values = torch.randn(batch_size, 3, 224, 224, device=device, dtype=dtype)
+        pixel_values = torch.randn(batch_size, 3, config.image_size, config.image_size, device=device, dtype=dtype)
 
         with torch.no_grad():
             pooled_output, last_hidden_state = model(pixel_values)
 
         assert pooled_output.shape == (batch_size, config.hidden_size)
-        num_patches = (224 // 16) ** 2
+        num_patches = (config.image_size // config.patch_size) ** 2
         assert last_hidden_state.shape == (batch_size, num_patches, config.hidden_size)
 
     def test_text_embeddings(self, device, dtype):
         """Test SigLip2TextEmbeddings."""
-        config = SigLip2TextConfig(vocab_size=1000, hidden_size=768, max_position_embeddings=512)
+        config = SigLip2TextConfig(vocab_size=100, hidden_size=32, max_position_embeddings=32)
         embeddings = SigLip2TextEmbeddings(config).to(device, dtype)
 
         batch_size = 2
@@ -285,11 +337,12 @@ class TestSigLip2Components(BaseTester):
     def test_text_encoder(self, device, dtype):
         """Test SigLip2TextEncoder."""
         config = SigLip2TextConfig(
-            vocab_size=1000,
-            hidden_size=768,
+            vocab_size=100,
+            hidden_size=32,
             num_hidden_layers=2,
-            num_attention_heads=12,
-            max_position_embeddings=512,
+            num_attention_heads=4,
+            intermediate_size=64,
+            max_position_embeddings=32,
         )
         encoder = SigLip2TextEncoder(config).to(device, dtype)
         embeddings = SigLip2TextEmbeddings(config).to(device, dtype)
@@ -309,11 +362,12 @@ class TestSigLip2Components(BaseTester):
     def test_text_model(self, device, dtype):
         """Test SigLip2TextModel."""
         config = SigLip2TextConfig(
-            vocab_size=1000,
-            hidden_size=768,
+            vocab_size=100,
+            hidden_size=32,
             num_hidden_layers=2,
-            num_attention_heads=12,
-            max_position_embeddings=512,
+            num_attention_heads=4,
+            intermediate_size=64,
+            max_position_embeddings=32,
         )
         model = SigLip2TextModel(config).to(device, dtype)
 
@@ -330,8 +384,8 @@ class TestSigLip2Components(BaseTester):
 
     def test_attention(self, device, dtype):
         """Test SigLip2Attention."""
-        hidden_size = 768
-        num_heads = 12
+        hidden_size = 32
+        num_heads = 4
         attention = SigLip2Attention(hidden_size=hidden_size, num_heads=num_heads).to(device, dtype)
 
         batch_size = 2
@@ -351,9 +405,14 @@ class TestSigLip2Components(BaseTester):
         tol = {"rtol": 5e-2, "atol": 5e-2} if dtype in (torch.float16, torch.bfloat16) else {}
         self.assert_close(output, output_without_mask, **tol)
 
-    @pytest.mark.parametrize("batch_size", [1, 2, 4])
-    @pytest.mark.parametrize("input_size", [(256, 256), (300, 400), (512, 512)])
-    @pytest.mark.parametrize("image_size", [(224, 224), (256, 256), (384, 384)])
+    @pytest.mark.parametrize(
+        ("batch_size", "input_size", "image_size"),
+        [
+            (1, (64, 64), (32, 32)),
+            (2, (48, 64), (32, 32)),
+            (4, (16, 16), (32, 32)),
+        ],
+    )
     def test_image_preprocessor(self, device, dtype, batch_size, input_size, image_size):
         """Test SigLip2ImagePreprocessor with different configurations."""
         preprocessor = SigLip2ImagePreprocessor(image_size=image_size).to(device, dtype)
@@ -366,11 +425,11 @@ class TestSigLip2Components(BaseTester):
 
     def test_image_preprocessor_single_image(self, device, dtype):
         """Test SigLip2ImagePreprocessor with single image (3D tensor)."""
-        image_size = (224, 224)
+        image_size = (32, 32)
         preprocessor = SigLip2ImagePreprocessor(image_size=image_size).to(device, dtype)
 
         # Test with single image (3D tensor) - preprocessor adds batch dimension
-        image = torch.randint(0, 255, (3, 256, 256), device=device, dtype=dtype)
+        image = torch.randint(0, 255, (3, 64, 64), device=device, dtype=dtype)
         with torch.no_grad():
             output = preprocessor(image)
         assert output.shape == (1, 3, image_size[0], image_size[1])


### PR DESCRIPTION
## What does this pull request do?

Replaces the production-scale SigLIP2 configuration used by routine unit tests with a small, representative configuration. The tests still cover two transformer layers, attention masking, both linear and identity projection paths, image/text/joint forwards, loss, gradcheck, and compile integration.

It also derives inputs from the test configuration and replaces the 27-case image-preprocessor Cartesian product with three representative cases covering downscaling, non-square batched input, and batched upscaling.

On Apple MPS with torch 2.9.1, the complete float32 file improved from 35.51 seconds on `main` to 1.57 seconds on this branch. The primary test model shrinks from 375,532,034 parameters to 52,770 parameters.

## Related issue or discussion

No linked issue.

## What did you check?

```text
python -m pytest tests/models/test_siglip2.py --device=mps --dtype=float32 --durations=5
# 21 passed, 1 skipped in 1.57s

python -m pytest tests/models/test_siglip2.py --device=cpu --dtype=float32,float64 -q
# 44 passed in 0.46s

pre-commit run --all-files
# all hooks passed
```

## How did AI help?

Codex profiled the test structure, implemented the test-only reduction, measured the MPS before/after runtime, and performed an independent code review. I verified the resulting focused tests and repository hooks.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (gpt-5.6-sol).