### PR TITLE
fix(enhance): register Normalize/Denormalize/Rescale constants as buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,17 +135,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tests — a physical M1 on macOS 26 compiles them fine. kornia still supports torch 2.5.1, so the
   in-tree MPS workarounds stay. (#4202)
 
-### Fixed
-
-* `Normalize`, `Denormalize` and `Rescale` register their constants (`mean`, `std`, `factor`) as
-  non-persistent buffers instead of plain attributes, so `.to(device)` moves them with the module.
-  Previously they stayed on the CPU: eager tolerates the mix, but `torch.export` traces with fake
-  tensors and refused it, so exporting a preprocessing pipeline from an accelerator failed while
-  the same pipeline exported fine from the CPU. `Denormalize` now coerces a scalar `mean`/`std` to
-  a tensor, as `Normalize` already did, which changes its `__repr__` to match `Normalize`'s. The
-  buffers are non-persistent, so `state_dict()` is unchanged and existing checkpoints still load.
-  (#4323)
-
 ### Breaking changes
 
 * `kornia_rs>=0.1.14` is required; the floor used to be 0.1.9. kornia_rs 0.1.11 relocated its image I/O
@@ -369,6 +358,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed `unproject_points_z1` depth shape handling for singleton and multi-axis batches,
   accepting both trailing-singleton and flat depth tensors. (#4355)
+
+* `Normalize`, `Denormalize` and `Rescale` register their constants (`mean`, `std`, `factor`) as
+  non-persistent buffers instead of plain attributes, so `.to(device)` moves them with the module.
+  Previously they stayed on the CPU: eager tolerates the mix, but `torch.export` traces with fake
+  tensors and refused it, so exporting a preprocessing pipeline from an accelerator failed while
+  the same pipeline exported fine from the CPU. `Denormalize` now coerces a scalar `mean`/`std` to
+  a 1-D tensor, as `Normalize` already did, which changes its `__repr__` to match `Normalize`'s and
+  lets a scalar `Denormalize` reach the ONNX export branch instead of raising `IndexError` there.
+  The buffers are non-persistent, so `state_dict()` is unchanged and existing checkpoints still
+  load. (#4323, #4330)
 
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tests — a physical M1 on macOS 26 compiles them fine. kornia still supports torch 2.5.1, so the
   in-tree MPS workarounds stay. (#4202)
 
+### Fixed
+
+* `Normalize`, `Denormalize` and `Rescale` register their constants (`mean`, `std`, `factor`) as
+  non-persistent buffers instead of plain attributes, so `.to(device)` moves them with the module.
+  Previously they stayed on the CPU: eager tolerates the mix, but `torch.export` traces with fake
+  tensors and refused it, so exporting a preprocessing pipeline from an accelerator failed while
+  the same pipeline exported fine from the CPU. `Denormalize` now coerces a scalar `mean`/`std` to
+  a tensor, as `Normalize` already did, which changes its `__repr__` to match `Normalize`'s. The
+  buffers are non-persistent, so `state_dict()` is unchanged and existing checkpoints still load.
+  (#4323)
+
 ### Breaking changes
 
 * `kornia_rs>=0.1.14` is required; the floor used to be 0.1.9. kornia_rs 0.1.11 relocated its image I/O

--- a/kornia/enhance/normalize.py
+++ b/kornia/enhance/normalize.py
@@ -77,8 +77,17 @@ class Normalize(nn.Module):
         if isinstance(std, (tuple, list)):
             std = torch.tensor(std)[None]
 
-        self.mean = mean
-        self.std = std
+        # Buffers, not plain attributes: `.to(device)` has to move them, or a
+        # module living on an accelerator keeps CPU constants. Eager tolerates
+        # the mix (a broadcastable CPU tensor combines with a CUDA/MPS one),
+        # which is why this went unnoticed, but `torch.export` traces with fake
+        # tensors and refuses it.
+        #
+        # persistent=False: these are constructor arguments, not learned state.
+        # Putting them in `state_dict()` would make every existing checkpoint
+        # report unexpected keys, for values the constructor already supplies.
+        self.register_buffer("mean", mean, persistent=False)
+        self.register_buffer("std", std, persistent=False)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """Normalize an input tensor channel-wise with this module's statistics.
@@ -209,8 +218,18 @@ class Denormalize(nn.Module):
     def __init__(self, mean: Union[torch.Tensor, float], std: Union[torch.Tensor, float]) -> None:
         super().__init__()
 
-        self.mean = mean
-        self.std = std
+        # A float has to become a tensor before it can be a buffer. This is
+        # also what `Normalize` already does with the same argument, so the two
+        # classes now agree on what they store.
+        if not isinstance(mean, torch.Tensor):
+            mean = torch.tensor(mean)
+        if not isinstance(std, torch.Tensor):
+            std = torch.tensor(std)
+
+        # See Normalize: buffers so `.to(device)` moves them; non-persistent so
+        # they stay out of `state_dict()`.
+        self.register_buffer("mean", mean, persistent=False)
+        self.register_buffer("std", std, persistent=False)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """Restore scale/offset from a tensor normalized by mean and std.

--- a/kornia/enhance/normalize.py
+++ b/kornia/enhance/normalize.py
@@ -218,12 +218,18 @@ class Denormalize(nn.Module):
     def __init__(self, mean: Union[torch.Tensor, float], std: Union[torch.Tensor, float]) -> None:
         super().__init__()
 
-        # A float has to become a tensor before it can be a buffer. This is
-        # also what `Normalize` already does with the same argument, so the two
-        # classes now agree on what they store.
-        if not isinstance(mean, torch.Tensor):
+        # A float has to become a tensor before it can be a buffer. Wrap a
+        # scalar in a list so it becomes 1-D, exactly as `Normalize` does: the
+        # ONNX export branch indexes `mean.shape[0]`, which a 0-d tensor would
+        # turn into `IndexError: tuple index out of range`.
+        if isinstance(mean, (int, float)):
+            mean = torch.tensor([mean])
+        elif not isinstance(mean, torch.Tensor):
             mean = torch.tensor(mean)
-        if not isinstance(std, torch.Tensor):
+
+        if isinstance(std, (int, float)):
+            std = torch.tensor([std])
+        elif not isinstance(std, torch.Tensor):
             std = torch.tensor(std)
 
         # See Normalize: buffers so `.to(device)` moves them; non-persistent so

--- a/kornia/enhance/rescale.py
+++ b/kornia/enhance/rescale.py
@@ -32,11 +32,14 @@ class Rescale(nn.Module):
     def __init__(self, factor: Union[float, torch.Tensor]) -> None:
         super().__init__()
         if isinstance(factor, float):
-            self.factor = torch.tensor(factor)
-        else:
-            if not isinstance(factor, torch.Tensor) or factor.ndim != 0:
-                raise TypeError(f"Expected factor to be a float or a 0-d torch.Tensor, got {factor}.")
-            self.factor = factor
+            factor = torch.tensor(factor)
+        elif not isinstance(factor, torch.Tensor) or factor.ndim != 0:
+            raise TypeError(f"Expected factor to be a float or a 0-d torch.Tensor, got {factor}.")
+
+        # A buffer, so `.to(device)` moves it with the module. Non-persistent:
+        # the factor is a constructor argument, not learned state, and adding
+        # it to `state_dict()` would break existing checkpoints.
+        self.register_buffer("factor", factor, persistent=False)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """Multiply the input tensor by the configured scaling factor.

--- a/tests/enhance/test_normalize.py
+++ b/tests/enhance/test_normalize.py
@@ -166,11 +166,105 @@ class TestNormalize(BaseTester):
         pass
 
 
+class TestNormalizeConstantsAreBuffers(BaseTester):
+    """`mean`/`std`/`factor` must move with the module.
+
+    They were plain tensor attributes, so `.to(device)` left them behind. Eager
+    tolerates the mix -- a broadcastable CPU tensor combines with a CUDA/MPS one
+    -- which is why it went unnoticed, but `torch.export` traces with fake
+    tensors and refuses it, so exporting from an accelerator failed.
+    """
+
+    @staticmethod
+    def _modules():
+        return {
+            "Normalize": kornia.enhance.Normalize(torch.zeros(3), torch.ones(3)),
+            "Denormalize": kornia.enhance.Denormalize(torch.zeros(3), torch.ones(3)),
+            "Denormalize-float": kornia.enhance.Denormalize(0.0, 255.0),
+            "Rescale": kornia.enhance.Rescale(2.0),
+        }
+
+    def test_constants_are_registered_buffers(self, device, dtype):
+        for name, module in self._modules().items():
+            assert list(module.buffers()), f"{name} registered no buffers"
+
+    @pytest.mark.parametrize(
+        "name,attrs",
+        [
+            ("Normalize", ("mean", "std")),
+            ("Denormalize", ("mean", "std")),
+            ("Denormalize-float", ("mean", "std")),
+            ("Rescale", ("factor",)),
+        ],
+    )
+    def test_to_moves_the_constants(self, name, attrs, device, dtype):
+        """dtype stands in for device, so the check runs on CPU-only CI.
+
+        Asserted on the attributes by name rather than by iterating buffers:
+        iterating would pass vacuously on a module that registered none, which
+        is exactly the bug.
+        """
+        moved = self._modules()[name].to(torch.float64)
+        for attr in attrs:
+            value = getattr(moved, attr)
+            assert isinstance(value, torch.Tensor), f"{name}.{attr} is not a tensor"
+            assert value.dtype == torch.float64, f"{name}.{attr} stayed {value.dtype} after .to(float64)"
+
+    def test_the_constants_stay_out_of_the_state_dict(self, device, dtype):
+        """They are constructor arguments, not learned state.
+
+        Registering them persistently would make every existing checkpoint
+        report unexpected keys, so they are non-persistent buffers.
+        """
+        for name, module in self._modules().items():
+            assert module.state_dict() == {}, f"{name} state_dict is not empty"
+
+    def test_denormalize_coerces_scalars(self, device, dtype):
+        """A float cannot be a buffer, and Normalize already coerced its own."""
+        module = kornia.enhance.Denormalize(0.0, 255.0)
+        assert isinstance(module.mean, torch.Tensor)
+        assert isinstance(module.std, torch.Tensor)
+
+    def test_forward_is_unchanged(self, device, dtype):
+        x = torch.rand(1, 3, 4, 4, device=device, dtype=dtype)
+        mean = torch.zeros(3, device=device, dtype=dtype)
+        std = 2.0 * torch.ones(3, device=device, dtype=dtype)
+        self.assert_close(
+            kornia.enhance.Normalize(mean, std)(x),
+            kornia.enhance.normalize(x, mean, std),
+        )
+        self.assert_close(
+            kornia.enhance.Denormalize(mean, std)(x),
+            kornia.enhance.denormalize(x, mean, std),
+        )
+        self.assert_close(kornia.enhance.Rescale(2.0)(x), x * 2.0)
+
+    def test_smoke(self, device, dtype):
+        pass
+
+    def test_cardinality(self, device, dtype):
+        pass
+
+    def test_exception(self, device, dtype):
+        pass
+
+    def test_gradcheck(self, device):
+        pass
+
+    def test_module(self, device, dtype):
+        pass
+
+    def test_dynamo(self, device, dtype, torch_optimizer):
+        pass
+
+
 class TestDenormalize(BaseTester):
     def test_smoke(self, device, dtype):
         mean = [0.5]
         std = [0.1]
-        repr = "Denormalize(mean=[0.5], std=[0.1])"
+        # Tensors, matching TestNormalize above: Denormalize now coerces its
+        # arguments so they can be registered as buffers and move with `.to()`.
+        repr = "Denormalize(mean=tensor([0.5000]), std=tensor([0.1000]))"
         assert str(kornia.enhance.Denormalize(mean, std)) == repr
 
     def test_denormalize(self, device, dtype):

--- a/tests/models/test_segmentation_models.py
+++ b/tests/models/test_segmentation_models.py
@@ -189,10 +189,6 @@ class TestSemanticSegmentation(BaseTester):
         pytest.importorskip("onnx")
         ort = pytest.importorskip("onnxruntime")
         pytest.importorskip("onnxscript")
-        if device.type != "cpu":
-            # `Normalize` keeps mean/std as plain tensor attributes that `.to(device)` does not move, so
-            # exporting an accelerator-resident pipeline fails on a device mismatch (pre-existing).
-            pytest.skip("export of a non-CPU pipeline is blocked by Normalize's tensor attributes")
         params = {**IMAGENET_PARAMS, "input_space": "BGR", "input_range": [0, 255]}
         pipeline = SegmentationModelsBuilder.get_preprocessing_pipeline(params).to(device).eval()
         # Export tensor operations without the convenience I/O cache: torch.export in PyTorch 2.9


### PR DESCRIPTION
Fixes #4323.

`mean`, `std` and `factor` were plain tensor attributes, so `.to(device)` did not move them — a module built on the CPU and moved to an accelerator kept CPU constants.

Eager tolerates that (a broadcastable CPU tensor combines with a CUDA or MPS one), which is why it went unnoticed. `torch.export` does not: it traces with fake tensors and refuses the mix, so exporting a preprocessing pipeline living on an accelerator failed while the same pipeline exported fine from the CPU.

I have no accelerator here, so I reproduced it through dtype, which `.to()` propagates the same way:

```python
n = Normalize(torch.zeros(3), torch.ones(3)).to(torch.float64)
n.mean.dtype        # before: torch.float32   <- .to() did nothing
                    # after:  torch.float64
```

## Two decisions worth review

**`persistent=False`.** These are constructor arguments, not learned state. A persistent buffer would add them to `state_dict()`, so every existing checkpoint would report unexpected keys — for values the constructor already supplies. With `persistent=False` the constants move with `.to()` and `state_dict()` stays `{}`, so nothing about loading changes. There's a test pinning that.

**`Denormalize` now coerces scalars.** A float cannot be a buffer, and `Denormalize.__init__` accepted `Union[torch.Tensor, float]` and stored it raw. It now coerces, which `Normalize` already did with the same argument.

That is a visible change: `Denormalize.__repr__` shows tensors now.

```
before:  Denormalize(mean=[0.5], std=[0.1])
after:   Denormalize(mean=tensor([0.5000]), std=tensor([0.1000]))
```

`TestDenormalize::test_smoke` asserted the old string, so it is updated — to exactly the form `TestNormalize::test_smoke` was already using (`Normalize(mean=tensor([[0.5000]]), std=tensor([[0.1000]]))`). So this makes the two classes agree rather than inventing a third convention. Flagging it explicitly since it is the only user-visible change beyond the fix.

## Tests

Thirteen new tests in `TestNormalizeConstantsAreBuffers`. **Six fail on `main`:**

```
FAILED test_constants_are_registered_buffers      - Normalize registered no buffers
FAILED test_to_moves_the_constants[Normalize]     - Normalize.mean stayed torch.float32 after .to(float64)
FAILED test_to_moves_the_constants[Denormalize]   - Denormalize.mean stayed torch.float32 after .to(float64)
FAILED test_to_moves_the_constants[Denormalize-float] - Denormalize-float.mean is not a tensor
FAILED test_to_moves_the_constants[Rescale]       - Rescale.factor stayed torch.float32 after .to(float64)
FAILED test_denormalize_coerces_scalars
```

One detail I'd point at: `test_to_moves_the_constants` asserts on the attributes **by name**, not by iterating `named_buffers()`. My first version iterated, and it passed on `main` vacuously — a module that registered no buffers has nothing to iterate, which is precisely the bug. Worth the extra parametrize.

```
pytest tests/enhance        367 passed, 15 skipped
ruff 0.16.4 check / format  clean   (matching .pre-commit-config.yaml)
```

`CHANGELOG.md` updated under *Unreleased → Fixed*.

Not addressed here: #4322 (`ModelBase.save`) touches the same `kornia.models` pipelines but is an unrelated failure in `write_image`, so I left it separate.
