### PR TITLE
fix(solvers): finite gradients for solve_cubic at a repeated real root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tests — a physical M1 on macOS 26 compiles them fine. kornia still supports torch 2.5.1, so the
   in-tree MPS workarounds stay. (#4202)
 
+### Fixed
+
+* `solve_cubic` no longer returns NaN gradients for a cubic with a repeated or near-repeated real
+  root. Its `D <= 0` branch takes `acos(R / sqrt(-Q3))`; the branch condition puts the ratio inside
+  `[-1, 1]`, but a repeated root drives it to exactly `+-1`, where `d(acos)/dx` is unbounded. The
+  gradient is now taken a margin inside the domain while the value is kept exact, so the roots are
+  unchanged. Reached in practice through `solve_quartic`'s resolvent cubic. (#4290)
+
 ### Breaking changes
 
 * `kornia_rs>=0.1.14` is required; the floor used to be 0.1.9. kornia_rs 0.1.11 relocated its image I/O

--- a/kornia/geometry/solvers/polynomial_solver.py
+++ b/kornia/geometry/solvers/polynomial_solver.py
@@ -179,7 +179,24 @@ def solve_cubic(coeffs: torch.Tensor) -> torch.Tensor:
     mask_D_zero_solutions = (a_D_zero <= 0) & (a_Q_zero != 0)
 
     if torch.any(mask_D_zero):
-        theta_D_zero = torch.acos(R[mask_D_zero] / torch.sqrt(-Q3[mask_D_zero]))
+        # D <= 0 guarantees R^2 <= -Q3, so the ratio is in [-1, 1] and acos is
+        # defined. Its *derivative* is not: d(acos)/dx is unbounded at x = +-1,
+        # which is exactly where a cubic with a repeated real root lands --
+        # reached routinely through solve_quartic's resolvent cubic whenever
+        # the quartic has a close real root pair.
+        #
+        # Clamping to [-1, 1] does not help; acos would still be evaluated at
+        # the boundary. So the value is kept exact and only the gradient is
+        # taken at a point a margin inside the domain: the two acos terms
+        # cancel in the forward pass, and the detached one contributes no
+        # gradient, leaving d/d(ratio) evaluated at the clamped point. Where
+        # the clamp saturates that derivative is 0, which is the usual finite
+        # stand-in for a root that is genuinely non-differentiable in the
+        # coefficients at a repeat.
+        ratio = R[mask_D_zero] / torch.sqrt(-Q3[mask_D_zero])
+        eps = torch.finfo(ratio.dtype).eps
+        ratio_for_grad = torch.clamp(ratio, min=-1.0 + eps, max=1.0 - eps)
+        theta_D_zero = torch.acos(ratio_for_grad) + (torch.acos(ratio) - torch.acos(ratio_for_grad)).detach()
         sqrt_Q_D_zero = torch.sqrt(-Q[mask_D_zero])
         x0_D_zero = 2 * sqrt_Q_D_zero * torch.cos(theta_D_zero / 3.0) - b_a_3[mask_D_zero]
         x1_D_zero = 2 * sqrt_Q_D_zero * torch.cos((theta_D_zero + 2 * _PI) / 3.0) - b_a_3[mask_D_zero]

--- a/tests/geometry/solvers/test_polynomial_solver.py
+++ b/tests/geometry/solvers/test_polynomial_solver.py
@@ -91,6 +91,62 @@ class TestCubicSolver(BaseTester):
         coeffs = torch.tensor([[2.0, 3.0, -11.0, -6.0]], device=device, dtype=torch.float64, requires_grad=True)
         self.gradcheck(solver.solve_cubic, (coeffs,))
 
+    @pytest.mark.parametrize(
+        "coeffs",
+        [
+            # (x - 1)^2 (x + 2): a repeated real root puts R / sqrt(-Q3) exactly
+            # on acos's domain boundary, where its derivative is unbounded.
+            [1.0, 0.0, -3.0, 2.0],
+            # The same root pair a hair apart, which is the case reached in
+            # practice through solve_quartic's resolvent cubic.
+            [1.0, 0.0, -3.0, 2.0 - 1e-6],
+            # Repeated root away from 1, to show it is the repeat and not the value.
+            [1.0, -8.0, 20.0, -16.0],
+        ],
+    )
+    def test_repeated_root_gradients_are_finite(self, coeffs, device, dtype):
+        """A repeated real root must not produce NaN or inf gradients.
+
+        The `D <= 0` branch takes `acos(R / sqrt(-Q3))`. `D <= 0` guarantees the
+        ratio is in [-1, 1], but a repeated root drives it to exactly +-1, where
+        `d(acos)/dx` is unbounded -- so the backward pass returned NaN while the
+        forward value was correct.
+        """
+        c = torch.tensor([coeffs], device=device, dtype=dtype, requires_grad=True)
+        roots = solver.solve_cubic(c)
+        roots.sum().backward()
+        assert c.grad is not None
+        assert torch.isfinite(c.grad).all(), f"non-finite gradient: {c.grad}"
+
+    def test_repeated_root_values_are_unchanged(self, device, dtype):
+        """Guarding the gradient must not move the roots.
+
+        The gradient is taken a margin inside acos's domain while the value is
+        kept exact, so this pins the forward pass against a fix that clamps the
+        value instead and silently degrades a repeated root.
+        """
+        coeffs = torch.tensor([[1.0, 0.0, -3.0, 2.0]], device=device, dtype=dtype)
+        roots = solver.solve_cubic(coeffs)
+        self.assert_close(
+            roots[0].sort().values,
+            torch.tensor([-2.0, 1.0, 1.0], device=device, dtype=dtype),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+    def test_quartic_with_a_repeated_root_has_finite_gradients(self, device, dtype):
+        """The path that reaches this in practice.
+
+        `solve_quartic` builds a resolvent cubic; a quartic with a close real
+        root pair sends it straight to the boundary.
+        """
+        # (x - 1)^2 (x - 2)(x - 3)
+        coeffs = torch.tensor([[1.0, -7.0, 17.0, -17.0, 6.0]], device=device, dtype=dtype, requires_grad=True)
+        roots = solver.solve_quartic(coeffs)
+        roots.sum().backward()
+        assert coeffs.grad is not None
+        assert torch.isfinite(coeffs.grad).all(), f"non-finite gradient: {coeffs.grad}"
+
 
 class TestMultiplyDegOnePoly(BaseTester):
     def test_smoke(self, device, dtype):

--- a/tests/geometry/solvers/test_polynomial_solver.py
+++ b/tests/geometry/solvers/test_polynomial_solver.py
@@ -124,7 +124,16 @@ class TestCubicSolver(BaseTester):
         The gradient is taken a margin inside acos's domain while the value is
         kept exact, so this pins the forward pass against a fix that clamps the
         value instead and silently degrades a repeated root.
+
+        Restricted to single and double precision on purpose. A repeated root
+        is ill-conditioned -- the roots separate like the square root of any
+        perturbation -- so in bfloat16 they land about 0.09 away from 1.0 on
+        `main` too. Asserting a tolerance there would be measuring the dtype,
+        not this change.
         """
+        if dtype not in (torch.float32, torch.float64):
+            pytest.skip("repeated-root conditioning dominates in half precision")
+
         coeffs = torch.tensor([[1.0, 0.0, -3.0, 2.0]], device=device, dtype=dtype)
         roots = solver.solve_cubic(coeffs)
         self.assert_close(


### PR DESCRIPTION
Fixes #4290.

## The bug

`solve_cubic`'s `D <= 0` branch takes `acos(R / sqrt(-Q3))`. The branch condition guarantees the ratio is in `[-1, 1]`, so the forward value is fine — but `d(acos)/dx` is unbounded at `x = ±1`, and a repeated or near-repeated real root drives the ratio to exactly that boundary.

```python
coeffs = torch.tensor([[1.0, 0.0, -3.0, 2.0]], requires_grad=True)   # (x-1)^2 (x+2)
solve_cubic(coeffs).sum().backward()
# roots: [1.0, -2.0, 1.0]        correct
# grad:  [nan, nan, nan, -inf]
```

Reached routinely, not exotically: `solve_quartic` builds a resolvent cubic, so any quartic with a close real root pair lands here.

## Why the obvious fix doesn't work

**Clamping the ratio to `[-1, 1]` does nothing.** `acos` is still evaluated *at* the boundary, and its derivative there is still infinite:

```
acos(clamp(1.0, -1, 1))           grad -inf
acos(clamp(1.0, -1+eps, 1-eps))   grad  0
```

**And clamping to a margin corrupts the value.** With `eps = finfo(float32).eps`, `acos(1-eps) ≈ 4.9e-4` instead of `0`, and `cos((theta + 2π)/3)` amplifies that into the roots:

```
before:            [0.9999999, -2.0, 1.0000007]
value-clamped fix: [1.0002818, -2.0, 0.9997182]     <- 2.8e-4 error
```

## What this does instead

Keeps the value exact and takes only the gradient a margin inside the domain. The two `acos` terms cancel in the forward pass; the detached one contributes no gradient, so `d/d(ratio)` is evaluated at the clamped point.

```python
ratio_for_grad = torch.clamp(ratio, min=-1.0 + eps, max=1.0 - eps)
theta = torch.acos(ratio_for_grad) + (torch.acos(ratio) - torch.acos(ratio_for_grad)).detach()
```

Forward output is **bit-identical to `main`** on every case I checked, repeated roots included:

| case | before | after |
|---|---|---|
| distinct `(x-2)(x+3)(x-1)` | `[1.9999999, -3.0, 1.0000001]` | same |
| distinct `(x-1)(x-2)(x-3)` | `[3.0, 0.9999999, 2.0]` | same |
| repeated `(x-1)²(x+2)` | `[0.9999999, -2.0, 1.0000007]` | same |
| triple `(x-1)³` | `[1.0, 1.0, 1.0]` | same |

Where the clamp saturates the subgradient is `0`. That is a choice, and worth stating plainly: the map from coefficients to roots is *genuinely* non-differentiable at a repeat (root splitting goes like a square root), so no finite value is "the" derivative there. `0` is the usual finite stand-in and matches what the `clamp` in `quaternion_exp_to_log` does for the same situation.

Same failure shape as #4007 (`acos`/`asin` boundary, fixed in #4228) — different call site.

## Tests

Five new tests in `TestCubicSolver`. **The three gradient ones fail on `main`:**

```
FAILED test_repeated_root_gradients_are_finite[cpu-float32-coeffs0]
  AssertionError: non-finite gradient: tensor([[nan, nan, nan, -inf]])
FAILED test_repeated_root_gradients_are_finite[cpu-float32-coeffs2]
  AssertionError: non-finite gradient: tensor([[nan, nan, nan, inf]])
FAILED test_quartic_with_a_repeated_root_has_finite_gradients[cpu-float32]
  AssertionError: non-finite gradient: tensor([[nan, nan, nan, nan, nan]])
```

`test_repeated_root_values_are_unchanged` is the one I'd keep even if the others were dropped: it pins the forward pass, so a later "simplification" to a plain value-clamp fails instead of silently degrading repeated roots by 2.8e-4.

```
pytest tests/geometry/solvers          92 passed
ruff 0.16.4 check / format             clean   (matching .pre-commit-config.yaml)
```

Also verified clean under `torch.autograd.set_detect_anomaly(True)` for both the cubic and the quartic path.

One note: `TestQuarticSolver::test_random` failed once during my mutation run. It draws unseeded `torch.rand` coefficients; it passes 8/8 with this change and 5/5 on `main`, so it is pre-existing flakiness rather than anything here. Happy to open a separate issue for seeding it.

`CHANGELOG.md` updated under *Unreleased → Fixed*.
