### PR TITLE
test: make zca whiten doctest robust

### DIFF
--- a/kornia/enhance/zca.py
+++ b/kornia/enhance/zca.py
@@ -292,11 +292,11 @@ def zca_whiten(inp: torch.Tensor, dim: int = 0, unbiased: bool = True, eps: floa
        blob/master/source/zca_whitening.ipynb>`__.
 
     Examples:
-        >>> x = torch.tensor([[0,1],[1,0],[-1,0]], dtype = torch.float32)
-        >>> zca_whiten(x)
-        tensor([[ 0.0000,  1.1547],
-                [ 1.0000, -0.5773],
-                [-1.0000, -0.5773]])
+    >>> x = torch.tensor([[0,1],[1,0],[-1,0]], dtype = torch.float32)
+    >>> zca_whiten(x).round(decimals=3)
+    tensor([[ 0.0000,  1.1550],
+            [ 1.0000, -0.5770],
+            [-1.0000, -0.5770]])
 
     """
     if not isinstance(inp, torch.Tensor):

--- a/kornia/enhance/zca.py
+++ b/kornia/enhance/zca.py
@@ -292,11 +292,11 @@ def zca_whiten(inp: torch.Tensor, dim: int = 0, unbiased: bool = True, eps: floa
        blob/master/source/zca_whitening.ipynb>`__.
 
     Examples:
-    >>> x = torch.tensor([[0,1],[1,0],[-1,0]], dtype = torch.float32)
-    >>> zca_whiten(x).round(decimals=3)
-    tensor([[ 0.0000,  1.1550],
-            [ 1.0000, -0.5770],
-            [-1.0000, -0.5770]])
+        >>> x = torch.tensor([[0,1],[1,0],[-1,0]], dtype = torch.float32)
+        >>> zca_whiten(x).round(decimals=3)
+        tensor([[ 0.0000,  1.1550],
+                [ 1.0000, -0.5770],
+                [-1.0000, -0.5770]])
 
     """
     if not isinstance(inp, torch.Tensor):


### PR DESCRIPTION
## What does this pull request do?

Updates the `zca_whiten` doctest to round the returned tensor to 3 decimal places before displaying it.

The previous doctest depended on a float32 value being printed on a platform-sensitive side of a 4-decimal rounding boundary. Rounding the displayed result to 3 decimals keeps the returned matrix visible while making the doctest more robust.

## Related issue or discussion

Related to #4086

## What did you check?

- `pixi run doctest` — 645 passed, 15 skipped
- `pixi run lint` — Ruff check passed, Ruff format passed
- `git diff --check` — passed
- Focused doctest: `pixi run uv run pytest --doctest-modules kornia/enhance/zca.py` — 4 passed
- ULP distance to the 4-decimal rounding boundary:
  - Before: 9.7 ULP
  - After rounding to 3 decimals: 419.2 ULP
  - The weakest margin improves by about 43x.

## Notes

No `CHANGELOG.md` entry is needed because this is a doctest-only change.

The macOS CI timeout in `tests/models/test_sam_onnx.py::test_sam_encoder_to_onnx` is unrelated to this change.

Please leave #4086 open; this PR only addresses the `zca_whiten` doctest case.

## How did AI help?

AI was used to help review and QA the implementation, check the test coverage, and identify potential issues or edge cases. I manually reviewed the suggested change and verified it by running the doctest and lint checks locally.