### PR TITLE
fix(geometry): preserve xyzwhd dimension order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `kernel_size >= 63` now raises: CPU used to return a usable-looking answer there while MPS silently returned
   something else for the same call.
 
+* Fix `Boxes3D.from_tensor(..., mode="xyzwhd")` to preserve width, height, and depth field order for asymmetric
+  boxes. (#4189)
+
 * `RandomTransplantation` and `RandomTransplantation3D` transplanted nothing on MPS when no `excluded_labels`
   were given: PyTorch's MPS backend evaluates `all()` over the empty excluded-label axis to an undefined value,
   usually `False`, so every donor label was filtered out and the output equalled the input. The filter is now skipped when there is

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -1154,7 +1154,7 @@ class Boxes3D:
             height = boxes[..., 4] - boxes[..., 1] + 1
             depth = boxes[..., 5] - boxes[..., 2] + 1
         elif mode == "xyzwhd":
-            depth, height, width = boxes[..., 4], boxes[..., 3], boxes[..., 5]
+            width, height, depth = boxes[..., 3], boxes[..., 4], boxes[..., 5]
         else:
             raise ValueError(f"Unknown mode {mode}")
 

--- a/tests/geometry/test_boxes.py
+++ b/tests/geometry/test_boxes.py
@@ -796,12 +796,12 @@ class TestBbox3D(BaseTester):
 
     @pytest.mark.parametrize("shape", [(1, 6), (1, 1, 6)])
     def test_from_tensor(self, shape, device, dtype):
-        box_xyzxyz = torch.as_tensor([[1, 2, 3, 4, 5, 6]], device=device, dtype=dtype).view(*shape)
-        box_xyzxyz_plus = torch.as_tensor([[1, 2, 3, 3, 4, 5]], device=device, dtype=dtype).view(*shape)
-        box_xyzwhd = torch.as_tensor([[1, 2, 3, 3, 3, 3]], device=device, dtype=dtype).view(*shape)
+        box_xyzxyz = torch.as_tensor([[1, 2, 3, 3, 5, 7]], device=device, dtype=dtype).view(*shape)
+        box_xyzxyz_plus = torch.as_tensor([[1, 2, 3, 2, 4, 6]], device=device, dtype=dtype).view(*shape)
+        box_xyzwhd = torch.as_tensor([[1, 2, 3, 2, 3, 4]], device=device, dtype=dtype).view(*shape)
 
         expected_box = torch.as_tensor(
-            [[[1, 2, 3], [3, 2, 3], [3, 4, 3], [1, 4, 3], [1, 2, 5], [3, 2, 5], [3, 4, 5], [1, 4, 5]]],  # Front  # Back
+            [[[1, 2, 3], [2, 2, 3], [2, 4, 3], [1, 4, 3], [1, 2, 6], [2, 2, 6], [2, 4, 6], [1, 4, 6]]],  # Front  # Back
             device=device,
             dtype=dtype,
         ).view(*shape[:-1], 8, 3)


### PR DESCRIPTION
## What does this pull request do?

`Boxes3D.from_tensor(..., mode="xyzwhd")` currently consumes the width, height, and depth fields in the wrong order.

The `xyzwhd` format is:

```text
x, y, z, width, height, depth
```

but the input path currently maps the final fields as:

```python
depth, height, width = boxes[..., 4], boxes[..., 3], boxes[..., 5]
```

For asymmetric boxes, this changes the intended `(width, height, depth)` ordering into `(depth, width, height)`.

This PR corrects only that input mapping:

```python
width, height, depth = boxes[..., 3], boxes[..., 4], boxes[..., 5]
```

The existing `TestBbox3D.test_from_tensor` case is also made asymmetric so the permutation is observable instead of being hidden by equal dimensions.

The existing parameterization continues to cover both accepted input ranks:

- `(N, 6)`
- `(B, N, 6)`

and the `xyzxyz`, `xyzxyz_plus`, and `xyzwhd` inputs describe the same asymmetric 3D box.

`Boxes3D.to_tensor("xyzwhd")` is intentionally unchanged because it already produces the correct field order.

`Boxes3D.get_boxes_shape()` is also intentionally unchanged; its `(depths, heights, widths)` return order is deliberate and documented.

No public mode contract or unrelated `Boxes3D` behavior is changed.

A bug-fix entry for this PR is included under `## Unreleased` in `CHANGELOG.md`.

## Related issue or discussion

Fixes #4058

## What did you check?

### Regression proof against the merge-base implementation

The updated `TestBbox3D.test_from_tensor` regression was run against the merge-base implementation in a detached temporary worktree at:

```text
e096943818fffedf4d2e605fe4a30ca4c117faf6
```

with only the updated test copied into that worktree.

```text
python -m pytest tests/geometry/test_boxes.py::TestBbox3D::test_from_tensor -q --tb=short --device=cpu --dtype=float32,float64
```

Result on the old implementation:

```text
4 failed in 1.62s
Mismatched elements: 12 / 24 (50.0%)
Greatest absolute difference: 2.0
```

All four failures occur at the asymmetric `xyzwhd` assertion. The preceding `xyzxyz` and `xyzxyz_plus` assertions pass, which isolates the regression to the `xyzwhd` input mapping.

The old mapping interprets an intended:

```text
width=2, height=3, depth=4
```

as:

```text
width=4, height=2, depth=3
```

### Focused regression on the corrected branch

```text
pixi run test-module tests/geometry/test_boxes.py::TestBbox3D::test_from_tensor --device=cpu --dtype=float32,float64
```

```text
4 passed
```

### Full relevant module

```text
pixi run test-module tests/geometry/test_boxes.py --device=cpu --dtype=float32,float64
```

```text
124 passed
```

### Lint and formatting

```text
pixi run lint
```

```text
ruff check   Passed
ruff format  Passed
```

### Type checking

```text
pixi run typecheck
```

```text
Exit code 0
```

The command reports one existing deprecation diagnostic in `kornia/feature/lightglue.py` for `torch.cuda.amp.custom_fwd`; it is unrelated to this change.

### Pre-commit

```text
pixi run uv run pre-commit run --files kornia/geometry/boxes.py tests/geometry/test_boxes.py
```

All applicable hooks passed, including formatting, line-ending, Ruff, codespell, merge-conflict, and license-header checks.

The branch was also rebased onto the current `upstream/main` without conflicts, and:

```text
git diff --check upstream/main...HEAD
```

passes.

## How did AI help?

I used AI-assisted tooling to help inspect the existing implementation and test coverage, compare the local patch against the maintainer-confirmed scope, and run the repository validation steps.

I reviewed the resulting source and test diff myself, verified that the asymmetric regression fails specifically against the merge-base `xyzwhd` implementation, confirmed that the corrected version passes both accepted input ranks, and reran the relevant module, lint, type checking, pre-commit, and Git checks locally before preparing this pull request.