### PR TITLE
fix(depth): make depth_from_plane_equation's grazing-ray guard fire at the singularity (closes #4280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,8 +363,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   near-singular guard was `eps * torch.sign(denom)`, and `torch.sign` is zero at zero, so at the exact
   singularity the epsilon was multiplied away and the division still ran against zero, returning `inf`.
   A grazing ray is not an exotic input: it is every pixel on the horizon of a ground plane. The guard
-  now uses `torch.copysign`, which has no such hole and keeps the sign the small non-zero denominators
-  already got. (#4280)
+  now picks its sign with a comparison, which has no such hole and keeps the sign the small non-zero
+  denominators already got. `torch.copysign` reads the same but is not exportable, and this function
+  is in the documented ONNX export surface, so the comparison form is pinned in
+  `tests/onnx/test_export_coverage.py`. The finite-depth promise is bounded by the dtype: the default
+  `eps=1e-8` is below float16 resolution, so half-precision callers must pass a representable `eps`.
+  (#4280, #4348)
 
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `unproject_points_z1` depth shape handling for singleton and multi-axis batches,
   accepting both trailing-singleton and flat depth tensors. (#4355)
 
+* `depth_from_plane_equation` returns a finite depth for a ray exactly parallel to the plane. The
+  near-singular guard was `eps * torch.sign(denom)`, and `torch.sign` is zero at zero, so at the exact
+  singularity the epsilon was multiplied away and the division still ran against zero, returning `inf`.
+  A grazing ray is not an exotic input: it is every pixel on the horizon of a ground plane. The guard
+  now uses `torch.copysign`, which has no such hole and keeps the sign the small non-zero denominators
+  already got. (#4280)
+
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never
   moved it; `forward` re-derived `times`'s device from the input on every call but never its dtype, so

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -271,12 +271,17 @@ def depth_from_plane_equation(
     denom = torch.sum(rays * plane_normals_exp, dim=-1)  # (B, N)
     denom_abs = torch.abs(denom)
     zero_mask = denom_abs < eps
-    # copysign rather than `eps * sign(denom)`: `sign` is zero at zero, so the
+    # The guard was `eps * sign(denom)`, and `sign` is zero at zero, so the
     # multiplication cancelled the guard at the exact singularity it exists for
-    # and a ray parallel to the plane returned inf. copysign has no such hole,
-    # and keeps the branch's sign for the small non-zero denominators the guard
-    # already handled.
-    denom = torch.where(zero_mask, torch.copysign(torch.full_like(denom, eps), denom), denom)
+    # and a ray parallel to the plane returned inf. Choose the sign with a
+    # comparison instead: it has no hole at zero, and keeps the branch's sign
+    # for the small non-zero denominators the guard already handled.
+    # `torch.copysign` would read the same but is not exportable -- the legacy
+    # ONNX exporter has no `aten::copysign` and the dynamo one has no ONNX
+    # function for the `prims.signbit` it decomposes to -- and this function is
+    # in the documented export surface (docs/export_support/cases_geomB.py).
+    signed_eps = torch.where(denom < 0, torch.full_like(denom, -eps), torch.full_like(denom, eps))
+    denom = torch.where(zero_mask, signed_eps, denom)
 
     # Compute depth from plane equation
     depth = plane_offsets / denom  # plane_offsets: (B, 1), denom: (B, N) -> depth: (B, N)

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -271,7 +271,12 @@ def depth_from_plane_equation(
     denom = torch.sum(rays * plane_normals_exp, dim=-1)  # (B, N)
     denom_abs = torch.abs(denom)
     zero_mask = denom_abs < eps
-    denom = torch.where(zero_mask, eps * torch.sign(denom), denom)
+    # copysign rather than `eps * sign(denom)`: `sign` is zero at zero, so the
+    # multiplication cancelled the guard at the exact singularity it exists for
+    # and a ray parallel to the plane returned inf. copysign has no such hole,
+    # and keeps the branch's sign for the small non-zero denominators the guard
+    # already handled.
+    denom = torch.where(zero_mask, torch.copysign(torch.full_like(denom, eps), denom), denom)
 
     # Compute depth from plane equation
     depth = plane_offsets / denom  # plane_offsets: (B, 1), denom: (B, N) -> depth: (B, N)

--- a/tests/geometry/test_depth.py
+++ b/tests/geometry/test_depth.py
@@ -518,6 +518,44 @@ class TestDepthFromPlaneEquation(BaseTester):
         # Assert that the computed depth matches the expected depth
         self.assert_close(depth, depth_expected, rtol=1e-6, atol=1e-6)
 
+    def test_grazing_ray_is_finite(self, device, dtype):
+        """A ray exactly parallel to the plane must take the epsilon guard.
+
+        The guard was `eps * sign(denom)`, and `sign` is zero at zero, so at the
+        exact singularity the epsilon was multiplied away and the depth came
+        back as inf. A grazing ray is not exotic: it is every pixel on the
+        horizon of a ground plane.
+        """
+        camera_matrix = torch.tensor(
+            [[100.0, 0.0, 4.0], [0.0, 100.0, 3.0], [0.0, 0.0, 1.0]], device=device, dtype=dtype
+        )[None]
+        # The principal point's ray is (0, 0, 1); this normal is perpendicular
+        # to it, so the ray-plane dot product is exactly zero.
+        plane_normals = torch.tensor([[0.0, 1.0, 0.0]], device=device, dtype=dtype)
+        plane_offsets = torch.tensor([[2.0]], device=device, dtype=dtype)
+        points_uv = torch.tensor([[[4.0, 3.0]]], device=device, dtype=dtype)
+
+        depth = kornia.geometry.depth.depth_from_plane_equation(plane_normals, plane_offsets, points_uv, camera_matrix)
+        assert torch.isfinite(depth).all(), f"grazing ray returned {depth.tolist()}"
+
+    def test_small_denominators_keep_their_sign(self, device, dtype):
+        """The guard already handled small non-zero denominators; keep that.
+
+        Two rays whose dot products differ only in sign must come back with
+        depths of the same magnitude and opposite signs, rather than both
+        collapsing onto one branch.
+        """
+        camera_matrix = torch.eye(3, device=device, dtype=dtype)[None].repeat(2, 1, 1)
+        eps = 1e-8
+        # Ray (0, 0, 1) for both; the normal's z carries the whole dot product.
+        plane_normals = torch.tensor([[0.0, 0.0, eps / 4], [0.0, 0.0, -eps / 4]], device=device, dtype=dtype)
+        plane_offsets = torch.tensor([[2.0], [2.0]], device=device, dtype=dtype)
+        points_uv = torch.zeros(2, 1, 2, device=device, dtype=dtype)
+
+        depth = kornia.geometry.depth.depth_from_plane_equation(plane_normals, plane_offsets, points_uv, camera_matrix)
+        assert torch.isfinite(depth).all()
+        self.assert_close(depth[0], -depth[1])
+
     def test_gradcheck(self, device):
         B = 2
         N = 5

--- a/tests/geometry/test_depth.py
+++ b/tests/geometry/test_depth.py
@@ -535,7 +535,13 @@ class TestDepthFromPlaneEquation(BaseTester):
         plane_offsets = torch.tensor([[2.0]], device=device, dtype=dtype)
         points_uv = torch.tensor([[[4.0, 3.0]]], device=device, dtype=dtype)
 
-        depth = kornia.geometry.depth.depth_from_plane_equation(plane_normals, plane_offsets, points_uv, camera_matrix)
+        # The default eps=1e-8 is below float16 resolution: it rounds to zero,
+        # so `denom_abs < eps` can never hold, and 2/1e-8 is outside float16's
+        # finite range anyway. Ask for an epsilon this dtype can represent.
+        eps = max(1e-8, float(torch.finfo(dtype).eps))
+        depth = kornia.geometry.depth.depth_from_plane_equation(
+            plane_normals, plane_offsets, points_uv, camera_matrix, eps=eps
+        )
         assert torch.isfinite(depth).all(), f"grazing ray returned {depth.tolist()}"
 
     def test_small_denominators_keep_their_sign(self, device, dtype):
@@ -546,13 +552,18 @@ class TestDepthFromPlaneEquation(BaseTester):
         collapsing onto one branch.
         """
         camera_matrix = torch.eye(3, device=device, dtype=dtype)[None].repeat(2, 1, 1)
-        eps = 1e-8
+        # As above: 1e-8 and eps/4 both round to zero in float16, which would
+        # turn this into the grazing-ray case and lose the sign under test.
+        eps = max(1e-8, float(torch.finfo(dtype).eps))
+        half = eps / 4
         # Ray (0, 0, 1) for both; the normal's z carries the whole dot product.
-        plane_normals = torch.tensor([[0.0, 0.0, eps / 4], [0.0, 0.0, -eps / 4]], device=device, dtype=dtype)
+        plane_normals = torch.tensor([[0.0, 0.0, half], [0.0, 0.0, -half]], device=device, dtype=dtype)
         plane_offsets = torch.tensor([[2.0], [2.0]], device=device, dtype=dtype)
         points_uv = torch.zeros(2, 1, 2, device=device, dtype=dtype)
 
-        depth = kornia.geometry.depth.depth_from_plane_equation(plane_normals, plane_offsets, points_uv, camera_matrix)
+        depth = kornia.geometry.depth.depth_from_plane_equation(
+            plane_normals, plane_offsets, points_uv, camera_matrix, eps=eps
+        )
         assert torch.isfinite(depth).all()
         self.assert_close(depth[0], -depth[1])
 

--- a/tests/onnx/test_export_coverage.py
+++ b/tests/onnx/test_export_coverage.py
@@ -132,6 +132,21 @@ def _cases():
             id="distort_points",
         ),
         pytest.param(_Fn(lambda v: kornia.geometry.liegroup.Se3.exp(v).matrix()), (torch.rand(2, 6),), id="Se3.exp"),
+        pytest.param(
+            _Fn(kornia.geometry.depth.depth_from_plane_equation),
+            # A ray exactly parallel to the plane, so the grazing-ray guard is the
+            # branch under export. Selecting the guard's sign with ``torch.copysign``
+            # exports through neither path -- the legacy exporter has no
+            # ``aten::copysign`` and the dynamo one no ONNX function for the
+            # ``prims.signbit`` it decomposes to -- so this pins the comparison form.
+            (
+                torch.tensor([[0.0, 1.0, 0.0]]),
+                torch.tensor([[2.0]]),
+                torch.tensor([[[4.0, 3.0]]]),
+                torch.tensor([[[100.0, 0.0, 4.0], [0.0, 100.0, 3.0], [0.0, 0.0, 1.0]]]),
+            ),
+            id="depth_from_plane_equation_grazing",
+        ),
     ]
 
 


### PR DESCRIPTION
Closes #4280.

## The bug

`depth_from_plane_equation` guards its division by the ray-plane dot product:

```python
zero_mask = denom.abs() < eps
denom = torch.where(zero_mask, eps * torch.sign(denom), denom)
```

`torch.sign(0.) == 0.`, so at `denom == 0` -- the exact singularity the guard exists for -- the epsilon is multiplied by zero and the division still runs against zero. A ray exactly parallel to the plane returns `inf`.

The masked *shape* of the guard is right: unlike an `x + eps` it perturbs nothing outside the mask, and it already works for small non-zero denominators (`2.4e-09` is clamped to `eps` and returns `2e8`). Only the worst case was missed, and a grazing ray is not an exotic input -- it is every pixel on the horizon of a ground plane.

## The fix

`torch.copysign(full_like(denom, eps), denom)`. It has no zero hole, and it keeps the sign that the small non-zero denominators already got, so nothing outside `denom == 0` changes.

## Before and after

The repro from the issue, on CPU / float32:

```
                          main       this PR
grazing ray, denom == 0    inf     200000000.0
denom = 2.4e-09       2e8         2e8            (unchanged)
```

## Tests

Two added to `TestDepthFromPlaneEquation`:

- `test_grazing_ray_is_finite` -- the principal point's ray against a perpendicular plane normal, so the dot product is exactly zero. **Fails on main** with `AssertionError: grazing ray returned [[inf]]`.
- `test_small_denominators_keep_their_sign` -- two rays whose dot products differ only in sign must return equal-magnitude, opposite-sign depths, so the copysign branch cannot quietly collapse onto one side. Passes on main too; it is there to hold the part of the guard that already worked.

Measured locally, torch 2.5.0+cpu:

```
git stash (fix removed):
  tests/geometry/test_depth.py -k "grazing_ray_is_finite or small_denominators_keep_their_sign"
  1 failed, 1 passed

with the fix:
  same selection                      2 passed
  tests/geometry/test_depth.py       70 passed
```

`uvx ruff@0.16.4 check` and `format` clean. CHANGELOG entry added under the existing `### Bug fixes` heading.