### PR TITLE
fix(geometry): preserve list padding metadata in Boxes.__getitem__

### DIFF
--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -303,6 +303,16 @@ class Boxes:
     def __getitem__(self, key: slice | int | torch.Tensor) -> Boxes:
         new_box = type(self)(self._data[key], False)
         new_box._mode = self._mode
+        # Preserve list-padding metadata so to_tensor() still trims pad rows (#4179).
+        # An int key drops the batch axis and returns an unbatched object (no _N).
+        if self._N is not None and not isinstance(key, int):
+            if isinstance(key, torch.Tensor):
+                indices = key.tolist()
+                if isinstance(indices, int):
+                    indices = [indices]
+                new_box._N = [self._N[i] for i in indices]
+            else:
+                new_box._N = list(self._N[key])
         return new_box
 
     def __setitem__(self, key: slice | int | torch.Tensor, value: Boxes) -> Boxes:

--- a/tests/geometry/test_boxes.py
+++ b/tests/geometry/test_boxes.py
@@ -220,6 +220,18 @@ class TestBoxes2D(BaseTester):
         self.assert_close(boxes.data, boxes_before, atol=0.0, rtol=0.0)
         self.assert_close(replacement.data, replacement_before, atol=0.0, rtol=0.0)
 
+    def test_getitem_preserves_list_padding_metadata(self, device, dtype):
+        # #4179: slicing a list-backed Boxes must keep _N so pad rows stay trimmed.
+        first = torch.tensor([[[1.0, 2.0], [4.0, 2.0], [4.0, 3.0], [1.0, 3.0]]], device=device, dtype=dtype)
+        lb = Boxes([first, torch.cat([first, first])])
+        assert lb._N == [1, 0]
+        sliced = lb[0:1]
+        assert sliced._N == [1]
+        exported = sliced.to_tensor("xyxy")
+        assert isinstance(exported, list)
+        assert len(exported) == 1
+        assert exported[0].shape == (1, 4)
+
     def test_smoke(self, device, dtype):
         def _create_tensor_box():
             # Sample two points of the rectangle


### PR DESCRIPTION
## Description

Fixes #4179.

`Boxes.__getitem__` rebuilt from the padded tensor and only copied `_mode`, dropping `_N`. Sliced list-backed objects then exported pad rows as boxes via `to_tensor()`.

Preserve `_N` for slice / tensor indexing; int keys still drop the batch axis (no `_N`).

## Test plan

```bash
pytest tests/geometry/test_boxes.py::TestBoxes2D::test_getitem_preserves_list_padding_metadata -q --device=cpu
```

1 passed.

## AI assistance

AI-generated fix and regression test. I reviewed the diff and ran the focused test locally.

Made with [Cursor](https://cursor.com)