### PR TITLE
fix(color): support empty accelerator transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `VisualPrompter.predict()` called without any prompt (the "run the prediction without prompts" example on the
   Segment Anything page) raised `TypeError: object of type 'NoneType' has no len()` from the prompt augmentation
   container; it now predicts from the image embedding alone, as documented. (#4178)
+
+* Preserve empty color tensors on accelerator backends instead of asking `reshape` to infer an ambiguous batch
+  dimension. This lets the YUV420 and YUV422 empty-input conversions return their documented empty RGB output on
+  MPS, matching CPU behavior (#4185).
+
 * Follow-up fixes to the documentation revamp (#4155): the landing page's filtering card quoted the combined
   `filters`/`color`/`enhance`/`morphology` count next to a `kornia.filters` label, the "Why Kornia?" hero carousel
   resumed after a visitor picked a tab, the Community page linked to the now-unregistered `librecv.org`, and the

--- a/kornia/color/utils.py
+++ b/kornia/color/utils.py
@@ -60,6 +60,10 @@ def _apply_linear_transformation(
 
     # BRANCH 2: GPU/Accelerators (Conv2d)
     else:
+        # ``reshape(-1, ...)`` cannot infer a batch dimension from an empty tensor.
+        if image_compute.numel() == 0:
+            return image_compute.clone()
+
         # Reshape for conv2d: (B*..., C, H, W)
         input_flat = image_compute.reshape(-1, 3, input_shape[-2], input_shape[-1])
 

--- a/kornia/color/utils.py
+++ b/kornia/color/utils.py
@@ -49,8 +49,9 @@ def _apply_linear_transformation(
     # Empirical benchmarks show that einsum is faster on CPU for this specific pattern,
     # while conv2d offers significant speedups on GPU/CUDA.
     # We branch to ensure optimal performance on both devices.
-    # BRANCH 1: CPU (Einsum)
-    if image_compute.device.type == "cpu":
+    # BRANCH 1: CPU and empty tensors (Einsum)
+    # Einsum handles every empty shape and keeps image, kernel, and bias in the graph.
+    if image_compute.device.type == "cpu" or image_compute.numel() == 0:
         out = torch.einsum("oi, ...ihw -> ...ohw", kernel_compute, image_compute)
 
         if bias_compute is not None:
@@ -60,10 +61,6 @@ def _apply_linear_transformation(
 
     # BRANCH 2: GPU/Accelerators (Conv2d)
     else:
-        # ``reshape(-1, ...)`` cannot infer a batch dimension from an empty tensor.
-        if image_compute.numel() == 0:
-            return image_compute.clone()
-
         # Reshape for conv2d: (B*..., C, H, W)
         input_flat = image_compute.reshape(-1, 3, input_shape[-2], input_shape[-1])
 

--- a/testing/known_failure_xfails/mps_float32.txt
+++ b/testing/known_failure_xfails/mps_float32.txt
@@ -13,8 +13,6 @@
 # Keep the entries sorted by node ID: KnownFailureTracker prints its regeneration output sorted,
 # so an unsorted file turns the next re-record into a whole-file diff.
 # Format: <exact exception type>\t<pytest node ID>
-RuntimeError	tests/color/test_yuv.py::TestYuv420ToRgb::test_empty_input[mps-float32]
-RuntimeError	tests/color/test_yuv.py::TestYuv422ToRgb::test_empty_input[mps-float32]
 NotImplementedError	tests/geometry/epipolar/test_essential.py::TestFindEssential::test_degenerate_case[mps-float32-10-5]
 NotImplementedError	tests/geometry/epipolar/test_essential.py::TestFindEssential::test_degenerate_case[mps-float32-5-5]
 NotImplementedError	tests/geometry/epipolar/test_essential.py::TestFindEssential::test_epipolar_constraint[mps-float32]

--- a/testing/known_failure_xfails/mps_float32.txt
+++ b/testing/known_failure_xfails/mps_float32.txt
@@ -1,6 +1,6 @@
 # Exact failure baseline recorded from
 # https://github.com/kornia/kornia/actions/runs/33808269822/job/100824208527 -- that job ran
-# without --xfail-known-failures, so it reports these 14 as failures: it is the run the baseline
+# without --xfail-known-failures, so it reports these 12 as failures: it is the run the baseline
 # was recorded from, not a replay of this file.
 # macos-15-arm64, Python 3.13, PyTorch 2.14.0, MPS float32, no CPU fallback,
 # one pytest process for the full suite (tests marked device_agnostic are deselected on an mps-only run).

--- a/testing/known_failure_xfails/mps_float32.txt
+++ b/testing/known_failure_xfails/mps_float32.txt
@@ -6,9 +6,8 @@
 # one pytest process for the full suite (tests marked device_agnostic are deselected on an mps-only run).
 # Remove an entry when it becomes a strict XPASS; fix or explicitly add any new failure. Tracked in #4159.
 # torch 2.14.0 added MPS kernels for the eigen/QR/LU/SVD family and for both grid_sample backward
-# passes, which took this baseline from 200 entries to 14. Two causes remain:
+# passes, which took this baseline from 200 entries to 12. One cause remains:
 #   NotImplementedError  aten::_linalg_eigvals has no MPS kernel (the 5-point essential solver).
-#   RuntimeError         yuv420/yuv422 empty-input reshape, a kornia degenerate-shape defect.
 # tests/geometry/test_ransac.py is skipped on MPS, not pinned: it aborts the process (#4204).
 # Keep the entries sorted by node ID: KnownFailureTracker prints its regeneration output sorted,
 # so an unsorted file turns the next re-record into a whole-file diff.

--- a/tests/color/test_utils.py
+++ b/tests/color/test_utils.py
@@ -41,3 +41,20 @@ class TestApplyLinearTransformation(BaseTester):
         assert actual.dtype == torch.float32
         assert actual.is_contiguous()
         self.assert_close(actual, expected, atol=0.0, rtol=0.0)
+
+    def test_empty_input_autograd(self, device):
+        for shape in ((0, 3, 4, 4), (2, 3, 0, 4), (2, 0, 3, 4, 4)):
+            image = torch.zeros(shape, device=device, dtype=torch.float32, requires_grad=True)
+            kernel = torch.eye(3, device=device, dtype=torch.float32, requires_grad=True)
+            bias = torch.zeros(3, device=device, dtype=torch.float32, requires_grad=True)
+
+            actual = _apply_linear_transformation(image, kernel, bias)
+            actual.sum().backward()
+
+            assert actual.shape == image.shape
+            assert actual.is_contiguous()
+            assert image.grad is not None
+            assert kernel.grad is not None
+            assert bias.grad is not None
+            self.assert_close(kernel.grad, torch.zeros_like(kernel))
+            self.assert_close(bias.grad, torch.zeros_like(bias))


### PR DESCRIPTION
Closes the YUV empty-input slice of #4159.

## Summary

- Route empty accelerator tensors through the existing `einsum` path before `conv2d` tries to infer `reshape(-1, 3, H, W)` from zero elements.
- Preserve image, kernel, and bias autograd connections for empty batches and empty spatial dimensions.
- Keep the existing CPU path and non-empty accelerator fast path unchanged.
- Remove the two fixed YUV420 and YUV422 failures from the strict MPS baseline.
- Update the rewritten PyTorch 2.14.0 baseline header after removing those final RuntimeError entries.
- Document the fix in the changelog.

The accelerator reshape cannot infer its leading dimension from zero elements, and `conv2d` cannot accept a zero spatial dimension. The existing `einsum` implementation handles every empty shape and preserves zero gradients for the transformation kernel and bias, while non-empty accelerator tensors continue through the optimized convolution path.

## Verification

- Direct transformation utility tests on CPU and Apple MPS: 2 passed per device, including three empty shapes with image, kernel, and bias autograd assertions.
- Empty-input YUV420 and YUV422 tests: 2 passed per device.
- Full `tests/color/test_yuv.py`: CPU 114 passed; Apple MPS 107 passed, 7 skipped.
- Full `tests/color`: CPU 442 passed, 2 skipped; Apple MPS 411 passed, 33 skipped.
- Ruff check and format: passed.
- Ty type check: passed.
- Changed-file pre-commit suite: passed.
- Reviewed head `1a59a83` passed the full 40-check hosted matrix; its readiness-triggered repeat completed all 36 jobs successfully, including the PyTorch 2.14.0 MPS matrix.
- Current head `8a902ff` changes only the stale MPS baseline prose from 14 entries to 12. The manifest contains 12 entries, `git diff --check` passes, and the changed-file pre-commit suite passes. All 40 fresh hosted checks passed, including Apple MPS.

`PYTORCH_ENABLE_MPS_FALLBACK` was unset for MPS verification.

## AI assistance

Generative AI tools assisted with repository navigation, implementation drafting, test execution, and diff analysis. The resulting four-file change was narrowed to empty-tensor dispatch, direct autograd coverage, the strict-baseline update, and the changelog entry, then verified with the checks listed above.

The account holder reviewed and approved the substantive four-file diff at `1a59a83` on 2026-09-04 and accepted responsibility for that reviewed head. Current head `8a902ff` adds the reviewer-requested comment-only count correction. Account-holder review of the current head remains before the pull request is marked ready again.

