### PR TITLE
fix(geometry): return max_num instead of NaN for singular H in symmetric_transfer_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,8 +369,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   When `safe_inverse_with_mask` flags an input as non-invertible, the unshielded inverse matrix containing
   non-finite values propagated `NaN` through `oneway_transfer_error` and the arithmetic mask
   `(there + back) * mask + max_num * (~mask)`, poisoning both the forward error and autograd gradients.
-  Invalid inverse matrices are now guarded with an identity fallback before transfer error calculation,
-  and the final masking uses `torch.where` to cleanly assign `max_num`. (#4203)
+  Singular rows are now replaced by the identity *before* the differentiable inverse is taken, so the
+  gradients with respect to both the correspondences and `H` itself stay finite (zero on the singular
+  rows), and the final masking uses `torch.where` to cleanly assign `max_num`. Values for invertible
+  homographies are unchanged; for `squared=False` a singular row now scores `max_num` rather than the
+  previous `(max_num + eps).sqrt()`, matching the documented contract. (#4203)
 
 * Constructing `ScaleSpaceDetector` with `compile_modules` no longer permanently mutates the process-global
   `torch._dynamo.config.capture_dynamic_output_shape_ops` setting. (#4134)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,6 +365,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `N < 3` raised an incidental `IndexError`, while `N >= 3` silently returned `(B, 2)` extents computed from the
   wrong vertices. (#4218)
 
+* Fix `symmetric_transfer_error` returning `NaN` instead of `max_num` for singular homographies.
+  When `safe_inverse_with_mask` flags an input as non-invertible, the unshielded inverse matrix containing
+  non-finite values propagated `NaN` through `oneway_transfer_error` and the arithmetic mask
+  `(there + back) * mask + max_num * (~mask)`, poisoning both the forward error and autograd gradients.
+  Invalid inverse matrices are now guarded with an identity fallback before transfer error calculation,
+  and the final masking uses `torch.where` to cleanly assign `max_num`. (#4203)
+
 * Constructing `ScaleSpaceDetector` with `compile_modules` no longer permanently mutates the process-global
   `torch._dynamo.config.capture_dynamic_output_shape_ops` setting. (#4134)
 

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -44,7 +44,8 @@ def oneway_transfer_error(
         eps: Small constant for safe sqrt.
 
     Returns:
-        the computed distance with shape :math:`(B, N)`.
+        the computed distance with shape :math:`(B, N)`. Rows whose homography is not invertible
+        score ``max_num``, i.e. ``torch.finfo(pts1.dtype).max``, for both values of ``squared``.
 
     """
     KORNIA_CHECK_SHAPE(H, ["B", "3", "3"])
@@ -109,7 +110,8 @@ def symmetric_transfer_error(
         eps: Small constant for safe sqrt.
 
     Returns:
-        the computed distance with shape :math:`(B, N)`.
+        the computed distance with shape :math:`(B, N)`. Rows whose homography is not invertible
+        score ``max_num``, i.e. ``torch.finfo(pts1.dtype).max``, for both values of ``squared``.
 
     """
     KORNIA_CHECK_SHAPE(H, ["B", "3", "3"])
@@ -122,10 +124,14 @@ def symmetric_transfer_error(
     max_num = torch.finfo(pts1.dtype).max
     # From Hartley and Zisserman, Symmetric transfer error (4.7)
     # dist = \sum_{i} (d(x, H^-1 x')**2 + d(x', Hx)**2)
-    H_inv, good_H = safe_inverse_with_mask(H)
+    # Shield the *input* of the inverse, not its output: ``inv_ex`` backward is
+    # ``-H_inv^T @ grad @ H_inv^T`` over a saved ``H_inv`` full of non-finite values, so masking the
+    # result afterwards still leaves ``0 * nan = nan`` in ``H.grad``. The mask is taken on a detached
+    # copy so it carries no graph, and the differentiable inverse then only ever sees a valid matrix.
+    _, good_H = safe_inverse_with_mask(H.detach())
     eye = torch.eye(3, device=H.device, dtype=H.dtype).expand_as(H)
     H_safe = torch.where(good_H.view(-1, 1, 1), H, eye)
-    H_inv_safe = torch.where(good_H.view(-1, 1, 1), H_inv, eye)
+    H_inv_safe, _ = safe_inverse_with_mask(H_safe)
 
     there: torch.Tensor = oneway_transfer_error(pts1, pts2, H_safe, True, eps)
     back: torch.Tensor = oneway_transfer_error(pts2, pts1, H_inv_safe, True, eps)
@@ -155,7 +161,8 @@ def line_segment_transfer_error_one_way(
         squared: if True (default is False), the squared distance is returned.
 
     Returns:
-        the computed distance with shape :math:`(B, N)`.
+        the computed distance with shape :math:`(B, N)`. Rows whose homography is not invertible
+        score ``max_num``, i.e. ``torch.finfo(pts1.dtype).max``, for both values of ``squared``.
 
     """
     KORNIA_CHECK_SHAPE(H, ["B", "3", "3"])

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -44,8 +44,7 @@ def oneway_transfer_error(
         eps: Small constant for safe sqrt.
 
     Returns:
-        the computed distance with shape :math:`(B, N)`. Rows whose homography is not invertible
-        score ``max_num``, i.e. ``torch.finfo(pts1.dtype).max``, for both values of ``squared``.
+        the computed distance with shape :math:`(B, N)`.
 
     """
     KORNIA_CHECK_SHAPE(H, ["B", "3", "3"])
@@ -161,8 +160,7 @@ def line_segment_transfer_error_one_way(
         squared: if True (default is False), the squared distance is returned.
 
     Returns:
-        the computed distance with shape :math:`(B, N)`. Rows whose homography is not invertible
-        score ``max_num``, i.e. ``torch.finfo(pts1.dtype).max``, for both values of ``squared``.
+        the computed distance with shape :math:`(B, N)`.
 
     """
     KORNIA_CHECK_SHAPE(H, ["B", "3", "3"])

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -123,14 +123,18 @@ def symmetric_transfer_error(
     # From Hartley and Zisserman, Symmetric transfer error (4.7)
     # dist = \sum_{i} (d(x, H^-1 x')**2 + d(x', Hx)**2)
     H_inv, good_H = safe_inverse_with_mask(H)
+    eye = torch.eye(3, device=H.device, dtype=H.dtype).expand_as(H_inv)
+    H_inv_safe = torch.where(good_H.view(-1, 1, 1), H_inv, eye)
 
     there: torch.Tensor = oneway_transfer_error(pts1, pts2, H, True, eps)
-    back: torch.Tensor = oneway_transfer_error(pts2, pts1, H_inv, True, eps)
+    back: torch.Tensor = oneway_transfer_error(pts2, pts1, H_inv_safe, True, eps)
     good_H_reshape: torch.Tensor = good_H.view(-1, 1).expand_as(there)
-    out = (there + back) * good_H_reshape.to(there.dtype) + max_num * (~good_H_reshape).to(there.dtype)
-    if squared:
-        return out
-    return (out + eps).sqrt()
+
+    out = there + back
+    if not squared:
+        out = (out + eps).sqrt()
+    max_tensor = torch.full_like(out, max_num)
+    return torch.where(good_H_reshape, out, max_tensor)
 
 
 def line_segment_transfer_error_one_way(

--- a/kornia/geometry/homography.py
+++ b/kornia/geometry/homography.py
@@ -123,10 +123,11 @@ def symmetric_transfer_error(
     # From Hartley and Zisserman, Symmetric transfer error (4.7)
     # dist = \sum_{i} (d(x, H^-1 x')**2 + d(x', Hx)**2)
     H_inv, good_H = safe_inverse_with_mask(H)
-    eye = torch.eye(3, device=H.device, dtype=H.dtype).expand_as(H_inv)
+    eye = torch.eye(3, device=H.device, dtype=H.dtype).expand_as(H)
+    H_safe = torch.where(good_H.view(-1, 1, 1), H, eye)
     H_inv_safe = torch.where(good_H.view(-1, 1, 1), H_inv, eye)
 
-    there: torch.Tensor = oneway_transfer_error(pts1, pts2, H, True, eps)
+    there: torch.Tensor = oneway_transfer_error(pts1, pts2, H_safe, True, eps)
     back: torch.Tensor = oneway_transfer_error(pts2, pts1, H_inv_safe, True, eps)
     good_H_reshape: torch.Tensor = good_H.view(-1, 1).expand_as(there)
 

--- a/tests/geometry/test_homography.py
+++ b/tests/geometry/test_homography.py
@@ -154,6 +154,30 @@ class TestSymmetricTransferError(BaseTester):
         expected = torch.tensor([0.0, 2.0, 10.0], device=device, dtype=dtype)[None]
         self.assert_close(symmetric_transfer_error(pts1, pts2, H), expected, atol=1e-4, rtol=1e-4)
 
+    def test_singular(self, device, dtype):
+        max_num = torch.finfo(dtype).max
+        pts1 = torch.rand(2, 5, 2, device=device, dtype=dtype, requires_grad=True)
+        pts2 = torch.rand(2, 5, 2, device=device, dtype=dtype)
+        H = torch.eye(3, device=device, dtype=dtype).unsqueeze(0).repeat(2, 1, 1)
+        # Make second homography in the batch singular
+        H[1] = 0.0
+        H[1, 0, 0] = 1.0
+
+        for squared in (True, False):
+            err = symmetric_transfer_error(pts1, pts2, H, squared=squared)
+            assert not torch.isnan(err).any()
+            assert torch.isfinite(err[0]).all()
+            expected_singular = torch.full_like(err[1], max_num)
+            self.assert_close(err[1], expected_singular)
+
+        # Check gradient finiteness across mixed batch
+        err = symmetric_transfer_error(pts1, pts2, H)
+        err[0].sum().backward()
+        assert pts1.grad is not None
+        assert not torch.isnan(pts1.grad).any()
+        assert torch.isfinite(pts1.grad[0]).all()
+        assert (pts1.grad[1] == 0.0).all()
+
 
 class TestFindHomographyDLT(BaseTester):
     def test_smoke(self, device, dtype):

--- a/tests/geometry/test_homography.py
+++ b/tests/geometry/test_homography.py
@@ -178,6 +178,32 @@ class TestSymmetricTransferError(BaseTester):
         assert torch.isfinite(pts1.grad[0]).all()
         assert (pts1.grad[1] == 0.0).all()
 
+    def test_singular_gradient_wrt_homography(self, device, dtype):
+        pts1 = torch.rand(2, 5, 2, device=device, dtype=dtype)
+        pts2 = torch.rand(2, 5, 2, device=device, dtype=dtype)
+        H = torch.eye(3, device=device, dtype=dtype).unsqueeze(0).repeat(2, 1, 1)
+        H[1] = 0.0
+        H[1, 0, 0] = 1.0
+        H.requires_grad_(True)
+
+        symmetric_transfer_error(pts1, pts2, H)[0].sum().backward()
+        assert H.grad is not None
+        assert torch.isfinite(H.grad).all()
+        assert (H.grad[1] == 0.0).all()
+
+    def test_singular_gradient_through_estimated_homography(self, device, dtype):
+        # ``find_homography_dlt_iterated`` differentiates the error through an estimated ``H``, so a
+        # singular intermediate must not poison the gradient of the correspondences that produced it.
+        pts1 = torch.rand(2, 5, 2, device=device, dtype=dtype, requires_grad=True)
+        pts2 = torch.rand(2, 5, 2, device=device, dtype=dtype)
+        eye = torch.eye(3, device=device, dtype=dtype)
+        zeros = torch.zeros(3, 3, device=device, dtype=dtype)
+        H = torch.stack([eye * pts1[0, 0, 0], zeros * pts1[1, 0, 0]])
+
+        symmetric_transfer_error(pts1, pts2, H).sum().backward()
+        assert pts1.grad is not None
+        assert torch.isfinite(pts1.grad).all()
+
 
 class TestFindHomographyDLT(BaseTester):
     def test_smoke(self, device, dtype):


### PR DESCRIPTION
## What does this pull request do?

Fix `symmetric_transfer_error` returning `NaN` instead of `max_num` when given a singular homography matrix.

When an input homography matrix is singular, `safe_inverse_with_mask` marks `good_H` as `False` and returns non-finite values (`NaN` / `Inf`) in `H_inv`. The previous implementation evaluated `oneway_transfer_error` with `H_inv` unshielded and attempted to mask the result using arithmetic: `(there + back) * mask + max_num * (~mask)`. Because `NaN * 0.0` evaluates to `NaN` in IEEE 754 floating-point arithmetic, `out` became `NaN` instead of `max_num`. In addition, during backpropagation, evaluating unshielded `NaN` values produced `NaN` gradients across the whole batch.

Shielding the *output* of the inverse is not enough for the backward pass: `inv_ex`'s backward is `-H_inv^T @ grad @ H_inv^T` over a saved `H_inv` full of `NaN`, so the exact-zero gradient `torch.where` hands the bad row still becomes `0 * NaN = NaN` in `H.grad`. That matters because `find_homography_dlt_iterated` (`homography.py:299`) differentiates the error through an estimated `H`, so the `NaN` reaches the correspondences on the differentiable-estimator path that motivates #4203. The *input* of the inverse is shielded instead.

This PR:
1. Takes the invertibility mask on a detached copy of `H`, replaces singular rows with the identity, and only then computes the differentiable inverse, so gradients with respect to both the correspondences and `H` itself stay finite (exactly `0` on the singular rows).
2. Uses `torch.where` to select `max_num` where `good_H` is `False`.
3. Handles both `squared=True` (default) and `squared=False` so non-invertible homographies reliably receive `max_num`. For `squared=False` this is a small behaviour change beyond the `NaN` repair: a singular row scored `(max_num + eps).sqrt()` before and scores `max_num` now. The one in-tree consumer, `find_homography_dlt_iterated`, feeds the error to `exp(-errors / (2 * soft_inl_th**2))`, which underflows to `0` at either magnitude, so no in-tree behaviour moves. The CHANGELOG entry says so.
4. Documents the `max_num` contract in the `Returns:` section, which #4203 assumed was already documented and was not.
5. Adds regression tests: `test_singular` (finite errors on valid rows, `max_num` on singular rows, finite gradients w.r.t. the correspondences), `test_singular_gradient_wrt_homography`, and `test_singular_gradient_through_estimated_homography` for the `H`-in-graph case.

## Related issue or discussion

Closes #4203

## What did you check?

Ran the new tests against unmodified `main` first to confirm they catch the regression:

```text
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError: Failed: got tensor([nan, nan, nan, nan, nan])
```

Forward output is `torch.equal` to the previous head of this branch for both `squared=True` and `squared=False`, over a mixed batch containing a singular row, so nothing moves for valid inputs. `max_num` is dtype-correct: float16 `65504.0`, bfloat16 `3.3895e38`, float32 `3.4028e38`, float64 `1.7977e308`. The extra batched 3x3 inverse costs `7.60 ms -> 8.53 ms` at `B=2048` on CPU.

```text
$ pytest tests/geometry/test_homography.py tests/geometry/test_ransac.py --dtype=float32,float64
============== 156 passed, 22 skipped, 4 xpassed, 2 warnings in 13.80s ==============

$ pytest tests/geometry/test_homography.py -k Symmetric --dtype=float16,bfloat16
======================== 13 passed, 118 deselected in 0.63s ========================

$ ruff check / ruff format --diff on both changed files
All checks passed!
```
