### PR TITLE
Fix rank-4 bbox input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of `view`, so a non-contiguous leading-dimension stride (a transpose, a slice that drops boxes, an
   `expand`) returns a boolean as documented instead of raising `RuntimeError`. (#4174)
 
+* `infer_bbox_shape` and `bbox_to_mask` now reject rank-4 `(B, N, 4, 2)` inputs with `ShapeError`. Previously,
+  `N < 3` raised an incidental `IndexError`, while `N >= 3` silently returned `(B, 2)` extents computed from the
+  wrong vertices. (#4218)
+
 * Constructing `ScaleSpaceDetector` with `compile_modules` no longer permanently mutates the process-global
   `torch._dynamo.config.capture_dynamic_output_shape_ops` setting. (#4134)
 
@@ -785,11 +789,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whose exponent range holds both the guard and the squares, and the wider dtypes are byte-identical at every
   pixel whose gradient is not exactly zero; a patch with such pixels (a saturated region) loses their `sqrt(eps)`
   contribution, a change of at most `1e-5` per pixel before normalisation.
-
-### Fixed
-
-* `infer_bbox_shape` and `bbox_to_mask` now reject rank-4 `(B, N, 4, 2)` inputs with `ShapeError` instead of
-  raising an incidental `IndexError` or silently returning incorrectly shaped results. (#4218)
 
 ## :rocket: [0.6.11] - 2022-03-28
 ### :new:  New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -786,6 +786,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pixel whose gradient is not exactly zero; a patch with such pixels (a saturated region) loses their `sqrt(eps)`
   contribution, a change of at most `1e-5` per pixel before normalisation.
 
+### Fixed
+
+* `infer_bbox_shape` and `bbox_to_mask` now reject rank-4 `(B, N, 4, 2)` inputs with `ShapeError` instead of
+  raising an incidental `IndexError` or silently returning incorrectly shaped results. (#4218)
+
 ## :rocket: [0.6.11] - 2022-03-28
 ### :new:  New Features
 

--- a/kornia/geometry/bbox.py
+++ b/kornia/geometry/bbox.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 import torch
 
+from kornia.core.check import KORNIA_CHECK_SHAPE
 from kornia.core.utils import is_exporting
 
 from .linalg import transform_points
@@ -152,15 +153,13 @@ def infer_bbox_shape(boxes: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         The inclusive ``+1`` arithmetic differs from torchvision, COCO, and albumentations and is tracked in
         `#3934 <https://github.com/kornia/kornia/issues/3934>`_.
 
-    .. warning::
-        Rank-4 input is not validated. The fixed indices then read boxes instead of vertices, so fewer than three
-        boxes per batch raise ``IndexError`` and three or more return wrongly shaped values. This wart is tracked
-        in `#4180 <https://github.com/kornia/kornia/issues/4180>`_.
-
     Args:
         boxes: a tensor containing the coordinates of the bounding boxes to be extracted. The tensor must have shape
             :math:`(N, 4, 2)`, where each box is defined in the following ``clockwise`` order: top-left, top-right,
             bottom-right, bottom-left. The coordinates must be in the x, y order.
+
+    Raises:
+        ShapeError: if ``boxes`` does not have shape :math:`(N, 4, 2)`.
 
     Returns:
         - Bounding box heights, shape of :math:`(N,)`.
@@ -182,6 +181,8 @@ def infer_bbox_shape(boxes: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         (tensor([2., 2.]), tensor([2., 3.]))
 
     """
+    KORNIA_CHECK_SHAPE(boxes, ["N", "4", "2"])
+
     width: torch.Tensor = boxes[:, 1, 0] - boxes[:, 0, 0] + 1
     height: torch.Tensor = boxes[:, 2, 1] - boxes[:, 0, 1] + 1
     return height, width
@@ -249,6 +250,9 @@ def bbox_to_mask(boxes: torch.Tensor, width: int, height: int) -> torch.Tensor:
     Returns:
         the output mask tensor.
 
+    Raises:
+        ShapeError: if ``boxes`` does not have shape :math:`(B, 4, 2)`.
+
     Note:
         It is currently non-differentiable.
 
@@ -267,6 +271,8 @@ def bbox_to_mask(boxes: torch.Tensor, width: int, height: int) -> torch.Tensor:
                  [0., 0., 0., 0., 0.]]])
 
     """
+    KORNIA_CHECK_SHAPE(boxes, ["B", "4", "2"])
+
     # NOTE: `validate_bbox`'s boolean result was previously computed here and discarded — it
     # never raised, so it performed no validation while adding a data-dependent graph break
     # (`torch.any(...)` -> Python `if`) that blocked torch.compile fullgraph (e.g. RandomErasing,

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -230,10 +230,9 @@ class Boxes:
           adds one per axis and
           :func:`~kornia.geometry.bbox.bbox_to_mask` fills through the bottom-right vertex's row and column, so
           both read their input as inclusive: pass them the ``'vertices_plus'`` export rather than
-          ``'vertices'``, which they read as one pixel larger per axis. Both consumers take unbatched
-          :math:`(N, 4, 2)` input and neither detects a batched one, so index or flatten a batched
-          :math:`(B, N, 4, 2)` export before passing it; see
-          `#4180 <https://github.com/kornia/kornia/issues/4180>`_.
+          ``'vertices'``, which they read as one pixel larger per axis. Both consumers require unbatched
+          :math:`(N, 4, 2)` input and raise :class:`~kornia.core.exceptions.ShapeError` for a batched
+          :math:`(B, N, 4, 2)` export, so index or flatten it before passing it.
           :func:`~kornia.geometry.bbox.validate_bbox` is invariant in exact arithmetic, because its ``+1``
           terms cancel;
           :func:`~kornia.geometry.bbox.nms` computes exclusive areas, and

--- a/tests/geometry/test_bbox.py
+++ b/tests/geometry/test_bbox.py
@@ -19,9 +19,11 @@ import pytest
 import torch
 
 import kornia
+from kornia.core.exceptions import ShapeError
 from kornia.geometry.bbox import (
     bbox_generator,
     bbox_generator3d,
+    bbox_to_mask,
     infer_bbox_shape,
     infer_bbox_shape3d,
     nms,
@@ -65,17 +67,19 @@ class TestBbox2D(BaseTester):
         self.assert_close(height, torch.tensor([5.0], device=device, dtype=dtype), atol=0.0, rtol=0.0)
         self.assert_close(width, torch.tensor([0.0], device=device, dtype=dtype), atol=0.0, rtol=0.0)
 
-    def test_wart_infer_bbox_shape_rank4_is_not_validated_4180(self, device, dtype):
-        # Wart pin for kornia#4180: rank-4 input is read at fixed box indices instead
-        # of vertex indices. Fewer than three boxes raise, while three or more return
-        # extents of shape (B, 2) built from the wrong vertices.
-        with pytest.raises(IndexError):
-            infer_bbox_shape(torch.zeros(1, 2, 4, 2, device=device, dtype=dtype))
+    @pytest.mark.parametrize("num_boxes", [2, 3])
+    def test_infer_bbox_shape_rejects_rank4_4180(self, device, dtype, num_boxes):
+        boxes = torch.zeros(1, num_boxes, 4, 2, device=device, dtype=dtype)
 
-        boxes = torch.arange(24, device=device, dtype=dtype).reshape(1, 3, 4, 2)
-        height, width = infer_bbox_shape(boxes)
-        self.assert_close(height, torch.tensor([[17.0, 17.0]], device=device, dtype=dtype), atol=0.0, rtol=0.0)
-        self.assert_close(width, torch.tensor([[9.0, 9.0]], device=device, dtype=dtype), atol=0.0, rtol=0.0)
+        with pytest.raises(ShapeError, match="expected 3 dimensions, got 4"):
+            infer_bbox_shape(boxes)
+
+    @pytest.mark.parametrize("num_boxes", [2, 3])
+    def test_bbox_to_mask_rejects_rank4_4180(self, device, dtype, num_boxes):
+        boxes = torch.zeros(1, num_boxes, 4, 2, device=device, dtype=dtype)
+
+        with pytest.raises(ShapeError, match="expected 3 dimensions, got 4"):
+            bbox_to_mask(boxes, width=5, height=5)
 
     def test_convention_validate_bbox_checks_parallelograms_and_accepts_contiguous_batched_boxes(self, device, dtype):
         # The validator only compares the top and bottom edge vectors at fixed vertex


### PR DESCRIPTION
## What does this pull request do?

`infer_bbox_shape` and `bbox_to_mask` document rank-3 `(N, 4, 2)` inputs, but rank-4 `(B, N, 4, 2)` tensors previously produced either an incidental `IndexError` or silently wrong-shaped results. This adds the standard `KORNIA_CHECK_SHAPE` guard to both functions so invalid rank-4 inputs consistently raise `ShapeError`.

It also replaces the existing wart test with regression coverage for both former failure modes, adds equivalent coverage for `bbox_to_mask`, and updates the public documentation and changelog.

## Related issue or discussion

Fixes #4180

## What did you check?

```text
python -m pytest tests/geometry/test_bbox.py -q
28 passed

python -m pytest --doctest-modules kornia/geometry/bbox.py -q
7 passed

python -m pytest tests/geometry/test_bbox.py -k "rank4_4180" -q
4 passed
```

The valid-input path also passed a direct `torch.compile(..., fullgraph=True)` check for `bbox_to_mask` and a TorchScript check for `infer_bbox_shape`. Ruff, formatting, codespell, license-header, and the other configured pre-commit hooks passed on the changed files.

## How did AI help?

Codex helped trace the two failure modes, implement the shape guards and regression tests, update the related documentation, and run the focused verification. The final diff and test results were reviewed against Kornia's contribution guidelines before submission.