### PR TITLE
fix(geometry): use reshape instead of view in bbox validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `validate_bbox` and `validate_bbox3d` flatten rank-4 `(B, N, 4, 2)` / `(B, N, 8, 3)` input with `reshape`
+  instead of `view`, so a non-contiguous leading-dimension stride (a transpose, a slice that drops boxes, an
+  `expand`) returns a boolean as documented instead of raising `RuntimeError`. (#4174)
+
 * Constructing `ScaleSpaceDetector` with `compile_modules` no longer permanently mutates the process-global
   `torch._dynamo.config.capture_dynamic_output_shape_ops` setting. (#4134)
 

--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -61,7 +61,7 @@ def validate_bbox(boxes: torch.Tensor) -> bool:
 
     Args:
         boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have the shape
-            of :math:`(B, 4, 2)` or view-compatible :math:`(B, N, 4, 2)`, where each box is defined in the
+            of :math:`(B, 4, 2)` or :math:`(B, N, 4, 2)`, where each box is defined in the
             following ``clockwise`` order: top-left, top-right, bottom-right, bottom-left. The coordinates must be in
             the x, y order.
 

--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -52,11 +52,8 @@ def validate_bbox(boxes: torch.Tensor) -> bool:
         and zero-area boxes; other vertex relabelings can fail. The inclusive ``+1`` terms, tracked in
         `#3934 <https://github.com/kornia/kornia/issues/3934>`_, cancel in exact arithmetic, but finite-precision
         rounding can make the result differ from exclusive arithmetic, particularly for low-precision dtypes.
-
-    .. warning::
-        Rank-4 input is flattened with ``view``. A stride layout whose leading dimensions cannot be flattened this
-        way raises ``RuntimeError`` instead of returning a boolean. This wart is tracked in
-        `#4174 <https://github.com/kornia/kornia/issues/4174>`_.
+        Rank-4 input is flattened with ``reshape``, so any stride layout is accepted, matching the shape the
+        docstring documents.
 
     .. warning::
         :func:`validate_bbox3d` raises ``AssertionError`` where this function returns ``False``. That
@@ -73,7 +70,7 @@ def validate_bbox(boxes: torch.Tensor) -> bool:
         return False
 
     if len(boxes.shape) == 4:
-        boxes = boxes.view(-1, 4, 2)
+        boxes = boxes.reshape(-1, 4, 2)
 
     x_tl, y_tl = boxes[..., 0, 0], boxes[..., 0, 1]
     x_tr, y_tr = boxes[..., 1, 0], boxes[..., 1, 1]
@@ -111,7 +108,7 @@ def validate_bbox3d(boxes: torch.Tensor) -> bool:
         raise AssertionError(f"Box shape must be (B, 8, 3) or (B, N, 8, 3). Got {boxes.shape}.")
 
     if len(boxes.shape) == 4:
-        boxes = boxes.view(-1, 8, 3)
+        boxes = boxes.reshape(-1, 8, 3)
 
     # The cube checks below read the data, which graph capture cannot do; skip them under export.
     if is_exporting():

--- a/tests/geometry/test_bbox.py
+++ b/tests/geometry/test_bbox.py
@@ -112,6 +112,10 @@ class TestBbox2D(BaseTester):
         assert not sliced.is_contiguous()
         assert validate_bbox(sliced) is True
 
+        expanded = torch.zeros(1, 3, 4, 2, device=device, dtype=dtype).expand(2, -1, -1, -1)
+        assert expanded.stride(0) == 0
+        assert validate_bbox(expanded) is True
+
     def test_convention_validate_bbox_invariance_is_exact_arithmetic_only(self, device):
         # In float16 the inclusive +1 rounds distinct sub-unit spans to the same
         # value, although the exclusive span difference exceeds the 1e-4 threshold.

--- a/tests/geometry/test_bbox.py
+++ b/tests/geometry/test_bbox.py
@@ -100,13 +100,17 @@ class TestBbox2D(BaseTester):
         trapezoid = torch.tensor([[[[0.0, 0.0], [10.0, 0.0], [10.0, 5.0], [3.0, 5.0]]]], device=device, dtype=dtype)
         assert validate_bbox(trapezoid) is False
 
-    def test_wart_validate_bbox_rank4_view_layout_4174(self, device, dtype):
-        # Wart pin for kornia#4174: rank-4 input is flattened with view, so an
-        # incompatible leading-dimension stride raises instead of returning a boolean.
+    def test_convention_validate_bbox_accepts_noncontiguous_rank4_layout_4174(self, device, dtype):
+        # Fix pin for kornia#4174: rank-4 input is flattened with reshape, so a stride
+        # layout whose leading dimensions cannot be merged by view now returns a
+        # boolean instead of raising RuntimeError.
         boxes = torch.zeros(2, 3, 4, 2, device=device, dtype=dtype).transpose(0, 1)
         assert not boxes.is_contiguous()
-        with pytest.raises(RuntimeError):
-            validate_bbox(boxes)
+        assert validate_bbox(boxes) is True
+
+        sliced = torch.zeros(2, 4, 4, 2, device=device, dtype=dtype)[:, 1:]
+        assert not sliced.is_contiguous()
+        assert validate_bbox(sliced) is True
 
     def test_convention_validate_bbox_invariance_is_exact_arithmetic_only(self, device):
         # In float16 the inclusive +1 rounds distinct sub-unit spans to the same
@@ -362,6 +366,14 @@ class TestBbox3D(BaseTester):
 
         # Validate
         assert validate_bbox3d(bbox)
+
+    def test_convention_validate_bbox3d_accepts_noncontiguous_rank4_layout_4174(self, device, dtype):
+        # Fix pin for kornia#4174: rank-4 input is flattened with reshape, so a stride
+        # layout whose leading dimensions cannot be merged by view now returns a
+        # boolean instead of raising RuntimeError.
+        boxes = torch.zeros(2, 3, 8, 3, device=device, dtype=dtype).transpose(0, 1)
+        assert not boxes.is_contiguous()
+        assert validate_bbox3d(boxes) is True
 
     def test_bounding_boxes_dim_inferring(self, device, dtype):
         boxes = torch.tensor(


### PR DESCRIPTION
## What does this pull request do?

`validate_bbox` and `validate_bbox3d` now flatten rank-4 inputs with `reshape`, so non-contiguous layouts do not hit the old `Tensor.view` error. This follow-up removes the stale `view-compatible` wording from the `validate_bbox` docstring and adds coverage for an `expand(...)` zero-stride layout, alongside the existing transpose and slice cases.

## Related issue or discussion

Fixes #4174.

## What did you check?

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/geometry/test_bbox.py -v --device=cpu --dtype=float32` -> 26 passed in 5.34s
- `ruff check kornia/geometry/bbox.py tests/geometry/test_bbox.py` -> All checks passed
- `ruff format --check kornia/geometry/bbox.py tests/geometry/test_bbox.py` -> 2 files already formatted
- `git diff --check` -> clean

`pixi` is not installed here, so the focused test and Ruff checks were run with the available Python 3.11 environment.

## How did AI help?

I used AI to spot the stale docstring wording and the missing zero-stride regression case. I reviewed the diff and ran the checks above myself.