### PR TITLE
test(onnx): skip the export coverage tests on torch < 2.5

### DIFF
--- a/tests/onnx/test_export_coverage.py
+++ b/tests/onnx/test_export_coverage.py
@@ -30,15 +30,29 @@ import torch
 from torch import nn
 
 import kornia
+from kornia.core._compat import torch_version_lt
 from kornia.core.utils import _torch_inverse_cast
 from kornia.geometry.epipolar.numeric import matrix_cofactor_tensor
 
+# Every tensor here is created device-free and fed to onnxruntime as numpy: the work is CPU-bound
+# whatever ``--device`` says, so the accelerator legs must not repeat it.
+pytestmark = pytest.mark.device_agnostic
+
 onnx = pytest.importorskip("onnx")
 ort = pytest.importorskip("onnxruntime")
+pytest.importorskip("onnxscript")  # the dynamo exporter hard-requires it; the ``docs`` extra lacks it
 
-if not hasattr(torch.onnx, "ONNXProgram"):
-    # ``torch.onnx.export(..., dynamo=True)`` and the ``ONNXProgram`` it returns (with ``.save()``)
-    # arrived together in torch 2.5; older releases only have the TorchScript exporter.
+if torch_version_lt(2, 5, 0):
+    # ``torch.onnx.export(..., dynamo=True)`` only reaches the current exporter -- and returns the
+    # ``ONNXProgram`` with ``.save()`` this file needs -- from torch 2.5. On 2.1-2.3 the ``dynamo=``
+    # keyword does not exist at all (TypeError); 2.4 accepts it but routes to the retired
+    # ``dynamo_export``, which the onnxscript releases we resolve no longer serve.
+    # ``hasattr(torch.onnx, "ONNXProgram")`` is not a usable probe: that class has existed since 2.2
+    # as ``dynamo_export``'s return type, which is why the previous guard did not skip.
+    # The floor is deliberately 2.5 rather than the 2.6 that ``tests/filters/test_gaussian.py``
+    # requires for its smoke test: these cases pin the export-time code paths on the oldest
+    # exporter-capable release, and torch 2.5.1 is a blocking PR leg, so a regression there must
+    # fail rather than skip.
     pytest.skip("the dynamo ONNX exporter needs torch >= 2.5", allow_module_level=True)
 
 
@@ -66,7 +80,10 @@ def _export_and_run(module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> tupl
     onnx.checker.check_model(model)
 
     session = ort.InferenceSession(buf.getvalue(), providers=["CPUExecutionProvider"])
-    feeds = {inp.name: x.numpy() for inp, x in zip(session.get_inputs(), inputs)}
+    # An input the exporter folded into the graph would shorten ``get_inputs()`` and shift the rest
+    # into the wrong slots; the feed must match one to one.
+    assert len(session.get_inputs()) == len(inputs), [i.name for i in session.get_inputs()]
+    feeds = {inp.name: x.numpy() for inp, x in zip(session.get_inputs(), inputs, strict=True)}
     return eager, session.run(None, feeds)
 
 

--- a/tests/onnx/test_resize_onnx.py
+++ b/tests/onnx/test_resize_onnx.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 import torch
 
+from kornia.core._compat import torch_version_lt
 from kornia.geometry.transform import Resize
 
 # Every test in this module must stay device-free: the mark deselects the whole file on non-CPU devices.
@@ -29,9 +30,18 @@ pytestmark = pytest.mark.device_agnostic
 
 onnx = pytest.importorskip("onnx")
 ort = pytest.importorskip("onnxruntime")
+pytest.importorskip("onnxscript")
+
+if torch_version_lt(2, 5, 0):
+    # Same floor as ``tests/onnx/test_export_coverage.py``: ``dynamo=True`` reaches the current
+    # exporter from torch 2.5 (no such keyword on 2.1-2.3, the retired ``dynamo_export`` on 2.4).
+    # These tests used to carry ``dynamo`` in their names, which the conftest deselects whenever
+    # ``KORNIA_TEST_OPTIMIZER`` is unset, so no CI job ever collected them; they are named for
+    # what they check instead.
+    pytest.skip("the dynamo ONNX exporter needs torch >= 2.5", allow_module_level=True)
 
 
-def test_resize_dynamo_with_binding():
+def test_resize_export_binding():
     model = Resize((32, 32), interpolation="bilinear")
     model.eval()
 
@@ -62,7 +72,7 @@ def test_resize_dynamo_with_binding():
             os.unlink(temp_path)
 
 
-def test_resize_upscale_dynamo():
+def test_resize_export_upscale():
     """Test upscaling with dynamo."""
     model = Resize((128, 128))
     model.eval()
@@ -93,7 +103,7 @@ def test_resize_upscale_dynamo():
             os.unlink(temp_path)
 
 
-def test_resize_downscale_dynamo():
+def test_resize_export_downscale():
     """Test downscaling with dynamo."""
     model = Resize((16, 16))
     model.eval()
@@ -124,7 +134,7 @@ def test_resize_downscale_dynamo():
             os.unlink(temp_path)
 
 
-def test_resize_nearest_dynamo():
+def test_resize_export_nearest():
     """Test nearest neighbor interpolation with dynamo."""
     model = Resize((32, 32), interpolation="nearest")
     model.eval()


### PR DESCRIPTION
## Summary

The scheduled CPU matrix went red on torch 2.2.2 / 2.3.1 / 2.4.0 after #4182: all 13 cases in `tests/onnx/test_export_coverage.py` failed. Two different reasons, per the logs:

- **2.2.2 / 2.3.1**: `TypeError: export() got an unexpected keyword argument 'dynamo'` — the keyword does not exist before 2.4.
- **2.4.0**: `dynamo=True` is accepted but routes to the retired `dynamo_export` path, which the onnxscript releases we resolve no longer serve (`OnnxExporterError`).

The module guard was `hasattr(torch.onnx, "ONNXProgram")`, but that class has existed since 2.2 as `dynamo_export`'s return type, so it never skipped. Gate on `torch_version_lt(2, 5, 0)` instead. The floor is 2.5 rather than the 2.6 `tests/filters/test_gaussian.py` uses for its smoke test, on purpose and documented in the file: these cases pin the export paths on the oldest exporter-capable release, and torch 2.5.1 is a blocking PR leg, so a regression there must fail rather than skip.

Also in the same module: `importorskip("onnxscript")` (the `docs` extra installs onnx/onnxruntime without it), `pytestmark = device_agnostic` so accelerator legs do not repeat CPU-bound exports, and the onnxruntime feed asserts a one-to-one input match instead of a silently truncating `zip`.

`tests/onnx/test_resize_onnx.py` had the same unguarded `dynamo=True` calls but was never collected: its tests carried `dynamo` in their names, which the conftest deselects whenever `KORNIA_TEST_OPTIMIZER` is unset, and no dynamo job includes `tests/onnx`. They are renamed for what they check, gated the same way, and now run.

Test-only change, no changelog entry.

## Test plan

- [x] torch 2.4.0 (fresh venv, onnxscript 0.7.1): `tests/onnx` -> 18 passed, both modules skipped
- [x] torch 2.5.1 and 2.9.1: `tests/onnx` -> 35 passed (the 4 Resize tests now collected)
- [x] `--device=cuda` collects nothing from the coverage module (device_agnostic)
- [x] pre-commit on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
