### PR TITLE
fix(geometry): promote dtype in PinholeCamera.scale_ for int64 height/width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -402,6 +402,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the dtype of `points`; it used to build a CPU float32 tensor, which raised `RuntimeError`
   on every accelerator and widened float16/bfloat16 results to float32. (#4340)
 
+* `PinholeCamera.scale_` now rebinds ``height``/``width`` to the promoted result instead of
+  writing into their storage, so a camera built with int64 sizes (as the class example does) no
+  longer raises ``RuntimeError: result type Float can't be cast to the desired output type Long``
+  and matches :meth:`scale`. As a consequence ``scale_`` no longer mutates the ``height``/``width``
+  tensors the caller passed to the constructor; ``intrinsics`` are still updated in place. (#4341)
+
 * `kornia.io.load_image` and `write_image` work on the kornia_rs that a plain `pip install kornia`
   resolves. kornia_rs 0.1.11 moved its image readers and writers from the package root into
   `kornia_rs.io`, and kornia kept calling the root, so on 0.1.11 and newer `load_image` raised

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -295,6 +295,10 @@ class PinholeCamera:
     def scale_(self, scale_factor: Union[float, torch.Tensor]) -> "PinholeCamera":
         r"""Scale the pinhole model in-place.
 
+        The intrinsics are updated in place while ``height`` and ``width``
+        are rebound to the floating-point scaled size, so an integer image
+        size is promoted as in :meth:`scale`.
+
         Args:
             scale_factor: a torch.Tensor with the scale factor. It has
               to be broadcastable with class members. The expected shape is
@@ -302,6 +306,11 @@ class PinholeCamera:
 
         Returns:
             the camera model with scaled parameters.
+
+        .. note::
+            As a consequence of the rebinding, ``scale_`` no longer mutates
+            the ``height``/``width`` tensors the caller passed to the
+            constructor; ``intrinsics`` are still updated in place.
 
         """
         # scale the intrinsic parameters
@@ -313,7 +322,6 @@ class PinholeCamera:
         self.height = self.height * scale_factor
         self.width = self.width * scale_factor
         return self
-
     def project(self, point_3d: torch.Tensor) -> torch.Tensor:
         r"""Project a 3d point in world coordinates onto the 2d camera plane.
 

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -310,8 +310,8 @@ class PinholeCamera:
         self.intrinsics[..., 0, 2] *= scale_factor
         self.intrinsics[..., 1, 2] *= scale_factor
         # scale the image height/width
-        self.height *= scale_factor
-        self.width *= scale_factor
+        self.height = self.height * scale_factor
+        self.width = self.width * scale_factor
         return self
 
     def project(self, point_3d: torch.Tensor) -> torch.Tensor:

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -322,6 +322,7 @@ class PinholeCamera:
         self.height = self.height * scale_factor
         self.width = self.width * scale_factor
         return self
+
     def project(self, point_3d: torch.Tensor) -> torch.Tensor:
         r"""Project a 3d point in world coordinates onto the 2d camera plane.
 

--- a/tests/geometry/camera/test_pinhole.py
+++ b/tests/geometry/camera/test_pinhole.py
@@ -486,6 +486,34 @@ class TestPinholeCamera(BaseTester):
         self.assert_close(pinhole_scale.height, pinhole.height * scale_val, atol=1e-4, rtol=1e-4)
         self.assert_close(pinhole_scale.width, pinhole.width * scale_val, atol=1e-4, rtol=1e-4)
 
+    def test_scale_inplace_int64_size(self, device, dtype):
+        """Regression test: scale_ must promote int64 height/width to float.
+
+        PR #4341: PinholeCamera.scale_ used to write the scaled result into
+        the int64 storage, which raised RuntimeError on every accelerator.
+        """
+        import kornia
+        batch_size = 1
+        fx, fy, cx, cy = 1.0, 2.0, 4.0, 3.0
+        tx, ty, tz = 1.0, 2.0, 3.0
+        s = torch.tensor([0.5], device=device, dtype=dtype)
+
+        intrinsics = self._create_intrinsics(batch_size, fx, fy, cx, cy, device=device, dtype=dtype)
+        extrinsics = self._create_extrinsics(batch_size, tx, ty, tz, device=device, dtype=dtype)
+        # Build camera with int64 height/width (as the class docstring example does)
+        height = torch.tensor([6], device=device)
+        width = torch.tensor([8], device=device)
+
+        cam = kornia.geometry.camera.PinholeCamera(intrinsics, extrinsics, height, width)
+        expected = cam.clone().scale(s)
+        out = cam.scale_(s)
+        assert out is cam, "scale_ must return self"
+        assert cam.height.is_floating_point(), "height must be promoted to float"
+        assert cam.height.dtype == expected.height.dtype, "height dtype must match scale()"
+        self.assert_close(cam.height, expected.height, atol=0.0, rtol=0.0)
+        self.assert_close(cam.width, expected.width, atol=0.0, rtol=0.0)
+        self.assert_close(cam.intrinsics, expected.intrinsics, atol=0.0, rtol=0.0)
+
     def test_pinhole_camera_project_and_unproject(self, device, dtype):
         batch_size = 5
         n = 2  # Point per batch

--- a/tests/geometry/camera/test_pinhole.py
+++ b/tests/geometry/camera/test_pinhole.py
@@ -493,6 +493,7 @@ class TestPinholeCamera(BaseTester):
         the int64 storage, which raised RuntimeError on every accelerator.
         """
         import kornia
+
         batch_size = 1
         fx, fy, cx, cy = 1.0, 2.0, 4.0, 3.0
         tx, ty, tz = 1.0, 2.0, 3.0


### PR DESCRIPTION
## Problem

`PinholeCamera` constructor accepts int64 `height`/`width` — that is what the class's own example builds. `scale()` handles this by promoting the result to float. Its in-place twin `scale_()` writes the float result back into the int64 tensor and raises:

```
RuntimeError: result type Float can't be cast to the desired output type Long
```

So a camera built exactly as documented cannot be scaled in place, and the two twins have two different dtype policies for the same attribute.

## Root cause

`self.height *= scale_factor` (in-place) writes a float result into int64 storage. `self.height = self.height * scale_factor` (rebind) creates a new float tensor.

## Fix

Change `self.height *= scale_factor` → `self.height = self.height * scale_factor` (and the same for `width`), so the attribute is rebound to the promoted float tensor, matching `scale()`'s dtype policy.

**Side-effect note**: The byte-identical claim holds for values but not for side effects. `scale_` no longer mutates the `height`/`width` tensors the caller passed to the constructor; `intrinsics` are still updated in place. The only in-tree `.scale_(` caller works on a `clone()`, so nothing in kornia breaks, but this is user-visible and documented in the updated docstring. Issue #4264 stays open for the intrinsics write-through.

## Verification

- **Ascend NPU (910B, torch_npu)**: old code raises `Result type DT_FLOAT can't be cast to the desired output type DT_INT64`; patched code returns float32 height/width on NPU.
- **CPU int64**: patched code returns float32 (old code raised).
- **CPU float32/NPU float32**: unchanged (regression checks).

**Note**: This PR is stacked on #4340 (contains its commit as first of two). Once #4340 merges, this should be rebased onto `main` with only the #4341 commit.

Fixes #4265