### PR TITLE
fix(geometry): fill height and width for the whole batch in PinholeCamera.from_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,6 +376,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model's dtype instead of coming back as float32. `OnnxLightGlue` without `onnxruntime` raises an
   `ImportError` that names `pip install "kornia[onnx]"`, like the lazy-loader handles do, instead of a
   bare `BaseError`. (#4301)
+* `PinholeCamera.from_parameters` now fills `height` and `width` for the whole batch. It built them with
+  `height_tmp[..., 0] += height` on a `(B,)` zero tensor, so every batch element after the first kept `0`
+  while `fx`, `fy`, `cx`, `cy`, `tx`, `ty` and `tz` were broadcast correctly, and the camera looked healthy
+  until something read its image size. `batch_size=1`, the only case that worked, is unchanged. (#4279)
 * `unproject_meshgrid` now returns the documented `(*, H, W, 3)` shape when `W` is 1. It squeezed the
   meshgrid with a bare `.squeeze()`, which drops the width axis along with the leading batch axis whenever
   `W == 1`, so `unproject_meshgrid(1, 3, K)` and `unproject_meshgrid(3, 1, K)` returned the same shape with

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -424,11 +424,9 @@ class PinholeCamera:
         extrinsics[..., 0, -1] += tx
         extrinsics[..., 1, -1] += ty
         extrinsics[..., 2, -1] += tz
-        # create image hegith and width
-        height_tmp = torch.zeros(batch_size, device=device, dtype=dtype)
-        height_tmp[..., 0] += height
-        width_tmp = torch.zeros(batch_size, device=device, dtype=dtype)
-        width_tmp[..., 0] += width
+        # create image height and width, one entry per batch element
+        height_tmp = torch.full((batch_size,), height, device=device, dtype=dtype)
+        width_tmp = torch.full((batch_size,), width, device=device, dtype=dtype)
         return self(intrinsics, extrinsics, height_tmp, width_tmp)
 
 

--- a/tests/geometry/camera/test_pinhole.py
+++ b/tests/geometry/camera/test_pinhole.py
@@ -388,6 +388,32 @@ class TestPinholeCamera(BaseTester):
         assert pinhole.rotation_matrix.shape == (batch_size, 3, 3)
         assert pinhole.translation_vector.shape == (batch_size, 3, 1)
 
+    @pytest.mark.parametrize("batch_size", (1, 2, 5))
+    def test_from_parameters(self, batch_size, device, dtype):
+        height, width = 6, 8
+        fx = torch.arange(1, batch_size + 1, device=device, dtype=dtype) * 100.0
+        fy = fx / 2.0
+        cx = torch.full((batch_size,), width / 2, device=device, dtype=dtype)
+        cy = torch.full((batch_size,), height / 2, device=device, dtype=dtype)
+        tx = torch.arange(batch_size, device=device, dtype=dtype)
+        ty, tz = tx + 1.0, tx + 2.0
+
+        pinhole = kornia.geometry.camera.PinholeCamera.from_parameters(
+            fx, fy, cx, cy, height, width, tx, ty, tz, batch_size, device=device, dtype=dtype
+        )
+
+        assert pinhole.batch_size == batch_size
+        # ``height`` and ``width`` are broadcast over the whole batch, like every other parameter
+        self.assert_close(pinhole.height, torch.full((batch_size,), float(height), device=device, dtype=dtype))
+        self.assert_close(pinhole.width, torch.full((batch_size,), float(width), device=device, dtype=dtype))
+        self.assert_close(pinhole.fx, fx)
+        self.assert_close(pinhole.fy, fy)
+        self.assert_close(pinhole.cx, cx)
+        self.assert_close(pinhole.cy, cy)
+        self.assert_close(pinhole.tx, tx)
+        self.assert_close(pinhole.ty, ty)
+        self.assert_close(pinhole.tz, tz)
+
     def test_pinhole_camera_scale(self, device, dtype):
         batch_size = 2
         height, width = 4, 6


### PR DESCRIPTION
## What does this pull request do?

`PinholeCamera.from_parameters(..., batch_size=B)` filled `height` and `width` only for element `0`:

```python
height_tmp = torch.zeros(batch_size, device=device, dtype=dtype)
height_tmp[..., 0] += height
```

Every other parameter (`fx`, `fy`, `cx`, `cy`, `tx`, `ty`, `tz`) is broadcast over the batch, so the camera looks healthy until something reads its image size:

```text
height: [6.0, 0.0]
width : [8.0, 0.0]
fx    : [100.0, 200.0]
tx    : [1.0, 2.0]
```

Both are now built with `torch.full((batch_size,), ...)`, matching the rest of the constructor. `batch_size=1`, the only case that worked before, is unchanged.

Also adds `TestPinholeCamera::test_from_parameters`, parametrized over `batch_size` in `(1, 2, 5)`, asserting every parameter including `height` and `width` over the whole batch.

## Related issue or discussion

Closes #4279

## What did you check?

The new test on unmodified `main` fails exactly where the issue says it should, and passes at `batch_size=1`:

```text
4 failed, 2 passed, 38 deselected
FAILED test_from_parameters[cpu-float32-2] - AssertionError: Tensor-likes are not close!
FAILED test_from_parameters[cpu-float32-5]
FAILED test_from_parameters[cpu-float64-2]
FAILED test_from_parameters[cpu-float64-5]
```

`tests/geometry/test_depth_warper.py` builds `batch_size=2` cameras through this helper, so it exercises the changed path; it passes unchanged, since `DepthWarper` takes its output size explicitly rather than from the camera.

```text
$ pytest tests/geometry/camera tests/geometry/test_depth_warper.py tests/geometry/test_depth.py --dtype=float32,float64
================== 332 passed, 1 skipped, 12 warnings in 4.29s ==================

$ ruff check / ruff format --diff on both changed files
All checks passed!
```
