### PR TITLE
test(feature): make the batched-vs-single detector pin tie-safe

### DIFF
--- a/tests/feature/test_scale_space_detector.py
+++ b/tests/feature/test_scale_space_detector.py
@@ -55,6 +55,26 @@ def _require_affine_orientation_kernels(device: torch.device, dtype: torch.dtype
             pytest.skip(f"no {name} kernel for {dtype} on {device.type}")
 
 
+def _canonical_order(lafs: torch.Tensor, responses: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sort one image's detections into a batch-size-independent order.
+
+    `topk` breaks equal responses by position, and the positions it ranks over differ between a
+    batched and a single-image call, so comparing two calls row by row compares an ordering that is
+    not defined. Half precision makes those ties the norm rather than the exception: bfloat16
+    quantises this module's candidate responses to a handful of distinct values.
+
+    Sorting on the centre first turns the comparison into a set comparison. The remaining keys only
+    decide between rows that share a centre, and those agree to a ULP anyway, so the order does not
+    depend on last-bit differences the way a response-first sort would.
+    """
+    rows = [
+        (float(lafs[i, 0, 2]), float(lafs[i, 1, 2]), *(float(v) for v in lafs[i].flatten()), float(responses[i]))
+        for i in range(lafs.shape[0])
+    ]
+    order = torch.tensor(sorted(range(len(rows)), key=rows.__getitem__), device=lafs.device)
+    return lafs[order], responses[order]
+
+
 class TestScaleSpaceDetector(BaseTester):
     def test_shape(self, device, dtype):
         inp = torch.rand(1, 1, 32, 32, device=device, dtype=dtype)
@@ -374,12 +394,16 @@ class TestScaleSpaceDetector(BaseTester):
         assert 0 < int(filled[0].sum()) < det.num_features, "expected a partially filled result"
         assert bool((resps[~filled] == 0).all()), f"sentinel leaked: min response {resps.min().item()}"
         assert (resps > torch.finfo(dtype).min / 4).all()
-        # and the single-image path agrees, which it did not before. Up to tolerance, not bit-for-bit:
-        # the response convolutions pick batch-size-dependent kernels on some CPUs (ubuntu CI), so the
-        # same candidates carry last-ULP-different scores.
+        # and the single-image path agrees, which it did not before. As a set, not row by row: the
+        # two calls rank over differently shaped volumes, so `topk` orders equal responses
+        # differently, and in bfloat16 this input's responses tie constantly (#4219). Up to
+        # tolerance, not bit-for-bit either: the response convolutions pick batch-size-dependent
+        # kernels on some CPUs (ubuntu CI), so the same candidates carry last-ULP-different scores.
         lafs1, resps1 = det(inp[:1])
-        self.assert_close(resps1[0], resps[0])
-        self.assert_close(lafs1[0], lafs[0])
+        batched_lafs, batched_resps = _canonical_order(lafs[0], resps[0])
+        single_lafs, single_resps = _canonical_order(lafs1[0], resps1[0])
+        self.assert_close(single_resps, batched_resps)
+        self.assert_close(single_lafs, batched_lafs)
 
     def test_padding_survives_the_affine_and_orientation_modules(self, device, dtype):
         # Same contract as `MultiResolutionDetector.forward`: the shape and orientation modules

--- a/tests/feature/test_scale_space_detector.py
+++ b/tests/feature/test_scale_space_detector.py
@@ -67,10 +67,12 @@ def _canonical_order(lafs: torch.Tensor, responses: torch.Tensor) -> tuple[torch
     decide between rows that share a centre, and those agree to a ULP anyway, so the order does not
     depend on last-bit differences the way a response-first sort would.
     """
-    rows = [
-        (float(lafs[i, 0, 2]), float(lafs[i, 1, 2]), *(float(v) for v in lafs[i].flatten()), float(responses[i]))
-        for i in range(lafs.shape[0])
-    ]
+    # One transfer each, not one per scalar: reading the keys straight off the device tensors costs a
+    # separate synchronization per element, which is 4500 of them for the default 500 detections and
+    # measured 1215 ms against 1.81 ms on MPS for an identical result.
+    laf_rows = lafs.detach().cpu().tolist()
+    resp_rows = responses.detach().cpu().tolist()
+    rows = [(laf[0][2], laf[1][2], *laf[0], *laf[1], resp) for laf, resp in zip(laf_rows, resp_rows)]
     order = torch.tensor(sorted(range(len(rows)), key=rows.__getitem__), device=lafs.device)
     return lafs[order], responses[order]
 


### PR DESCRIPTION
Closes #4219.

## The defect

`test_batched_underfill_does_not_leak_the_topk_sentinel` ends by checking that the
single-image path agrees with the batched one, row by row:

```python
lafs1, resps1 = det(inp[:1])
self.assert_close(resps1[0], resps[0])
self.assert_close(lafs1[0], lafs[0])
```

That ordering is not defined. The two calls run `topk` over differently shaped
volumes, so equal responses come back in a different order — and in half precision
equal responses are the rule, not the exception: bfloat16 quantises this input's 500
candidate responses to about **16 distinct values**.

On torch 2.14 the test fails on CPU bfloat16 for precisely that reason. The two runs
agree on everything that matters:

- responses are **bitwise identical** between the calls (`max|diff| == 0`);
- exactly two LAF rows differ, and they are **swapped with each other**, both carrying
  response `0.00225830078125`.

So the detector found the same keypoints with the same scores and `topk` broke a tie
differently at `B = 2` than at `B = 1`. `float16` and `float32` pass on the same seed
because they resolve those two responses apart.

This is latent rather than new: the blocking half legs pin torch **2.9.1**, where the
tie happens to break the same way for both batch sizes.

## The fix

Sort both results into a canonical order before comparing, so the assertion is about
the *set* of detections rather than their positions. The sentinel assertions the test
is named for — which pass, and which are the reason the test exists — are untouched.

**The sort is on the centre first, deliberately, not on the response.** A
response-first sort would be no better than the positional comparison it replaces:
in bfloat16 the responses tie constantly, so the tiebreaker would decide almost every
row, and the existing comment in this test already warns that ubuntu CI can produce
last-ULP-different scores. Sorting on the centre means the remaining keys only ever
separate rows that share a centre, and those agree to a ULP anyway — so no sort
position depends on a last-bit difference.

## Verified

Passes at `float32`, `float64`, `float16` and `bfloat16`, on torch **2.14.0** and on
**2.9.1** (the half CI pin), macOS/arm64, Python 3.11.

The pin still discriminates. Substituting a mutated single-image result for the real
one fails the assertion:

| injected divergence | float32 | float16 | bfloat16 |
| --- | --- | --- | --- |
| unmutated | passes | passes | passes |
| one detection dropped | fails | fails | fails |
| a centre moved 3 px | fails | fails | fails |
| a sentinel leaked into a response | fails | fails | fails |
| all LAF scales x1.05 | fails | fails | fails |
| one response x1.05 | fails | passes | passes |

The last row is a pre-existing property of the half tolerances, not something this
change introduces: the responses here are ~0.0022, and 5% of that is far inside the
repository's `atol` for those dtypes. It was equally invisible to the positional
comparison.

Whole file: 125 passed at `--dtype=float32,float64`; 65 passed / 1 skipped at each
half dtype under `--xfail-known-failures` with the matching profile. No manifest line
changes — this node was never recorded, since it is green at the 2.9.1 pin CI uses.
`pre-commit run --all-files` clean.

Test-only change; no CHANGELOG entry.

Posted on behalf of @ducha-aiki by Claude (Opus 5, 1M context).
