### PR TITLE
ci: guard pinned runner availability

### DIFF
--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -21,6 +21,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pinned-runner-macos-15:
+    name: Pinned runner availability (macos-15)
+    if: github.event_name == 'schedule'
+    runs-on: macos-15
+    steps:
+      - name: Confirm macos-15 runner availability
+        run: echo "macos-15 runner is available"
+
+  pinned-runner-windows-2022:
+    name: Pinned runner availability (windows-2022)
+    if: github.event_name == 'schedule'
+    runs-on: windows-2022
+    steps:
+      - name: Confirm windows-2022 runner availability
+        run: echo "windows-2022 runner is available"
+
   check-skip:
     # For scheduled runs, check if only documentation files changed
     # If so, skip the expensive test runs

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -23,16 +23,24 @@ concurrency:
 jobs:
   pinned-runner-macos-15:
     name: Pinned runner availability (macos-15)
-    if: github.event_name == 'schedule'
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      github.repository == 'kornia/kornia' &&
+      startsWith(github.workflow_ref, 'kornia/kornia/.github/workflows/scheduled_test_cpu.yml@')
     runs-on: macos-15
+    timeout-minutes: 5
     steps:
       - name: Confirm macos-15 runner availability
         run: echo "macos-15 runner is available"
 
   pinned-runner-windows-2022:
     name: Pinned runner availability (windows-2022)
-    if: github.event_name == 'schedule'
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      github.repository == 'kornia/kornia' &&
+      startsWith(github.workflow_ref, 'kornia/kornia/.github/workflows/scheduled_test_cpu.yml@')
     runs-on: windows-2022
+    timeout-minutes: 5
     steps:
       - name: Confirm windows-2022 runner availability
         run: echo "windows-2022 runner is available"

--- a/tests/test_half_precision_ci.py
+++ b/tests/test_half_precision_ci.py
@@ -878,12 +878,15 @@ def test_reusable_test_workflow_names_candidate_by_resolved_torch() -> None:
     assert "-${{ matrix.pytorch-version }}\n" not in workflow.partition("Upload candidate manifest")[2]
 
 
-def test_pinned_runner_images_have_scheduled_availability_guards() -> None:
+def test_pinned_runner_images_have_availability_guards() -> None:
     root = Path(project_conftest.__file__).parent
     pr_workflow = (root / ".github" / "workflows" / "pr_test_cpu.yml").read_text(encoding="utf-8")
     scheduled_workflow = (root / ".github" / "workflows" / "scheduled_test_cpu.yml").read_text(encoding="utf-8")
 
-    assert re.search(r"  tests-mps:.*?\n      os: macos-15\n", pr_workflow, re.DOTALL)
+    _, separator, tests_mps_tail = pr_workflow.partition("  tests-mps:\n")
+    assert separator, "missing tests-mps job"
+    tests_mps = re.split(r"\n(?=  [\w-]+:\n)", tests_mps_tail, maxsplit=1)[0]
+    assert "\n      os: macos-15\n" in tests_mps
     assert "          - os: windows-2022\n" in pr_workflow
     assert "          - os: windows-2022\n" in scheduled_workflow
 
@@ -893,8 +896,14 @@ def test_pinned_runner_images_have_scheduled_availability_guards() -> None:
         guard = re.split(r"\n(?=  [\w-]+:\n)", tail, maxsplit=1)[0]
 
         assert f"    name: Pinned runner availability ({label})\n" in guard
-        assert "    if: github.event_name == 'schedule'\n" in guard
+        assert (
+            "    if: >-\n"
+            "      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&\n"
+            "      github.repository == 'kornia/kornia' &&\n"
+            "      startsWith(github.workflow_ref, 'kornia/kornia/.github/workflows/scheduled_test_cpu.yml@')\n"
+        ) in guard
         assert f"    runs-on: {label}\n" in guard
+        assert "    timeout-minutes: 5\n" in guard
         assert "    needs:" not in guard
 
 

--- a/tests/test_half_precision_ci.py
+++ b/tests/test_half_precision_ci.py
@@ -878,6 +878,26 @@ def test_reusable_test_workflow_names_candidate_by_resolved_torch() -> None:
     assert "-${{ matrix.pytorch-version }}\n" not in workflow.partition("Upload candidate manifest")[2]
 
 
+def test_pinned_runner_images_have_scheduled_availability_guards() -> None:
+    root = Path(project_conftest.__file__).parent
+    pr_workflow = (root / ".github" / "workflows" / "pr_test_cpu.yml").read_text(encoding="utf-8")
+    scheduled_workflow = (root / ".github" / "workflows" / "scheduled_test_cpu.yml").read_text(encoding="utf-8")
+
+    assert re.search(r"  tests-mps:.*?\n      os: macos-15\n", pr_workflow, re.DOTALL)
+    assert "          - os: windows-2022\n" in pr_workflow
+    assert "          - os: windows-2022\n" in scheduled_workflow
+
+    for label in ("macos-15", "windows-2022"):
+        _, separator, tail = scheduled_workflow.partition(f"  pinned-runner-{label}:\n")
+        assert separator, f"missing scheduled availability guard for {label}"
+        guard = re.split(r"\n(?=  [\w-]+:\n)", tail, maxsplit=1)[0]
+
+        assert f"    name: Pinned runner availability ({label})\n" in guard
+        assert "    if: github.event_name == 'schedule'\n" in guard
+        assert f"    runs-on: {label}\n" in guard
+        assert "    needs:" not in guard
+
+
 @pytest.mark.parametrize("workflow_name", ["pr_test_cpu.yml", "scheduled_test_cpu.yml"])
 def test_cpu_half_workflow_uses_complete_profile(workflow_name: str) -> None:
     root = Path(project_conftest.__file__).parent


### PR DESCRIPTION
## What does this pull request do?

Adds independent availability jobs for the pinned `macos-15` and `windows-2022` runner labels in the scheduled CPU workflow. The guards run on direct upstream `schedule` and manual `workflow_dispatch` executions, while repository and workflow identity checks keep them out of push and reusable `workflow_call` paths. Each guard runs directly on its exact pinned image with a single echo step, has `timeout-minutes: 5`, and has no dependency on `check-skip` or `pre-tests`.

A focused workflow-text regression test verifies that the PR MPS leg remains pinned to `macos-15` specifically inside `tests-mps`, that the PR and scheduled Windows 2.5.1 legs retain `windows-2022`, and that both availability guards keep their event/workflow identity conditions, exact labels, five-minute timeout, and skip independence.

## Related issue or discussion

Fixes #4208

## What did you check?

The focused pinned-runner invariant passed, and all repository pre-commit checks passed.

```text
$ pixi run test-module tests/test_half_precision_ci.py -k pinned_runner_images
$ pixi run pre-commit-all
```

## How did AI help?

AI helped inspect the workflow execution conditions, tighten the runner-pin regression test, and apply the maintainer-requested manual probe and timeout behavior. The focused regression and repository pre-commit checks were run afterward.