### PR TITLE
fix(geometry): guard denom == 0 in depth_from_plane_equation to prevent infinite depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `depth_from_plane_equation` now guards rays perpendicular to the plane normal (`denom == 0`). The
+  previous guard multiplied `eps` by `torch.sign(denom)`, which evaluates to `0.0` at `denom == 0` and
+  returned `inf`. The guard now uses a zero-safe sign fallback so grazing rays are clamped to a finite
+  depth. (#4280)
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never
   moved it; `forward` re-derived `times`'s device from the input on every call but never its dtype, so

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -271,7 +271,8 @@ def depth_from_plane_equation(
     denom = torch.sum(rays * plane_normals_exp, dim=-1)  # (B, N)
     denom_abs = torch.abs(denom)
     zero_mask = denom_abs < eps
-    denom = torch.where(zero_mask, eps * torch.sign(denom), denom)
+    sign = torch.where(denom < 0, denom.new_tensor(-1.0), denom.new_tensor(1.0))
+    denom = torch.where(zero_mask, eps * sign, denom)
 
     # Compute depth from plane equation
     depth = plane_offsets / denom  # plane_offsets: (B, 1), denom: (B, N) -> depth: (B, N)

--- a/tests/geometry/test_depth.py
+++ b/tests/geometry/test_depth.py
@@ -534,3 +534,13 @@ class TestDepthFromPlaneEquation(BaseTester):
             eps=1e-6,
             atol=1e-4,
         )
+
+    def test_grazing_ray_singularity(self, device, dtype):
+        K = torch.tensor([[100.0, 0.0, 4.0], [0.0, 100.0, 3.0], [0.0, 0.0, 1.0]], device=device, dtype=dtype)[None]
+        px = torch.tensor([[[4.0, 3.0]]], device=device, dtype=dtype)
+        plane_normals = torch.tensor([[0.0, 1.0, 0.0]], device=device, dtype=dtype)
+        plane_offsets = torch.tensor([[2.0]], device=device, dtype=dtype)
+        depth = kornia.geometry.depth.depth_from_plane_equation(plane_normals, plane_offsets, px, K, eps=1e-8)
+        assert torch.isfinite(depth).all()
+        expected = plane_offsets.repeat(1, 1) / 1e-8
+        self.assert_close(depth, expected, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## What does this pull request do?

\depth_from_plane_equation\ guarded its division by the ray-plane dot product with:
\\\python
denom_abs = torch.abs(denom)
zero_mask = denom_abs < eps
denom = torch.where(zero_mask, eps * torch.sign(denom), denom)
\\\
When \denom == 0\ (for instance, a grazing ray perpendicular to the plane normal), \	orch.sign(0.) == 0.\, multiplying \ps\ by zero and causing the guard to be a no-op. The division then produced \inf\.

This change uses a zero-safe fallback for \sign\ so that \denom == 0\ is clamped to \ps\ (or \-eps\ if negative), matching other values within \(-eps, eps)\ and ensuring the computed depth remains finite.

## Related issue or discussion

Closes #4280

## What did you check?

- Added a regression test \	est_grazing_ray_singularity\ in \	ests/geometry/test_depth.py\ checking that grazing rays with \denom == 0\ produce finite depth values matching \plane_offsets / eps\.
- Ran \pytest tests/geometry/test_depth.py::TestDepthFromPlaneEquation --device=cpu --dtype=float32,float64\ (all 19 tests pass).
- Ran \uff check\ on modified files.