### PR TITLE
fix(tests): run the polynomial-solver gradchecks instead of shadowing BaseTester.gradcheck

### DIFF
--- a/tests/geometry/solvers/test_polynomial_solver.py
+++ b/tests/geometry/solvers/test_polynomial_solver.py
@@ -49,7 +49,12 @@ class TestQuadraticSolver(BaseTester):
         self.assert_close(roots[0], expected_solutions[0])
 
     def test_gradcheck(self, device):
-        coeffs = torch.rand(1, 3, device=device, dtype=torch.float64, requires_grad=True)
+        # Deterministic, strictly positive discriminant (b^2 - 4ac = 1): `torch.rand` draws
+        # all-positive coefficients, whose discriminant is usually negative, and the no-real-root
+        # branch returns zeros with an identically zero gradient -- so a random draw checks
+        # nothing roughly three times out of four. The zero-discriminant triple is excluded on
+        # purpose: `sqrt` is not differentiable at 0.
+        coeffs = torch.tensor([[1.0, -5.0, 6.0]], device=device, dtype=torch.float64, requires_grad=True)
         self.gradcheck(solver.solve_quadratic, (coeffs,))
 
 
@@ -81,7 +86,9 @@ class TestCubicSolver(BaseTester):
         self.assert_close(roots[0], expected_solutions[0], rtol=1e-3, atol=1e-3)
 
     def test_gradcheck(self, device):
-        coeffs = torch.rand(1, 4, device=device, dtype=torch.float64, requires_grad=True)
+        # Deterministic three-distinct-real-roots case (roots 2, -3, -1/2), so the check does not
+        # depend on an unseeded draw. Repeated roots are excluded: they sit on the `sqrt` kink.
+        coeffs = torch.tensor([[2.0, 3.0, -11.0, -6.0]], device=device, dtype=torch.float64, requires_grad=True)
         self.gradcheck(solver.solve_cubic, (coeffs,))
 
 

--- a/tests/geometry/solvers/test_polynomial_solver.py
+++ b/tests/geometry/solvers/test_polynomial_solver.py
@@ -48,9 +48,9 @@ class TestQuadraticSolver(BaseTester):
         roots = solver.solve_quadratic(coeffs)
         self.assert_close(roots[0], expected_solutions[0])
 
-    def gradcheck(self, device):
+    def test_gradcheck(self, device):
         coeffs = torch.rand(1, 3, device=device, dtype=torch.float64, requires_grad=True)
-        assert self.gradcheck(solver.solve_quadratic, (coeffs), raise_exception=True, fast_mode=True)
+        self.gradcheck(solver.solve_quadratic, (coeffs,))
 
 
 class TestCubicSolver(BaseTester):
@@ -80,9 +80,9 @@ class TestCubicSolver(BaseTester):
         roots = solver.solve_cubic(coeffs)
         self.assert_close(roots[0], expected_solutions[0], rtol=1e-3, atol=1e-3)
 
-    def gradcheck(self, device):
+    def test_gradcheck(self, device):
         coeffs = torch.rand(1, 4, device=device, dtype=torch.float64, requires_grad=True)
-        assert self.gradcheck(solver.solve_cubic, (coeffs), raise_exception=True, fast_mode=True)
+        self.gradcheck(solver.solve_cubic, (coeffs,))
 
 
 class TestMultiplyDegOnePoly(BaseTester):


### PR DESCRIPTION
### Description

`tests/geometry/solvers/test_polynomial_solver.py` declares its gradient tests as `def gradcheck(self, device)` instead of `def test_gradcheck(self, device)`:

```python
class TestQuadraticSolver(BaseTester):
    ...
    def gradcheck(self, device):
        coeffs = torch.rand(1, 3, device=device, dtype=torch.float64, requires_grad=True)
        assert self.gradcheck(solver.solve_quadratic, (coeffs), raise_exception=True, fast_mode=True)
```

This has two effects:

1. **The tests never run.** pytest collects `test_*`, so `solve_quadratic` and `solve_cubic` have had no gradient coverage.
2. **They would crash if they did run.** The method name shadows `BaseTester.gradcheck`, so the body's `self.gradcheck(...)` recurses into the test method itself rather than reaching the helper:

```
TypeError: TestQuadraticSolver.gradcheck() got an unexpected keyword argument 'raise_exception'
```

These two are the only `def gradcheck(self` in the entire test suite — the other **146** test files all use `def test_gradcheck`:

```console
$ grep -rn "    def gradcheck(self" tests/
tests/geometry/solvers/test_polynomial_solver.py:51:    def gradcheck(self, device):
tests/geometry/solvers/test_polynomial_solver.py:83:    def gradcheck(self, device):

$ grep -rln "def test_gradcheck" tests/ | wc -l
146
```

### Changes

* Rename both methods to `test_gradcheck` so pytest collects them and `self.gradcheck` resolves to `BaseTester.gradcheck`.
* `(coeffs)` → `(coeffs,)`, so the inputs are a real 1-tuple like every sibling (`self.gradcheck(kgl.inverse_transformation, (trans_01,))`).
* Drop `raise_exception=True, fast_mode=True` and the `assert` wrapper — both are already the `BaseTester.gradcheck` defaults and no sibling passes them.

Naming them `test_gradcheck` also picks up the `*gradcheck*` name-based MPS/XLA marker that `conftest.py` applies, which the comment in `BaseTester.gradcheck` relies on.

### Verification

Reproduced the `TypeError` against the current `main` body, then ran both gradchecks with the fix applied (CPU, float64, real `kornia.geometry.solvers`):

```
--- unpatched (as written in main) ---
TypeError: TestQuadraticSolver.gradcheck() got an unexpected keyword argument 'raise_exception'
--- patched ---
quad gradcheck OK
cubic gradcheck OK
```

`ruff check` and `ruff format --check` (v0.16.4, repo config) both pass on the changed file.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
