### PR TITLE
docs: improve search metadata and canonical links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Documentation pages now provide search-specific titles and descriptions, canonical tutorial links, and a
+  canonicalized redirect from the retired highlighted-features page. (#4226)
+
 * `kornia.feature.laf_is_filled(laf)` returns the `(B, N)` mask of the slots a detection filled, the complement
   of a detector's zero-LAF padding. Fixed-shape detectors pad the slots no detection filled with an all-zero LAF,
   and those slots must be dropped before matching -- their descriptors are identical to one another, so they match

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ English | [简体中文](README_zh-CN.md)
 <a href="https://colab.sandbox.google.com/github/kornia/tutorials/blob/master/nbs/hello_world_tutorial.ipynb">Try it Now</a> •
 <a href="https://www.kornia.org/tutorials/">Tutorials</a> •
 <a href="https://github.com/kornia/kornia-examples">Examples</a> •
-<a href="https://kornia.github.io//kornia-blog">Blog</a> •
+<a href="https://www.kornia.org/kornia-blog/">Blog</a> •
 <a href="https://discord.gg/HfnywwpBnD">Community</a>
 
 [![PyPI version](https://badge.fury.io/py/kornia.svg)](https://pypi.org/project/kornia)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ English | [简体中文](README_zh-CN.md)
 <!-- prettier-ignore -->
 <a href="https://kornia.readthedocs.io">Docs</a> •
 <a href="https://colab.sandbox.google.com/github/kornia/tutorials/blob/master/nbs/hello_world_tutorial.ipynb">Try it Now</a> •
-<a href="https://kornia.github.io/tutorials/">Tutorials</a> •
+<a href="https://www.kornia.org/tutorials/">Tutorials</a> •
 <a href="https://github.com/kornia/kornia-examples">Examples</a> •
 <a href="https://kornia.github.io//kornia-blog">Blog</a> •
 <a href="https://discord.gg/HfnywwpBnD">Community</a>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -14,7 +14,7 @@
 <a href="https://colab.sandbox.google.com/github/kornia/tutorials/blob/master/nbs/hello_world_tutorial.ipynb">Try it Now</a> •
 <a href="https://www.kornia.org/tutorials/">Tutorials</a> •
 <a href="https://github.com/kornia/kornia-examples">Examples</a> •
-<a href="https://kornia.github.io//kornia-blog">Blog</a> •
+<a href="https://www.kornia.org/kornia-blog/">Blog</a> •
 <a href="https://discord.gg/HfnywwpBnD">Community</a>
 
 [![PyPI version](https://badge.fury.io/py/kornia.svg)](https://pypi.org/project/kornia)

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -12,7 +12,7 @@
 <!-- prettier-ignore -->
 <a href="https://kornia.readthedocs.io">Docs</a> •
 <a href="https://colab.sandbox.google.com/github/kornia/tutorials/blob/master/nbs/hello_world_tutorial.ipynb">Try it Now</a> •
-<a href="https://kornia.github.io/tutorials/">Tutorials</a> •
+<a href="https://www.kornia.org/tutorials/">Tutorials</a> •
 <a href="https://github.com/kornia/kornia-examples">Examples</a> •
 <a href="https://kornia.github.io//kornia-blog">Blog</a> •
 <a href="https://discord.gg/HfnywwpBnD">Community</a>
@@ -114,7 +114,7 @@
 
 ## 例子
 
-可以尝试通过这些 [教程](https://kornia.github.io/tutorials/) 来学习和使用这个库。
+可以尝试通过这些 [教程](https://www.kornia.org/tutorials/) 来学习和使用这个库。
 
 <div align="center">
   <a href="https://colab.sandbox.google.com/github/kornia/tutorials/blob/master/nbs/hello_world_tutorial.ipynb" target="_blank">

--- a/docs/source/_extra/llms-full.txt
+++ b/docs/source/_extra/llms-full.txt
@@ -195,4 +195,4 @@ Durable findings from earlier CUDA runs (2026-08-07, see benchmarks/README.md):
 - Docs: <https://kornia.readthedocs.io/en/latest/>
 - Machine-readable index: <https://kornia.readthedocs.io/en/latest/llms.txt>
 - Source: <https://github.com/kornia/kornia>
-- Tutorials: <https://kornia.github.io/tutorials/>
+- Tutorials: <https://www.kornia.org/tutorials/>

--- a/docs/source/_extra/llms.txt
+++ b/docs/source/_extra/llms.txt
@@ -19,7 +19,7 @@ For the full self-contained reference with runnable examples, fetch [llms-full.t
 - [Conventions & Pitfalls](https://kornia.readthedocs.io/en/latest/get-started/conventions.html): the canonical conventions reference — read before generating Kornia code
 - [API Stability Policy](https://kornia.readthedocs.io/en/latest/get-started/stability.html): which modules are stable, and how deprecation works
 - [Installation](https://kornia.readthedocs.io/en/latest/get-started/installation.html): pip/conda/source installation
-- [Tutorials](https://kornia.github.io/tutorials/): runnable end-to-end examples
+- [Tutorials](https://www.kornia.org/tutorials/): runnable end-to-end examples
 
 ## Core API
 

--- a/docs/source/applications/face_detection.rst
+++ b/docs/source/applications/face_detection.rst
@@ -1,6 +1,9 @@
 Face Detection
 ==============
 
+.. meta::
+   :description: Detect multiple faces in images and video with Kornia's real-time PyTorch FaceDetector and YuNet model.
+
 .. image:: https://github.com/ShiqiYu/libfacedetection/raw/master/images/cnnresult.png
    :align: right
    :width: 20%
@@ -38,4 +41,4 @@ Using our API you can easily detect faces in images as shown below:
     for det in dets:
         print(det.score, det.top_left, det.bottom_right)
 
-Play with the detector yourself and generate new images with this `tutorial <https://kornia.github.io/tutorials/nbs/face_detection.html>`_.
+Play with the detector yourself and generate new images with this `tutorial <https://www.kornia.org/tutorials/nbs/face_detection.html>`_.

--- a/docs/source/applications/image_augmentations.rst
+++ b/docs/source/applications/image_augmentations.rst
@@ -1,6 +1,9 @@
 Image Augmentation
 ==================
 
+.. meta::
+   :description: Build differentiable, GPU-accelerated image augmentation pipelines for PyTorch with Kornia.
+
 Image Augmentation is a data augmentation method that generates more training data
 from the existing training samples. Image Augmentation is especially useful in domains
 where training data is limited or expensive to obtain like in biomedical applications.

--- a/docs/source/applications/image_denoising.rst
+++ b/docs/source/applications/image_denoising.rst
@@ -1,6 +1,9 @@
 Image Denoising
 ===============
 
+.. meta::
+   :description: Remove image noise with differentiable total-variation denoising and Kornia's PyTorch vision operators.
+
 Image denoising removes noise from an image while preserving its structure. Because every Kornia operator is
 differentiable, a classic variational approach such as total-variation denoising can be written as a few lines of
 optimization with :func:`kornia.losses.total_variation`:
@@ -20,4 +23,4 @@ optimization with :func:`kornia.losses.total_variation`:
         loss.backward()
         optimizer.step()
 
-Follow the full walk-through in the `total variation denoising tutorial <https://kornia.github.io/tutorials/nbs/total_variation_denoising.html>`_.
+Follow the full walk-through in the `total variation denoising tutorial <https://www.kornia.org/tutorials/nbs/total_variation_denoising.html>`_.

--- a/docs/source/applications/image_matching.rst
+++ b/docs/source/applications/image_matching.rst
@@ -1,6 +1,9 @@
 Image Matching
 ==============
 
+.. meta::
+   :description: Match images with Kornia's PyTorch local features, LoFTR, geometric estimation and RANSAC tools.
+
 Image matching is a process of finding pixel and region correspondences between two images of the same scene.
 Such correspondences are useful for 3D reconstruction of the scene and relative camera pose estimation.
 It is also known as "wide baseline stereo"; you can read more about it on the `Wide Baseline Stereo Blog <https://ducha-aiki.github.io/wide-baseline-stereo-blog/2021/01/09/wxbs-in-simple-terms.html>`_.
@@ -31,7 +34,7 @@ correspondences between two grayscale images in a single call:
 .. image:: https://raw.githubusercontent.com/kornia/data/main/matching/matching_loftr.jpg
    :alt: LoFTR correspondences between two images
 
-You can also go through our full tutorial using Colab, found `here <https://kornia.github.io/tutorials/nbs/image_matching.html>`_.
+You can also go through our full tutorial using Colab, found `here <https://www.kornia.org/tutorials/nbs/image_matching.html>`_.
 
 Which model should I use?
 -------------------------

--- a/docs/source/applications/image_registration.rst
+++ b/docs/source/applications/image_registration.rst
@@ -1,6 +1,9 @@
 Image Registration
 ==================
 
+.. meta::
+   :description: Align images with differentiable registration and PyTorch autograd using Kornia's ImageRegistrator.
+
 Image registration is the process of transforming different sets of data into one coordinate system. Data may be multiple photographs, data from different sensors, times, depths, or viewpoints. It is used in computer vision, medical imaging, and compiling and analyzing images and data from satellites. Registration is necessary in order to be able to compare or integrate the data obtained from these different measurements.
 
 Learn more: `https://paperswithcode.com/task/image-registration <https://paperswithcode.com/task/image-registration>`_
@@ -24,4 +27,4 @@ Then, if you want to perform a more sophisticated process:
 
 .. literalinclude:: ../_static/image_registration.py
 
-To reproduce the same results as in the video shown above, you can go through our full tutorial using Colab, found `here <https://kornia.github.io/tutorials/nbs/image_registration.html>`_.
+To reproduce the same results as in the video shown above, you can go through our full tutorial using Colab, found `here <https://www.kornia.org/tutorials/nbs/image_registration.html>`_.

--- a/docs/source/applications/image_stitching.rst
+++ b/docs/source/applications/image_stitching.rst
@@ -1,6 +1,9 @@
 Image Stitching
 ===============
 
+.. meta::
+   :description: Create image panoramas with Kornia's PyTorch ImageStitcher, LoFTR matching and RANSAC estimation.
+
 Image stitching is the process of combining multiple images with overlapping fields of view to produce a panorama. Here, we provide :py:class:`~kornia.contrib.image_stitching.ImageStitcher` to easily stitch a number of images.
 
 .. image:: https://raw.githubusercontent.com/kornia/data/main/matching/stitch_before.png

--- a/docs/source/applications/visual_prompting.rst
+++ b/docs/source/applications/visual_prompting.rst
@@ -1,6 +1,9 @@
 Visual Prompting
 ================
 
+.. meta::
+   :description: Segment images from points and boxes with Kornia VisualPrompter and the Segment Anything Model in PyTorch.
+
 .. image:: https://raw.githubusercontent.com/kornia/tutorials/master/tutorials/assets/visual_prompter.png
    :alt: SAM masks predicted by VisualPrompter from box prompts, with their confidence scores
    :width: 100%
@@ -55,6 +58,6 @@ How to use with Kornia
       multimask_output=True,
    )
 
-You can also go through our full tutorial using Colab, found `here <https://kornia.github.io/tutorials/nbs/visual_prompter.html>`_.
+You can also go through our full tutorial using Colab, found `here <https://www.kornia.org/tutorials/nbs/visual_prompter.html>`_.
 
 Integration with other libraries, fine-tuning and more examples are coming soon.

--- a/docs/source/color.rst
+++ b/docs/source/color.rst
@@ -10,7 +10,7 @@ Color space conversions on float image tensors of shape :math:`(*, C, H, W)` wit
 plus color maps and sepia. Every operation exists as a function and as an ``nn.Module``.
 
 .. note::
-   Check a tutorial for color space conversions `here <https://kornia.github.io/tutorials/nbs/hello_world_tutorial.html>`__.
+   Check a tutorial for color space conversions `here <https://www.kornia.org/tutorials/nbs/hello_world_tutorial.html>`__.
 
 .. list-table::
    :widths: 30 70

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -600,6 +600,7 @@ _DEFAULT_DESCRIPTION = (
 )
 _SOCIAL_IMAGE = "https://github.com/kornia/data/raw/main/kornia_banner_pixie.png"
 _PAGE_REDIRECTS = {"get-started/highlights": "get-started/introduction"}
+_NOINDEX_PAGES = {"404", "genindex", "py-modindex", "search"}
 _META_TAG_RE = re.compile(r"<meta\b[^>]*>", re.IGNORECASE)
 _META_ATTR_RE = re.compile(r'(\w+)="([^"]*)"')
 
@@ -618,38 +619,42 @@ def _inject_social_metatags(app, pagename, templatename, context, doctree):
         if attrs.get("name", "").lower() == "description" and attrs.get("content"):
             match = attrs["content"]
             break
-    # Sphinx hands the title over already HTML-escaped; unescape so ``esc`` below does not double it.
-    page_title = html.unescape(context.get("title") or project)
-    if match:
+    # Sphinx hands the title over already HTML-escaped and it can contain theme markup.
+    page_title = re.sub(r"<[^>]+>", "", html.unescape(context.get("title") or project))
+    page_title = " ".join(page_title.split())
+    redirect_target = _PAGE_REDIRECTS.get(pagename)
+    if match and not redirect_target:
         description = html.unescape(match).strip().strip('"')
-    elif pagename == master_doc:
-        description = _DEFAULT_DESCRIPTION
+    elif context.get("title") and pagename not in _NOINDEX_PAGES and not redirect_target:
+        description = f"{page_title}: documentation for Kornia, the differentiable computer vision library for PyTorch."
     else:
-        description = (
-            f"Learn about {page_title} in Kornia, the differentiable computer vision library for PyTorch, "
-            "including its APIs, behavior and usage."
-        )
+        description = _DEFAULT_DESCRIPTION
     description = " ".join(description.split())
     if len(description) > 300:
         description = description[:297].rsplit(" ", 1)[0] + "..."
-    title = page_title
-    if pagename != master_doc:
-        title = f"{title} - {project}"
-    redirect_target = _PAGE_REDIRECTS.get(pagename)
+    title = f"{page_title} - {project}"
+    if pagename == master_doc:
+        title = f"{project} — Differentiable Computer Vision for PyTorch"
     url = context.get("pageurl") or f"{html_baseurl}{app.builder.get_target_uri(pagename)}"
+    if pagename == master_doc:
+        url = html_baseurl
+        context["pageurl"] = url
+    refresh_url = None
     if redirect_target:
         # Keep obsolete docs URLs out of results while sending users and canonical signals to their replacement.
         url = f"{html_baseurl}{app.builder.get_target_uri(redirect_target)}"
         context["pageurl"] = url
+        refresh_url = app.builder.get_relative_uri(pagename, redirect_target)
     esc = html.escape
 
     extra = []
     if not match:
         extra.append(f'<meta name="description" content="{esc(description)}" />')
+    if pagename in _NOINDEX_PAGES:
+        extra.append('<meta name="robots" content="noindex, follow" />')
     if redirect_target:
         extra += [
-            '<meta name="robots" content="noindex, follow" />',
-            f'<meta http-equiv="refresh" content="0; url={esc(url)}" />',
+            f'<meta http-equiv="refresh" content="0; url={esc(refresh_url)}" />',
         ]
     extra += [
         '<meta property="og:type" content="website" />',
@@ -664,7 +669,7 @@ def _inject_social_metatags(app, pagename, templatename, context, doctree):
         f'<meta name="twitter:description" content="{esc(description)}" />',
         f'<meta name="twitter:image" content="{_SOCIAL_IMAGE}" />',
     ]
-    context["metatags"] = metatags + "\n" + "\n".join(extra)
+    context["metatags"] = "\n".join(extra) + "\n" + metatags
 
 
 # -- Deep-link compatibility ------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -599,6 +599,7 @@ _DEFAULT_DESCRIPTION = (
     "and curated deep learning models."
 )
 _SOCIAL_IMAGE = "https://github.com/kornia/data/raw/main/kornia_banner_pixie.png"
+_PAGE_REDIRECTS = {"get-started/highlights": "get-started/introduction"}
 _META_TAG_RE = re.compile(r"<meta\b[^>]*>", re.IGNORECASE)
 _META_ATTR_RE = re.compile(r'(\w+)="([^"]*)"')
 
@@ -617,20 +618,39 @@ def _inject_social_metatags(app, pagename, templatename, context, doctree):
         if attrs.get("name", "").lower() == "description" and attrs.get("content"):
             match = attrs["content"]
             break
-    description = html.unescape(match).strip().strip('"') if match else _DEFAULT_DESCRIPTION
+    # Sphinx hands the title over already HTML-escaped; unescape so ``esc`` below does not double it.
+    page_title = html.unescape(context.get("title") or project)
+    if match:
+        description = html.unescape(match).strip().strip('"')
+    elif pagename == master_doc:
+        description = _DEFAULT_DESCRIPTION
+    else:
+        description = (
+            f"Learn about {page_title} in Kornia, the differentiable computer vision library for PyTorch, "
+            "including its APIs, behavior and usage."
+        )
     description = " ".join(description.split())
     if len(description) > 300:
         description = description[:297].rsplit(" ", 1)[0] + "..."
-    # Sphinx hands the title over already HTML-escaped; unescape so ``esc`` below does not double it.
-    title = html.unescape(context.get("title") or project)
+    title = page_title
     if pagename != master_doc:
         title = f"{title} - {project}"
-    url = f"{html_baseurl}{pagename}.html"
+    redirect_target = _PAGE_REDIRECTS.get(pagename)
+    url = context.get("pageurl") or f"{html_baseurl}{app.builder.get_target_uri(pagename)}"
+    if redirect_target:
+        # Keep obsolete docs URLs out of results while sending users and canonical signals to their replacement.
+        url = f"{html_baseurl}{app.builder.get_target_uri(redirect_target)}"
+        context["pageurl"] = url
     esc = html.escape
 
     extra = []
     if not match:
         extra.append(f'<meta name="description" content="{esc(description)}" />')
+    if redirect_target:
+        extra += [
+            '<meta name="robots" content="noindex, follow" />',
+            f'<meta http-equiv="refresh" content="0; url={esc(url)}" />',
+        ]
     extra += [
         '<meta property="og:type" content="website" />',
         f'<meta property="og:site_name" content="{esc(project)}" />',
@@ -712,7 +732,8 @@ def _inject_navbar_menus(app, pagename, templatename, context, doctree):
 
 
 def setup(app):
-    app.connect("html-page-context", _inject_social_metatags)
+    # Run after the theme's canonical URL normalizer so redirects can replace ``pageurl``.
+    app.connect("html-page-context", _inject_social_metatags, priority=900)
     app.connect("html-page-context", _inject_anchor_redirects)
     app.connect("html-page-context", _inject_navbar_menus)
     app.connect("env-check-consistency", _check_navbar_menus)

--- a/docs/source/get-started/highlights.rst
+++ b/docs/source/get-started/highlights.rst
@@ -1,10 +1,8 @@
 :orphan:
+:nosearch:
 
 Highlighted Features
 ====================
-
-.. meta::
-   :description: This page has moved. The overview of Kornia's modules and accessible AI models now lives on the "What is Kornia?" page.
 
 This page has moved: the module overview and the accessible AI models section are now part of
 :doc:`introduction`.

--- a/docs/source/get-started/index.rst
+++ b/docs/source/get-started/index.rst
@@ -69,5 +69,5 @@ Looking for a specific function instead? The :doc:`API reference </api>` documen
    :caption: Resources
    :hidden:
 
-   Tutorials <https://kornia.github.io/tutorials/>
+   Tutorials <https://www.kornia.org/tutorials/>
    ONNX, torch.compile & torch.export support <export-support>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,8 @@
 
 .. title:: Differentiable Computer Vision for PyTorch
 
+.. _kornia-docs-home:
+
 Kornia: Differentiable Computer Vision for PyTorch
 ==================================================
 
@@ -16,12 +18,12 @@ Kornia: Differentiable Computer Vision for PyTorch
      /* Room for the two-column hero; the theme caps articles at 960px. */
      .bd-main .bd-content .bd-article-container { max-width: 1240px; }
      /* The document title provides the semantic H1 and browser title; the hero is its visible presentation. */
-     section#kornia-differentiable-computer-vision-for-pytorch > h1:first-child {
+     span#kornia-docs-home + h1 {
        border: 0; clip: rect(0 0 0 0); height: 1px; margin: -1px; overflow: hidden;
        padding: 0; position: absolute; white-space: nowrap; width: 1px;
      }
      /* Hairline separator above each section, matching the link board's line. */
-     section#kornia-differentiable-computer-vision-for-pytorch > section {
+     span#kornia-docs-home ~ section {
        border-top: 1px solid var(--pst-color-border);
        margin-top: 3rem;
        padding-top: 1.75rem;

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,10 @@
 .. meta::
-   :description: Kornia is the open-source geometric computer vision library for Spatial AI and robotics, built on PyTorch: batched, GPU-ready and differentiable image transforms, filters, camera geometry, data augmentation and curated models for detection, segmentation and image matching.
+   :description: Kornia is the open-source differentiable computer vision library for PyTorch, with GPU-accelerated image processing, geometry, augmentation and vision models.
+
+.. title:: Differentiable Computer Vision for PyTorch
+
+Kornia: Differentiable Computer Vision for PyTorch
+==================================================
 
 .. raw:: html
 
@@ -10,8 +15,13 @@
      button.sidebar-toggle.secondary-toggle { display: none !important; }
      /* Room for the two-column hero; the theme caps articles at 960px. */
      .bd-main .bd-content .bd-article-container { max-width: 1240px; }
+     /* The document title provides the semantic H1 and browser title; the hero is its visible presentation. */
+     section#kornia-differentiable-computer-vision-for-pytorch > h1:first-child {
+       border: 0; clip: rect(0 0 0 0); height: 1px; margin: -1px; overflow: hidden;
+       padding: 0; position: absolute; white-space: nowrap; width: 1px;
+     }
      /* Hairline separator above each section, matching the link board's line. */
-     .bd-article section {
+     section#kornia-differentiable-computer-vision-for-pytorch > section {
        border-top: 1px solid var(--pst-color-border);
        margin-top: 3rem;
        padding-top: 1.75rem;
@@ -35,8 +45,8 @@
            <button type="button" class="kornia-pip__copy" data-copy="pip install kornia"
                    aria-label="Copy install command"><i class="fa-regular fa-copy"></i></button>
          </div>
-         <h1 class="kornia-hero__title">Computer vision for<br>
-         <span class="kornia-accent">robotics &amp; Spatial AI.</span></h1>
+         <p class="kornia-hero__title">Computer vision for<br>
+         <span class="kornia-accent">robotics &amp; Spatial AI.</span></p>
 
       .. container:: kornia-hero-actions
 
@@ -243,7 +253,7 @@ Prefer to learn by example? :doc:`Image matching <applications/image_matching>`,
      <div>
        <p class="kornia-linkboard__title">Docs</p>
        <a href="applications/image_augmentations.html">Quick Start</a>
-       <a href="https://kornia.github.io/tutorials/">Tutorial</a>
+       <a href="https://www.kornia.org/tutorials/">Tutorial</a>
        <a href="api.html">API</a>
      </div>
      <div>

--- a/docs/source/models/affnet.rst
+++ b/docs/source/models/affnet.rst
@@ -1,6 +1,9 @@
 AffNet
 ======
 
+.. meta::
+   :description: Estimate affine-covariant local feature shapes with AffNet, Kornia's pretrained PyTorch model.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Affine shape estimation` :bdg-secondary:`MIT`

--- a/docs/source/models/defmo.rst
+++ b/docs/source/models/defmo.rst
@@ -1,6 +1,9 @@
 DeFMO
 =====
 
+.. meta::
+   :description: Deblur fast-moving objects into high-speed RGBA subframes with Kornia's pretrained DeFMO model.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Enhance` :bdg-primary:`Deblurring` :bdg-secondary:`Apache-2.0`

--- a/docs/source/models/dexined.rst
+++ b/docs/source/models/dexined.rst
@@ -3,6 +3,9 @@
 DexiNed
 =======
 
+.. meta::
+   :description: Detect thin image edges with DexiNed, Kornia's pretrained PyTorch edge-detection model.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Edge detection` :bdg-secondary:`MIT`

--- a/docs/source/models/efficient_vit.rst
+++ b/docs/source/models/efficient_vit.rst
@@ -1,6 +1,9 @@
 EfficientViT
 ============
 
+.. meta::
+   :description: Use EfficientViT pretrained PyTorch vision backbones for image classification, detection and segmentation with Kornia.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Segmentation` :bdg-primary:`Classification` :bdg-primary:`Detection` :bdg-secondary:`Apache-2.0`

--- a/docs/source/models/hardnet.rst
+++ b/docs/source/models/hardnet.rst
@@ -1,6 +1,9 @@
 HardNet
 =======
 
+.. meta::
+   :description: Describe local image patches with HardNet, Kornia's pretrained 128-dimensional PyTorch feature descriptor.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Local feature descriptor` :bdg-secondary:`MIT`

--- a/docs/source/models/loftr.rst
+++ b/docs/source/models/loftr.rst
@@ -1,6 +1,9 @@
 LoFTR
 =====
 
+.. meta::
+   :description: Match image correspondences without keypoints using LoFTR, Kornia's pretrained PyTorch transformer matcher.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Image matching` :bdg-secondary:`Apache-2.0`

--- a/docs/source/models/mobile_sam.rst
+++ b/docs/source/models/mobile_sam.rst
@@ -1,6 +1,9 @@
 MobileSAM
 =========
 
+.. meta::
+   :description: Generate prompt-based image masks with MobileSAM and Kornia's lightweight PyTorch visual-prompting API.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Segmentation` :bdg-primary:`Visual prompting` :bdg-secondary:`Apache-2.0`

--- a/docs/source/models/rt_detr.rst
+++ b/docs/source/models/rt_detr.rst
@@ -1,6 +1,9 @@
 RT-DETR
 =======
 
+.. meta::
+   :description: Detect objects in real time with RT-DETR, Kornia's pretrained end-to-end PyTorch transformer detector.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Object detection` :bdg-secondary:`Apache-2.0`

--- a/docs/source/models/segment_anything.rst
+++ b/docs/source/models/segment_anything.rst
@@ -1,6 +1,9 @@
 Segment Anything (SAM)
 ======================
 
+.. meta::
+   :description: Segment objects from point and box prompts with the Segment Anything Model and Kornia's PyTorch VisualPrompter.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Segmentation` :bdg-primary:`Visual prompting` :bdg-secondary:`Apache-2.0`

--- a/docs/source/models/sold2.rst
+++ b/docs/source/models/sold2.rst
@@ -1,6 +1,9 @@
 SOLD2
 =====
 
+.. meta::
+   :description: Detect and match line segments with SOLD², Kornia's pretrained PyTorch line-feature model.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Line detection` :bdg-primary:`Line matching` :bdg-secondary:`MIT`

--- a/docs/source/models/tiny_vit.rst
+++ b/docs/source/models/tiny_vit.rst
@@ -3,6 +3,9 @@
 TinyViT
 =======
 
+.. meta::
+   :description: Use TinyViT pretrained PyTorch vision transformers for image classification and as Kornia's MobileSAM encoder.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Image classification` :bdg-primary:`Detection`

--- a/docs/source/models/vit.rst
+++ b/docs/source/models/vit.rst
@@ -3,6 +3,9 @@
 Vision Transformer (ViT)
 ========================
 
+.. meta::
+   :description: Build or load pretrained Vision Transformer encoders with Kornia's PyTorch ViT implementation.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Image classification` :bdg-secondary:`Apache-2.0`

--- a/docs/source/models/vit_mobile.rst
+++ b/docs/source/models/vit_mobile.rst
@@ -3,6 +3,9 @@
 MobileViT
 =========
 
+.. meta::
+   :description: Build lightweight MobileViT PyTorch backbones for classification, detection and segmentation with Kornia.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Image classification` :bdg-primary:`Detection` :bdg-primary:`Segmentation`

--- a/docs/source/models/yunet.rst
+++ b/docs/source/models/yunet.rst
@@ -3,6 +3,9 @@
 YuNet
 =====
 
+.. meta::
+   :description: Detect faces and facial landmarks with YuNet, Kornia's real-time pretrained PyTorch face detector.
+
 .. rst-class:: kornia-badges
 
 :bdg-primary:`Face detection` :bdg-secondary:`Apache-2.0`

--- a/kornia/augmentation/container/augment.py
+++ b/kornia/augmentation/container/augment.py
@@ -90,7 +90,7 @@ class AugmentationSequential(TransformMatrixMinIn, ImageSequential):
         It is not clear how to deal with the conversions of masks, bounding boxes and keypoints.
 
     .. note::
-        See a working example `here <https://kornia.github.io/tutorials/nbs/data_augmentation_sequential.html>`__.
+        See a working example `here <https://www.kornia.org/tutorials/nbs/data_augmentation_sequential.html>`__.
 
     Examples:
         >>> import kornia

--- a/kornia/augmentation/container/patch.py
+++ b/kornia/augmentation/container/patch.py
@@ -74,7 +74,7 @@ class PatchSequential(ImageSequential):
         Those transformations in ``kornia.geometry`` will not be taken into account.
 
     .. note::
-        See a working example `here <https://kornia.github.io/tutorials/nbs/data_patch_sequential.html>`__.
+        See a working example `here <https://www.kornia.org/tutorials/nbs/data_patch_sequential.html>`__.
 
     Examples:
         >>> import kornia.augmentation as K

--- a/kornia/color/gray.py
+++ b/kornia/color/gray.py
@@ -71,7 +71,7 @@ def rgb_to_grayscale(image: torch.Tensor, rgb_weights: Optional[torch.Tensor] = 
         grayscale version of the image with shape :math:`(*,1,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/color_conversions.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/color_conversions.html>`__.
 
     Example:
         >>> input = torch.rand(2, 3, 4, 5)

--- a/kornia/color/hsv.py
+++ b/kornia/color/hsv.py
@@ -40,7 +40,7 @@ def rgb_to_hsv(image: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
         The H channel values are in the range 0..2pi. S and V are in the range 0..1.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/color_conversions.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/color_conversions.html>`__.
 
     Example:
         >>> input = torch.rand(2, 3, 4, 5)

--- a/kornia/contrib/connected_components.py
+++ b/kornia/contrib/connected_components.py
@@ -32,7 +32,7 @@ def connected_components(image: torch.Tensor, num_iterations: int = 100) -> torc
         This is an experimental API subject to changes and optimization improvements.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/connected_components.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/connected_components.html>`__.
 
     Args:
         image: the binarized input image with shape :math:`(*, 1, H, W)`.

--- a/kornia/enhance/adjust.py
+++ b/kornia/enhance/adjust.py
@@ -150,7 +150,7 @@ def adjust_saturation(image: torch.Tensor, factor: Union[float, torch.Tensor]) -
         Adjusted image in the shape of :math:`(*, 3, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> x = torch.ones(1, 3, 3, 3)
@@ -226,7 +226,7 @@ def adjust_hue(image: torch.Tensor, factor: Union[float, torch.Tensor]) -> torch
         Adjusted image in the shape of :math:`(*, 3, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> x = torch.ones(1, 3, 2, 2)
@@ -271,7 +271,7 @@ def adjust_gamma(
         Adjusted image in the shape of :math:`(*, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/image_enhancement.html>`__.
 
     .. note::
        The non-negativity check on ``gamma``/``gain`` runs on CPU and CUDA (via ``torch._assert_async``).
@@ -361,7 +361,7 @@ def adjust_contrast(image: torch.Tensor, factor: Union[float, torch.Tensor], cli
         Adjusted image in the shape of :math:`(*, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/image_enhancement.html>`__.
 
     .. note::
        The non-negativity check on ``factor`` runs on CPU and CUDA (via ``torch._assert_async``).
@@ -500,7 +500,7 @@ def adjust_brightness(
         Adjusted torch.Tensor in the shape of :math:`(*, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/image_enhancement.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/image_enhancement.html>`__.
 
     Example:
         >>> x = torch.ones(1, 1, 2, 2)

--- a/kornia/filters/blur.py
+++ b/kornia/filters/blur.py
@@ -55,7 +55,7 @@ def box_blur(
         the blurred torch.Tensor with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/filtering_operators.html>`__.
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)

--- a/kornia/filters/blur_pool.py
+++ b/kornia/filters/blur_pool.py
@@ -247,7 +247,7 @@ def blur_pool2d(input: torch.Tensor, kernel_size: tuple[int, int] | int, stride:
         This function is tested against https://github.com/adobe/antialiased-cnns.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/filtering_operators.html>`__.
 
     Examples:
         >>> input = torch.eye(5)[None, None]
@@ -287,7 +287,7 @@ def max_blur_pool2d(
         This function is tested against https://github.com/adobe/antialiased-cnns.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/filtering_operators.html>`__.
 
     Examples:
         >>> input = torch.eye(5)[None, None]

--- a/kornia/filters/canny.py
+++ b/kornia/filters/canny.py
@@ -59,7 +59,7 @@ def canny(
         - the canny edge detection filtered by thresholds and hysteresis, shape of :math:`(B,1,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/canny.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/canny.html>`__.
 
     Example:
         >>> input = torch.rand(5, 3, 4, 4)

--- a/kornia/filters/gaussian.py
+++ b/kornia/filters/gaussian.py
@@ -63,7 +63,7 @@ def gaussian_blur2d(
         RuntimeError: if kernel_size is not a positive odd integer.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/gaussian_blur.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/gaussian_blur.html>`__.
 
     Examples:
         >>> import torch

--- a/kornia/filters/laplacian.py
+++ b/kornia/filters/laplacian.py
@@ -46,7 +46,7 @@ def laplacian(
         the blurred image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_edges.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/filtering_edges.html>`__.
 
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)

--- a/kornia/filters/median.py
+++ b/kornia/filters/median.py
@@ -46,7 +46,7 @@ def median_blur(input: torch.Tensor, kernel_size: tuple[int, int] | int) -> torc
         the blurred input torch.Tensor with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_operators.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/filtering_operators.html>`__.
 
     Example:
         >>> input = torch.rand(2, 4, 5, 7)

--- a/kornia/filters/sobel.py
+++ b/kornia/filters/sobel.py
@@ -43,7 +43,7 @@ def spatial_gradient(input: torch.Tensor, mode: str = "sobel", order: int = 1, n
         the derivatives of the input feature map. with shape :math:`(B, C, 2, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_edges.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/filtering_edges.html>`__.
 
     Examples:
         >>> input = torch.rand(1, 3, 4, 4)
@@ -148,7 +148,7 @@ def sobel(input: torch.Tensor, normalized: bool = True, eps: float = 1e-6) -> to
         the sobel edge gradient magnitudes map with shape :math:`(B,C,H,W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/filtering_edges.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/filtering_edges.html>`__.
 
     Example:
         >>> input = torch.rand(1, 3, 4, 4)

--- a/kornia/filters/unsharp.py
+++ b/kornia/filters/unsharp.py
@@ -73,7 +73,7 @@ class UnsharpMask(nn.Module):
         - Output: :math:`(B, C, H, W)`
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/unsharp_mask.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/unsharp_mask.html>`__.
 
     Examples:
         >>> input = torch.rand(2, 4, 5, 5)

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -289,7 +289,7 @@ def rotate(
         The rotated tensor with shape as input.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/rotate_affine.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/rotate_affine.html>`__.
 
     Example:
         >>> img = torch.rand(1, 3, 4, 4)

--- a/kornia/geometry/transform/imgwarp.py
+++ b/kornia/geometry/transform/imgwarp.py
@@ -229,7 +229,7 @@ def warp_perspective(
         This function is often used in conjunction with :func:`get_perspective_transform`.
 
     .. note::
-        See a working example `here <https://kornia.github.io/tutorials/nbs/warp_perspective.html>`_.
+        See a working example `here <https://www.kornia.org/tutorials/nbs/warp_perspective.html>`_.
 
     """
     if not isinstance(src, torch.Tensor):
@@ -340,7 +340,7 @@ def warp_affine(
         :func:`get_shear_matrix2d`, :func:`get_affine_matrix2d`, :func:`invert_affine_transform`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/rotate_affine.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/rotate_affine.html>`__.
 
     Example:
        >>> img = torch.rand(1, 4, 5, 6)

--- a/kornia/losses/total_variation.py
+++ b/kornia/losses/total_variation.py
@@ -42,7 +42,7 @@ def total_variation(img: torch.Tensor, reduction: str = "sum") -> torch.Tensor:
         torch.Size([2, 5, 3])
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/total_variation_denoising.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/total_variation_denoising.html>`__.
        Total Variation is formulated with summation, however this is not resolution invariant.
        Thus, `reduction='mean'` was added as an optional reduction method.
 

--- a/kornia/morphology/morphology.py
+++ b/kornia/morphology/morphology.py
@@ -65,7 +65,7 @@ def dilation(
         Dilated image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -158,7 +158,7 @@ def erosion(
         Eroded image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -252,7 +252,7 @@ def opening(
        torch.Tensor: Opened image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -329,7 +329,7 @@ def closing(
        Closed image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -408,7 +408,7 @@ def gradient(
        Gradient image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -476,7 +476,7 @@ def top_hat(
        Top hat transformed image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)
@@ -547,7 +547,7 @@ def bottom_hat(
        Top hat transformed image with shape :math:`(B, C, H, W)`.
 
     .. note::
-       See a working example `here <https://kornia.github.io/tutorials/nbs/morphology_101.html>`__.
+       See a working example `here <https://www.kornia.org/tutorials/nbs/morphology_101.html>`__.
 
     Example:
         >>> tensor = torch.rand(1, 3, 5, 5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 "Bug Tracker" = "https://github.com/kornia/kornia/issues"
 Documentation = "https://kornia.readthedocs.io/en/latest"
 Download = "https://github.com/kornia/kornia"
-Homepage = "https://kornia.github.io/"
+Homepage = "https://www.kornia.org/"
 Issues = "https://github.com/kornia/kornia/issues"
 "Source Code" = "https://github.com/kornia/kornia"
 


### PR DESCRIPTION
## What does this pull request do?

Improves the documentation search presentation and URL consistency:

- gives the docs homepage one semantic H1, a descriptive browser/social title, and a clean root canonical
- adds unique descriptions to application and model pages, with safe title-aware fallbacks elsewhere
- canonicalizes the obsolete highlighted-features page, forwards users with a relative redirect, and excludes the stub from documentation search
- noindexes generated search/index/error utility pages without mixing that signal into redirect canonicalization
- updates repository tutorial, Blog, and package homepage links to their canonical HTTPS kornia.org URLs

## Related issue or discussion

Follow-up to a technical SEO audit of kornia.org and the Read the Docs site.

## What did you check?

```text
$ /Users/oldufo/dev/kornia/.venv/bin/python -m sphinx -W -b html docs/source /tmp/kornia-seo-review-build.LOTQnf
build succeeded

$ pixi run pre-commit-all
all checks passed
```

Also verified across the generated output that each page has one description, canonical, and Open Graph URL; the homepage has exactly one H1 and a canonical ending at `/en/latest/`; the retired page has a relative refresh plus replacement canonical and cannot surface in Sphinx search; and only the generated 404/search/index pages carry `noindex, follow`.

## How did AI help?

Codex audited the live site and repository, implemented the metadata and link changes, incorporated two rounds of review feedback, rendered and inspected the generated HTML, ran repository validation, and completed a separate final code review.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (gpt-5.6-sol).
