### PR TITLE
fix(feature): remove the dead flash_attn path from LightGlue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,7 +293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `kornia.feature.LightGlue` no longer probes for `flash_attn`; the SDPA path it always used is now
-  the only one. (#XXXX)
+  the only one. (#4287)
 
 * `RandAugment`, `AutoAugment`, `TrivialAugment` and `AugMix` no longer silently upcast half-precision
   batches to `float32`. `OperationBase.forward` — the shared gate every auto-augment op routes through —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `kornia.feature.LightGlue` no longer probes for `flash_attn`; the SDPA path it always used is now
+  the only one. (#XXXX)
+
 * `RandAugment`, `AutoAugment`, `TrivialAugment` and `AugMix` no longer silently upcast half-precision
   batches to `float32`. `OperationBase.forward` — the shared gate every auto-augment op routes through —
   moved its `batch_prob` mask to `input.device` but not `input.dtype`, and since `batch_prob` is `float32`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,7 +293,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `kornia.feature.LightGlue` no longer probes for `flash_attn`; the SDPA path it always used is now
-  the only one. (#4287)
+  the only one. `kornia.feature.lightglue.Attention.enable_flash`, the public attribute that recorded
+  whether the probe had succeeded, was renamed to `Attention.allow_flash` and now simply mirrors the
+  constructor argument of the same name. (#4287)
 
 * `RandAugment`, `AutoAugment`, `TrivialAugment` and `AugMix` no longer silently upcast half-precision
   batches to `float32`. `OperationBase.forward` — the shared gate every auto-augment op routes through —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,9 +293,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `kornia.feature.LightGlue` no longer probes for `flash_attn`; the SDPA path it always used is now
-  the only one. `kornia.feature.lightglue.Attention.enable_flash`, the public attribute that recorded
-  whether the probe had succeeded, was renamed to `Attention.allow_flash` and now simply mirrors the
-  constructor argument of the same name. (#4287)
+  the only one. `kornia.feature.lightglue.Attention.enable_flash`, the attribute that combined the
+  constructor argument with the probe result (and so always equalled the argument, because SDPA is
+  present on every supported torch), was renamed to `Attention.allow_flash`. (#4287)
 
 * `RandAugment`, `AutoAugment`, `TrivialAugment` and `AugMix` no longer silently upcast half-precision
   batches to `float32`. `OperationBase.forward` — the shared gate every auto-augment op routes through —

--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -30,16 +30,6 @@ from kornia.core.download import hf_url, load_state_dict_from_url
 from kornia.core.utils import is_exporting
 from kornia.feature.laf import laf_to_three_points, scale_laf
 
-try:
-    from flash_attn.modules.mha import FlashCrossAttention
-except ModuleNotFoundError:
-    FlashCrossAttention = None
-
-if FlashCrossAttention or hasattr(F, "scaled_dot_product_attention"):
-    FLASH_AVAILABLE = True
-else:
-    FLASH_AVAILABLE = False
-
 
 def math_clamp(x, min_, max_):  # type: ignore
     """Clamp a value to lie within [min, max]."""
@@ -146,17 +136,8 @@ class Attention(nn.Module):
 
     def __init__(self, allow_flash: bool) -> None:
         super().__init__()
-        if allow_flash and not FLASH_AVAILABLE:
-            warnings.warn(
-                "FlashAttention is not available. For optimal speed, consider installing flash-attn.",
-                stacklevel=2,
-            )
-        self.enable_flash = allow_flash and FLASH_AVAILABLE
-        self.has_sdp = hasattr(F, "scaled_dot_product_attention")
-        if allow_flash and FlashCrossAttention:
-            self.flash_ = FlashCrossAttention()
-        if self.has_sdp:
-            torch.backends.cuda.enable_flash_sdp(allow_flash)
+        self.allow_flash = allow_flash
+        torch.backends.cuda.enable_flash_sdp(allow_flash)
 
     def forward(
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, mask: Optional[torch.Tensor] = None
@@ -176,28 +157,15 @@ class Attention(nn.Module):
         Returns:
             Attention output with shape :math:`(B, H, N_q, D_h)`.
         """
-        if self.enable_flash and q.device.type == "cuda":
+        if self.allow_flash and q.device.type == "cuda":
             # use torch 2.0 scaled_dot_product_attention with flash
-            if self.has_sdp:
-                args = [x.half().contiguous() for x in [q, k, v]]
-                v = F.scaled_dot_product_attention(*args, attn_mask=mask).to(q.dtype)  # type: ignore
-                return v if mask is None else v.nan_to_num()
-            else:
-                KORNIA_CHECK(mask is None)
-                q, k, v = (x.transpose(-2, -3).contiguous() for x in [q, k, v])
-                m = self.flash_(q.half(), torch.stack([k, v], 2).half())
-                return m.transpose(-2, -3).to(q.dtype).clone()
-        elif self.has_sdp:
+            args = [x.half().contiguous() for x in [q, k, v]]
+            v = F.scaled_dot_product_attention(*args, attn_mask=mask).to(q.dtype)  # type: ignore
+            return v if mask is None else v.nan_to_num()
+        else:
             args = [x.contiguous() for x in [q, k, v]]
             v = F.scaled_dot_product_attention(*args, attn_mask=mask)  # type: ignore
             return v if mask is None else v.nan_to_num()
-        else:
-            s = q.shape[-1] ** -0.5
-            sim = torch.einsum("...id,...jd->...ij", q, k) * s
-            if mask is not None:
-                sim.masked_fill(~mask, -float("inf"))
-            attn = F.softmax(sim, -1)
-            return torch.einsum("...ij,...jd->...id", attn, v)
 
 
 class SelfBlock(nn.Module):
@@ -279,7 +247,7 @@ class CrossBlock(nn.Module):
             nn.GELU(),
             nn.Linear(2 * embed_dim, embed_dim),
         )
-        if flash and FLASH_AVAILABLE:
+        if flash:
             self.flash = Attention(True)
         else:
             self.flash = None  # type: ignore
@@ -954,7 +922,7 @@ class LightGlue(nn.Module):
             Minimum number of keypoints required for width pruning on that device.
             A negative value disables pruning for the device.
         """
-        if self.conf.flash and FLASH_AVAILABLE and device.type == "cuda":
+        if self.conf.flash and device.type == "cuda":
             return self.pruning_keypoint_thresholds["flash"]
         else:
             return self.pruning_keypoint_thresholds[device.type]

--- a/tests/feature/test_lightglue.py
+++ b/tests/feature/test_lightglue.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 
 from kornia.feature.lightglue import (
+    Attention,
     LearnableFourierPositionalEncoding,
     LightGlue,
     TokenConfidence,
@@ -28,7 +29,7 @@ from kornia.feature.lightglue import (
     rotate_half,
 )
 
-from testing.base import BaseTester
+from testing.base import BaseTester, assert_close
 
 # ---------------------------------------------------------------------------
 # Pure function tests
@@ -144,6 +145,36 @@ def test_apply_cached_rotary_emb_shape():
     t = torch.rand(B, 1, N, D)
     out = apply_cached_rotary_emb(freqs, t)
     assert out.shape == t.shape
+
+
+def test_attention_allow_flash_matches_on_cpu():
+    """On CPU, ``allow_flash`` never selects the CUDA-only branch, so both settings take the
+    same ``scaled_dot_product_attention`` path and must produce identical outputs, with and
+    without a boolean mask (exercising the ``nan_to_num`` handling of fully-masked rows).
+    """
+    torch.manual_seed(0)
+    B, H, N, Dh = 1, 2, 5, 8
+    q = torch.rand(B, H, N, Dh)
+    k = torch.rand(B, H, N, Dh)
+    v = torch.rand(B, H, N, Dh)
+
+    attn_no_flash = Attention(allow_flash=False)
+    attn_flash = Attention(allow_flash=True)
+
+    out_no_flash = attn_no_flash(q, k, v)
+    out_flash = attn_flash(q, k, v)
+    assert_close(out_no_flash, out_flash)
+
+    # First query row cannot attend to anything: softmax produces NaN there, which
+    # ``Attention.forward`` replaces via ``nan_to_num``.
+    mask = torch.ones(B, H, N, N, dtype=torch.bool)
+    mask[:, :, 0, :] = False
+
+    out_no_flash_masked = attn_no_flash(q, k, v, mask=mask)
+    out_flash_masked = attn_flash(q, k, v, mask=mask)
+    assert not torch.isnan(out_no_flash_masked).any()
+    assert not torch.isnan(out_flash_masked).any()
+    assert_close(out_no_flash_masked, out_flash_masked)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/feature/test_lightglue.py
+++ b/tests/feature/test_lightglue.py
@@ -158,23 +158,29 @@ def test_attention_allow_flash_matches_on_cpu():
     k = torch.rand(B, H, N, Dh)
     v = torch.rand(B, H, N, Dh)
 
-    attn_no_flash = Attention(allow_flash=False)
-    attn_flash = Attention(allow_flash=True)
+    # ``Attention.__init__`` flips the process-global ``torch.backends.cuda`` flash-SDPA switch;
+    # put back whatever this test found so later tests in a CUDA run do not depend on its order.
+    flash_sdp_was_enabled = torch.backends.cuda.flash_sdp_enabled()
+    try:
+        attn_no_flash = Attention(allow_flash=False)
+        attn_flash = Attention(allow_flash=True)
 
-    out_no_flash = attn_no_flash(q, k, v)
-    out_flash = attn_flash(q, k, v)
-    assert_close(out_no_flash, out_flash)
+        out_no_flash = attn_no_flash(q, k, v)
+        out_flash = attn_flash(q, k, v)
+        assert_close(out_no_flash, out_flash)
 
-    # First query row cannot attend to anything: softmax produces NaN there, which
-    # ``Attention.forward`` replaces via ``nan_to_num``.
-    mask = torch.ones(B, H, N, N, dtype=torch.bool)
-    mask[:, :, 0, :] = False
+        # First query row cannot attend to anything: softmax produces NaN there, which
+        # ``Attention.forward`` replaces via ``nan_to_num``.
+        mask = torch.ones(B, H, N, N, dtype=torch.bool)
+        mask[:, :, 0, :] = False
 
-    out_no_flash_masked = attn_no_flash(q, k, v, mask=mask)
-    out_flash_masked = attn_flash(q, k, v, mask=mask)
-    assert not torch.isnan(out_no_flash_masked).any()
-    assert not torch.isnan(out_flash_masked).any()
-    assert_close(out_no_flash_masked, out_flash_masked)
+        out_no_flash_masked = attn_no_flash(q, k, v, mask=mask)
+        out_flash_masked = attn_flash(q, k, v, mask=mask)
+        assert not torch.isnan(out_no_flash_masked).any()
+        assert not torch.isnan(out_flash_masked).any()
+        assert_close(out_no_flash_masked, out_flash_masked)
+    finally:
+        torch.backends.cuda.enable_flash_sdp(flash_sdp_was_enabled)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

`kornia/feature/lightglue.py` probed for the optional `flash_attn` package at import time and used
the probe result to pick between three code paths in `Attention.forward`: an SDPA path, a
`flash_attn`-backed path, and an `einsum` fallback for torch builds without
`scaled_dot_product_attention`. `F.scaled_dot_product_attention` exists on every torch version
kornia supports (floor 2.5.1), so `has_sdp` was always `True` and the other two branches were dead
code guarded behind a package kornia never declares as a dependency (it isn't in `pyproject.toml`
under any extra).

Removed:
- The `try/except ModuleNotFoundError` import of `flash_attn.modules.mha.FlashCrossAttention` and
  the module-level `FLASH_AVAILABLE` flag.
- `Attention.__init__`'s "FlashAttention is not available..." warning (it could never fire), the
  `self.flash_ = FlashCrossAttention()` construction, and `self.has_sdp`.
- `Attention.forward`'s `flash_attn` branch and its `einsum` fallback branch.
- The three remaining `FLASH_AVAILABLE` reads outside `Attention` (`CrossBlock.__init__`,
  `LightGlue.pruning_min_kpts`), simplified since the flag was always `True`.

Kept unchanged:
- `Attention.__init__(allow_flash)`'s signature and the `torch.backends.cuda.enable_flash_sdp(allow_flash)`
  call, in its original position (now the last statement, since the `has_sdp` guard around it was
  always true).
- The `flash` config key and `TransformerLayer(..., flash=...)` / `CrossBlock(..., flash=...)`
  signatures.
- The CUDA half-cast SDPA branch (`if self.allow_flash and q.device.type == "cuda": ... x.half() ...`)
  byte-for-byte in behaviour — `self.enable_flash` is renamed to `self.allow_flash` (it held the same
  value as the constructor argument once `FLASH_AVAILABLE` is always true) but the branch body is
  untouched.

## Why

Part of the dependency-cleanup effort tracked in kornia#4261: removing optional imports kornia
never declared as a dependency, where the guarded code paths were unreachable given kornia's actual
supported-torch floor.

## What was verified

Run from the worktree root with `/Users/oldufo/dev/kornia/.venv/bin/python`
(torch 2.14.0; `kornia.__file__` confirmed to resolve to this worktree before every run):

- `python -m pytest tests/feature/test_lightglue.py -q`
  → before the change: `30 passed, 1 skipped`; after adding the new `Attention` test:
  `31 passed, 1 skipped`. The pre-existing tests are byte-identical and pass unchanged, confirming
  the surviving SDPA path is the one CI always exercised.
- `python -m pytest tests/test_api_surface.py -q` → `13 passed`. `FLASH_AVAILABLE` was never listed
  in `tests/api_surface.json` and `lightglue.py` has no `__all__`, so no inventory change was
  needed.
- `python -m pytest --doctest-modules kornia/feature/lightglue.py -q` → `no tests ran` (the module
  has no doctests).
- `grep -rn "flash_attn\|FLASH_AVAILABLE\|FlashCrossAttention" kornia tests docs` → empty.
- `python -m ruff check kornia/feature/lightglue.py` → `All checks passed!`
- `git add -A && pre-commit run --all-files` → all hooks passed (ruff check, ruff format,
  codespell, license header, etc.), no files modified by the hooks.

New test added in `tests/feature/test_lightglue.py`:
`test_attention_allow_flash_matches_on_cpu` instantiates `Attention(allow_flash=False)` and
`Attention(allow_flash=True)` and checks they produce `assert_close`-identical outputs on CPU for
the same random `q`/`k`/`v`, both with no mask and with a boolean mask that leaves one query row
fully masked (forcing the `nan_to_num` path to fire). This pins that both constructor settings take
the same SDPA branch on CPU and that mask/`nan_to_num` handling survived the refactor.

## What is not covered

- No CUDA-specific run was performed in this environment (none available); the CUDA half-cast
  branch's code path is unchanged byte-for-byte from before, and CI's existing CPU-only
  `test_lightglue.py` suite is the regression witness for the SDPA path, as scoped by the task
  brief.
- No change was made to `pyproject.toml` / packaging metadata since `flash_attn` was never listed
  there.

Refs #4261.

Posted on behalf of @ducha-aiki by Claude (Claude Fable 5.1).
