### PR TITLE
fix(geometry): use math.pi in rad2deg/deg2rad to preserve full precision

### DIFF
--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -24,7 +24,6 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 
-from kornia.constants import pi
 from kornia.core._compat import deprecated
 from kornia.core.check import KORNIA_CHECK, KORNIA_CHECK_SHAPE
 from kornia.core.utils import _inverse_3x3_closed_form, _torch_inverse_cast, is_compiling

--- a/kornia/geometry/conversions.py
+++ b/kornia/geometry/conversions.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from typing import Optional
 
@@ -113,7 +114,7 @@ def rad2deg(tensor: torch.Tensor) -> torch.Tensor:
     if not isinstance(tensor, torch.Tensor):
         raise TypeError(f"Input type is not a torch.Tensor. Got {type(tensor)}")
 
-    return 180.0 * tensor / pi.to(tensor.device).type(tensor.dtype)
+    return 180.0 * tensor / math.pi
 
 
 def deg2rad(tensor: torch.Tensor) -> torch.Tensor:
@@ -146,7 +147,7 @@ def deg2rad(tensor: torch.Tensor) -> torch.Tensor:
     if not isinstance(tensor, torch.Tensor):
         raise TypeError(f"Input type is not a torch.Tensor. Got {type(tensor)}")
 
-    return tensor * pi.to(tensor.device).type(tensor.dtype) / 180.0
+    return tensor * math.pi / 180.0
 
 
 def pol2cart(rho: torch.Tensor, phi: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
fix(geometry): use math.pi in rad2deg/deg2rad to preserve full precision

Fixes #3937

## Problem

`kornia.geometry.conversions.rad2deg` / `deg2rad` convert the float32
constant `pi` to the input tensor's dtype via:

```python
pi.to(tensor.device).type(tensor.dtype)
```

This has two precision bugs:

1. **Integer inputs** — `pi` is truncated to `3` (its float32 value cast to
   `int64`), so results are ~5% off (e.g. `rad2deg([1,2,3])` returns
   `[60,120,180]` instead of `[57.3, 114.6, 171.9]`).
2. **float64 inputs** — the constant is already truncated to float32 precision
   before the division, so ~7 significant digits are silently lost and can
   never be recovered by upcasting.

## Root cause

The constant `180.0` is a Python double and always exact, but `pi` is a
float32 tensor that gets force-cast to the input dtype. Integer casting
truncates to `3`; float64 casting loses the float32→float64 recoverable
precision.

## Fix

Use the built-in `math.pi` (Python double, full precision) for the constant,
and drop the `pi.to(device).type(tensor.dtype)` cast. The constant is now
always exact, independent of input dtype. `180.0` was already a Python
double, so the two are now consistent.

```python
# before
return 180.0 * tensor / pi.to(tensor.device).type(tensor.dtype)
# after
return 180.0 * tensor / math.pi
```

## Verification (Ascend NPU)

- `rad2deg(torch.tensor([1,2,3]))` → `[57.2958, 114.5916, 171.8873]`
  (before: `[60,120,180]`)
- `rad2deg(torch.tensor(math.pi, dtype=torch.float64))` → `180.0` (<1e-10 err)
- Results match NumPy `np.degrees` ground truth; device/dtype placement
  preserved.