### PR TITLE
docs: follow-up fixes to the site revamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `filters`/`color`/`enhance`/`morphology` count next to a `kornia.filters` label, the "Why Kornia?" hero carousel
   resumed after a visitor picked a tab, the Community page linked to the now-unregistered `librecv.org`, and the
   GPU page promised CUDA measurements the committed benchmark runs do not yet contain. `pydata-sphinx-theme` is now
-  version-bounded, since the site's CSS and JS target theme internals. (#4172)
+  version-bounded, since the site's CSS and JS target theme internals. (#4173)
 * Reset an automatic augmentation policy's cached transformation matrix before applying it again, both for a
   sub-policy inside `TrivialAugment`, `RandAugment` and `AutoAugment` and for those policies nested inside
   `AugmentationSequential`. Consecutive calls that selected the same geometric policy could transform the input with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Follow-up fixes to the documentation revamp (#4155): the landing page's filtering card quoted the combined
+  `filters`/`color`/`enhance`/`morphology` count next to a `kornia.filters` label, the "Why Kornia?" hero carousel
+  resumed after a visitor picked a tab, the Community page linked to the now-unregistered `librecv.org`, and the
+  GPU page promised CUDA measurements the committed benchmark runs do not yet contain. `pydata-sphinx-theme` is now
+  version-bounded, since the site's CSS and JS target theme internals. (#4172)
 * Reset an automatic augmentation policy's cached transformation matrix before applying it again, both for a
   sub-policy inside `TrivialAugment`, `RandAugment` and `AutoAugment` and for those policies nested inside
   `AugmentationSequential`. Consecutive calls that selected the same geometric policy could transform the input with

--- a/docs/fetch_dependents.py
+++ b/docs/fetch_dependents.py
@@ -133,9 +133,9 @@ def crawl(kind: str, max_pages: int) -> tuple[int | None, list[dict], bool]:
         time.sleep(DELAY_S)
 
 
-def load_existing() -> dict:
-    if OUT.exists():
-        return json.loads(OUT.read_text())
+def load_existing(path: Path = OUT) -> dict:
+    if path.exists():
+        return json.loads(path.read_text())
     return {}
 
 
@@ -165,7 +165,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", type=Path, default=OUT)
     args = parser.parse_args(argv)
 
-    data = load_existing()
+    data = load_existing(args.out)
     for kind in args.kind or ["repositories", "packages"]:
         print(f"crawling {kind}...", file=sys.stderr)
         total, rows, complete = crawl(kind, args.max_pages)

--- a/docs/generate_adoption.py
+++ b/docs/generate_adoption.py
@@ -61,7 +61,8 @@ def _round_headline(count: int) -> str:
     if count >= 10_000:
         return f"{count // 1000}K"
     if count >= 1_000:
-        return f"{count / 1000:.1f}K".replace(".0K", "K")
+        # Truncate rather than round: 1,290 is "1.2K", and 9,999 must not become "10K".
+        return f"{count // 100 / 10:.1f}K".replace(".0K", "K")
     return str(count)
 
 

--- a/docs/generate_benchmarks.py
+++ b/docs/generate_benchmarks.py
@@ -156,7 +156,7 @@ def hero_figures(results_root: Path) -> dict | None:
             continue
         cpu = _throughput(devices["cpu"], HERO["op"], HERO["batch"], HERO["backend"])
         gpu = _throughput(devices[accelerators[0]], HERO["op"], HERO["batch"], HERO["backend"])
-        if cpu is None or gpu is None or cpu <= 0:
+        if cpu is None or gpu is None or cpu <= 0 or gpu <= 0:
             continue
         meta = devices[accelerators[0]]["metadata"]
         return {

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -755,14 +755,20 @@ def main():
     with torch.no_grad():
         detections = face_detector(K.color.bgr_to_rgb(img_crowd) * 255.0)[0]
     faces = [K.contrib.FaceDetectorResult(d) for d in detections]
-    boxes = torch.stack([torch.cat([f.top_left, f.bottom_right]) for f in faces if f.score > 0.7])[None]
-    out = img_crowd.clone()
-    for pad in (0, 1, 2):  # three passes give a 3 px outline
-        out = K.image.draw_rectangle(
-            out, boxes + torch.tensor([-pad, -pad, pad, pad]), color=torch.tensor([0.4, 1.0, 0.2])
-        )
-    cv2.imwrite(str(OUTPUT_PATH / "face_detection.png"), K.image.tensor_to_image((out[0] * 255.0).byte()))
-    print(f"Generated image example for FaceDetector. {boxes.shape[1]} faces")
+    confident = [torch.cat([f.top_left, f.bottom_right]) for f in faces if f.score > 0.7]
+    if not confident:
+        # A checkpoint or asset change could leave nothing above the threshold; this is the last
+        # block of main(), so bail out here rather than abort after everything else was written.
+        print("Skipped image example for FaceDetector: no detection above the score threshold")
+    else:
+        boxes = torch.stack(confident)[None]
+        out = img_crowd.clone()
+        for pad in (0, 1, 2):  # three passes give a 3 px outline
+            out = K.image.draw_rectangle(
+                out, boxes + torch.tensor([-pad, -pad, pad, pad]), color=torch.tensor([0.4, 1.0, 0.2])
+            )
+        cv2.imwrite(str(OUTPUT_PATH / "face_detection.png"), K.image.tensor_to_image((out[0] * 255.0).byte()))
+        print(f"Generated image example for FaceDetector. {boxes.shape[1]} faces")
 
 
 if __name__ == "__main__":

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -756,19 +756,15 @@ def main():
         detections = face_detector(K.color.bgr_to_rgb(img_crowd) * 255.0)[0]
     faces = [K.contrib.FaceDetectorResult(d) for d in detections]
     confident = [torch.cat([f.top_left, f.bottom_right]) for f in faces if f.score > 0.7]
-    if not confident:
-        # A checkpoint or asset change could leave nothing above the threshold; this is the last
-        # block of main(), so bail out here rather than abort after everything else was written.
-        print("Skipped image example for FaceDetector: no detection above the score threshold")
-    else:
+    out = img_crowd.clone()
+    if confident:
         boxes = torch.stack(confident)[None]
-        out = img_crowd.clone()
         for pad in (0, 1, 2):  # three passes give a 3 px outline
             out = K.image.draw_rectangle(
                 out, boxes + torch.tensor([-pad, -pad, pad, pad]), color=torch.tensor([0.4, 1.0, 0.2])
             )
-        cv2.imwrite(str(OUTPUT_PATH / "face_detection.png"), K.image.tensor_to_image((out[0] * 255.0).byte()))
-        print(f"Generated image example for FaceDetector. {boxes.shape[1]} faces")
+    cv2.imwrite(str(OUTPUT_PATH / "face_detection.png"), K.image.tensor_to_image((out[0] * 255.0).byte()))
+    print(f"Generated image example for FaceDetector. {len(confident)} faces")
 
 
 if __name__ == "__main__":

--- a/docs/source/_static/css/pydata.css
+++ b/docs/source/_static/css/pydata.css
@@ -843,8 +843,7 @@ html[data-theme="dark"] .bd-content .sd-tab-set .sd-tab-content {
     z-index: 1060;
 }
 
-.kornia-navbar-dropdown:hover .kornia-navbar-dropdown__menu,
-.kornia-navbar-dropdown:focus-within .kornia-navbar-dropdown__menu {
+.kornia-navbar-dropdown.is-open .kornia-navbar-dropdown__menu {
     display: block;
 }
 
@@ -867,7 +866,7 @@ html[data-theme="dark"] .bd-content .sd-tab-set .sd-tab-content {
     transition: transform 120ms ease-in-out;
 }
 
-.kornia-navbar-dropdown:hover .kornia-navbar-dropdown__caret {
+.kornia-navbar-dropdown.is-open .kornia-navbar-dropdown__caret {
     transform: rotate(180deg);
 }
 
@@ -878,8 +877,7 @@ html[data-theme="dark"] .bd-content .sd-tab-set .sd-tab-content {
     padding: 0.6rem 0.4rem;
 }
 
-.kornia-navbar-dropdown:hover .kornia-navbar-dropdown__menu--mega,
-.kornia-navbar-dropdown:focus-within .kornia-navbar-dropdown__menu--mega {
+.kornia-navbar-dropdown.is-open .kornia-navbar-dropdown__menu--mega {
     display: block;
 }
 

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -234,26 +234,50 @@ document.addEventListener("DOMContentLoaded", function () {
     caret.className = "fa-solid fa-chevron-down kornia-navbar-dropdown__caret";
     link.appendChild(caret);
 
-    // The panel opens from CSS (:hover / :focus-within); mirror that state onto the trigger so a
-    // screen reader is told the menu exists and whether it is open. The inline sidebar copy is
-    // always expanded, so it announces as such and needs no listeners.
+    // Keep the panel's explicit open class and the trigger's ARIA state in sync. The inline sidebar
+    // copy is always expanded, so it announces as such and needs no listeners.
     link.setAttribute("aria-haspopup", "true");
     link.setAttribute("aria-expanded", inline ? "true" : "false");
     if (inline) return;
-    const expose = (open) => link.setAttribute("aria-expanded", String(open));
-    li.addEventListener("pointerenter", () => expose(true));
-    li.addEventListener("pointerleave", () => expose(false));
-    li.addEventListener("focusin", () => expose(true));
-    li.addEventListener("focusout", function (e) {
-      if (!li.contains(e.relatedTarget)) expose(false);
+    let hovered = false;
+    let focusWithin = false;
+    let dismissed = false;
+    function syncOpenState() {
+      const open = !dismissed && (hovered || focusWithin);
+      li.classList.toggle("is-open", open);
+      link.setAttribute("aria-expanded", String(open));
+    }
+    li.addEventListener("pointerenter", function () {
+      hovered = true;
+      dismissed = false;
+      syncOpenState();
     });
-    // Escape closes a keyboard-opened menu: dropping focus out of the item ends :focus-within.
+    li.addEventListener("pointerleave", function () {
+      hovered = false;
+      syncOpenState();
+    });
+    li.addEventListener("focusin", function () {
+      focusWithin = true;
+      dismissed = false;
+      syncOpenState();
+    });
+    li.addEventListener("focusout", function (e) {
+      if (li.contains(e.relatedTarget)) return;
+      focusWithin = false;
+      dismissed = false;
+      syncOpenState();
+    });
+    // Escape closes the menu and returns focus to its trigger. ``dismissed`` keeps a hovered item
+    // closed until the pointer re-enters or focus leaves and returns.
     li.addEventListener("keydown", function (e) {
       if (e.key !== "Escape") return;
       const active = document.activeElement;
       if (!li.contains(active)) return;
-      active.blur();
-      expose(false);
+      e.preventDefault();
+      e.stopPropagation();
+      link.focus();
+      dismissed = true;
+      syncOpenState();
     });
   }
 

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -165,6 +165,7 @@ document.addEventListener("DOMContentLoaded", function () {
     let startedAt = 0;
     let remaining = PERIOD_MS;
     let paused = false;
+    let stopped = false;
 
     function advance() {
       if (document.hidden) {
@@ -182,19 +183,24 @@ document.addEventListener("DOMContentLoaded", function () {
       timer = setTimeout(advance, remaining);
     }
     function pause() {
-      if (paused || timer === null) return;
+      if (stopped || paused || timer === null) return;
       paused = true;
       clearTimeout(timer);
       remaining = Math.max(200, remaining - (Date.now() - startedAt));
       tabSet.classList.add("is-paused");
     }
     function resume() {
-      if (!paused) return;
+      if (stopped || !paused) return;
       paused = false;
       tabSet.classList.remove("is-paused");
       schedule();
     }
+    // Choosing a tab ends the cycle for good. A click always arrives as pointerenter -> change ->
+    // pointerleave, so without ``stopped`` the trailing pointerleave would resume the carousel the
+    // visitor just took over; the same holds for focusin -> change -> focusout on the keyboard.
     function stop() {
+      stopped = true;
+      paused = false;
       clearTimeout(timer);
       timer = null;
       tabSet.classList.remove("is-autoplaying", "is-paused");
@@ -227,6 +233,28 @@ document.addEventListener("DOMContentLoaded", function () {
     const caret = document.createElement("i");
     caret.className = "fa-solid fa-chevron-down kornia-navbar-dropdown__caret";
     link.appendChild(caret);
+
+    // The panel opens from CSS (:hover / :focus-within); mirror that state onto the trigger so a
+    // screen reader is told the menu exists and whether it is open. The inline sidebar copy is
+    // always expanded, so it announces as such and needs no listeners.
+    link.setAttribute("aria-haspopup", "true");
+    link.setAttribute("aria-expanded", inline ? "true" : "false");
+    if (inline) return;
+    const expose = (open) => link.setAttribute("aria-expanded", String(open));
+    li.addEventListener("pointerenter", () => expose(true));
+    li.addEventListener("pointerleave", () => expose(false));
+    li.addEventListener("focusin", () => expose(true));
+    li.addEventListener("focusout", function (e) {
+      if (!li.contains(e.relatedTarget)) expose(false);
+    });
+    // Escape closes a keyboard-opened menu: dropping focus out of the item ends :focus-within.
+    li.addEventListener("keydown", function (e) {
+      if (e.key !== "Escape") return;
+      const active = document.activeElement;
+      if (!li.contains(active)) return;
+      active.blur();
+      expose(false);
+    });
   }
 
   function menuFrom(items) {
@@ -286,6 +314,9 @@ document.addEventListener("DOMContentLoaded", function () {
       const link = document.createElement("a");
       link.className = "nav-link";
       link.href = "#";
+      // It opens a menu instead of navigating, so announce it as a button rather than as a link
+      // that goes nowhere; ``href`` stays for keyboard focusability.
+      link.setAttribute("role", "button");
       link.textContent = "Ecosystem";
       link.addEventListener("click", (e) => e.preventDefault());
       li.appendChild(link);

--- a/docs/source/community/community.rst
+++ b/docs/source/community/community.rst
@@ -2,7 +2,7 @@ Community
 =========
 
 .. meta::
-   :description: Join the Kornia community: Discord for chat, GitHub for development, Twitter/X, LinkedIn and YouTube for news, the Chinese community on QQ and Zhihu, and the wider LibreCV ecosystem.
+   :description: Join the Kornia community: Discord for chat, GitHub for development, Twitter/X, LinkedIn and YouTube for news, the Chinese community on QQ and Zhihu, and the wider Kornia AI ecosystem.
 
 Kornia is built by people who talk to each other in the open. Pick your channel:
 
@@ -43,8 +43,8 @@ Kornia is built by people who talk to each other in the open. Pick your channel:
 
 A newsletter is under construction — announcements land on the channels above in the meantime.
 
-Kornia is part of a wider open ecosystem: the `LibreCV <https://librecv.org>`_ community,
-`Kornia AI <https://kornia.org>`_ (the non-profit behind the library, see :doc:`the governance page
+Kornia is part of a wider open ecosystem: `Kornia AI <https://kornia.org>`_ (the non-profit behind
+the library, see :doc:`the governance page
 </get-started/governance>`), and integrations such as the `OpenCV AI Kit
 <https://docs.luxonis.com/en/latest/pages/tutorials/creating-custom-nn-models/#kornia>`_ and
 :doc:`kornia-rs </get-started/edge>`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -132,7 +132,7 @@ def _public_operator_count() -> int:
         contextlib.redirect_stderr(io.StringIO()),
     ):
         warnings.simplefilter("ignore")
-        for info in pkgutil.walk_packages(kornia.__path__, "kornia."):
+        for info in pkgutil.walk_packages(kornia.__path__, "kornia.", onerror=lambda name: None):
             if skip.search(info.name) or any(part.startswith("_") for part in info.name.split(".")[1:]):
                 continue
             try:
@@ -158,34 +158,28 @@ def _landing_page_counts() -> dict[str, str]:
 
     The public-name counts read the stable-core inventory that ``tests/test_api_surface.py`` pins;
     ``kornia.feature`` and ``kornia.models`` are outside it, so they are counted from the live
-    package and from the model pages under ``docs/source/models/``. ``operators`` is the
-    library-wide total from :func:`_public_operator_count`, floored to the hundred below it so the
-    page can say "1,000+" and stay true between releases.
+    package and from the model pages under ``docs/source/models/``. Each count names exactly the
+    module the card it appears on links to. ``operators-floor`` is the library-wide total from
+    :func:`_public_operator_count`, floored to the hundred below it so the page can say "1,000+"
+    and stay true between releases.
     """
     with open("../../tests/api_surface.json", encoding="utf-8") as handle:
         surface = {name: len(names) for name, names in json.load(handle).items()}
     import kornia.feature
 
     operators = _public_operator_count()
-    image_processing = sum(
-        surface[name] for name in ("kornia.filters", "kornia.color", "kornia.enhance", "kornia.morphology")
-    )
-    losses_metrics = surface["kornia.losses"] + surface["kornia.metrics"]
     model_pages = [entry for entry in os.listdir("models") if entry.endswith(".rst") and entry != "index.rst"]
+    # Every entry here is quoted by a page; a substitution nothing references is dead weight that
+    # reads as an available figure, so add one when a page needs it rather than ahead of time.
     return {
         "geometry": str(surface["kornia.geometry"]),
         "feature": str(len(kornia.feature.__all__)),
-        "image-processing": str(image_processing),
-        "losses-metrics": str(losses_metrics),
+        "filters": str(surface["kornia.filters"]),
         "augmentation": str(surface["kornia.augmentation"]),
         "models": str(len(model_pages)),
-        "operators": f"{operators:,}",
         "operators-floor": f"{operators // 100 * 100:,}",
         "dependents": f"{_adoption['repositories']:,}",
-        "dependents-listed": f"{_adoption['repositories_listed']:,}",
-        "dependents-rounded": str(_adoption["repositories_rounded"]),
         "dependent-packages": f"{_adoption['packages']:,}",
-        "dependents-date": str(_adoption["generated_at"]),
     }
 
 

--- a/docs/source/get-started/gpu-acceleration.rst
+++ b/docs/source/get-started/gpu-acceleration.rst
@@ -32,7 +32,8 @@ Three habits make GPU pipelines fast:
 Augmentations are the typical win: a :class:`~kornia.augmentation.AugmentationSequential` pipeline samples and
 applies transforms for the entire batch on the GPU, inside the training loop, and most operators also run under
 ``torch.compile`` for kernel fusion. The :doc:`performance page <performance>` shows measured eager-mode
-comparisons against torchvision, albumentations, OpenCV and PIL on CPU, CUDA and Apple silicon, and the
+comparisons against torchvision, albumentations, OpenCV and PIL on the devices the committed benchmark runs
+cover -- CPU and Apple silicon today, with more hardware being added -- and the
 :doc:`precision page <precision>` documents ``float16``/``bfloat16`` support.
 
 Apple silicon (``device="mps"``) is supported as well. PyTorch's MPS backend has no ``float64`` tensors, so keep

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -233,7 +233,7 @@ models. Six places to start below; the full map is the :doc:`API reference <api>
       or inside a loss.
 
       +++
-      |count-image-processing| operators · ``kornia.filters`` :octicon:`arrow-right`
+      |count-filters| operators · ``kornia.filters`` :octicon:`arrow-right`
 
    .. grid-item-card:: Augment everything
       :img-top: _static/img/AugmentationSequential.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
 ]
 docs = [
   "furo",
-  "pydata-sphinx-theme",
+  "pydata-sphinx-theme>=0.21,<0.22",  # _static/css/pydata.css and js/custom.js target theme internals
   "ivy>=1.0.0.0",
   "kornia_moons",
   "matplotlib",

--- a/uv.lock
+++ b/uv.lock
@@ -1027,7 +1027,7 @@ requires-dist = [
     { name = "packaging" },
     { name = "pillow", marker = "extra == 'dev'" },
     { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pydata-sphinx-theme", marker = "extra == 'docs'" },
+    { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = ">=0.21,<0.22" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-timeout", marker = "extra == 'dev'" },


### PR DESCRIPTION
Follow-up to #4155, which landed before these came out of review. Docs-only plus two small script fixes; no library code touched.

### Content corrections

- **Landing page quoted the wrong number.** The filtering card rendered `|count-image-processing|` — `filters + color + enhance + morphology` = **212** — next to a `kornia.filters` label, on a card linking to the `filters` page, which documents **67** names. Colour and enhance already have their own card, so it double-counted. The card now quotes the module it names.
- **`get-started/gpu-acceleration`** claimed the performance page shows comparisons on "CPU, CUDA and Apple silicon", but `benchmarks/results/0.9.0rc1/` only holds `apple-m1`/`apple-m4` cpu+mps runs, and the only "cuda" on the rendered page is inside the contribute command. Reworded to name the devices the committed runs cover, phrased so it stays true as coverage grows rather than pinning a device list.
- **Dead link.** The Community page linked to `https://librecv.org` in both its prose and its `meta` description; the domain no longer resolves (NXDOMAIN). `doc-links.yml` runs `--offline` on pull requests, which is why CI was green.

### Behaviour

- **The hero carousel restarted after a visitor picked a tab**, contradicting its own comment ("choosing a tab stops it for good"). A click arrives as `pointerenter` → `change` → `pointerleave`: `stop()` cleared the timer but left `paused === true`, so the trailing `pointerleave` → `resume()` rescheduled it. Fixed with a `stopped` flag honoured by `pause`/`resume`. Same path on the keyboard via `focusin`/`change`/`focusout`.
- **Navbar dropdown a11y.** The menus now mirror their CSS open state onto `aria-haspopup`/`aria-expanded`, close on <kbd>Escape</kbd>, and the Ecosystem trigger is announced as a button instead of a link that goes nowhere. (They were already keyboard-reachable via `:focus-within`.)

### Build robustness

- `pkgutil.walk_packages` in `conf.py` had no `onerror`, so it swallowed `ImportError` but **re-raised everything else** a `kornia.*` sub-package might throw at import — failing the whole docs build where the intent is clearly "skip it and keep counting".
- `hero_figures` guarded `cpu <= 0` but not `gpu`, while the caller computes `max(gpu, cpu) / min(gpu, cpu)`. A zero accelerator throughput would raise `ZeroDivisionError` at conf-read time and take the build down instead of just omitting the chart.
- `fetch_dependents.py --out` was honoured on write but not on read, so `--out other.json --max-pages 5` merged against the default snapshot and then overwrote the target wholesale — the opposite of the docstring's "a partial crawl merges into the existing file".
- `generate_examples.py` called `torch.stack` on a possibly-empty list in the last block of `main()`, which would abort the script after every other image had been regenerated.
- `_round_headline` promised "never rounds up past the real figure" but rounded to nearest: 1,290 → `"1.3K"`, 9,999 → `"10K"`. Now truncates.
- **Pinned `pydata-sphinx-theme` to the 0.21 line.** The site's CSS and JS target theme internals (`#pst-secondary-sidebar`, `.bd-navbar-elements`, `#pst-page-toc-nav`, `.bd-sidebar-primary`), and Read the Docs installs `.[docs]` **without** `uv.lock`, so an unbounded upstream release lands straight on the live site. Worth noting: my first attempt at a bound silently resolved the theme *down* to 0.17.1 — the pin is deliberately the version the site was built and reviewed against (0.21.0), and `uv.lock`'s resolved version is unchanged.
- Dropped the five `rst_epilog` substitutions no page references.

### Verification

- `pixi run -e default build-docs` (`sphinx -W`) succeeds on theme 0.21.0.
- Rendered output re-checked: the card reads "67 operators · `kornia.filters`"; the other landing figures (289 / 84 / 86 / 14 / "1,200+") are unchanged; no `librecv` reference survives anywhere in the build.
- `pixi run -e default pre-commit-all` passes, as does `.github/scripts/check_doc_links.py --offline`.
- The carousel fix was checked by driving the real `custom.js` against a DOM stub with fake timers: the "selection stops the cycle" case **fails on merged `main`** (the carousel advances off the chosen tab) and passes here. Not added to the repo — kornia has no JS test harness and adding one is out of scope for this fix.

Not addressed here, worth its own issue: `pixi run doctest` is `pytest --doctest-modules kornia/`, so none of the prose `.. code-block:: python` examples added in #4155 are executed by CI, even though `sphinx.ext.doctest` is already enabled.

Written by Claude (Opus 5) on behalf of @ducha-aiki

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
