### PR TITLE
fix(geometry): accept as_padded_sequence on VideoBoxes.to_tensor

### DIFF
--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -968,18 +968,22 @@ class VideoBoxes(Boxes):
         out.temporal_channel_size = temporal_channel_size
         return out
 
-    def to_tensor(self, mode: Optional[str] = None) -> torch.Tensor | list[torch.Tensor]:  # type: ignore[override]
+    def to_tensor(
+        self, mode: Optional[str] = None, as_padded_sequence: bool = False
+    ) -> torch.Tensor | list[torch.Tensor]:  # type: ignore[override]
         r"""Cast :class:`VideoBoxes` to a tensor with the temporal axis restored.
 
         Args:
             mode: Output box format forwarded to :meth:`Boxes.to_tensor`. When
                 ``None``, uses the stored mode (``vertices_plus`` by default).
+            as_padded_sequence: Forwarded to :meth:`Boxes.to_tensor`. Inherited
+                helpers such as :meth:`get_boxes_shape` pass ``True``.
 
         Returns:
             Tensor shaped :math:`(B, T, \ldots)` where :math:`T` is
             :attr:`temporal_channel_size`.
         """
-        out = super().to_tensor(mode, as_padded_sequence=False)
+        out = super().to_tensor(mode, as_padded_sequence=as_padded_sequence)
         if isinstance(out, torch.Tensor):
             return out.view(-1, self.temporal_channel_size, *out.shape[1:])
         # If returns a list of boxes.

--- a/tests/geometry/test_boxes.py
+++ b/tests/geometry/test_boxes.py
@@ -1173,6 +1173,16 @@ class TestVideoBoxes(BaseTester):
         cloned.data[0, 0, 0, 0] = -1
         assert not torch.equal(cloned.data, video_boxes.data)
 
+    def test_get_boxes_shape_accepts_as_padded_sequence(self, device, dtype):
+        # #4176: inherited get_boxes_shape passes as_padded_sequence=True to to_tensor.
+        boxes = self._sample_video_boxes(device, dtype, batch=1, time=1, n_boxes=1)
+        video_boxes = VideoBoxes.from_tensor(boxes)
+        heights, widths = video_boxes.get_boxes_shape()
+        assert heights.shape == (1, 1, 1)
+        assert widths.shape == (1, 1, 1)
+        self.assert_close(heights, torch.tensor([[[3.0]]], device=device, dtype=dtype))
+        self.assert_close(widths, torch.tensor([[[3.0]]], device=device, dtype=dtype))
+
     def test_public_api_surface(self):
         # Pin #4016: VideoBoxes is exported and the overrides are documented.
         assert "VideoBoxes" in boxes_module.__all__


### PR DESCRIPTION
## Description

Fixes #4176.

`Boxes.get_boxes_shape` (and other inherited helpers) call `self.to_tensor(..., as_padded_sequence=True)`. `VideoBoxes.to_tensor` only accepted `mode`, so every `VideoBoxes.get_boxes_shape()` call raised `TypeError`.

Forward `as_padded_sequence` to `Boxes.to_tensor` and keep the temporal reshape.

## Test plan

```bash
pytest tests/geometry/test_boxes.py::TestVideoBoxes::test_get_boxes_shape_accepts_as_padded_sequence -q --device=cpu
```

1 passed.

## AI assistance

AI-generated fix and regression test. I reviewed the diff and ran the focused VideoBoxes test locally.

Made with [Cursor](https://cursor.com)