### PR TITLE
fix(geometry): handle z1 unprojection depth by tensor rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,7 +357,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * Fixed `unproject_points_z1` depth shape handling for singleton and multi-axis batches,
-  accepting both trailing-singleton and flat depth tensors. (#4282)
+  accepting both trailing-singleton and flat depth tensors. (#4355)
 
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed `unproject_points_z1` depth shape handling for singleton and multi-axis batches,
+  accepting both trailing-singleton and flat depth tensors. (#4282)
+
 * `RenderingDeFMO` (used by `DeFMO`) no longer crashes on a half-precision forward pass. Its rendering
   time-steps (`times`) were a plain Python attribute, not a registered buffer, so `nn.Module.to()` never
   moved it; `forward` re-derived `times`'s device from the input on every call but never its dtype, so

--- a/kornia/geometry/camera/projection_z1.py
+++ b/kornia/geometry/camera/projection_z1.py
@@ -68,7 +68,8 @@ def unproject_points_z1(
 
     Args:
         points_in_cam_canonical: torch.Tensor representing the points to unproject with shape (..., 2).
-        extension: torch.Tensor representing the extension (depth) of the points to unproject with shape (..., 1).
+        extension: torch.Tensor representing the extension (depth) of the points to unproject with shape
+            (..., 1) or (...), matching the points' leading dimensions. Defaults to unit depth.
 
     Returns:
         torch.Tensor representing the unprojected points with shape (..., 3).
@@ -88,7 +89,7 @@ def unproject_points_z1(
             device=points_in_cam_canonical.device,
             dtype=points_in_cam_canonical.dtype,
         )  # (..., 1)
-    elif extension.shape[0] > 1:
+    elif extension.ndim == points_in_cam_canonical.ndim - 1:
         extension = extension[..., None]  # (..., 1)
 
     return torch.cat([points_in_cam_canonical * extension, extension], dim=-1)

--- a/tests/geometry/camera/test_projections.py
+++ b/tests/geometry/camera/test_projections.py
@@ -100,6 +100,26 @@ class TestProjectionZ1(BaseTester):
         expected = torch.tensor([[2.0, 4.0, 2.0], [9.0, 12.0, 3.0]], device=device, dtype=dtype)
         self.assert_close(unproject_points_z1(points, extension), expected)
 
+    @pytest.mark.parametrize("batch_shape", [(), (0,), (1,), (2,), (1, 2), (2, 3)])
+    @pytest.mark.parametrize("column_depth", [False, True])
+    def test_unproject_depth_shapes_4282(self, device, dtype, batch_shape, column_depth):
+        points = torch.tensor([1.0, 2.0], device=device, dtype=dtype).expand(batch_shape + (2,))
+        depth_shape = batch_shape + (1,) if column_depth else batch_shape
+        depth = torch.full(depth_shape, 3.0, device=device, dtype=dtype)
+        expected = torch.tensor([3.0, 6.0, 3.0], device=device, dtype=dtype).expand(batch_shape + (3,))
+        actual = unproject_points_z1(points, depth)
+        self.assert_close(actual, expected)
+        self.assert_close(project_points_z1(actual), points)
+        self.assert_close(torch.jit.script(unproject_points_z1)(points, depth), expected)
+
+    @pytest.mark.parametrize("column_depth", [False, True])
+    def test_unproject_batched_depth_gradcheck(self, device, column_depth):
+        points = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=device, dtype=torch.float64)
+        depth = torch.tensor([2.0, 3.0], device=device, dtype=torch.float64)
+        if column_depth:
+            depth = depth.unsqueeze(-1)
+        self.gradcheck(unproject_points_z1, (points, depth))
+
     def test_dx_proj_x(self, device, dtype):
         points = torch.tensor([1.0, 2.0, 3.0], device=device, dtype=dtype)
         expected = torch.tensor(


### PR DESCRIPTION
## What does this pull request do?

`unproject_points_z1` uses the first depth dimension to decide whether to add a trailing axis. This rejects the documented `(N, 1)` depth for `N > 1`, while flat depth fails for singleton batches.

Compare tensor ranks instead, adding an axis only when depth has one fewer dimension than the points. Document both accepted layouts and add regression tests for unbatched, empty, singleton and multi-axis inputs, projection round trips, TorchScript and gradients.

## Related issue or discussion

Fixes #4282.

Related: #4294 documents the existing bug but does not fix it. Its temporary failure assertion for #4282 and the corresponding warning should not survive this fix; whichever PR lands second will need to account for that overlap.

## What did you check?

Local environment: macOS arm64, Python 3.11.9, PyTorch 2.14.0. Commands ran in an isolated virtual environment with an editable install of this checkout.

- Before the fix, the new regressions produced 13 failures and 13 passes on CPU float32/float64.
- `python -m pytest tests/geometry/camera --device=cpu --dtype=float32,float64 -q --tb=short`: 235 passed, 1 skipped.
- `python -m pytest --doctest-modules kornia/geometry/camera/projection_z1.py -q`: 3 passed.
- `python -m pre_commit run --all-files`: all hooks passed.
- `ty check kornia --python <venv>/bin/python`: no errors; one deprecation warning in unchanged `lightglue.py`.
- Manual `torch.compile` probe with `backend="aot_eager", fullgraph=True`: all 12 shape/layout combinations matched eager output, with the compilation cache reset between cases. A single-cache run hit Dynamo's eight-recompilation limit.
- `git diff --check`: passed.

CUDA, MPS and Inductor execution were not tested locally.

## How did AI help?

AI assisted with investigating the issue and related PRs, implementing the fix and regression tests, and running the local checks above. Validation included failing tests on the original implementation, explicit numerical expectations and projection round trips, gradient checks, and a final diff review.
