### PR TITLE
test(feature): replace the torchvision deform_conv2d parity test with a hardcoded literal

### DIFF
--- a/tests/feature/test_aliked.py
+++ b/tests/feature/test_aliked.py
@@ -23,22 +23,12 @@ from kornia.feature.aliked.deform_conv2d import deform_conv2d
 
 from testing.base import BaseTester
 
-
-def _has_torchvision() -> bool:
-    try:
-        import torchvision.ops  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
 # ---------------------------------------------------------------------------
 # deform_conv2d tests
 # ---------------------------------------------------------------------------
 
 
-class TestDeformConv2d:
+class TestDeformConv2d(BaseTester):
     """Tests for the pure-PyTorch deform_conv2d implementation."""
 
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
@@ -78,32 +68,146 @@ class TestDeformConv2d:
         out = deform_conv2d(x, offset, weight, padding=padding, stride=stride)
         assert out.shape == (B, C_out, H_out, W_out)
 
-    @pytest.mark.skipif(not _has_torchvision(), reason="torchvision not installed")
-    @pytest.mark.parametrize("dtype", [torch.float32])
+    @staticmethod
+    def _torchvision_reference_inputs():
+        """Deterministic float64 CPU inputs shared by the hardcoded literals below.
+
+        B=1, C_in=2, H=W=4, C_out=2, kH=kW=3, padding=1, stride=1 -- small enough that the
+        (1, 2, 4, 4) = 32-element output fits in a hardcoded literal, per AGENTS.md's guidance to
+        prefer a literal plus its generation snippet over a live optional-dependency comparison.
+        """
+        B, C_in, H, W = 1, 2, 4, 4
+        C_out, kH, kW = 2, 3, 3
+        x = torch.linspace(-1, 1, B * C_in * H * W, dtype=torch.float64).reshape(B, C_in, H, W)
+        weight = torch.linspace(-0.5, 0.5, C_out * C_in * kH * kW, dtype=torch.float64).reshape(C_out, C_in, kH, kW)
+        bias = torch.tensor([0.1, -0.2], dtype=torch.float64)
+        offset = 0.3 * torch.sin(torch.arange(B * 2 * kH * kW * H * W, dtype=torch.float64)).reshape(B, 18, H, W)
+        mask = torch.sigmoid(torch.cos(torch.arange(B * kH * kW * H * W, dtype=torch.float64))).reshape(B, 9, H, W)
+        return x, weight, bias, offset, mask
+
+    # Generated once with torchvision (not a kornia dependency, so unavailable in CI -- this is
+    # why the test this replaces, `test_matches_torchvision`, never ran there) in a throwaway venv:
+    #   uv venv /tmp/tv && uv pip install --python /tmp/tv/bin/python torch torchvision
+    #   -> torch==2.14.0, torchvision==0.29.0 (CPU wheels, Python 3.11.0)
+    # Snippet (inputs built exactly as `_torchvision_reference_inputs` above):
+    #   import torch, torchvision.ops as tvops
+    #   torch.set_printoptions(precision=10)
+    #   x, weight, bias, offset, mask = _torchvision_reference_inputs()
+    #   for use_mask in (False, True):
+    #       out = tvops.deform_conv2d(
+    #           x, offset, weight, bias=bias, padding=1, stride=1, mask=mask if use_mask else None
+    #       )
+    #       print(use_mask, out)
+    _EXPECTED_NO_MASK = torch.tensor(
+        [
+            1.3524878443,
+            1.9642850189,
+            1.4678019606,
+            0.8534719288,
+            1.4020842470,
+            1.9136044871,
+            1.8863619178,
+            1.2793386143,
+            0.8920304159,
+            1.2077669486,
+            0.9345327788,
+            0.4964185813,
+            0.2459445647,
+            0.0819180146,
+            -0.1149317217,
+            -0.0837964278,
+            -0.4751185738,
+            -0.4331255309,
+            -0.1060449678,
+            0.0392646305,
+            0.2247573785,
+            0.6240284088,
+            0.7780789016,
+            0.4968604144,
+            0.9902952558,
+            1.4242185698,
+            1.5622926375,
+            1.1953252054,
+            0.6699741701,
+            1.4466645925,
+            1.5290271874,
+            0.7818486934,
+        ],
+        dtype=torch.float64,
+    ).reshape(1, 2, 4, 4)
+    _EXPECTED_WITH_MASK = torch.tensor(
+        [
+            0.7464577357,
+            1.0163278244,
+            0.7994783630,
+            0.4874494644,
+            0.7544586797,
+            1.0291377431,
+            1.0361463498,
+            0.7093859204,
+            0.4840123409,
+            0.6248190328,
+            0.4886002027,
+            0.2803572404,
+            0.1663333364,
+            0.0952250511,
+            -0.0103768928,
+            -0.0005014362,
+            -0.3440748865,
+            -0.3220334021,
+            -0.1632313152,
+            -0.0853091101,
+            0.0239935903,
+            0.2204502075,
+            0.2789350116,
+            0.1407094840,
+            0.3924910576,
+            0.6243384778,
+            0.7212428510,
+            0.4743984538,
+            0.2333181531,
+            0.6454519918,
+            0.6817443629,
+            0.3121810405,
+        ],
+        dtype=torch.float64,
+    ).reshape(1, 2, 4, 4)
+
     @pytest.mark.parametrize("use_mask", [False, True])
-    def test_matches_torchvision(self, device, dtype, use_mask):
-        """Pure-PyTorch implementation should match torchvision reference."""
-        import torchvision.ops as tvops
+    def test_matches_torchvision_reference(self, device, dtype, use_mask):
+        """Pure-PyTorch implementation should match a hardcoded torchvision-generated literal.
 
-        B, C_in, H, W = 2, 4, 10, 10
-        C_out, kH, kW = 8, 3, 3
-        K = kH * kW
-        padding = 1
+        Replaces a live comparison against ``torchvision.ops.deform_conv2d`` (skipif-guarded on
+        torchvision, which no CI environment installs, so it never ran there) with a literal
+        generated once offline -- see the comment above ``_EXPECTED_NO_MASK``.
+        """
+        if device.type == "mps" and dtype == torch.float64:
+            pytest.skip("MPS does not support float64")
 
-        H_out = H  # padding=1, stride=1, 3x3 kernel
-        W_out = W
+        x64, weight64, bias64, offset64, mask64 = self._torchvision_reference_inputs()
+        expected64 = self._EXPECTED_WITH_MASK if use_mask else self._EXPECTED_NO_MASK
 
-        torch.manual_seed(0)
-        x = torch.randn(B, C_in, H, W, device=device, dtype=dtype)
-        weight = torch.randn(C_out, C_in, kH, kW, device=device, dtype=dtype)
-        bias = torch.randn(C_out, device=device, dtype=dtype)
-        offset = torch.randn(B, 2 * K, H_out, W_out, device=device, dtype=dtype) * 0.5
-        mask = torch.rand(B, K, H_out, W_out, device=device, dtype=dtype) if use_mask else None
+        x = x64.to(device=device, dtype=dtype)
+        weight = weight64.to(device=device, dtype=dtype)
+        bias = bias64.to(device=device, dtype=dtype)
+        offset = offset64.to(device=device, dtype=dtype)
+        mask = mask64.to(device=device, dtype=dtype) if use_mask else None
 
-        out_ours = deform_conv2d(x, offset, weight, bias=bias, padding=padding, mask=mask)
-        out_tv = tvops.deform_conv2d(x, offset, weight, bias=bias, padding=padding, mask=mask)
+        out = deform_conv2d(x, offset, weight, bias=bias, padding=1, stride=1, mask=mask)
+        expected = expected64.to(device=device, dtype=dtype)
 
-        assert torch.allclose(out_ours, out_tv, atol=1e-4), f"Max diff: {(out_ours - out_tv).abs().max():.2e}"
+        if dtype == torch.float64 and device.type == "cpu":
+            self.assert_close(out, expected, rtol=1e-6, atol=1e-6)
+        else:
+            self.assert_close(out, expected)
+
+        # Guard a float32 precision regression against the float64 reference, regardless of the
+        # dtype this test instance is parametrized over.
+        mask32 = mask64.float() if use_mask else None
+        out_f32 = deform_conv2d(
+            x64.float(), offset64.float(), weight64.float(), bias=bias64.float(), padding=1, stride=1, mask=mask32
+        )
+        assert torch.allclose(out_f32.double(), expected64, atol=1e-5)
 
     def test_gradients(self, device):
         """Gradients should flow through the pure-PyTorch implementation."""

--- a/tests/feature/test_aliked.py
+++ b/tests/feature/test_aliked.py
@@ -207,7 +207,7 @@ class TestDeformConv2d(BaseTester):
         out_f32 = deform_conv2d(
             x64.float(), offset64.float(), weight64.float(), bias=bias64.float(), padding=1, stride=1, mask=mask32
         )
-        assert torch.allclose(out_f32.double(), expected64, atol=1e-5)
+        assert torch.allclose(out_f32.double(), expected64, rtol=0, atol=1e-5)
 
     def test_gradients(self, device):
         """Gradients should flow through the pure-PyTorch implementation."""

--- a/tests/feature/test_aliked.py
+++ b/tests/feature/test_aliked.py
@@ -89,10 +89,16 @@ class TestDeformConv2d(BaseTester):
     # why the test this replaces, `test_matches_torchvision`, never ran there) in a throwaway venv:
     #   uv venv /tmp/tv && uv pip install --python /tmp/tv/bin/python torch torchvision
     #   -> torch==2.14.0, torchvision==0.29.0 (CPU wheels, Python 3.11.0)
-    # Snippet (inputs built exactly as `_torchvision_reference_inputs` above):
+    # Standalone snippet for that venv (which has neither kornia nor pytest, so the inputs are inlined
+    # rather than imported; keep them identical to `_torchvision_reference_inputs` above):
     #   import torch, torchvision.ops as tvops
     #   torch.set_printoptions(precision=10)
-    #   x, weight, bias, offset, mask = _torchvision_reference_inputs()
+    #   B, C_in, H, W, C_out, kH, kW = 1, 2, 4, 4, 2, 3, 3
+    #   x = torch.linspace(-1, 1, B * C_in * H * W, dtype=torch.float64).reshape(B, C_in, H, W)
+    #   weight = torch.linspace(-0.5, 0.5, C_out * C_in * kH * kW, dtype=torch.float64).reshape(C_out, C_in, kH, kW)
+    #   bias = torch.tensor([0.1, -0.2], dtype=torch.float64)
+    #   offset = 0.3 * torch.sin(torch.arange(B * 2 * kH * kW * H * W, dtype=torch.float64)).reshape(B, 18, H, W)
+    #   mask = torch.sigmoid(torch.cos(torch.arange(B * kH * kW * H * W, dtype=torch.float64))).reshape(B, 9, H, W)
     #   for use_mask in (False, True):
     #       out = tvops.deform_conv2d(
     #           x, offset, weight, bias=bias, padding=1, stride=1, mask=mask if use_mask else None
@@ -197,7 +203,10 @@ class TestDeformConv2d(BaseTester):
         expected = expected64.to(device=device, dtype=dtype)
 
         if dtype == torch.float64 and device.type == "cpu":
-            self.assert_close(out, expected, rtol=1e-6, atol=1e-6)
+            # The literal is quoted to 10 decimals (its own rounding is <= 5e-11) and kornia's float64
+            # CPU result lands within 5e-11 of it, so an absolute bound of 1e-9 still has 20x headroom;
+            # a looser bound would only hide float64 arithmetic bugs.
+            self.assert_close(out, expected, rtol=0, atol=1e-9)
         else:
             self.assert_close(out, expected)
 


### PR DESCRIPTION
## What changed

`tests/feature/test_aliked.py::TestDeformConv2d::test_matches_torchvision` compared
`kornia.feature.aliked.deform_conv2d.deform_conv2d` against `torchvision.ops.deform_conv2d`,
guarded by `@pytest.mark.skipif(not _has_torchvision(), ...)`. kornia has never declared
`torchvision` as a dependency, and no CI environment installs it, so this test has never run
there — only ever locally, by hand, by whoever happened to have torchvision on their machine.

- Deleted `_has_torchvision()` and `test_matches_torchvision`.
- Added `test_matches_torchvision_reference` on the same `TestDeformConv2d` class (now a
  `testing.base.BaseTester` subclass, for `self.assert_close`), parametrized over
  `use_mask in (False, True)` and driven by the suite's injected `device`/`dtype` fixtures.
  It builds deterministic float64 CPU inputs (`B=1, C_in=2, H=W=4, C_out=2, kH=kW=3, padding=1,
  stride=1`) via `_torchvision_reference_inputs()` (`torch.linspace`/`torch.arange`/`sin`/`cos`/
  `sigmoid`, no RNG), casts them to the fixture's `device`/`dtype`, and compares kornia's output
  against one of two hardcoded `float64` literals (`_EXPECTED_NO_MASK`, `_EXPECTED_WITH_MASK`,
  32 numbers each) generated once offline with torchvision itself — see the comment above
  `_EXPECTED_NO_MASK` for the exact generation snippet and versions
  (`torch==2.14.0`, `torchvision==0.29.0`, CPU wheels, Python 3.11.0).
  - float64-on-CPU compares at `rtol=0, atol=1e-9` (the literal is quoted to 10 decimals and
    kornia's float64 result lands within 5e-11 of it); every other device/dtype combination
    (including MPS, which skips float64) uses `BaseTester`'s default per-dtype tolerance.
  - One extra assertion recomputes kornia's result at float32 (regardless of which dtype the
    test instance is parametrized over) and checks it against the float64 literal at
    `atol=1e-5`, to catch a float32 precision regression.
- No other torchvision references remain in this file; `test_gradients`,
  `test_zero_offset_matches_regular_conv`, and `test_output_shape` are untouched.

## Why

Part of #4261: kornia optionally imports packages it never declares as dependencies, which
hides untested code paths from CI. Here, the hidden path was an entire test — CI has silently
never exercised `deform_conv2d` against the torchvision reference it claims to match, on any
platform, ever. The hardcoded literal makes the comparison run everywhere, at both float32 and
float64, without adding a runtime or CI dependency.

## What was verified

All commands run from the branch worktree with `/Users/oldufo/dev/kornia/.venv/bin/python`
(torch 2.14.0, no torchvision installed); `kornia.__file__` was printed and confirmed to name
`/Users/oldufo/dev/kornia/.claude/worktrees/deps-audit/kornia/__init__.py`.

- Literal generation, in a throwaway venv (`uv venv /tmp/tv && uv pip install --python
  /tmp/tv/bin/python torch torchvision`, CPU wheels): resolved `torch==2.14.0`,
  `torchvision==0.29.0`. Ran a snippet that builds the exact same inputs as
  `_torchvision_reference_inputs()` and calls `torchvision.ops.deform_conv2d` with
  `torch.set_printoptions(precision=10)`; the printed `(1, 2, 4, 4)`, 32-element tensors for
  `use_mask=False` and `use_mask=True` were copied verbatim into `_EXPECTED_NO_MASK` /
  `_EXPECTED_WITH_MASK`.
- `pytest tests/feature/test_aliked.py -k DeformConv2d -q --dtype=float32,float64` →
  `8 passed, 30 deselected`.
- `pytest tests/feature/test_aliked.py -q --dtype=float32,float64` (whole file) →
  `35 passed, 3 skipped` (the 3 skips are pre-existing `need --runslow option to run` skips
  elsewhere in this file, unrelated to this change).
- `pytest tests/test_api_surface.py -q` → `13 passed` (no public API changed; test-only diff).
- `grep -rn torchvision tests/feature/test_aliked.py` → only the new helper/test names and the
  generation-snippet comment; no `import torchvision` remains in this file. (Other test files —
  `tests/geometry/transform/test_affine.py`, `tests/augmentation/test_torch_export.py` — still
  reference torchvision; out of scope for this task, per the brief.)
- `git add -A && pre-commit run --all-files` → all hooks Passed (ruff-format reflowed the two
  literal lists to one value per line; content unchanged).
- Perturbation self-check: temporarily changed `_EXPECTED_NO_MASK`'s first value from
  `1.3524878443` to `1.9524878443` and reran
  `pytest tests/feature/test_aliked.py -k test_matches_torchvision_reference -q
  --dtype=float32,float64`. Result: `2 failed, 2 passed` — both `use_mask=False` cases
  (`cpu-float32-False`, `cpu-float64-False`) failed with `Mismatched elements: 1 / 32 (3.1%)`
  against the corrupted value; the two `use_mask=True` cases were unaffected, as expected. The
  file was then restored to the original literal and the full suite re-verified green
  (`35 passed, 3 skipped`) before committing.

## What is not covered

- No CUDA or MPS run was done (this environment has neither); the float64 assertion path is
  skipped on MPS by design (`pytest.skip("MPS does not support float64")`, matching the sibling
  tests in this class), and non-CPU/float64 combinations fall through to `BaseTester`'s default
  per-dtype tolerance rather than the tighter `1e-9` used for CPU float64.
- float16/bfloat16 pass against the literal on CPU with `BaseTester`'s default tolerances
  (measured max deviation 1.0e-3 and 9.2e-3, at most 0.63 of the allowed bound); no CUDA/MPS
  half-precision run.
- The literal was generated with a single (torch, torchvision) version pair; it is not
  cross-checked against other torchvision releases.

Posted on behalf of @ducha-aiki by Claude (Claude Fable 5.1).

