### PR TITLE
fix(contrib): keep distance_transform gradients finite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+
 * `kornia.io.load_image` and `write_image` work on the kornia_rs that a plain `pip install kornia`
   resolves. kornia_rs 0.1.11 moved its image readers and writers from the package root into
   `kornia_rs.io`, and kornia kept calling the root, so on 0.1.11 and newer `load_image` raised
@@ -362,6 +363,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so instead of mislabelling the tensor. The nightly PyPI job now imports the installed wheel from
   outside the checkout (it used to import the source tree) and round-trips an image instead of only
   importing. (#4326)
+
+* `distance_transform` no longer returns NaN gradients when the cascade's convolution is exactly zero, including
+  sparse masks and all-zero inputs; the existing forward output is unchanged. (#4232)
+
+
 * `SemanticSegmentation.visualize` works for CUDA, MPS and half-precision models. It indexed the
   CPU-drawn colormap with the mask's `argmax`, which raises for CUDA and MPS masks, and recognised a
   softmax head with `torch.allclose(sum, 1)` at float32-sized default tolerances, which a float16 or

--- a/kornia/contrib/distance_transform.py
+++ b/kornia/contrib/distance_transform.py
@@ -76,7 +76,9 @@ def _distance_transform_2d_impl(image: torch.Tensor, kernel_size: int, h: float)
 
     for i in range(n_iters):
         cdt = filter2d(boundary, kernel, border_type="replicate")
-        cdt = -h * torch.log(cdt)
+        positive = cdt > 0
+        cdt = -h * torch.log(torch.where(positive, cdt, torch.ones_like(cdt)))
+        cdt = torch.where(positive, cdt, torch.zeros_like(cdt))
         cdt = torch.nan_to_num(cdt, nan=0.0, posinf=0.0, neginf=0.0)
 
         mask = cdt > 0
@@ -108,7 +110,9 @@ def _distance_transform_3d_impl(image: torch.Tensor, kernel_size: int, h: float)
 
     for i in range(n_iters):
         cdt = filter3d(boundary, kernel, border_type="replicate")
-        cdt = -h * torch.log(cdt)
+        positive = cdt > 0
+        cdt = -h * torch.log(torch.where(positive, cdt, torch.ones_like(cdt)))
+        cdt = torch.where(positive, cdt, torch.zeros_like(cdt))
         cdt = torch.nan_to_num(cdt, nan=0.0, posinf=0.0, neginf=0.0)
 
         mask = cdt > 0

--- a/tests/contrib/test_conv_distance_transformer.py
+++ b/tests/contrib/test_conv_distance_transformer.py
@@ -173,6 +173,24 @@ class TestConvDistanceTransform(BaseTester):
         sample3d = torch.ones(B, C, D, H, W, device=device, dtype=torch.float64, requires_grad=True)
         self.gradcheck(kornia.contrib.distance_transform, (sample3d,))
 
+    @pytest.mark.parametrize("shape", [(1, 1, 4, 4), (1, 1, 4, 4, 4)], ids=["2d", "3d"])
+    @pytest.mark.parametrize("has_signal", [False, True], ids=["all-zero", "one-hot"])
+    def test_zero_convolution_has_finite_gradients(self, shape, has_signal, device, dtype):
+        sample = torch.zeros(*shape, device=device, dtype=dtype)
+        if has_signal:
+            sample[(0, 0, *((1,) * (len(shape) - 2)))] = 1.0
+        sample.requires_grad_(True)
+
+        output = kornia.contrib.distance_transform(sample)
+        assert torch.isfinite(output).all()
+        if not has_signal:
+            assert torch.equal(output, torch.zeros_like(output))
+
+        output.sum().backward()
+        assert sample.grad is not None
+        assert sample.grad.shape == sample.shape
+        assert torch.isfinite(sample.grad).all()
+
     def test_loss_grad(self, device, dtype):
         B, C, H, W = 1, 1, 32, 32
         sample1 = torch.rand(B, C, H, W, device=device, dtype=dtype, requires_grad=True)


### PR DESCRIPTION
## What does this pull request do?

Fixes NaN gradients in `kornia.contrib.distance_transform` when an intermediate convolution evaluates to exactly zero.

Previously, both the 2D and 3D implementations evaluated:

```python
cdt = -h * torch.log(cdt)
cdt = torch.nan_to_num(cdt, nan=0.0, posinf=0.0, neginf=0.0)
```

When `cdt == 0`, `torch.log(0)` produces `-inf`. `torch.nan_to_num` repairs the forward value, but the backward still passes through the singular derivative of `log` at zero, which can produce NaN gradients.

The fix avoids evaluating `log` at inactive positions:

```python
positive = cdt > 0
cdt = -h * torch.log(torch.where(positive, cdt, torch.ones_like(cdt)))
cdt = torch.where(positive, cdt, torch.zeros_like(cdt))
```

This is applied to both `_distance_transform_2d_impl` and `_distance_transform_3d_impl`.

The zero-convolution positions therefore follow a finite inactive branch instead of passing through `log(0)`, while positive convolution values retain the existing computation.

The existing `torch.nan_to_num(...)` step is intentionally retained so handling of exceptional non-finite inputs and the surrounding behavior remain unchanged.

The patch does not clamp the convolution result before `log`; doing so would turn zero positions into positive distance values and change the existing mask/forward semantics.

### Regression coverage

A dedicated regression test was added for both:

- 2D input: `(1, 1, 4, 4)`
- 3D input: `(1, 1, 4, 4, 4)`

and for:

- all-zero inputs
- one-hot inputs

across the repository's `float32` / `float64` CPU test matrix.

The regression verifies that:

- the forward output is finite;
- the all-zero case remains exactly zero;
- backward completes successfully;
- `sample.grad` is produced;
- the gradient shape exactly matches the input shape;
- all gradient entries are finite.

The regression was also checked against the unpatched implementation, where the affected cases fail because the gradients contain NaNs.

I additionally compared patched and pre-fix forward results on representative sparse, one-hot, and all-zero inputs using exact `torch.equal` comparisons. The forward results remain unchanged while the affected gradients become finite.

### Compatibility with #4158

This was checked after rebasing onto the current `main`, which already contains #4158.

The two fixes address separate failure modes in the same function:

- #4158 handles kernel working precision / `exp(-dist / h)` underflow;
- this change prevents the later logarithm from being evaluated where the convolution result is zero.

The #4158 behavior, kernel construction, working-dtype handling, `_check_h_range`, offsets, ONNX-safe operations, and public API are unchanged by this patch.

## Related issue or discussion

Fixes #4183.

## What did you check?

### Regression test

```text
pixi run test-module tests/contrib/test_conv_distance_transformer.py::TestConvDistanceTransform::test_zero_convolution_has_finite_gradients --device=cpu --dtype=float32,float64

8 passed
```

### Full distance-transform test module

```text
pixi run test-module tests/contrib/test_conv_distance_transformer.py --device=cpu --dtype=float32,float64

42 passed
```

### Lint / formatting

```text
pixi run lint

ruff check    Passed
ruff format   Passed
```

### Type checking

```text
pixi run typecheck
```

Result:

```text
exit code 0
```

The command reports one existing deprecation diagnostic in `kornia/feature/lightglue.py` for `torch.cuda.amp.custom_fwd`; it is unrelated to this change.

### Pre-commit

Targeted pre-commit was run for:

```text
kornia/contrib/distance_transform.py
tests/contrib/test_conv_distance_transformer.py
```

The applicable formatting, lint, merge-conflict, large-file, codespell, and license-header checks pass. On Windows, the mixed-line-ending hook normalized the two touched files when required.

### Git / scope checks

The branch was rebased onto current `upstream/main`.

The final source change is limited to:

```text
kornia/contrib/distance_transform.py
tests/contrib/test_conv_distance_transformer.py
```

with:

```text
2 files changed, 24 insertions(+), 2 deletions(-)
```

`git diff --check` exits successfully.

## How did AI help?

I used AI-assisted tooling to help inspect the existing implementation and test coverage, reproduce the reported backward failure, compare the patch against the issue's requested scope, and organize the validation steps.

I reviewed the resulting source and test changes myself, verified the regression against the pre-fix behavior, checked exact forward-output preservation, confirmed finite gradients after the fix, rebased onto the merged #4158 implementation, and reran the relevant tests, lint, type checking, pre-commit, and Git scope checks before preparing this pull request.