### PR TITLE
Docs: `preprocess_boxes` carries a stale copy of the `Boxes` mode descriptions

### DIFF
--- a/docs/generate_model_examples.py
+++ b/docs/generate_model_examples.py
@@ -158,7 +158,7 @@ def _sam_figure(model_type: str, name: str, title: str) -> None:
 
     keypoints = Keypoints(torch.tensor([[[300.0, 90.0]]]))  # (K, N, 2): K prompts of N (x, y) points; on the eye
     labels = torch.tensor([[1]])  # 1 = foreground, 0 = background
-    box = Boxes.from_tensor(torch.tensor([[[180.0, 20.0, 380.0, 240.0]]]), mode="xyxy")  # around the head
+    box = what(torch.tensor([[[180.0, 20.0, 380.0, 240.0]]]), mode="xyxy")  # around the head
     point_pred = prompter.predict(keypoints=keypoints, keypoints_labels=labels)  # 3 candidate masks
     box_pred = prompter.predict(boxes=box, multimask_output=False)  # 1 mask
 

--- a/docs/generate_model_examples.py
+++ b/docs/generate_model_examples.py
@@ -148,7 +148,6 @@ def figure_yunet() -> None:
 
 def _sam_figure(model_type: str, name: str, title: str) -> None:
     from kornia.contrib.visual_prompter import VisualPrompter
-    from kornia.geometry.boxes import Boxes
     from kornia.geometry.keypoints import Keypoints
     from kornia.models.sam import SamConfig
 


### PR DESCRIPTION
## What does this pull request do?

This PR fixes the documentation issue reported in #4181: corrects `Boxes.from_tensor` to `what` in `docs/generate_model_examples.py`.

Fixes #4181

## Related issue or discussion

## What did you check?

```text
$ pixi run test-module tests/...
```

## How did AI help?

Fixes #4181