### PR TITLE
test: reduce redundant MPS test work

### DIFF
--- a/tests/contrib/test_kmeans.py
+++ b/tests/contrib/test_kmeans.py
@@ -26,7 +26,7 @@ from testing.base import BaseTester
 class TestKMeans(BaseTester):
     @pytest.mark.parametrize(
         ("num_clusters", "tolerance", "max_iterations"),
-        [(3, 1e-4, 10), (10, 1e-3, 1000), (1, 1.0, 10)],
+        [(3, 1e-4, 3), (10, 1e-3, 1000), (1, 1.0, 10)],
     )
     def test_smoke(self, device, dtype, num_clusters, tolerance, max_iterations):
         N = 1000
@@ -47,7 +47,7 @@ class TestKMeans(BaseTester):
         assert out2.dtype == dtype
 
     @pytest.mark.parametrize("num_clusters", [3])
-    @pytest.mark.parametrize("tolerance", [10e-4])
+    @pytest.mark.parametrize("tolerance", [1e-3])
     @pytest.mark.parametrize("max_iterations", [100])
     def test_cardinality(self, device, dtype, num_clusters, tolerance, max_iterations):
         N = 1000
@@ -68,24 +68,24 @@ class TestKMeans(BaseTester):
 
         # case: cluster_center = 0:
         with pytest.raises(BaseError) as errinfo:
-            kornia.contrib.KMeans(0, None, 10e-4, 10, 0)
+            kornia.contrib.KMeans(0, None, 1e-3, 10, 0)
         assert "num_clusters can't be 0" in str(errinfo.value)
 
         # case: cluster centers is not a 2D tensor
         with pytest.raises(ShapeError) as errinfo:
             starting_centers = torch.rand((2, 3, 5), device=device, dtype=dtype)
-            kmeans = kornia.contrib.KMeans(None, starting_centers, 10e-4, 100, 0)
+            kmeans = kornia.contrib.KMeans(None, starting_centers, 1e-3, 100, 0)
         assert "Shape dimension mismatch" in str(errinfo.value)
 
         # case: input data is not a 2D tensor
         with pytest.raises(ShapeError) as errinfo:
-            kmeans = kornia.contrib.KMeans(3, None, 10e-4, 100, 0)
+            kmeans = kornia.contrib.KMeans(3, None, 1e-3, 100, 0)
             kmeans.fit(torch.rand((1000, 5, 60), dtype=dtype, device=device))
         assert "Shape dimension mismatch" in str(errinfo.value) or "Expected shape" in str(errinfo.value)
 
         # case: column dimensions of cluster centers and data to be predicted do not match
         with pytest.raises(Exception) as errinfo:
-            kmeans = kornia.contrib.KMeans(3, None, 10e-4, 100, 0)
+            kmeans = kornia.contrib.KMeans(3, None, 1e-3, 100, 0)
             kmeans.fit(torch.rand((1000, 5), dtype=dtype))
             kmeans.predict(torch.rand((10, 7), dtype=dtype))
         assert "7 != 5" in str(errinfo)
@@ -110,7 +110,7 @@ class TestKMeans(BaseTester):
     def test_module(self, device, dtype):
         x = TestKMeans._create_data(device, dtype)
 
-        kmeans = kornia.contrib.KMeans(3, None, 10e-4, 10000, 2023)
+        kmeans = kornia.contrib.KMeans(3, None, 1e-3, 10000, 2023)
         kmeans.fit(x)
 
         centers = kmeans.cluster_centers
@@ -131,7 +131,7 @@ class TestKMeans(BaseTester):
 
     def test_dynamo(self, device, dtype, torch_optimizer):
         x = TestKMeans._create_data(device, dtype)
-        kmeans_params = (3, None, 10e-4, 10000, 2023)
+        kmeans_params = (3, None, 1e-3, 10000, 2023)
         predict_param = torch.tensor([[-14, 16], [45, 12]], dtype=dtype, device=device)
 
         kmeans = kornia.contrib.KMeans(*kmeans_params)

--- a/tests/contrib/test_kmeans.py
+++ b/tests/contrib/test_kmeans.py
@@ -24,9 +24,10 @@ from testing.base import BaseTester
 
 
 class TestKMeans(BaseTester):
-    @pytest.mark.parametrize("num_clusters", [3, 10, 1])
-    @pytest.mark.parametrize("tolerance", [10e-4, 10e-5, 10e-1])
-    @pytest.mark.parametrize("max_iterations", [10, 1000])
+    @pytest.mark.parametrize(
+        ("num_clusters", "tolerance", "max_iterations"),
+        [(3, 1e-4, 10), (10, 1e-3, 1000), (1, 1.0, 10)],
+    )
     def test_smoke(self, device, dtype, num_clusters, tolerance, max_iterations):
         N = 1000
         D = 2

--- a/tests/enhance/test_equalization.py
+++ b/tests/enhance/test_equalization.py
@@ -36,14 +36,25 @@ class TestEqualization(BaseTester):
         assert res.device == img.device
         assert res.dtype == img.dtype
 
-    @pytest.mark.parametrize("B, C", [(None, 1), (None, 3), (1, 1), (1, 3), (4, 1), (4, 3)])
-    def test_cardinality(self, B, C, device, dtype):
+    @pytest.mark.parametrize(
+        ("B", "C", "grid_size"),
+        [
+            (None, 1, (2, 2)),
+            (None, 3, (2, 2)),
+            (1, 1, (2, 2)),
+            (1, 3, (2, 2)),
+            (4, 1, (2, 2)),
+            (4, 3, (2, 2)),
+            (4, 3, (8, 8)),
+        ],
+    )
+    def test_cardinality(self, B, C, grid_size, device, dtype):
         H, W = 10, 20
         if B is None:
             img = torch.rand(C, H, W, device=device, dtype=dtype)
         else:
             img = torch.rand(B, C, H, W, device=device, dtype=dtype)
-        res = enhance.equalize_clahe(img, grid_size=(2, 2))
+        res = enhance.equalize_clahe(img, grid_size=grid_size)
         assert res.shape == img.shape
 
     @pytest.mark.parametrize("clip, grid", [(0.0, None), (None, (2, 2)), (2.0, (2, 2))])

--- a/tests/enhance/test_equalization.py
+++ b/tests/enhance/test_equalization.py
@@ -43,7 +43,7 @@ class TestEqualization(BaseTester):
             img = torch.rand(C, H, W, device=device, dtype=dtype)
         else:
             img = torch.rand(B, C, H, W, device=device, dtype=dtype)
-        res = enhance.equalize_clahe(img)
+        res = enhance.equalize_clahe(img, grid_size=(2, 2))
         assert res.shape == img.shape
 
     @pytest.mark.parametrize("clip, grid", [(0.0, None), (None, (2, 2)), (2.0, (2, 2))])

--- a/tests/filters/test_guided.py
+++ b/tests/filters/test_guided.py
@@ -33,8 +33,7 @@ class TestGuidedBlur(BaseTester):
     @pytest.mark.parametrize("guide_dim", [1, 3])
     @pytest.mark.parametrize("input_dim", [1, 3])
     @pytest.mark.parametrize("kernel_size", [5, (3, 5)])
-    @pytest.mark.parametrize("eps", [0.1, 0.01])
-    def test_smoke(self, batch_size, guide_dim, input_dim, kernel_size, eps, device, dtype):
+    def test_smoke(self, batch_size, guide_dim, input_dim, kernel_size, device, dtype):
         H, W = 8, 16
         guide = torch.randn(batch_size, guide_dim, H, W, device=device, dtype=dtype)
         inp = torch.randn(batch_size, input_dim, H, W, device=device, dtype=dtype)

--- a/tests/losses/test_mutual_information.py
+++ b/tests/losses/test_mutual_information.py
@@ -142,7 +142,7 @@ class TestMutualInformationLoss(BaseTester):
             self.value_ranges_check(device, dtype)
 
     def test_trivial_signal_normalizes_to_zero(self, device, dtype):
-        signal = torch.tensor([[0.25], [0.75]], device=device, dtype=dtype)
+        signal = torch.tensor([[0.25, 0.25, 0.25], [0.75, 0.75, 0.75]], device=device, dtype=dtype)
 
         self.assert_close(_normalize_signal(signal, num_bins=64), torch.zeros_like(signal))
 

--- a/tests/losses/test_mutual_information.py
+++ b/tests/losses/test_mutual_information.py
@@ -21,6 +21,7 @@ from kornia.losses.mutual_information import (
     MIKernel,
     MILossFromRef,
     NMILossFromRef,
+    _normalize_signal,
     mutual_information_loss,
     mutual_information_loss_2d,
     normalized_mutual_information_loss,
@@ -140,8 +141,13 @@ class TestMutualInformationLoss(BaseTester):
         for _ in range(10):
             self.value_ranges_check(device, dtype)
 
+    def test_trivial_signal_normalizes_to_zero(self, device, dtype):
+        signal = torch.tensor([[0.25], [0.75]], device=device, dtype=dtype)
+
+        self.assert_close(_normalize_signal(signal, num_bins=64), torch.zeros_like(signal))
+
     @pytest.mark.parametrize("kernel", [MIKernel.xu, MIKernel.rectangular, MIKernel.truncated_gaussian])
-    @pytest.mark.parametrize("dims", [(5,), (2, 4), (2, 1, 4), (2, 1, 2, 4), (2, 1, 2, 1, 4)])
+    @pytest.mark.parametrize("dims", [(5,), (3, 1), (2, 8), (2, 1, 8), (2, 1, 2, 8), (2, 1, 2, 1, 8)])
     def test_batch_consistency(self, device, dtype, kernel, dims):
         torch.manual_seed(0)  # Fix seed for reproducibility
 
@@ -150,7 +156,7 @@ class TestMutualInformationLoss(BaseTester):
 
         # flatten batch dims
         unique_batch_dim_1 = img1.reshape((-1,) + img1.shape[-1:])
-        unique_batch_dim_2 = img2.reshape((-1,) + img1.shape[-1:])
+        unique_batch_dim_2 = img2.reshape((-1,) + img2.shape[-1:])
 
         # Compute batch loss
         loss_batch = mutual_information_loss(img1, img2, num_bins=64, kernel_function=kernel)
@@ -180,12 +186,8 @@ class TestMutualInformationLoss(BaseTester):
             f"The shape of the batched losses for nmi is wrong: {normalized_loss_batch.shape} vs {dims[:-1]}."
         )
 
-        assert torch.allclose(loss_batch.flatten(), loss_iterative, atol=1e-4), (
-            f"Batch mismatch for mi! Batch: {loss_batch}, Iterative: {loss_iterative}"
-        )
-        assert torch.allclose(normalized_loss_batch.flatten(), normalized_loss_iterative, atol=1e-4), (
-            f"Batch mismatch for nmi! Batch: {normalized_loss_batch}, Iterative: {normalized_loss_iterative}"
-        )
+        self.assert_close(loss_batch.flatten(), loss_iterative)
+        self.assert_close(normalized_loss_batch.flatten(), normalized_loss_iterative)
 
     def test_module(self, device, dtype):
         pred = torch.rand(2, 3, 3, 2, device=device, dtype=dtype)

--- a/tests/losses/test_mutual_information.py
+++ b/tests/losses/test_mutual_information.py
@@ -141,56 +141,51 @@ class TestMutualInformationLoss(BaseTester):
             self.value_ranges_check(device, dtype)
 
     @pytest.mark.parametrize("kernel", [MIKernel.xu, MIKernel.rectangular, MIKernel.truncated_gaussian])
-    @pytest.mark.parametrize("dim_param", range(5))
-    def test_batch_consistency(self, device, dtype, kernel, dim_param):
+    @pytest.mark.parametrize("dims", [(5,), (2, 4), (2, 1, 4), (2, 1, 2, 4), (2, 1, 2, 1, 4)])
+    def test_batch_consistency(self, device, dtype, kernel, dims):
         torch.manual_seed(0)  # Fix seed for reproducibility
 
-        # Create random dimensions
-        dims = torch.randint(low=1, high=8, size=(dim_param + 1,))
-        dims = tuple(map(int, dims))
+        img1 = torch.rand(dims, device=device, dtype=dtype)
+        img2 = torch.rand(dims, device=device, dtype=dtype)
 
-        for _ in range(3):
-            img1 = torch.rand(dims, device=device, dtype=dtype)
-            img2 = torch.rand(dims, device=device, dtype=dtype)
+        # flatten batch dims
+        unique_batch_dim_1 = img1.reshape((-1,) + img1.shape[-1:])
+        unique_batch_dim_2 = img2.reshape((-1,) + img1.shape[-1:])
 
-            # flatten batch dims
-            unique_batch_dim_1 = img1.reshape((-1,) + img1.shape[-1:])
-            unique_batch_dim_2 = img2.reshape((-1,) + img1.shape[-1:])
+        # Compute batch loss
+        loss_batch = mutual_information_loss(img1, img2, num_bins=64, kernel_function=kernel)
+        normalized_loss_batch = normalized_mutual_information_loss(img1, img2, num_bins=64, kernel_function=kernel)
 
-            # Compute batch loss
-            loss_batch = mutual_information_loss(img1, img2, num_bins=64, kernel_function=kernel)
-            normalized_loss_batch = normalized_mutual_information_loss(img1, img2, num_bins=64, kernel_function=kernel)
-
-            # Compute iterative loss for verification
-            losses = []
-            normalized_losses = []
-            for i in range(unique_batch_dim_1.shape[0]):
-                loss = mutual_information_loss(
-                    unique_batch_dim_1[i], unique_batch_dim_2[i], num_bins=64, kernel_function=kernel
-                )
-                normalized_loss = normalized_mutual_information_loss(
-                    unique_batch_dim_1[i], unique_batch_dim_2[i], num_bins=64, kernel_function=kernel
-                )
-                losses.append(loss)
-                normalized_losses.append(normalized_loss)
-
-            loss_iterative = torch.stack(losses)
-            normalized_loss_iterative = torch.stack(normalized_losses)
-
-            # Compare
-            assert loss_batch.shape == dims[:-1], (
-                f"The shape of the batched losses for mi is wrong: {loss_batch.shape} vs {dims[:-1]}."
+        # Compute iterative loss for verification
+        losses = []
+        normalized_losses = []
+        for i in range(unique_batch_dim_1.shape[0]):
+            loss = mutual_information_loss(
+                unique_batch_dim_1[i], unique_batch_dim_2[i], num_bins=64, kernel_function=kernel
             )
-            assert normalized_loss_batch.shape == dims[:-1], (
-                f"The shape of the batched losses for nmi is wrong: {normalized_loss_batch.shape} vs {dims[:-1]}."
+            normalized_loss = normalized_mutual_information_loss(
+                unique_batch_dim_1[i], unique_batch_dim_2[i], num_bins=64, kernel_function=kernel
             )
+            losses.append(loss)
+            normalized_losses.append(normalized_loss)
 
-            assert torch.allclose(loss_batch.flatten(), loss_iterative, atol=1e-4), (
-                f"Batch mismatch for mi! Batch: {loss_batch}, Iterative: {loss_iterative}"
-            )
-            assert torch.allclose(normalized_loss_batch.flatten(), normalized_loss_iterative, atol=1e-4), (
-                f"Batch mismatch for nmi! Batch: {normalized_loss_batch}, Iterative: {normalized_loss_iterative}"
-            )
+        loss_iterative = torch.stack(losses)
+        normalized_loss_iterative = torch.stack(normalized_losses)
+
+        # Compare
+        assert loss_batch.shape == dims[:-1], (
+            f"The shape of the batched losses for mi is wrong: {loss_batch.shape} vs {dims[:-1]}."
+        )
+        assert normalized_loss_batch.shape == dims[:-1], (
+            f"The shape of the batched losses for nmi is wrong: {normalized_loss_batch.shape} vs {dims[:-1]}."
+        )
+
+        assert torch.allclose(loss_batch.flatten(), loss_iterative, atol=1e-4), (
+            f"Batch mismatch for mi! Batch: {loss_batch}, Iterative: {loss_iterative}"
+        )
+        assert torch.allclose(normalized_loss_batch.flatten(), normalized_loss_iterative, atol=1e-4), (
+            f"Batch mismatch for nmi! Batch: {normalized_loss_batch}, Iterative: {normalized_loss_iterative}"
+        )
 
     def test_module(self, device, dtype):
         pred = torch.rand(2, 3, 3, 2, device=device, dtype=dtype)

--- a/tests/models/test_vision_transformer.py
+++ b/tests/models/test_vision_transformer.py
@@ -27,12 +27,12 @@ class TestVisionTransformer(BaseTester):
     @pytest.mark.parametrize(
         ("B", "H", "D", "image_size"),
         [
-            (1, 1, 240, 32),
-            (2, 3, 240, 224),
-            (1, 8, 240, 224),
-            (2, 1, 768, 32),
-            (1, 3, 768, 224),
-            (2, 8, 768, 32),
+            (2, 1, 240, 32),
+            (1, 1, 768, 224),
+            (2, 3, 768, 32),
+            (1, 3, 240, 224),
+            (2, 8, 240, 224),
+            (1, 8, 768, 32),
         ],
     )
     def test_smoke(self, device, dtype, B, H, D, image_size):

--- a/tests/models/test_vision_transformer.py
+++ b/tests/models/test_vision_transformer.py
@@ -24,16 +24,24 @@ from testing.base import BaseTester
 
 
 class TestVisionTransformer(BaseTester):
-    @pytest.mark.parametrize("B", [1, 2])
-    @pytest.mark.parametrize("H", [1, 3, 8])
-    @pytest.mark.parametrize("D", [240, 768])
-    @pytest.mark.parametrize("image_size", [32, 224])
+    @pytest.mark.parametrize(
+        ("B", "H", "D", "image_size"),
+        [
+            (1, 1, 240, 32),
+            (2, 3, 240, 224),
+            (1, 8, 240, 224),
+            (2, 1, 768, 32),
+            (1, 3, 768, 224),
+            (2, 8, 768, 32),
+        ],
+    )
     def test_smoke(self, device, dtype, B, H, D, image_size):
         patch_size = 16
+        depth = 2
         T = image_size**2 // patch_size**2 + 1  # tokens size
 
         img = torch.rand(B, 3, image_size, image_size, device=device, dtype=dtype)
-        vit = VisionTransformer(image_size=image_size, num_heads=H, embed_dim=D).to(device, dtype)
+        vit = VisionTransformer(image_size=image_size, num_heads=H, embed_dim=D, depth=depth).to(device, dtype)
 
         out = vit(img)
         assert isinstance(out, torch.Tensor)
@@ -41,7 +49,7 @@ class TestVisionTransformer(BaseTester):
 
         feats = vit.encoder_results
         assert isinstance(feats, list)
-        assert len(feats) == 12
+        assert len(feats) == depth
         for f in feats:
             assert f.shape == (B, T, D)
 
@@ -60,3 +68,4 @@ class TestVisionTransformer(BaseTester):
         vit = VisionTransformer(backbone=backbone_mock, num_heads=8).to(device, dtype)
         out = vit(img)
         assert out.shape == (1, 197, 128)
+        assert len(vit.encoder_results) == 12


### PR DESCRIPTION
## What does this pull request do?

Reduces redundant work in five MPS-heavy test groups while preserving their behavioral coverage:

- CLAHE cardinality keeps all six rank/batch/channel cases, but uses a 2x2 tile grid; the default 8x8 path remains covered by smoke and numerical tests.
- Mutual-information batch consistency keeps ranks 1 through 5, singleton and multiple batch dimensions, and all three kernels, using deterministic compact shapes and one exact batched-vs-iterative comparison per case.
- VisionTransformer smoke coverage uses six representative tuples covering both batch sizes, all head counts, both embedding dimensions, and both image sizes with depth 2. The existing default-depth backbone forward now explicitly verifies all 12 encoder results.
- KMeans smoke coverage pairs the existing cluster-count, tolerance, and iteration-limit categories into three representative fits; numerical convergence remains covered separately.
- GuidedBlur removes an `eps` parameter axis whose value was overwritten before use.

The initial reduction dropped the directly affected MPS float32 selection from 95 cases and 218.15 seconds on `main` to 46 cases and approximately 18 seconds, about 12x faster. Review follow-ups restore targeted branch and pairwise coverage without reintroducing the redundant cross-products.

## Related issue or discussion

No linked issue.

## What did you check?

```text
python -m pytest <directly affected test nodes> --device=mps --dtype=float32 --durations=30
# Initial reduction: 46 affected cases passed; approximately 18s versus 218.15s on main

python -m pytest tests/enhance/test_equalization.py tests/filters/test_guided.py tests/losses/test_mutual_information.py tests/models/test_vision_transformer.py tests/contrib/test_kmeans.py --device=cpu --dtype=float32,float64 -q
# Final review-fix branch: 265 passed, 6 skipped in 3.50s

pre-commit run --all-files
# all hooks passed
```

## How did AI help?

Codex analyzed per-test timestamps from the full MPS CI log, benchmarked the highest-confidence candidates, implemented the reductions, and ran an independent coverage-focused review. I verified the MPS before/after measurement, both CPU dtypes, and repository hooks.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (gpt-5.6-sol).