### PR TITLE
docs(core): update stale CI torch version in comments (2.9.1 → 2.14.0)

### DIFF
--- a/kornia/core/_small_linalg.py
+++ b/kornia/core/_small_linalg.py
@@ -171,10 +171,10 @@ def _inverse_3x3_cross(input: torch.Tensor) -> torch.Tensor:
     Prefer :func:`_inverse_3x3_scalar` wherever a graph is being captured. The reason is
     **kernel coverage, not ONNX lowering**: a backend with no ``cross`` kernel for the working
     dtype makes this raise rather than return -- torch 2.5.1 has no ``bfloat16`` ``cross`` on
-    MPS, while 2.9.1 does.
+    MPS, while 2.14.0 does.
 
     ONNX lowering is *not* a reason, measured: ``torch.linalg.cross`` lowers on both torch
-    versions kornia's CI runs -- 2.5.1 (legacy exporter) and 2.9.1 (legacy and dynamo) -- to
+    versions kornia's CI runs -- 2.5.1 (legacy exporter) and 2.14.0 (legacy and dynamo) -- to
     ``Slice``/``Mul``/``Sub``/``Concat``. What neither exporter lowers on either version is
     ``aten::linalg_inv``, which is what :func:`kornia.core.utils._torch_inverse_cast` avoids by
     reaching for a closed form in the first place. torch 2.0-2.4 is below the declared floor; CI does not run it

--- a/kornia/core/utils.py
+++ b/kornia/core/utils.py
@@ -197,7 +197,7 @@ def _inverse_3x3_closed_form(input: torch.Tensor) -> torch.Tensor:
     # Under tracing/export (legacy ONNX / jit.trace / dynamo ONNX) stick to the plain scalar
     # adjugate. NOTE the original rationale here -- "whereas ``cross`` may not [lower]" -- does not
     # hold on the torch versions CI runs: measured, ``torch.linalg.cross`` lowers on 2.5.1 (legacy
-    # exporter) and on 2.9.1 (both exporters). The split is kept because it is still the safer
+    # exporter) and on 2.14.0 (both exporters). The split is kept because it is still the safer
     # capture path (scalar arithmetic needs no per-dtype kernel at all, and ``cross`` has real
     # kernel gaps -- no bfloat16 on MPS in torch 2.5.1), not because ``cross`` fails to export.
     # Collapsing the two branches is a behavior change and belongs in its own PR.


### PR DESCRIPTION
Update stale CI torch-version references in two docstring/comment blocks.

**Background**

`kornia/core/_small_linalg.py` and `kornia/core/utils.py` both contain
prose that cites the torch versions measured during ONNX-lowering
experiments. Those comments still reference `2.9.1` as the upper CI
version, but the PR CI matrix (`pr_test_cpu.yml`) has moved on:

```yaml
# pr_test_cpu.yml
pytorch-version: ["2.5.1", "2.14.0"]   # main matrix
pytorch-version: ["2.14.0"]            # dynamo / compile leg
```

The functional claims remain valid — `torch.linalg.cross` still lowers
correctly and `aten::linalg_inv` still does not export — so this is a
documentation-only correction.

**Changes**

| File | Location | Before | After |
|------|----------|--------|-------|
| `kornia/core/_small_linalg.py` | line 174 | `while 2.9.1 does` | `while 2.14.0 does` |
| `kornia/core/_small_linalg.py` | line 177 | `2.9.1 (legacy and dynamo)` | `2.14.0 (legacy and dynamo)` |
| `kornia/core/utils.py` | line 200 | `2.9.1 (both exporters)` | `2.14.0 (both exporters)` |

Closes #4206
