### PR TITLE
refactor: import Self, ParamSpec, TypedDict and NotRequired from typing instead of typing_extensions

### DIFF
--- a/kornia/augmentation/auto/operations/base.py
+++ b/kornia/augmentation/auto/operations/base.py
@@ -15,12 +15,11 @@
 # limitations under the License.
 #
 
-from typing import Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Callable, Dict, List, Optional, Self, Tuple, TypeVar
 
 import torch
 from torch import nn
 from torch.distributions import Bernoulli, RelaxedBernoulli
-from typing_extensions import Self
 
 from kornia.augmentation.base import _AugmentationBase
 

--- a/kornia/augmentation/container/ops.py
+++ b/kornia/augmentation/container/ops.py
@@ -17,11 +17,10 @@
 
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, List, Optional, ParamSpec, Type, TypeVar, Union
 
 import torch
 from torch import nn
-from typing_extensions import ParamSpec
 
 import kornia.augmentation as K
 from kornia.augmentation.base import _AugmentationBase

--- a/kornia/feature/adalam/core.py
+++ b/kornia/feature/adalam/core.py
@@ -16,10 +16,9 @@
 #
 
 import math
-from typing import Optional, Tuple, Union
+from typing import NotRequired, Optional, Tuple, TypedDict, Union
 
 import torch
-from typing_extensions import NotRequired, TypedDict
 
 from .ransac import ransac
 from .utils import dist_matrix, orientation_diff

--- a/kornia/feature/keynet.py
+++ b/kornia/feature/keynet.py
@@ -15,12 +15,11 @@
 # limitations under the License.
 #
 
-from typing import List, Optional
+from typing import List, Optional, TypedDict
 
 import torch
 import torch.nn.functional as F
 from torch import nn
-from typing_extensions import TypedDict
 
 from kornia.core.download import hf_url, load_state_dict_from_url
 from kornia.filters import SpatialGradient

--- a/kornia/feature/scale_space_detector.py
+++ b/kornia/feature/scale_space_detector.py
@@ -17,12 +17,11 @@
 
 import math
 from contextlib import nullcontext
-from typing import ContextManager, List, Optional, Tuple, Union
+from typing import ContextManager, List, Optional, Tuple, TypedDict, Union
 
 import torch
 import torch.nn.functional as F
 from torch import nn
-from typing_extensions import TypedDict
 
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 from kornia.geometry.subpix import (

--- a/tests/test_declared_imports.py
+++ b/tests/test_declared_imports.py
@@ -77,8 +77,10 @@ DIST_TO_IMPORT = {
 }
 
 # Third-party modules that are allowed without appearing in ``pyproject.toml``: torch, which is a
-# declared runtime dependency, installs them, so anything that can import torch has them too.
-IMPLICIT_ALLOWED = {"typing_extensions"}
+# declared runtime dependency, installs them, so anything that can import torch has them too. Empty
+# since ``typing_extensions`` gave way to ``typing`` (every name kornia used is in the 3.11 stdlib);
+# an entry here is a package kornia imports on torch's word alone, so keep it empty when you can.
+IMPLICIT_ALLOWED: frozenset[str] = frozenset()
 
 # Extras that exist for contributors, not for users of the library: nothing a user runs may depend
 # on them, so they do not make a package "declared". Every other extra is user-facing and does.


### PR DESCRIPTION
Follow-up to the dependency cleanup (#4259). `kornia/` imported `typing_extensions` in five files without declaring it; `tests/test_declared_imports.py` tolerated that as the single `IMPLICIT_ALLOWED` entry on the grounds that torch requires it. With `requires-python >= 3.11` every name kornia used is in the standard library, so the import can simply go:

| file | name | in `typing` since |
|---|---|---|
| `kornia/augmentation/auto/operations/base.py` | `Self` | 3.11 |
| `kornia/augmentation/container/ops.py` | `ParamSpec` | 3.10 |
| `kornia/feature/keynet.py`, `kornia/feature/scale_space_detector.py` | `TypedDict` | 3.8 |
| `kornia/feature/adalam/core.py` | `TypedDict`, `NotRequired` | 3.11 |

`IMPLICIT_ALLOWED` becomes an empty `frozenset` with a comment saying why it should stay empty; the test that checks its premise (torch must require every entry) is kept for the day someone adds one.

What this does and does not buy: nothing changes in what gets installed, torch still pulls `typing_extensions` in. What changes is that kornia no longer imports a package on another package's word, so the declared-imports pin has no exception left.

Verified: 725 tests over the five modules' suites (`test_keynet`, `test_scale_space_detector`, `test_matching` for AdaLAM, `test_auto_operation`, `augmentation/container`) plus `tests/test_declared_imports.py` pass; `ty check kornia` reports the same 146 diagnostics as `main`; pre-commit clean.

Posted on behalf of @ducha-aiki by Claude (Claude Fable 5.1).
