### PR TITLE
fix(sensors): preserve device and dtype for scalar depth in Z1Projection.unproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 
+* `Z1Projection.unproject` now materialises a python `int`/`float` `depth` on the device and
+  in the dtype of `points`; it used to build a CPU float32 tensor, which raised `RuntimeError`
+  on every accelerator and widened float16/bfloat16 results to float32. (#4340)
+
 * `kornia.io.load_image` and `write_image` work on the kornia_rs that a plain `pip install kornia`
   resolves. kornia_rs 0.1.11 moved its image readers and writers from the package root into
   `kornia_rs.io`, and kornia kept calling the root, so on 0.1.11 and newer `load_image` raised

--- a/kornia/sensors/camera/projection_model.py
+++ b/kornia/sensors/camera/projection_model.py
@@ -73,7 +73,7 @@ class Z1Projection:
 
         """
         if isinstance(depth, (float, int)):
-            depth = torch.Tensor([depth])
+            depth = torch.as_tensor([depth], device=points.data.device, dtype=points.data.dtype)
         return Vector3.from_coords(points.x * depth, points.y * depth, depth)
 
 

--- a/kornia/sensors/camera/projection_model.py
+++ b/kornia/sensors/camera/projection_model.py
@@ -59,7 +59,7 @@ class Z1Projection:
 
         Args:
             points: Vector2 representing the points to unproject.
-            depth: torch.Tensor representing the depth of the points to unproject.
+            depth: a :class:`torch.Tensor` of shape ``(B,)``, or a python scalar for a single point.
 
         Returns:
             Vector3 representing the unprojected points.

--- a/tests/sensors/camera/test_projection_model.py
+++ b/tests/sensors/camera/test_projection_model.py
@@ -83,21 +83,15 @@ class TestProjection(BaseTester):
         accelerator and widened float16/bfloat16 results to float32.
         """
         projection = Z1Projection()
-        points = Vector2(
-            torch.tensor([[0.25, 0.5]], device=device, dtype=dtype)
-        )
+        points = Vector2(torch.tensor([[0.25, 0.5]], device=device, dtype=dtype))
         expected = projection.unproject(
             points,
             torch.tensor([4.0], device=device, dtype=dtype),
         ).data
         for depth in (4, 4.0):
             out = projection.unproject(points, depth)
-            assert out.data.device.type == device.type, (
-                f"expected device {device.type}, got {out.data.device.type}"
-            )
-            assert out.data.dtype == dtype, (
-                f"expected dtype {dtype}, got {out.data.dtype}"
-            )
+            assert out.data.device.type == device.type, f"expected device {device.type}, got {out.data.device.type}"
+            assert out.data.dtype == dtype, f"expected dtype {dtype}, got {out.data.dtype}"
             self.assert_close(out.data, expected, atol=0.0, rtol=0.0)
         # Also verify a vector depth still works unchanged
         out_vec = projection.unproject(points, torch.tensor([4.0], device=device, dtype=dtype))

--- a/tests/sensors/camera/test_projection_model.py
+++ b/tests/sensors/camera/test_projection_model.py
@@ -74,3 +74,31 @@ class TestProjection(BaseTester):
             ).data,
             expected,
         )
+
+    def test_unproject_scalar_depth(self, device, dtype):
+        """Regression test: scalar depth must preserve device and dtype.
+
+        PR #4340: Z1Projection.unproject used to build a CPU float32 tensor
+        for python int/float depth, which raised RuntimeError on every
+        accelerator and widened float16/bfloat16 results to float32.
+        """
+        projection = Z1Projection()
+        points = Vector2(
+            torch.tensor([[0.25, 0.5]], device=device, dtype=dtype)
+        )
+        expected = projection.unproject(
+            points,
+            torch.tensor([4.0], device=device, dtype=dtype),
+        ).data
+        for depth in (4, 4.0):
+            out = projection.unproject(points, depth)
+            assert out.data.device.type == device.type, (
+                f"expected device {device.type}, got {out.data.device.type}"
+            )
+            assert out.data.dtype == dtype, (
+                f"expected dtype {dtype}, got {out.data.dtype}"
+            )
+            self.assert_close(out.data, expected, atol=0.0, rtol=0.0)
+        # Also verify a vector depth still works unchanged
+        out_vec = projection.unproject(points, torch.tensor([4.0], device=device, dtype=dtype))
+        self.assert_close(out_vec.data, expected, atol=0.0, rtol=0.0)


### PR DESCRIPTION
## Problem

`Z1Projection.unproject` documents `depth: torch.Tensor | float` and its own doctest passes a python `int` `3`. When `depth` is a python scalar the method promotes it with:

```python
depth = torch.Tensor([depth])
```

`torch.Tensor([depth])` is a **CPU float32** constructor: it ignores the device and the dtype of `points`. On CPU the mismatch is invisible; on every accelerator the very next line — `points.x * depth` — raises `RuntimeError: Expected all tensors to be on the same device`. So the documented and doctested scalar form of the API works on exactly one device.

The same line also silently widens the dtype: with a `float16` (or `bfloat16` / `float64`) `points` tensor, the depth is promoted to `float32` and the downstream computation runs in mixed precision (half-precision inputs now stay in their dtype, previously widened to float32).

## Root cause

`torch.Tensor([depth])` does not propagate `device` or `dtype` from the caller.

## Fix

Use `torch.as_tensor([depth], device=points.data.device, dtype=points.data.dtype)` so the scalar depth matches the points' device and dtype.

## Verification

- **Ascend NPU (910B, torch_npu)**: old code raises `Expected all tensors to be on the same device. Expected NPU tensor`; patched code returns NPU tensors and preserves float32/bfloat16 dtype.
- **CPU float64**: patched code preserves float64 dtype (old code widened to float32).
- **Tensor-depth path**: unchanged (not affected by the scalar branch).
- **CPU float32 path**: returns identical values (regression check).

Fixes #4313