### PR TITLE
Remove unused preprocess_boxes helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-tree MPS workarounds stay. (#4202)
 
 ### Breaking changes
-* Removed the unused `preprocess_boxes` helper, which had no public export or caller. (#4181)
+* Removed the unused `preprocess_boxes` helper, which had no public export or caller. (#4181, #4321)
 
 * Non-maxima suppression applies one border rule at every window size. `NonMaximaSuppression2d` /
   `nms2d` with a window larger than `(7, 7)`, and `NonMaximaSuppression3d` / `nms3d`, no longer report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-tree MPS workarounds stay. (#4202)
 
 ### Breaking changes
+* Removed the unused `preprocess_boxes` helper, which had no public export or caller. (#4181)
 
 * Non-maxima suppression applies one border rule at every window size. `NonMaximaSuppression2d` /
   `nms2d` with a window larger than `(7, 7)`, and `NonMaximaSuppression3d` / `nms3d`, no longer report

--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -22,7 +22,7 @@ import torch
 from torch.distributions import Beta, Uniform
 
 from kornia.core.utils import _extract_device_dtype
-from kornia.geometry.boxes import Boxes
+
 from kornia.geometry.keypoints import Keypoints
 
 
@@ -427,48 +427,6 @@ def override_parameters(
     return out
 
 
-def preprocess_boxes(input: Union[torch.Tensor, Boxes], mode: str = "vertices_plus") -> Boxes:
-    r"""Preprocess input boxes.
-
-    Args:
-        input: 2D boxes, shape of :math:`(N, 4, 2)`, :math:`(B, N, 4, 2)` or a list of :math:`(N, 4, 2)`.
-            See below for more details.
-        mode: The format in which the boxes are provided.
-
-            * 'xyxy': boxes are assumed to be in the format ``xmin, ymin, xmax, ymax`` where
-              ``width = xmax - xmin``
-                and ``height = ymax - ymin``. With shape :math:`(N, 4)`, :math:`(B, N, 4)`.
-            * 'xyxy_plus': similar to 'xyxy' mode but where box width and length are defined as
-                ``width = xmax - xmin + 1`` and ``height = ymax - ymin + 1``.
-                With shape :math:`(N, 4)`, :math:`(B, N, 4)`.
-            * 'xywh': boxes are assumed to be in the format ``xmin, ymin, width, height`` where
-                ``width = xmax - xmin`` and ``height = ymax - ymin``. With shape :math:`(N, 4)`, :math:`(B, N, 4)`.
-            * 'vertices': boxes are defined by their vertices points in the following ``clockwise`` order:
-                *top-left, top-right, bottom-right, bottom-left*. Vertices coordinates are in (x,y) order. Finally,
-                box width and height are defined as ``width = xmax - xmin`` and ``height = ymax - ymin``.
-                With shape :math:`(N, 4, 2)` or :math:`(B, N, 4, 2)`.
-            * 'vertices_plus': similar to 'vertices' mode but where box width and length are defined as
-                ``width = xmax - xmin + 1`` and ``height = ymax - ymin + 1``. ymin + 1``.
-                With shape :math:`(N, 4, 2)` or :math:`(B, N, 4, 2)`.
-
-    Note:
-        **2D boxes format** is defined as a floating data type torch.Tensor of shape ``Nx4x2`` or ``BxNx4x2``
-        where each box is a `quadrilateral <https://en.wikipedia.org/wiki/Quadrilateral>`_ defined by
-        it's 4 vertices
-        coordinates (A, B, C, D). Coordinates must be in ``x, y`` order. The height and width of a box is defined as
-        ``width = xmax - xmin + 1`` and ``height = ymax - ymin + 1``. Examples of
-        `quadrilaterals <https://en.wikipedia.org/wiki/Quadrilateral>`_ are rectangles, rhombus and trapezoids.
-
-    """
-    # TODO: We may allow list here.
-    # input is BxNx4x2 or Boxes.
-    if isinstance(input, torch.Tensor):
-        if not (len(input.shape) == 4 and input.shape[2:] == torch.Size([4, 2])):
-            raise RuntimeError(f"Only BxNx4x2 torch.Tensor is supported. Got {input.shape}.")
-        input = Boxes.from_tensor(input, mode=mode)
-    if not isinstance(input, Boxes):
-        raise RuntimeError(f"Expect `Boxes` type. Got {type(input)}.")
-    return input
 
 
 def preprocess_keypoints(input: Union[torch.Tensor, Keypoints]) -> Keypoints:

--- a/kornia/augmentation/utils/helpers.py
+++ b/kornia/augmentation/utils/helpers.py
@@ -22,7 +22,6 @@ import torch
 from torch.distributions import Beta, Uniform
 
 from kornia.core.utils import _extract_device_dtype
-
 from kornia.geometry.keypoints import Keypoints
 
 
@@ -425,8 +424,6 @@ def override_parameters(
         else:
             raise ValueError(f"`{if_none_exist}` is not a valid option.")
     return out
-
-
 
 
 def preprocess_keypoints(input: Union[torch.Tensor, Keypoints]) -> Keypoints:


### PR DESCRIPTION
## Summary

- Removed the unused `preprocess_boxes` helper.
- Removed the now-unused `Boxes` import.
- Added the corresponding changelog entry.

Fixes #4181

## Checks

- `pixi run test-module tests/augmentation -k boxes`
  - 19 selected, 5576 deselected
  - Completed successfully.

- `git diff --check`
  - Passed.

## Notes
- `pixi run pre-commit-all` was run on Windows, but the `ruff-format` hook caused a large number of unrelated files to appear modified due to line-ending changes. Those unrelated changes were restored and are not included in this PR.
