### PR TITLE
test: pin undistort_points out-of-radius two-cycle

### DIFF
--- a/tests/geometry/calibration/test_undistort.py
+++ b/tests/geometry/calibration/test_undistort.py
@@ -18,6 +18,7 @@
 import pytest
 import torch
 
+from kornia.geometry.calibration.distort import distort_points
 from kornia.geometry.calibration.undistort import undistort_image, undistort_points
 
 from testing.base import BaseTester
@@ -62,6 +63,23 @@ class TestUndistortPoints(BaseTester):
         new_K = torch.rand(B, 3, 3, device=device, dtype=dtype)
         pointsu = undistort_points(points, K, distCoeff, new_K)
         assert pointsu.shape == (B, N, 2)
+
+    @pytest.mark.device_agnostic
+    def test_convention_out_of_radius_fixed_point_is_a_two_cycle_4285(self):
+        dtype = torch.float64
+        K = torch.tensor([[[100.0, 0.0, 4.0], [0.0, 100.0, 3.0], [0.0, 0.0, 1.0]]], dtype=dtype)
+        dist = torch.tensor([[0.5, 0.0, 0.0, 0.0]], dtype=dtype)
+        points = torch.tensor([[[304.0, 3.0]]], dtype=dtype)
+        distorted = distort_points(points, K, dist)
+
+        residuals = {}
+        for num_iters in (5, 6, 7, 8):
+            recovered = undistort_points(distorted, K, dist, num_iters=num_iters)
+            residuals[num_iters] = (recovered - points).abs().max()
+
+        self.assert_close(residuals[5], residuals[7])
+        self.assert_close(residuals[6], residuals[8])
+        assert residuals[6] > residuals[5] > 1
 
     def test_opencv_five_coeff(self, device, dtype):
         # Test using 5 distortion coefficients


### PR DESCRIPTION
Related to #4285

## What does this pull request do?

Adds a convention regression test for the out-of-radius behavior reported in #4285. The test round-trips the maintainer-verified float64 probe through `distort_points` and `undistort_points` and records the fixed-point iteration's two-cycle: iterations 5 and 7 have matching residuals, iterations 6 and 8 have matching residuals, and the even branch is larger than the odd branch while both remain invalid.

No absolute residual value is pinned, and there is no change to `undistort_points`, `undistort_image`, their public behavior, or documentation.

## Related issue or discussion

Related to #4285

## What did you check?

```text
$ pixi run test-module tests/geometry/calibration/test_undistort.py::TestUndistortPoints::test_convention_out_of_radius_fixed_point_is_a_two_cycle_4285 --device=cpu --dtype=float64
$ pixi run test-module tests/geometry/calibration/test_undistort.py --device=cpu --dtype=float64
```

The focused regression test and the full calibration undistortion test module both passed on CPU float64.

## How did AI help?

AI was used to inspect the relevant implementation and test conventions, add the focused regression test, run the requested checks, and inspect the final diff.

Posted on behalf of [@ducha-aiki](https://github.com/ducha-aiki) by Codex (gpt-6-astra).
