### PR TITLE
test(feature): give TestLAFAffNetShapeEstimator::test_toy a half-precision tolerance

### DIFF
--- a/testing/half_precision_xfails/cpu_bfloat16.txt
+++ b/testing/half_precision_xfails/cpu_bfloat16.txt
@@ -116,7 +116,6 @@ call	builtins.AssertionError	tests/contrib/test_hist_match.py::TestHistMatch::te
 call	builtins.AssertionError	tests/core/test_helpers.py::TestSvdCast::test_smoke[cpu-bfloat16]
 call	builtins.AssertionError	tests/enhance/test_jpeg.py::TestDiffJPEG::test_cardinality[cpu-bfloat16]
 call	builtins.AssertionError	tests/enhance/test_zca.py::TestZCA::test_dim_args[cpu-bfloat16-1]
-call	builtins.AssertionError	tests/feature/test_affine_shape_estimator.py::TestLAFAffNetShapeEstimator::test_toy[cpu-bfloat16]
 call	builtins.AssertionError	tests/feature/test_aliked.py::TestALIKED::test_descriptor_normalized[cpu-bfloat16]
 call	builtins.NotImplementedError	tests/feature/test_hynet.py::TestHyNet::test_jit[cpu-bfloat16]
 call	builtins.AssertionError	tests/feature/test_responces_local_features.py::TestBlobDoGSingle::test_blobs_batch[cpu-bfloat16]

--- a/testing/half_precision_xfails/cpu_float16.txt
+++ b/testing/half_precision_xfails/cpu_float16.txt
@@ -226,7 +226,6 @@ call	builtins.AssertionError	tests/augmentation/test_random_generator_3d.py::Tes
 call	builtins.AssertionError	tests/color/test_hls.py::TestRgbToHls::test_jit[cpu-float16]
 call	builtins.AssertionError	tests/color/test_hls.py::TestRgbToHls::test_module[cpu-float16]
 call	builtins.AssertionError	tests/color/test_rgb.py::TestRgb255Normals::test_back_and_forth[cpu-float16]
-call	builtins.AssertionError	tests/feature/test_affine_shape_estimator.py::TestLAFAffNetShapeEstimator::test_toy[cpu-float16]
 call	builtins.AssertionError	tests/feature/test_aliked.py::TestALIKED::test_descriptor_normalized[cpu-float16]
 call	builtins.NotImplementedError	tests/feature/test_hynet.py::TestHyNet::test_jit[cpu-float16]
 call	builtins.AssertionError	tests/feature/test_responces_local_features.py::TestBlobDoGSingle::test_blobs_batch[cpu-float16]

--- a/tests/feature/test_affine_shape_estimator.py
+++ b/tests/feature/test_affine_shape_estimator.py
@@ -345,8 +345,17 @@ class TestLAFAffNetShapeEstimator(BaseTester):
         laf = torch.tensor([[[[20.0, 0.0, 16.0], [0.0, 20.0, 16.0]]]], device=device, dtype=dtype)
         new_laf = aff(laf, inp)
         expected = torch.tensor([[[[33.2073, 0.0, 16.0], [-1.3766, 12.0456, 16.0]]]], device=device, dtype=dtype)
-        atol = 5e-3 if (device.type == "cuda" and dtype == torch.float32) else 1e-4
-        self.assert_close(new_laf, expected, atol=atol, rtol=1e-4)
+        if dtype in (torch.float16, torch.bfloat16):
+            # AffNet's convolutions carry reduced-precision noise proportional to the LAF's own scale
+            # (~33 px), not to each entry's magnitude, so the small a21 entry (-1.38) cannot be held to a
+            # relative bound: it misses by 0.024 (float16) and 0.031 (bfloat16), bitwise identical on
+            # torch 2.9.1 and 2.14.0. The 1e-1 bound is ~3 float16 ULP at that scale, so it is set by the
+            # dtype rather than by the observed miss and does not need re-tuning per platform. It still
+            # discriminates: a genuine shape regression moves these entries by O(1).
+            self.assert_close(new_laf, expected, atol=1e-1, rtol=1e-3 if dtype == torch.float16 else 7.8e-3)
+        else:
+            atol = 5e-3 if (device.type == "cuda" and dtype == torch.float32) else 1e-4
+            self.assert_close(new_laf, expected, atol=atol, rtol=1e-4)
 
     @pytest.mark.slow
     def test_gradcheck(self, device):


### PR DESCRIPTION
## What

`TestLAFAffNetShapeEstimator::test_toy` compared the recovered LAF against its float32
literal with a flat `atol=1e-4, rtol=1e-4` in every dtype. Both half dtypes failed, so
both nodes were recorded in `testing/half_precision_xfails/cpu_float16.txt` and
`cpu_bfloat16.txt` by #4154. This gives the test a half-precision branch and deletes
the two manifest lines in the same change.

It clears the `tests/feature/test_affine_shape_estimator.py` row (float16: 1,
bfloat16: 1) from the checklist in #4153.

## Why the flat tolerance is wrong here

The element that fails is not one of the large ones — it is `a21 = -1.3766`:

| dtype | element | actual | expected | \|diff\| | old bound allows | repo default allows |
| --- | --- | --: | --: | --: | --: | --: |
| float16 | `a11` = 33.2 | 33.1875 | 33.21875 | 0.0313 | 0.0034 | 0.0342 |
| float16 | **`a21` = -1.38** | -1.35254 | -1.37695 | **0.0244** | **0.0002** | **0.0024** |
| bfloat16 | **`a21` = -1.38** | -1.40625 | -1.375 | **0.0313** | 0.0002 | **0.0185** |
| bfloat16 | `a22` = 12.0 | 12.0 | 12.0625 | 0.0625 | 0.0013 | 0.1019 |

AffNet's convolutions carry reduced-precision noise proportional to the LAF's own
scale (~33 px), not to each entry's magnitude. The four entries above are one affine
matrix and share that scale, so the single small entry cannot be held to its own
relative bound. Note this also rules out simply calling `self.assert_close(new_laf,
expected)`: the repository's own `_DTYPE_PRECISIONS` defaults allow 0.0024 / 0.0185
at that element and would still fail. The sibling
`TestLAFAffineShapeEstimator::test_toy_preserve` in the same file already carries an
explicit absolute bound for exactly this reason.

## The bound

`atol=1e-1` with the repository's per-dtype `rtol` (`1e-3` float16, `7.8e-3`
bfloat16). `1e-1` is ~3 float16 ULP at the LAF's scale of 33 px — it is set by the
dtype, not fitted to the observed miss, so it does not need re-tuning if a platform's
half kernels differ. float32 and float64 keep the existing tight `1e-4`, including
the CUDA-float32 `5e-3` override.

It still discriminates. Substituting each of these for the pinned literal fails at
both half dtypes:

| perturbation | float16 | bfloat16 |
| --- | --- | --- |
| `a21` sign flipped | fails | fails |
| `a21` zeroed | fails | fails |
| identity fallback (the input LAF) | fails | fails |
| axes swapped | fails | fails |
| correct literal | passes | passes |
| `a21` drifted 1% (0.014) | passes | passes |

A genuine shape regression moves these entries by O(1); the bound tolerates
sub-1% drift, which is what half precision costs here.

## Verified

- Outputs are **bitwise identical on torch 2.9.1** — the version the blocking half
  legs pin — **and on 2.14.0**, so the tolerance was checked against what CI runs,
  not only against the local install. Both were measured on macOS/arm64, Python 3.11.
- `tests/feature/test_affine_shape_estimator.py` at `--dtype=float16` with
  `--xfail-known-failures --known-failure-profile=cpu-float16`: 31 passed, 2 skipped.
  At `--dtype=bfloat16` with `cpu-bfloat16`: 30 passed, 3 skipped. Nothing left in
  either profile for this file, which is the point of deleting the two lines.
- Same file at `--dtype=float32,float64`: 29 passed, 16 skipped.
- Whole file at both half dtypes on the torch 2.9.1 environment: 42 passed, 3 skipped.
- `pre-commit run --all-files` clean.

No library code is touched; this is a test-only change, so there is no CHANGELOG entry.

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
