### PR TITLE
test(models): skip the SAM ONNX export test on macOS runners

### DIFF
--- a/tests/models/test_sam_onnx.py
+++ b/tests/models/test_sam_onnx.py
@@ -17,6 +17,8 @@
 
 """ONNX export tests for SAM (image encoder subgraph)."""
 
+import sys
+
 import pytest
 
 from kornia.models.sam.model import Sam, SamConfig
@@ -31,6 +33,10 @@ def test_sam_has_to_onnx():
 
 
 @pytest.mark.timeout(120)
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="TorchScript tracing of the SAM encoder exceeds the 120s timeout on macOS CI runners",
+)
 def test_sam_encoder_to_onnx(tmp_path):
     """Sam.to_onnx() exports the image encoder subgraph with correct output name."""
     onnx = pytest.importorskip("onnx")


### PR DESCRIPTION
`tests/models/test_sam_onnx.py::test_sam_encoder_to_onnx` reliably exceeds its 120s `pytest-timeout` inside `torch/jit/_trace.py` on the macOS CI runner, failing the whole job while the other 8920 tests in it pass.

It is not a flake — the job failed identically on a re-run of the same commit:

- [`tests (macos-latest, float32, 3.12, 2.5.1)`, first run](https://github.com/kornia/kornia/actions/runs/33785713279/job/100751322238) — `1 failed, 8920 passed, 3577 skipped` in 337s
- [same job, re-run](https://github.com/kornia/kornia/actions/runs/33785713279/job/100759403909) — same test, same `Failed: Timeout (>120.0s) from pytest-timeout`

## Why skip rather than bump the timeout again

The test already shrinks the model to a tiny pseudo-SAM (`encoder_embed_dim=16`, `encoder_depth=1`, `encoder_num_heads=1`) specifically to keep the trace cheap, with a comment saying so, and #3784 already bumped the timeouts on this family of tests once. Raising the number a second time moves the threshold rather than fixing anything, and leaves the job one slow runner away from failing again.

The export path itself is platform-independent, so it stays covered on Linux and Windows — this only stops the macOS runner from gating on a tracing cost it cannot meet. `test_sam_has_to_onnx` is untouched and still runs everywhere.

## Checked

- `pytest tests/models/test_sam_onnx.py` on Linux: 2 passed — the skip is `sys.platform == "darwin"` only, so the export test still runs here.
- `pre-commit` clean on the changed file.
- Uses the same `@pytest.mark.skipif(sys.platform == ...)` form already used elsewhere in `tests/` for platform-specific CI limits.

Found while getting #4119 green; unrelated to that PR's contents, so it ships separately.

Written by Claude (Opus 5) on behalf of @ducha-aiki

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
