### PR TITLE
fix(geometry): keep the W axis in unproject_meshgrid when W is 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model's dtype instead of coming back as float32. `OnnxLightGlue` without `onnxruntime` raises an
   `ImportError` that names `pip install "kornia[onnx]"`, like the lazy-loader handles do, instead of a
   bare `BaseError`. (#4301)
+* `unproject_meshgrid` now returns the documented `(*, H, W, 3)` shape when `W` is 1. It squeezed the
+  meshgrid with a bare `.squeeze()`, which drops the width axis along with the leading batch axis whenever
+  `W == 1`, so `unproject_meshgrid(1, 3, K)` and `unproject_meshgrid(3, 1, K)` returned the same shape with
+  different values. The grid then broadcast across a phantom width in the two public functions built on it:
+  `depth_to_3d_v2` returned `(1, 3, 3, 3)` for a `W = 1` depth where `depth_to_3d` correctly returns
+  `(1, 3, 1, 3)`, and `warp_frame_depth` returned a 4-pixel-wide image for a 1-pixel-wide input. Only the
+  batch axis is dropped now. Output for every `W > 1` is byte-identical, and `depth_to_3d_v2` agrees with
+  `depth_to_3d` at `W = 1` as it already did everywhere else. (#4278)
 * The generated example figures in the API reference are rendered from RGB input.
   `docs/generate_examples.py` decoded the sample images with `cv2.imdecode` and wrote them with
   `cv2.imwrite`, both BGR, so every tensor the examples fed to kornia held reversed channels. The two

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -78,10 +78,12 @@ def unproject_meshgrid(
     """
     KORNIA_CHECK_SHAPE(camera_matrix, ["*", "3", "3"])
 
-    # create base coordinates grid
+    # create base coordinates grid. ``create_meshgrid`` returns ``(1, H, W, 2)``; drop only that leading
+    # batch axis. A bare ``squeeze()`` would also drop ``H`` or ``W`` whenever either is 1, and the grid
+    # would then broadcast across a phantom axis instead of keeping the documented ``(*, H, W, 3)`` shape.
     points_uv: torch.Tensor = create_meshgrid(
         height, width, normalized_coordinates=False, device=device, dtype=dtype
-    ).squeeze()  # HxWx2
+    ).squeeze(0)  # HxWx2
 
     # project pixels to camera frame
     camera_matrix_tmp: torch.Tensor = camera_matrix[:, None, None]  # Bx1x1x3x3

--- a/tests/geometry/test_depth.py
+++ b/tests/geometry/test_depth.py
@@ -78,6 +78,26 @@ class TestDepthTo3d(BaseTester):
         # test for now that the grid is correct and have homogeneous coords
         self.assert_close(grid[..., 2], torch.ones_like(grid[..., 2]))
 
+    @pytest.mark.parametrize(("height", "width"), [(1, 1), (1, 3), (3, 1), (2, 5)])
+    def test_unproject_meshgrid_degenerate_sizes(self, height, width, device, dtype):
+        # a single-column (W = 1) or single-row (H = 1) grid keeps its own axis
+        camera_matrix = torch.eye(3, device=device, dtype=dtype).repeat(2, 1, 1)
+        grid = kornia.geometry.unproject_meshgrid(height, width, camera_matrix, device=device, dtype=dtype)
+        assert grid.shape == (2, height, width, 3)
+
+    @pytest.mark.parametrize(("height", "width"), [(1, 1), (1, 3), (3, 1), (2, 5)])
+    def test_depth_to_3d_v2_degenerate_sizes(self, height, width, device, dtype):
+        depth = torch.rand(2, 1, height, width, device=device, dtype=dtype)
+        camera_matrix = torch.tensor(
+            [[[100.0, 0.0, 4.0], [0.0, 50.0, 3.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+        ).repeat(2, 1, 1)
+
+        points3d = kornia.geometry.depth.depth_to_3d(depth, camera_matrix)
+        points3d_v2 = kornia.geometry.depth.depth_to_3d_v2(depth[:, 0], camera_matrix)
+
+        assert points3d_v2.shape == (2, height, width, 3)
+        self.assert_close(points3d.permute(0, 2, 3, 1), points3d_v2)
+
     def test_unproject_denormalized(self, device, dtype):
         # this is for default normalize_points=False
         depth = 2 * torch.tensor(
@@ -276,6 +296,18 @@ class TestWarpFrameDepth(BaseTester):
 
         image_dst = kornia.geometry.depth.warp_frame_depth(image_src, depth_dst, src_trans_dst, camera_matrix)
         assert image_dst.shape == (batch_size, num_features, 3, 4)
+
+    @pytest.mark.parametrize(("height", "width"), [(1, 1), (1, 5), (4, 1)])
+    def test_shape_degenerate_sizes(self, height, width, device, dtype):
+        image_src = torch.rand(1, 2, height, width, device=device, dtype=dtype)
+        depth_dst = torch.rand(1, 1, height, width, device=device, dtype=dtype)
+        src_trans_dst = torch.eye(4, device=device, dtype=dtype)[None]
+        camera_matrix = torch.tensor(
+            [[[100.0, 0.0, 4.0], [0.0, 50.0, 3.0], [0.0, 0.0, 1.0]]], device=device, dtype=dtype
+        )
+
+        image_dst = kornia.geometry.depth.warp_frame_depth(image_src, depth_dst, src_trans_dst, camera_matrix)
+        assert image_dst.shape == (1, 2, height, width)
 
     def test_translation(self, device, dtype):
         # this is for normalize_points=False


### PR DESCRIPTION
## What does this pull request do?

`unproject_meshgrid` squeezed the grid it builds with a bare `.squeeze()`. `create_meshgrid` returns `(1, H, W, 2)`, so that call is meant to drop the leading batch axis, but it drops *every* size-1 axis. At `W == 1` the width axis goes with it, the grid broadcasts across a phantom width, and the documented `(*, H, W, 3)` contract breaks:

```text
unproject_meshgrid(H=1, W=3): (1, 1, 3, 3)
unproject_meshgrid(H=3, W=1): (1, 1, 3, 3)   same shape, different values
depth_to_3d(W=1)    shape: (1, 3, 3, 1)
depth_to_3d_v2(W=1) shape: (1, 3, 3, 3)      should be (1, 3, 1, 3)
warp_frame_depth(W=1) shape: (1, 2, 4, 4)    should be (1, 2, 4, 1)
```

`H = 1` is unaffected, because the batch axis absorbs the squeeze, and `H = W = 1` is correct by accident. `W = 1` is a degenerate but valid shape (a single image column, a 1-pixel-wide crop) and nothing raised.

The squeeze is now `squeeze(0)`, with a comment saying why the axis is named explicitly. Three regression tests are added, parametrized over degenerate and ordinary sizes: the grid shape itself, `depth_to_3d_v2` against `depth_to_3d` (the sharper pin, since the two agree everywhere else), and the `warp_frame_depth` output shape.

## Related issue or discussion

Closes #4278

## What did you check?

The new tests on unmodified `main` fail at `W = 1` and only there, which is exactly the reported shape:

```text
6 failed, 16 passed, 109 deselected
FAILED test_unproject_meshgrid_degenerate_sizes[cpu-float32-3-1] - assert torch.Size([2, 1, 3, 3]) == (2, 3, 1, 3)
FAILED test_depth_to_3d_v2_degenerate_sizes[cpu-float32-3-1]    - assert torch.Size([2, 3, 3, 3]) == (2, 3, 1, 3)
FAILED test_shape_degenerate_sizes[cpu-float32-4-1]             - assert torch.Size([1, 2, 4, 4]) == (1, 2, 4, 1)
```

Output for `W > 1` is unchanged. I compared `main` against this branch over a batched, asymmetric-`K`, float64 set of `unproject_meshgrid` (4x5, 7x2, 2x7, 13x11, both `normalize_points` values), `depth_to_3d_v2` and `warp_frame_depth` calls: `torch.equal` on all ten.

```text
$ pytest tests/geometry --dtype=float32 (excluding test_ransac.py)
====== 2593 passed, 50 skipped, 27 xfailed, 4 xpassed, 120 warnings in 85.46s ======

$ pytest tests/geometry/test_depth.py tests/geometry/test_depth_warper.py --dtype=float32,float64
================================ 157 passed in 2.34s ================================

$ ruff check / ruff format --diff on both changed files
All checks passed!
```
