### PR TITLE
test: drop version guards that the torch>=2.5.1 floor made dead; CUDA pixi tasks stop reinstalling torchvision

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -75,8 +75,8 @@ platforms = ["linux-64", "linux-aarch64", "win-64"]
 # ------------------------------------------------------------------------------
 
 [feature.cuda.tasks]
-install = { cmd = "uv sync --extra dev && uv pip install --reinstall torch torchvision --index pytorch-cu121", description = "Install dev dependencies (CUDA PyTorch)" }
-install-docs = { cmd = "uv sync --extra dev --extra docs && uv pip install --reinstall torch torchvision --index pytorch-cu121", description = "Install dev + docs (CUDA PyTorch)" }
+install = { cmd = "uv sync --extra dev && uv pip install --reinstall torch --index pytorch-cu121", description = "Install dev dependencies (CUDA PyTorch)" }
+install-docs = { cmd = "uv sync --extra dev --extra docs && uv pip install --reinstall torch --index pytorch-cu121", description = "Install dev + docs (CUDA PyTorch)" }
 # CUDA test tasks
 test-cuda = { cmd = "uv run pytest tests/", env = { KORNIA_TEST_DEVICE = "cuda" }, description = "Run tests on CUDA" }
 test-cuda-f32 = { cmd = "uv run pytest tests/", env = { KORNIA_TEST_DEVICE = "cuda", KORNIA_TEST_DTYPE = "float32" } }

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -77,7 +77,7 @@ from kornia.augmentation import (
 )
 from kornia.augmentation._2d.base import AugmentationBase2D
 from kornia.constants import Resample, pi
-from kornia.core._compat import torch_version, torch_version_le
+from kornia.core._compat import torch_version
 from kornia.core.utils import _torch_inverse_cast
 from kornia.geometry import create_meshgrid, transform_points
 
@@ -5414,10 +5414,6 @@ class TestRandomJPEG(BaseTester):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    torch_version_le(2, 0, 1),
-    reason="Test requires distributed tensor support introduced in PyTorch > 2.0.1 for transformers clip model.",
-)
 class TestRandomDissolving(BaseTester):
     torch.manual_seed(0)  # for random reproductibility
 

--- a/tests/filters/test_dissolving.py
+++ b/tests/filters/test_dissolving.py
@@ -18,7 +18,6 @@
 import pytest
 import torch
 
-from kornia.core._compat import torch_version_le
 from kornia.filters.dissolving import StableDiffusionDissolving
 
 from testing.base import BaseTester
@@ -31,10 +30,6 @@ WEIGHTS_CACHE_DIR = "weights/"
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    torch_version_le(2, 0, 1),
-    reason="Skipped for torch versions <= 2.0.1: transformers clip model needs distributed tensor.",
-)
 class TestStableDiffusionDissolving(BaseTester):
     @pytest.fixture(scope="class")
     def sdm_2_1(self):

--- a/tests/io/test_io_image.py
+++ b/tests/io/test_io_image.py
@@ -16,25 +16,15 @@
 #
 
 import io
-import sys
 from pathlib import Path
 from urllib.request import urlopen
 
+import kornia_rs
 import numpy as np
 import pytest
 import torch
 
-from kornia.core._compat import torch_version_ge
 from kornia.io import ImageLoadType, load_image, write_image
-
-try:
-    import kornia_rs
-except ImportError:
-    kornia_rs = None
-
-
-def available_package() -> bool:
-    return sys.version_info >= (3, 7, 0) and torch_version_ge(1, 10, 0) and kornia_rs is not None
 
 
 def create_random_img8(height: int, width: int, channels: int) -> np.ndarray:
@@ -90,7 +80,6 @@ def images_fn(png_image, jpg_image):
     return {"png": png_image, "jpg": jpg_image}
 
 
-@pytest.mark.skipif(not available_package(), reason="kornia_rs only supports python >=3.7 and pt >= 1.10.0")
 class TestIoImage:
     def test_smoke(self, tmp_path: Path) -> None:
         height, width = 4, 5


### PR DESCRIPTION
Follow-up to the dependency cleanup (#4259, #4261): three leftovers seen during the final pass, all dead under the current floors (`requires-python >= 3.11`, `torch >= 2.5.1`, `kornia_rs` a hard runtime dependency).

* `tests/io/test_io_image.py`: the module wrapped `import kornia_rs` in a `try`, and `available_package()` skipped the whole `TestIoImage` class unless Python >= 3.7, torch >= 1.10 and kornia_rs imported. None of those can be false any more; the guard, the `sys`/`torch_version_ge` imports it needed and the `skipif` are gone. `kornia_rs` is a plain import now, as in `conftest.py`.
* `tests/filters/test_dissolving.py` and `TestRandomDissolving` in `tests/augmentation/test_augmentation.py`: both classes were skipped on `torch <= 2.0.1` ("transformers clip model needs distributed tensor"). Same guard, two files; both decorators and the now-unused `torch_version_le` imports are removed. The classes stay `@pytest.mark.slow` behind the `diffusers` `importorskip`.
* `pixi.toml`: the CUDA `install`/`install-docs` tasks reinstalled `torch torchvision` from the cu121 index. torchvision is not a kornia dependency (the last test that used it went in #4289) and nothing in the repo imports it, so the task was installing an undeclared package into the CUDA environment. Now `torch` only.

Not touched, on purpose: the other dead version guards in `tests/` (`torch_version_le(1, 9, 1)` in eight files, `torch_version_lt(1, 11, 0)`, `torch_version_lt(2, 0, 0)` twice, the `py3.8` skips in `tests/models/test_tiny_vit.py` and `tests/geometry/test_conversions.py`, and the `< 2.2`/`< 2.3`/`< 2.4` CPU-half and ONNX guards). They are the same kind of dead code; this PR is limited to the three items called out in the review.

Verified: `tests/io` 21 passed; the two dissolving classes still collect and skip without `--runslow`; `pixi.toml` parses and the CUDA task reads `uv sync --extra dev && uv pip install --reinstall torch --index pytorch-cu121`; pre-commit clean on the changed files.

Posted on behalf of @ducha-aiki by Claude (Claude Fable 5.1).
