### PR TITLE
fix(tests): query CUDA autocast state portably in the DeDoDe AMP test

### DIFF
--- a/tests/feature/test_dedode.py
+++ b/tests/feature/test_dedode.py
@@ -30,8 +30,11 @@ class TestConvRefiner(BaseTester):
     def test_amp_matches_input_device(self, device):
         refiner = ConvRefiner(in_dim=4, hidden_dim=4, out_dim=4).to(device)
         autocast_enabled = []
+        # ``torch.is_autocast_enabled`` only accepts a device type from torch 2.4 onwards; the
+        # no-argument spelling reports the CUDA state on every torch kornia supports, which is
+        # the state the ``torch.autocast("cuda", ...)`` region inside ``ConvRefiner`` controls.
         refiner.block1.register_forward_pre_hook(
-            lambda _module, _inputs: autocast_enabled.append(torch.is_autocast_enabled("cuda"))
+            lambda _module, _inputs: autocast_enabled.append(torch.is_autocast_enabled())
         )
 
         with warnings.catch_warnings(record=True) as caught:


### PR DESCRIPTION
## What

`tests/feature/test_dedode.py::TestConvRefiner::test_amp_matches_input_device` fails on every
pre-2.4 torch in the scheduled CPU matrix. This fixes it.

## Why

The test was added in #4110 and queries the autocast state from a forward pre-hook:

```python
lambda _module, _inputs: autocast_enabled.append(torch.is_autocast_enabled("cuda"))
```

`torch.is_autocast_enabled` only grew its `device_type` argument in torch 2.4. On older
releases the call raises:

```
TypeError: torch.is_autocast_enabled() takes no arguments (1 given)
```

This turned **all ten** old-torch legs of the scheduled `Tests on CPU` workflow red on `main`
([run 33642556728](https://github.com/kornia/kornia/actions/runs/33642556728)) — 2.1.2, 2.2.2
and 2.3.1 across py3.11/3.12 and float32/float64. It is the *only* failure in the run; every
job reports `1 failed, ~8690 passed`. The 2.5.1 and 2.9.1 legs are green.

The library code the test guards (`torch.autocast("cuda", enabled=self.amp and feats.is_cuda, ...)`)
was already version-portable, so nothing in `kornia/` needed changing — only the test was broken.

## How

Use the no-argument spelling. It reports the **CUDA** autocast state on every torch kornia
supports (>= 2.0), which is exactly the state the `torch.autocast("cuda", ...)` region inside
`ConvRefiner` controls. This is the same spelling `kornia/core/utils.py` already relies on for
its `both=False` path, so no new version branch is introduced.

## Verification

Built dedicated venvs with real torch 2.1.2 and 2.3.1 (plus the repo's 2.9.1):

- Reproduced the exact CI `TypeError` on 2.3.1 before the change.
- After the change: `1 passed` on **2.1.2, 2.3.1 and 2.9.1**.
- **The pin still discriminates.** Temporarily reverting `enabled=self.amp and feats.is_cuda`
  in `decoder.py`/`encoder.py` makes the test fail with `assert not True` (the
  `device_type of 'cuda'` warning) on all three versions, then restored. So the regression test
  from #4110 still catches what it was written to catch.
- Confirmed the no-arg form is CUDA-specific rather than "current device": inside a
  `torch.autocast("cpu")` region it returns `False` while the `"cpu"` query returns `True`, on
  both 2.3.1 and 2.9.1.
- Grepped for other unguarded argument-form call sites; the only remaining ones are in
  `kornia/core/utils.py`, already behind `torch_version_ge(2, 4)`.
- `pixi run pre-commit-all`: all hooks pass.

No CHANGELOG entry: test-only fix, no user-visible behavior change.

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
