### PR TITLE
fix(solvers): stop solve_cubic's D>0 branch poisoning other rows' gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   form and reshapes internally, but both callers index dim 1 as the vertex axis, so the box axis was
   read as the vertices: an out-of-bounds error with one box, and three `(1, 3)` tensors -- one value
   per coordinate rather than per box -- with eight. (#4248, #4351)
+* `solve_cubic` and `solve_quartic` return finite gradients for a row whose neighbours in the
+  same batch take a different branch. The `D > 0` branch selected its rows with `abs(R) > 1e-16`
+  alone, so it evaluated `sqrt(D)` on `D < 0` rows too. Those rows are never read back, but the
+  resulting `-Q / nan` stays in the graph and its backward returns `nan`, which reaches every
+  coefficient: a three-real-root cubic differentiated correctly on its own and gave `nan` as soon
+  as a one-real-root cubic shared the batch, and `solve_quartic` inherited it through its
+  resolvent cubic. The forward values are unchanged. (#4334, #4338)
 
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never

--- a/kornia/geometry/solvers/polynomial_solver.py
+++ b/kornia/geometry/solvers/polynomial_solver.py
@@ -214,7 +214,10 @@ def solve_cubic(coeffs: torch.Tensor) -> torch.Tensor:
         AD = torch.zeros_like(R)
         BD = torch.zeros_like(R)
         R_abs = torch.abs(R)
-        mask_R_positive = R_abs > 1e-16
+        # Intersect with mask_D_positive: sqrt(D) on a D <= 0 row is nan, and
+        # although such a row is never read out of AD/BD, `-Q / nan` stays in
+        # the graph and its backward poisons every coefficient's gradient.
+        mask_R_positive = (R_abs > 1e-16) & mask_D_positive
         if torch.any(mask_R_positive):
             AD[mask_R_positive] = torch.pow(R_abs[mask_R_positive] + torch.sqrt(D[mask_R_positive]), 1 / 3)
             mask_R_positive_ = R < 0

--- a/testing/half_precision_xfails/cpu_float16.txt
+++ b/testing/half_precision_xfails/cpu_float16.txt
@@ -398,6 +398,7 @@ call	builtins.AssertionError	tests/geometry/liegroup/test_so3.py::TestSo3::test_
 call	builtins.AssertionError	tests/geometry/solvers/test_polynomial_solver.py::TestQuarticSolver::test_convention_gradient_is_finite_for_a_pure_biquadratic_4229[cpu-float16-coeffs0-expected0-expected_grad0]
 call	builtins.AssertionError	tests/geometry/solvers/test_polynomial_solver.py::TestQuarticSolver::test_convention_gradient_is_finite_for_a_pure_biquadratic_4229[cpu-float16-coeffs1-expected1-expected_grad1]
 call	builtins.AssertionError	tests/geometry/solvers/test_polynomial_solver.py::TestQuarticSolver::test_convention_gradient_is_finite_for_a_pure_biquadratic_4229[cpu-float16-coeffs2-None-expected_grad2]
+call	builtins.AssertionError	tests/geometry/solvers/test_polynomial_solver.py::TestQuarticSolver::test_convention_gradient_does_not_leak_across_batch_rows_4334[cpu-float16]
 call	builtins.AssertionError	tests/geometry/solvers/test_polynomial_solver.py::TestQuarticSolver::test_random[cpu-float16]
 call	builtins.AssertionError	tests/geometry/solvers/test_polynomial_solver.py::TestQuarticSolver::test_solve_quartic[cpu-float16-coeffs0-expected_solutions0]
 call	builtins.AssertionError	tests/geometry/solvers/test_polynomial_solver.py::TestQuarticSolver::test_solve_quartic[cpu-float16-coeffs3-expected_solutions3]

--- a/tests/geometry/solvers/test_polynomial_solver.py
+++ b/tests/geometry/solvers/test_polynomial_solver.py
@@ -506,10 +506,7 @@ class TestQuarticSolver(BaseTester):
         mixed = torch.tensor([four, two], device=device, dtype=dtype, requires_grad=True)
         solver.solve_quartic(mixed).sum().backward()
 
-        # Row 0 only. Row 1's own gradients are not this fix's to guarantee: they depend on
-        # solve_quartic's separate sqrt sites (#4229), which are torch-version sensitive --
-        # `x^4 - 16` alone is non-finite on torch <= 2.9.1 and finite on 2.14, where clamp
-        # zeroes the boundary gradient. Asserting over the whole batch would pin that moving
-        # target. What #4334 is about is row 0 being poisoned by row 1's presence.
+        # Check row 0 for the cross-batch contamination from #4334. Row 1's separate
+        # zero-radicand gradient convention was fixed in #4339 and is covered above.
         assert bool(torch.isfinite(mixed.grad[0]).all()), mixed.grad
         self.assert_close(mixed.grad[0], alone.grad[0])

--- a/tests/geometry/solvers/test_polynomial_solver.py
+++ b/tests/geometry/solvers/test_polynomial_solver.py
@@ -124,6 +124,33 @@ class TestCubicSolver(BaseTester):
         cubic_roots.sum().backward()
         assert bool(torch.isfinite(cubic_coeffs.grad).all()), cubic_coeffs.grad
 
+    def test_convention_gradient_does_not_leak_across_batch_rows_4334(self, device, dtype):
+        # #4334: the D > 0 branch keyed its work off `abs(R) > 1e-16` alone, so it evaluated
+        # sqrt(D) on D < 0 rows too. Those rows are never read back, but `-Q / nan` stays in
+        # the graph and DivBackward0 returns nan, which reaches every coefficient. The result
+        # is that a row differentiates fine alone and gives nan in a mixed batch.
+        three = [1.0, -7.0, 14.0, -8.0]  # (x-1)(x-2)(x-4): D < 0, three real roots, R != 0
+        one = [1.0, 0.0, 1.0, -2.0]  # (x-1)(x^2+x+2): D > 0, one real root, Q != 0
+
+        alone = torch.tensor([three], device=device, dtype=dtype, requires_grad=True)
+        solver.solve_cubic(alone).sum().backward()
+
+        mixed = torch.tensor([three, one], device=device, dtype=dtype, requires_grad=True)
+        solver.solve_cubic(mixed).sum().backward()
+
+        assert bool(torch.isfinite(mixed.grad).all()), mixed.grad
+        # Batching must not change the answer either, not merely keep it finite.
+        self.assert_close(mixed.grad[0], alone.grad[0])
+
+    def test_convention_batched_forward_is_unchanged_by_neighbours_4334(self, device, dtype):
+        # The forward pass was always correct; pin that, so a later fix that repairs the
+        # gradient by perturbing the value is caught here.
+        three = [1.0, -7.0, 14.0, -8.0]
+        one = [1.0, 0.0, 1.0, -2.0]
+        alone = torch.tensor([three], device=device, dtype=dtype)
+        mixed = torch.tensor([three, one], device=device, dtype=dtype)
+        self.assert_close(solver.solve_cubic(mixed)[0], solver.solve_cubic(alone)[0])
+
 
 class TestMultiplyDegOnePoly(BaseTester):
     def test_smoke(self, device, dtype):
@@ -466,3 +493,22 @@ class TestQuarticSolver(BaseTester):
                 rtol=1e-4,
                 atol=1e-4,
             )
+
+    def test_convention_gradient_does_not_leak_across_batch_rows_4334(self, device, dtype):
+        # #4334 through the resolvent cubic: a four-real-root quartic batched with a
+        # two-real-root one took nan gradients from solve_cubic's D > 0 branch.
+        four = [1.0, -10.0, 35.0, -50.0, 24.0]  # (x-1)(x-2)(x-3)(x-4)
+        two = [1.0, 0.0, 0.0, 0.0, -16.0]  # x^4 - 16
+
+        alone = torch.tensor([four], device=device, dtype=dtype, requires_grad=True)
+        solver.solve_quartic(alone).sum().backward()
+
+        mixed = torch.tensor([four, two], device=device, dtype=dtype, requires_grad=True)
+        solver.solve_quartic(mixed).sum().backward()
+
+        # Row 0 only. `x^4 - 16` has non-finite gradients on its own as well, from a separate
+        # defect in solve_quartic's own sqrt sites (#4229) that this change does not touch --
+        # so asserting over the whole batch here would pin an unrelated bug. What #4334 is
+        # about is row 0 being poisoned by row 1's presence, and that is what is checked.
+        assert bool(torch.isfinite(mixed.grad[0]).all()), mixed.grad
+        self.assert_close(mixed.grad[0], alone.grad[0])

--- a/tests/geometry/solvers/test_polynomial_solver.py
+++ b/tests/geometry/solvers/test_polynomial_solver.py
@@ -506,9 +506,10 @@ class TestQuarticSolver(BaseTester):
         mixed = torch.tensor([four, two], device=device, dtype=dtype, requires_grad=True)
         solver.solve_quartic(mixed).sum().backward()
 
-        # Row 0 only. `x^4 - 16` has non-finite gradients on its own as well, from a separate
-        # defect in solve_quartic's own sqrt sites (#4229) that this change does not touch --
-        # so asserting over the whole batch here would pin an unrelated bug. What #4334 is
-        # about is row 0 being poisoned by row 1's presence, and that is what is checked.
+        # Row 0 only. Row 1's own gradients are not this fix's to guarantee: they depend on
+        # solve_quartic's separate sqrt sites (#4229), which are torch-version sensitive --
+        # `x^4 - 16` alone is non-finite on torch <= 2.9.1 and finite on 2.14, where clamp
+        # zeroes the boundary gradient. Asserting over the whole batch would pin that moving
+        # target. What #4334 is about is row 0 being poisoned by row 1's presence.
         assert bool(torch.isfinite(mixed.grad[0]).all()), mixed.grad
         self.assert_close(mixed.grad[0], alone.grad[0])


### PR DESCRIPTION
Closes #4334.

The `D > 0` branch selected its rows with `abs(R) > 1e-16` — a condition on `R`, not on `D` — so it evaluated `sqrt(D)` on `D < 0` rows too. Those rows are never read back out of `AD`/`BD`, but `-Q / nan` stays in the graph, `DivBackward0` returns `nan` for them, and that lands on `Q.grad` and from there on every coefficient.

One line: intersect the mask with `mask_D_positive`.

**Verified by execution** (CPU, torch 2.5.0). The issue's repro, before → after:

```
solve_cubic,   1 row : [-7.0, -1.0, -1.9e-16, -1.7e-16]
solve_cubic,   2 rows: [nan, nan, nan, nan]        ->  [-7.0, -1.0, -1.9e-16, -1.7e-16]
solve_quartic, 2 rows: [nan, nan, nan, nan, nan]   ->  [-10.0, -1.0, 0.0, 0.0, 0.0]
```

At scale, a seeded random batch (float64):

| | `main` | this branch |
|---|---|---|
| `solve_cubic`, 50 000 rows | 12 312 rows with non-finite grad | **0** |
| `solve_quartic`, 20 000 rows | 5 684 | **0** |

The forward pass is untouched: `solve_cubic` on a 5 000-row batch is `torch.equal` to evaluating the same rows one at a time.

**Tests.** Three pins, in the shape the issue suggests — a mixed two-row batch, asserting both finiteness *and* that the batched gradient equals the single-row one, so a later fix that merely suppresses `nan` does not pass. Plus a forward-value pin, which passes on `main` on purpose: the values were always right, and that is what a gradient fix must not disturb. On `main`: **4 failed, 2 passed**; at this head: **6 passed**. Whole file, `--dtype=float32,float64`: **123 passed**.

**One thing worth flagging.** The issue's quartic pair uses `x^4 - 16` as the second row, and that polynomial has non-finite gradients *on its own* — `[nan, nan, nan, 0.0, 0.0]`, with or without this change. That is a separate defect in `solve_quartic`'s own `sqrt` sites, which looks like the #4229 territory the issue mentions, so I scoped the quartic assertion to row 0 rather than pin an unrelated bug. Happy to take that one next if you want it.

`ruff check` / `ruff format` clean at v0.16.4. `grep -rnE "#4334|issues/4334" kornia/ tests/` hits only the new test pins. CHANGELOG entry under `### Bug fixes`.