### PR TITLE
fix(camera): clone extrinsics in PinholeCamera.scale (closes #4264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,6 +436,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   step: a rejected entry is moved aside, the next source is tried, and the discarded source is
   re-fetched once. Without `validate` the behaviour is unchanged. (#4309, #4332)
 
+* `PinholeCamera.scale` no longer shares its `extrinsics` tensor with the source camera. The
+  intrinsics were cloned, the extrinsics were handed to the new object by reference, and the
+  constructor stores what it is given, so `scaled.tx = 7` moved the camera `scale()` was called on.
+  The returned camera's numbers are unchanged. (#4264, #4349)
+
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never
   moved it; `forward` re-derived `times`'s device from the input on every call but never its dtype, so

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -49,14 +49,16 @@ class PinholeCamera:
           :func:`~kornia.geometry.camera.perspective.unproject_points` and the ``normalize_points`` flags of
           :func:`~kornia.geometry.depth.depth_to_3d` and :func:`~kornia.geometry.depth.depth_to_3d_v2` read it
           as the Euclidean ray length instead, so the unprojected point has that norm rather than that ``z``.
-        - the class stores the tensors it is constructed from instead of copying them: :meth:`scale` returns a
-          new camera that **shares** ``extrinsics`` with the source, and :meth:`scale_` and the ``tx`` / ``ty``
-          / ``tz`` setters write into the caller's tensors. :meth:`clone` is the only deep copy.
+        - the class stores the tensors it is constructed from instead of copying them, so :meth:`scale_` and
+          the ``tx`` / ``ty`` / ``tz`` setters write into the caller's tensors. :meth:`scale` is the exception:
+          it returns a new camera that owns both its ``intrinsics`` and its ``extrinsics``. :meth:`clone` is
+          the deep copy of an existing camera.
 
     .. warning::
         :meth:`scale` and :meth:`scale_` rescale the principal point as ``cx' = s * cx`` — the half-pixel rule —
         which disagrees with the integer pixel centres above; it is tracked as a coordinated repair in
-        `#4263 <https://github.com/kornia/kornia/issues/4263>`_. The shared storage is
+        `#4263 <https://github.com/kornia/kornia/issues/4263>`_. The write-through to the caller's tensors
+        that remains on :meth:`scale_` and the setters is
         `#4264 <https://github.com/kornia/kornia/issues/4264>`_, the in-place :meth:`scale_` failure on an
         integer ``height`` / ``width`` with a floating-point scale factor
         `#4265 <https://github.com/kornia/kornia/issues/4265>`_, the shape
@@ -321,16 +323,15 @@ class PinholeCamera:
         Convention:
             - returns a **new** camera whose focal lengths, principal point and image size are multiplied by
               ``scale_factor``: ``fx' = s * fx`` and ``cx' = s * cx``, the half-pixel rule.
-            - the new camera **shares** its ``extrinsics`` tensor with the source, so writing ``tx`` / ``ty`` /
-              ``tz`` on either camera moves both; the intrinsics are cloned. :meth:`clone` is the deep copy.
+            - the new camera owns its ``intrinsics`` and its ``extrinsics``: both are cloned, so writing
+              ``tx`` / ``ty`` / ``tz`` on the returned camera leaves the source where it was.
             - with a floating-point ``scale_factor``, an integer ``height`` / ``width`` is promoted to floating
               point, unlike :meth:`scale_`. An integer factor preserves the integer image-size dtype.
 
         .. warning::
             The ``cx' = s * cx`` rule disagrees with the integer pixel centres the rest of the library
             enumerates; it is tracked as a coordinated repair in
-            `#4263 <https://github.com/kornia/kornia/issues/4263>`_. The shared ``extrinsics`` are
-            `#4264 <https://github.com/kornia/kornia/issues/4264>`_.
+            `#4263 <https://github.com/kornia/kornia/issues/4263>`_.
 
         Args:
             scale_factor: a torch.Tensor with the scale factor. It has
@@ -350,7 +351,11 @@ class PinholeCamera:
         # scale the image height/width
         height: torch.Tensor = scale_factor * self.height.clone()
         width: torch.Tensor = scale_factor * self.width.clone()
-        return PinholeCamera(intrinsics, self.extrinsics, height, width)
+        # The extrinsics are cloned for the same reason the intrinsics are: the
+        # constructor stores what it is given by reference, so handing over
+        # self.extrinsics would let the returned camera's tx/ty/tz setters and
+        # scale_ write into the source camera.
+        return PinholeCamera(intrinsics, self.extrinsics.clone(), height, width)
 
     def scale_(self, scale_factor: Union[float, torch.Tensor]) -> "PinholeCamera":
         r"""Scale the pinhole model in-place.

--- a/tests/geometry/camera/test_pinhole.py
+++ b/tests/geometry/camera/test_pinhole.py
@@ -573,6 +573,31 @@ class TestPinholeCamera(BaseTester):
         self.assert_close(pinhole_scale.height, pinhole.height * scale_val, atol=1e-4, rtol=1e-4)
         self.assert_close(pinhole_scale.width, pinhole.width * scale_val, atol=1e-4, rtol=1e-4)
 
+    def test_pinhole_camera_scale_does_not_alias_the_source(self, device, dtype):
+        """scale() returns a new camera, so writing to it must not reach the source.
+
+        The intrinsics were already cloned; the extrinsics were handed over by
+        reference, and the constructor stores what it is given. Setting tx on
+        the scaled camera therefore moved the source camera too.
+        """
+        batch_size = 2
+        height, width = 4, 6
+        intrinsics = self._create_intrinsics(batch_size, 1, 2, width / 2, height / 2, device=device, dtype=dtype)
+        extrinsics = self._create_extrinsics(batch_size, 1, 2, 3, device=device, dtype=dtype)
+        height_t = torch.ones(batch_size, device=device, dtype=dtype) * height
+        width_t = torch.ones(batch_size, device=device, dtype=dtype) * width
+        scale_factor = torch.ones(batch_size, device=device, dtype=dtype) * 2.0
+
+        pinhole = kornia.geometry.camera.PinholeCamera(intrinsics.clone(), extrinsics.clone(), height_t, width_t)
+        tx_before = pinhole.tx.clone()
+
+        pinhole_scale = pinhole.scale(scale_factor)
+        assert pinhole_scale.extrinsics is not pinhole.extrinsics
+        assert pinhole_scale.extrinsics.data_ptr() != pinhole.extrinsics.data_ptr()
+
+        pinhole_scale.tx = 7.0
+        self.assert_close(pinhole.tx, tx_before)
+
     def test_pinhole_camera_scale_inplace(self, device, dtype):
         batch_size = 2
         height, width = 4, 6
@@ -677,7 +702,8 @@ class TestPinholeCamera(BaseTester):
     def test_convention_clone_is_a_deep_copy(self, device, dtype):
         # Convention pin: clone() is the ONLY deep copy on PinholeCamera -- a new
         # object, new intrinsics and extrinsics tensors with different storage, and mutating the clone leaves the
-        # source untouched. Contrast scale(), which hands the SAME extrinsics to the new camera (kornia#4264).
+        # source untouched. scale() also returns a camera with its own tensors; scale_() and the tx / ty / tz
+        # setters are the ones that still write through to the caller (kornia#4264).
         # Snippet used to generate expected: build a tx = 2 camera, clone it, set clone.tx = 9; executed
         # 2026-09-05 (torch 2.14.0, every dtype) -> source tx [2.0], clone tx [9.0].
         cam = kornia.geometry.camera.PinholeCamera(
@@ -732,31 +758,19 @@ class TestPinholeCamera(BaseTester):
         self.assert_close(scaled.cy, torch.tensor([1.5], device=device, dtype=dtype), atol=0.0, rtol=0.0)
         self.assert_close(scaled.fx, torch.tensor([50.0], device=device, dtype=dtype), atol=0.0, rtol=0.0)
 
-    def test_wart_scale_shares_extrinsics_with_the_source_4264(self, device, dtype):
-        # Wart pin for kornia#4264: the class stores the tensors it is constructed from
-        # instead of copying them, so every mutating accessor writes into the CALLER's tensors, and scale()
-        # clones the intrinsics but passes ``self.extrinsics`` straight through, so the returned camera aliases
-        # the source's pose -- writing ``scaled.tx = 7`` (the tx setter writes into extrinsics) changes the
-        # SOURCE camera too. The second half below pins the three other legs of the same sentence: the
-        # constructor keeps the caller's ``intrinsics`` / ``extrinsics`` objects, the ``tx`` setter writes into
-        # the caller's extrinsics, and the in-place ``scale_`` rewrites the caller's intrinsics and image size.
-        # Snippet used to generate expected: scaled.extrinsics is cam.extrinsics -> True; after scaled.tx = 7 the
-        # source tx reads [7.0]; cam.intrinsics is K and cam.extrinsics is E -> True; after ``cam.tx = 5.0``
-        # E[0, 0, 3] reads 5.0; after ``cam.scale_(0.5)`` K[0, 0, 2] reads 2.0 (from 4.0), K[0, 0, 0] reads 50.0
-        # and the caller's height/width read [3.0] / [4.0] (from [6.0] / [8.0]); executed 2026-09-05
-        # (torch 2.14.0, cpu and mps, every dtype).
-        # Pins the CURRENT behavior; NOT a contract; delete when #4264 is repaired.
-        cam = kornia.geometry.camera.PinholeCamera(
-            _k44(device, dtype),
-            _e44(device, dtype, tx=1.0),
-            torch.tensor([6.0], device=device, dtype=dtype),
-            torch.tensor([8.0], device=device, dtype=dtype),
-        )
-        scaled = cam.scale(torch.tensor([2.0], device=device, dtype=dtype))
-        assert scaled.extrinsics is cam.extrinsics
-        assert scaled.intrinsics is not cam.intrinsics
-        scaled.tx = torch.tensor([7.0], device=device, dtype=dtype)
-        self.assert_close(cam.tx, torch.tensor([7.0], device=device, dtype=dtype), atol=0.0, rtol=0.0)
+    def test_wart_constructor_and_scale_inplace_write_through_to_the_caller_4264(self, device, dtype):
+        # Wart pin for kornia#4264: the class stores the tensors it is constructed from instead of copying
+        # them, so every mutating accessor writes into the CALLER's tensors -- the constructor keeps the
+        # caller's ``intrinsics`` / ``extrinsics`` objects, the ``tx`` setter writes into the caller's
+        # extrinsics, and the in-place ``scale_`` rewrites the caller's intrinsics and image size.
+        # The fourth leg of #4264 -- ``scale()`` handing ``self.extrinsics`` to the new camera by reference --
+        # is repaired, and is pinned the other way up by
+        # ``test_pinhole_camera_scale_does_not_alias_the_source``; it is deliberately not asserted here.
+        # Snippet used to generate expected: cam.intrinsics is K and cam.extrinsics is E -> True; after
+        # ``cam.tx = 5.0`` E[0, 0, 3] reads 5.0; after ``cam.scale_(0.5)`` K[0, 0, 2] reads 2.0 (from 4.0),
+        # K[0, 0, 0] reads 50.0 and the caller's height/width read [3.0] / [4.0] (from [6.0] / [8.0]);
+        # executed 2026-09-05 (torch 2.14.0, cpu and mps, every dtype).
+        # Pins the CURRENT behavior; NOT a contract; delete when the rest of #4264 is repaired.
         # The constructor stores, rather than copies, all four arguments.
         K = _k44(device, dtype)
         E = _e44(device, dtype, tx=1.0)


### PR DESCRIPTION
Closes #4264 -- the half the issue scopes as "a focused fix that is welcome as a PR".

## The bug

`scale()` clones the intrinsics and then hands `self.extrinsics` to the new camera by reference:

```python
return PinholeCamera(intrinsics, self.extrinsics, height, width)
```

The constructor stores what it is given, so the returned camera shares translation state with the source:

```
scaled is cam                       : False
scaled.extrinsics is cam.extrinsics : True     <- the bug
intrinsics share storage            : False
source cam.tx after `scaled.tx = 7` : 7.0      <- the source moved
```

## The fix

One `.clone()`, for the same reason the intrinsics already have one. The returned camera's numbers are byte-identical to today's, so nothing downstream changes.

## Scope

Only `scale()`. The issue's second half -- the constructor storing the caller's `K` / `E` by reference, so `scale_()` and the `tx` / `ty` / `tz` setters write through them -- is a change to the aliasing contract of every `PinholeCamera(...)` call site, and the issue puts that choice in the coordinated Repair and Deprecation window. Batch 5 documents it as it is. Untouched here.

## Tests

`test_pinhole_camera_scale_does_not_alias_the_source` asserts the two tensors are distinct objects with distinct storage, then mutates the scaled camera and asserts the source is unchanged.

Measured locally, torch 2.5.0+cpu:

```
without the fix:  1 failed   (assert on the source camera's tx)
with the fix:     tests/geometry/camera/test_pinhole.py -k scale   3 passed
                  tests/geometry/camera/test_pinhole.py           29 passed, 1 skipped
```

`uvx ruff@0.16.4 check` and `format` clean. CHANGELOG entry under `### Bug fixes`.