### PR TITLE
fix(feature): drop the dead `xformers` paths from DeDoDe's vendored DINOv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* DeDoDe's vendored DINOv2 no longer probes for `xformers`; the pure-PyTorch path it always ran is the
+  only one. (#XXXX)
+
 * `RandAugment`, `AutoAugment`, `TrivialAugment` and `AugMix` no longer silently upcast half-precision
   batches to `float32`. `OperationBase.forward` — the shared gate every auto-augment op routes through —
   moved its `batch_prob` mask to `input.device` but not `input.dtype`, and since `batch_prob` is `float32`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,7 +293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * DeDoDe's vendored DINOv2 no longer probes for `xformers`; the pure-PyTorch path it always ran is the
-  only one. (#XXXX)
+  only one. (#4288)
 
 * `RandAugment`, `AutoAugment`, `TrivialAugment` and `AugMix` no longer silently upcast half-precision
   batches to `float32`. `OperationBase.forward` — the shared gate every auto-augment op routes through —

--- a/kornia/feature/dedode/transformer/layers/attention.py
+++ b/kornia/feature/dedode/transformer/layers/attention.py
@@ -32,14 +32,6 @@ from torch import Tensor, nn
 logger = logging.getLogger("dinov2")
 
 
-try:
-    from xformers.ops import fmha, memory_efficient_attention, unbind
-
-    XFORMERS_AVAILABLE = True
-except ImportError:
-    XFORMERS_AVAILABLE = False
-
-
 class Attention(nn.Module):
     """Implement the standard Multi-Head Self-Attention mechanism.
 
@@ -97,31 +89,22 @@ class Attention(nn.Module):
 
 
 class MemEffAttention(Attention):
-    """Implement a memory-efficient version of Multi-Head Self-Attention using xFormers."""
+    """Implement Multi-Head Self-Attention with the signature the vendored DINOv2 blocks call.
+
+    The computation is the one of :class:`Attention`. The extra ``attn_bias`` argument is kept for
+    signature compatibility with the DINOv2 model builders that select this class, and must be ``None``.
+    """
 
     def forward(self, x: Tensor, attn_bias=None) -> Tensor:  # type: ignore[no-untyped-def]
         """Run this DeDoDe module forward.
 
         Args:
             x: Input token sequence with shape :math:`(B, N, C)`.
-            attn_bias: Optional attention bias from xFormers for nested tensor support.
+            attn_bias: Unsupported; must be ``None``.
 
         Returns:
             Attention output with shape :math:`(B, N, C)`.
         """
-        if not XFORMERS_AVAILABLE:
-            if attn_bias is not None:
-                raise ValueError("xFormers is required for nested tensors usage")
-            return super().forward(x)
-
-        B, N, C = x.shape
-        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads)
-
-        q, k, v = unbind(qkv, 2)
-
-        x = memory_efficient_attention(q, k, v, attn_bias=attn_bias)
-        x = x.reshape([B, N, C])
-
-        x = self.proj(x)
-        x = self.proj_drop(x)
-        return x
+        if attn_bias is not None:
+            raise NotImplementedError("attn_bias is not supported")
+        return super().forward(x)

--- a/kornia/feature/dedode/transformer/layers/attention.py
+++ b/kornia/feature/dedode/transformer/layers/attention.py
@@ -85,10 +85,11 @@ class Attention(nn.Module):
 
 
 class MemEffAttention(Attention):
-    """Implement Multi-Head Self-Attention with the signature the vendored DINOv2 blocks call.
+    """Implement Multi-Head Self-Attention under the class name the vendored DINOv2 builders select.
 
-    The computation is the one of :class:`Attention`. The extra ``attn_bias`` argument is kept for
-    signature compatibility with the DINOv2 model builders that select this class, and must be ``None``.
+    The computation is the one of :class:`Attention`. The class name is kept because the DINOv2 model
+    builders reference it; the extra ``attn_bias`` argument is kept so :meth:`forward` matches the upstream
+    DINOv2 signature. Nothing in kornia passes it, and it must be ``None``.
     """
 
     def forward(self, x: Tensor, attn_bias=None) -> Tensor:  # type: ignore[no-untyped-def]

--- a/kornia/feature/dedode/transformer/layers/attention.py
+++ b/kornia/feature/dedode/transformer/layers/attention.py
@@ -25,11 +25,7 @@
 #   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/models/vision_transformer.py
 
-import logging
-
 from torch import Tensor, nn
-
-logger = logging.getLogger("dinov2")
 
 
 class Attention(nn.Module):

--- a/kornia/feature/dedode/transformer/layers/block.py
+++ b/kornia/feature/dedode/transformer/layers/block.py
@@ -25,29 +25,15 @@
 #   https://github.com/facebookresearch/dino/blob/master/vision_transformer.py
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/layers/patch_embed.py
 
-import logging
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Callable
 
 import torch
 from torch import Tensor, nn
 
-from kornia.core.check import KORNIA_CHECK
-
-from .attention import Attention, MemEffAttention
+from .attention import Attention
 from .drop_path import DropPath
 from .layer_scale import LayerScale
 from .mlp import Mlp
-
-logger = logging.getLogger("dinov2")
-
-
-try:
-    from xformers.ops import fmha, index_select_cat, scaled_index_add
-
-    XFORMERS_AVAILABLE = True
-except ImportError:
-    logger.warning("xFormers not available")
-    XFORMERS_AVAILABLE = False
 
 
 class Block(nn.Module):
@@ -181,132 +167,29 @@ def drop_add_residual_stochastic_depth(
     return x_plus_residual.view_as(x)
 
 
-def get_branges_scales(x, sample_drop_ratio=0.0):
-    """Add bernoulli sampled range and scale."""
-    b, _n, _d = x.shape
-    sample_subset_size = max(int(b * (1 - sample_drop_ratio)), 1)
-    brange = (torch.randperm(b, device=x.device))[:sample_subset_size]
-    residual_scale_factor = b / sample_subset_size
-    return brange, residual_scale_factor
-
-
-def add_residual(x, brange, residual, residual_scale_factor, scaling_vector=None):
-    """Add residual connections."""
-    if scaling_vector is None:
-        x_flat = x.flatten(1)
-        residual = residual.flatten(1)
-        x_plus_residual = torch.index_add(x_flat, 0, brange, residual.to(dtype=x.dtype), alpha=residual_scale_factor)
-    else:
-        x_plus_residual = scaled_index_add(
-            x, brange, residual.to(dtype=x.dtype), scaling=scaling_vector, alpha=residual_scale_factor
-        )
-    return x_plus_residual
-
-
-attn_bias_cache: Dict[Tuple, Any] = {}
-
-
-def get_attn_bias_and_cat(x_list, branges=None):
-    """Perform the index select, cat the tensors, and provide the attn_bias from cache."""
-    batch_sizes = [b.shape[0] for b in branges] if branges is not None else [x.shape[0] for x in x_list]
-    all_shapes = tuple((b, x.shape[1]) for b, x in zip(batch_sizes, x_list))
-    if all_shapes not in attn_bias_cache.keys():
-        seqlens = []
-        for b, x in zip(batch_sizes, x_list):
-            for _ in range(b):
-                seqlens.append(x.shape[1])
-        attn_bias = fmha.BlockDiagonalMask.from_seqlens(seqlens)
-        attn_bias._batch_sizes = batch_sizes
-        attn_bias_cache[all_shapes] = attn_bias
-
-    if branges is not None:
-        cat_tensors = index_select_cat([x.flatten(1) for x in x_list], branges).view(1, -1, x_list[0].shape[-1])
-    else:
-        tensors_bs1 = tuple(x.reshape([1, -1, *x.shape[2:]]) for x in x_list)
-        cat_tensors = torch.cat(tensors_bs1, dim=1)
-
-    return attn_bias_cache[all_shapes], cat_tensors
-
-
-def drop_add_residual_stochastic_depth_list(
-    x_list: List[Tensor],
-    residual_func: Callable[[Tensor, Any], Tensor],
-    sample_drop_ratio: float = 0.0,
-    scaling_vector=None,
-) -> Tensor:
-    """Add residual connections to a list of tensors."""
-    # 1) generate random set of indices for dropping samples in the batch
-    branges_scales = [get_branges_scales(x, sample_drop_ratio=sample_drop_ratio) for x in x_list]
-    branges = [s[0] for s in branges_scales]
-    residual_scale_factors = [s[1] for s in branges_scales]
-
-    # 2) get attention bias and index+concat the tensors
-    attn_bias, x_cat = get_attn_bias_and_cat(x_list, branges)
-
-    # 3) apply residual_func to get residual, and split the result
-    residual_list = attn_bias.split(residual_func(x_cat, attn_bias=attn_bias))  # type: ignore
-
-    outputs = []
-    for x, brange, residual, residual_scale_factor in zip(x_list, branges, residual_list, residual_scale_factors):
-        outputs.append(add_residual(x, brange, residual, residual_scale_factor, scaling_vector).view_as(x))
-    return outputs
-
-
 class NestedTensorBlock(Block):
-    """Implement a Transformer block capable of processing :class:`torch.NestedTensor` inputs."""
+    """Implement a transformer block over a single token tensor.
 
-    def forward_nested(self, x_list: List[Tensor]) -> List[Tensor]:
-        """x_list contains a list of tensors to nest together and run."""
-        KORNIA_CHECK(isinstance(self.attn, MemEffAttention))
-
-        if self.training and self.sample_drop_ratio > 0.0:
-
-            def attn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
-                return self.attn(self.norm1(x), attn_bias=attn_bias)
-
-            def ffn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
-                return self.mlp(self.norm2(x))
-
-            x_list = drop_add_residual_stochastic_depth_list(
-                x_list,
-                residual_func=attn_residual_func,
-                sample_drop_ratio=self.sample_drop_ratio,
-                scaling_vector=self.ls1.gamma if isinstance(self.ls1, LayerScale) else None,
-            )
-            x_list = drop_add_residual_stochastic_depth_list(
-                x_list,
-                residual_func=ffn_residual_func,
-                sample_drop_ratio=self.sample_drop_ratio,
-                scaling_vector=self.ls2.gamma if isinstance(self.ls1, LayerScale) else None,
-            )
-            return x_list
-        else:
-
-            def attn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
-                return self.ls1(self.attn(self.norm1(x), attn_bias=attn_bias))
-
-            def ffn_residual_func(x: Tensor, attn_bias=None) -> Tensor:
-                return self.ls2(self.mlp(self.norm2(x)))
-
-            attn_bias, x = get_attn_bias_and_cat(x_list)
-            x = x + attn_residual_func(x, attn_bias=attn_bias)
-            x = x + ffn_residual_func(x)
-            return attn_bias.split(x)
+    The name is kept because the vendored DINOv2 model builders reference it. The nested-tensor
+    list path this class used to offer needed an optional third-party dependency kornia never
+    declared, so it was never reachable and has been removed.
+    """
 
     def forward(self, x_or_x_list):
         """Run this DeDoDe module forward.
 
         Args:
-            x_or_x_list: Either a single token tensor with shape :math:`(B, N, C)`, or a list of such tensors
-                for nested-tensor mode (requires xFormers).
+            x_or_x_list: A single token tensor with shape :math:`(B, N, C)`.
 
         Returns:
-            Output token tensor(s) with the same shape(s) as the input.
+            Output token tensor with the same shape as the input.
+
+        Raises:
+            TypeError: If the input is not a :class:`torch.Tensor`.
         """
         if isinstance(x_or_x_list, Tensor):
             return super().forward(x_or_x_list)
-        elif isinstance(x_or_x_list, list):
-            KORNIA_CHECK(XFORMERS_AVAILABLE, "Please install xFormers for nested tensors usage")
-            return self.forward_nested(x_or_x_list)
-        else:
-            raise AssertionError
+        raise TypeError(
+            "NestedTensorBlock only accepts a Tensor; the nested-tensor list path was removed, "
+            f"got {type(x_or_x_list).__name__}."
+        )

--- a/kornia/feature/dedode/transformer/layers/swiglu_ffn.py
+++ b/kornia/feature/dedode/transformer/layers/swiglu_ffn.py
@@ -72,19 +72,11 @@ class SwiGLUFFN(nn.Module):
         return self.w3(hidden)
 
 
-try:
-    from xformers.ops import SwiGLU
+class SwiGLUFFNFused(SwiGLUFFN):
+    """Implement :class:`SwiGLUFFN` with the DINOv2 hidden-dimension rounding.
 
-    XFORMERS_AVAILABLE = True
-except ImportError:
-    SwiGLU = SwiGLUFFN
-    XFORMERS_AVAILABLE = False
-
-
-class SwiGLUFFNFused(SwiGLU):
-    """Implement the fused SwiGLU activation and Feed-Forward Network.
-
-    This implementation is optimized for training speed and memory usage.
+    The hidden dimension is scaled by ``2 / 3`` and rounded up to a multiple of 8, which is the
+    shape the pretrained DINOv2 checkpoints were saved with.
     """
 
     def __init__(

--- a/tests/feature/test_dedode.py
+++ b/tests/feature/test_dedode.py
@@ -22,6 +22,7 @@ import torch
 
 from kornia.feature.dedode import DeDoDe
 from kornia.feature.dedode.decoder import ConvRefiner
+from kornia.feature.dedode.transformer.layers import MemEffAttention, NestedTensorBlock
 
 from testing.base import BaseTester
 
@@ -43,6 +44,35 @@ class TestConvRefiner(BaseTester):
 
         assert autocast_enabled == [device.type == "cuda"]
         assert not any("device_type of 'cuda'" in str(w.message) for w in caught)
+
+
+class TestMemEffAttention(BaseTester):
+    def test_attn_bias_raises(self, device, dtype):
+        attention = MemEffAttention(dim=8, num_heads=2).to(device, dtype).eval()
+        x = torch.rand(1, 5, 8, device=device, dtype=dtype)
+
+        with pytest.raises(NotImplementedError, match="attn_bias is not supported"):
+            attention(x, attn_bias=torch.zeros(1, 2, 5, 5, device=device, dtype=dtype))
+
+
+class TestNestedTensorBlock(BaseTester):
+    def test_tensor_input(self, device, dtype):
+        block = NestedTensorBlock(dim=8, num_heads=2).to(device, dtype).eval()
+        x = torch.rand(1, 5, 8, device=device, dtype=dtype)
+
+        out = block(x)
+
+        assert out.shape == (1, 5, 8)
+        # the block is a residual one, so the output has to differ from the input by the
+        # attention and feed-forward branches actually having run.
+        assert not torch.allclose(out, x)
+
+    def test_list_input_raises(self, device, dtype):
+        block = NestedTensorBlock(dim=8, num_heads=2).to(device, dtype).eval()
+        x = torch.rand(1, 5, 8, device=device, dtype=dtype)
+
+        with pytest.raises(TypeError, match="nested-tensor list path was removed"):
+            block([x])
 
 
 @pytest.mark.skip(reason="DeDoDe is ummaintained")


### PR DESCRIPTION
## What changed

Three vendored DINOv2 files under `kornia/feature/dedode/transformer/layers/` tried to import
`xformers.ops` at module load and kept a second, xformers-backed implementation behind the
resulting `XFORMERS_AVAILABLE` flag. kornia has never declared `xformers` as a dependency and it
is installed in no CI environment, so those imports always failed and only the pure-PyTorch
fallbacks ever ran. Importing `kornia.feature` even emitted a `logger.warning("xFormers not
available")` for a package the user was never asked to install.

- `attention.py`: the `try: from xformers.ops import fmha, memory_efficient_attention, unbind`
  block and `XFORMERS_AVAILABLE` are gone. `MemEffAttention.forward(x, attn_bias=None)` keeps its
  signature and its class name (the vendored DINOv2 builders select it by name), rejects a
  non-`None` `attn_bias` with `NotImplementedError("attn_bias is not supported")`, and otherwise
  computes exactly what the previous non-xformers branch computed (`super().forward(x)`).
  The rejection used to be `ValueError("xFormers is required for nested tensors usage")` — a path
  that could only ever raise, since `attn_bias` was only ever produced by the removed list path.
- `block.py`: the import, the `xFormers not available` warning, the module logger that existed
  only for that warning, `XFORMERS_AVAILABLE`, and the helpers used only by the nested-tensor list
  path (`get_branges_scales`, `add_residual`, `attn_bias_cache`, `get_attn_bias_and_cat`,
  `drop_add_residual_stochastic_depth_list`) are removed, along with
  `NestedTensorBlock.forward_nested`. `NestedTensorBlock.forward(x_or_x_list)` keeps its name and
  its Tensor behaviour; a list now raises `TypeError` saying the nested-tensor list path was
  removed (it previously failed a `KORNIA_CHECK`, i.e. `kornia.core.exceptions.BaseError`).
  `add_residual` also called `xformers.ops.scaled_index_add` in its `scaling_vector` branch, so
  that branch was a `NameError` waiting to happen.
- `swiglu_ffn.py`: the import is gone and `SwiGLUFFNFused` subclasses `SwiGLUFFN` directly, which
  is what the `SwiGLU = SwiGLUFFN` fallback already made it resolve to. Its class name and
  constructor signature are unchanged.
- `kornia/feature/dedode/transformer/layers/__init__.py` is untouched; every exported name is the
  same.

## Why

Part of #4261: kornia optionally imports packages it never declares as dependencies, which makes
the behaviour of the library depend on whatever happens to be in the user's environment, hides
untested code paths from CI, and (here) prints a warning about a package nobody asked for. The
surviving path is the one CI has always exercised.

## What was verified

All commands run from the branch worktree with `/Users/oldufo/dev/kornia/.venv/bin/python`
(torch 2.14.0); `kornia.__file__` was printed and confirmed to name the worktree checkout.

- Byte-identity witness. Same script run before and after the edits, saving keypoints/scores/
  descriptions of `kornia.feature.DeDoDe(detector_model="L", descriptor_model="G",
  amp_dtype=torch.float32)` (which is the configuration that actually instantiates the vendored
  DINOv2 ViT-L/14 encoder) in eval mode, on CPU float32, `torch.manual_seed(0)` before both model
  construction and input creation, on a `1x3x64x64` `torch.randn` image with `n=64`:

  ```
  python - <before.pt path> < witness.py     # on e8111a61
  python - <after.pt path>  < witness.py     # on this branch
  python - < compare.py                      # torch.equal on each tensor
  ```

  Result: `keypoints (1, 64, 2) torch.equal: True`, `scores (1, 64) torch.equal: True`,
  `descriptions (1, 64, 256) torch.equal: True`, `all equal: True`. The DINOv2 ViT-L/14 backbone
  used pretrained weights (downloaded to the torch hub cache); the VGG stem and the DeDoDe
  detector/descriptor heads were seeded random init, as `DeDoDe(...)` (not `from_pretrained`)
  builds them. The "before" run also printed `xFormers not available`; the "after" run does not.

- `python -m pytest tests/feature/test_dedode.py -q` → `4 passed, 2 skipped`. The pre-existing
  `TestDeDoDe` class is unchanged (it is `@pytest.mark.skip`-ed as unmaintained on main) and
  `TestConvRefiner` is untouched. Two new tests were added:
  `TestNestedTensorBlock` asserts `NestedTensorBlock(dim=8, num_heads=2)` on a `(1, 5, 8)` tensor
  returns shape `(1, 5, 8)` and is not the identity, and that a list input raises `TypeError`;
  `TestMemEffAttention::test_attn_bias_raises` pins the new `NotImplementedError`. Both new
  exception pins fail on the base revision (`BaseError` and `ValueError` respectively), so they
  discriminate.
- `python -m pytest tests/feature/ tests/test_api_surface.py -q` → `735 passed, 98 skipped`.
- `python -m pytest --doctest-modules kornia/feature/dedode/transformer/layers/ -q` → `no tests
  ran` (these vendored layer modules carry no doctest examples);
  `--doctest-modules kornia/feature/dedode/ -q` → `1 skipped` (the `DeDoDe` example is the
  weights-download-gated one).
- `grep -rn "xformers\|XFORMERS\|xFormers" kornia tests docs benchmarks` → no matches.
- `git add -A && pre-commit run --all-files` → all hooks Passed.
- `uvx "ty>=0.0.9,<0.0.10" check --python .venv kornia/feature/dedode` → All checks passed.

## What is not covered

- Nothing here was run on CUDA or MPS, and no half-precision run was done. The change is a
  deletion of never-executed branches plus one delegation, so device and dtype behaviour is the
  Tensor path's, unchanged.
- The witness covers `DeDoDe` end to end with the `G` descriptor (the only builder that
  instantiates DINOv2). The `B` descriptor does not use these layers at all.
- The removed list path cannot be tested, on this branch or on main, without installing
  `xformers`; it has never been exercised by kornia's tests.
- Both module-level `logger`s are gone: `block.py`'s existed only for the `xFormers not available`
  warning, and `attention.py`'s was never used.
- One level up, `DinoVisionTransformer.forward_features` in `dinov2.py` still branches on
  `isinstance(x, list)` into `forward_features_list`; that path raised before this change (the
  `KORNIA_CHECK` on `XFORMERS_AVAILABLE`) and now raises `TypeError` from the block. Removing the
  branch itself is a follow-up under #4261.
- A user who had installed `xformers` by hand loses the nested-tensor list path. kornia never
  declared, documented, or tested it, which is why this is filed under bug fixes rather than
  breaking changes.

Posted on behalf of @ducha-aiki by Claude (Claude Fable 5.1).

