### PR TITLE
test(onnx): point the standalone check helper at the renamed Resize tests

### DIFF
--- a/tests/onnx/check.py
+++ b/tests/onnx/check.py
@@ -22,12 +22,12 @@ sys.path.insert(0, str(script_dir))
 # ruff: noqa: E402
 import test_resize_onnx
 
-test_resize_onnx.test_resize_dynamo_with_binding()
+test_resize_onnx.test_resize_export_binding()
 print("Test 1 passed")
-test_resize_onnx.test_resize_upscale_dynamo()
+test_resize_onnx.test_resize_export_upscale()
 print("Test 2 passed")
-test_resize_onnx.test_resize_downscale_dynamo()
+test_resize_onnx.test_resize_export_downscale()
 print("Test 3 passed")
-test_resize_onnx.test_resize_nearest_dynamo()
+test_resize_onnx.test_resize_export_nearest()
 print("Test 4 passed")
 print("ALL TESTS PASSED")


### PR DESCRIPTION
## Summary

Follow-up to #4186, which renamed the four tests in `tests/onnx/test_resize_onnx.py` to `test_resize_export_*` but left the standalone helper `tests/onnx/check.py` calling the old names, so `python tests/onnx/check.py` raised `AttributeError`. The four calls now use the new names.

The helper predates pytest collecting those tests (they were hidden by the `dynamo` name filter until #4186). It still runs, but it is now redundant with `pytest tests/onnx/test_resize_onnx.py`; happy to delete it in this PR if you prefer that over keeping it in sync.

## Test plan

- [x] `python tests/onnx/check.py` prints `ALL TESTS PASSED` on torch 2.5.1 and 2.9.1
- [x] pre-commit on the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
