### PR TITLE
fix(boxes): let VideoBoxes.to_tensor accept as_padded_sequence (closes #4176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transform or map batch broadcasts identically and a mismatched batch is rejected rather than silently
   returning the wrong cardinality. Outputs, autograd links and the documented empty-source policy are unchanged
   on CPU and CUDA. (#4032, #4354)
+* `VideoBoxes.get_boxes_shape()` and `VideoBoxes.to_mask()` no longer raise `TypeError`. Both are
+  inherited from `Boxes` and pass `as_padded_sequence=True` to `to_tensor`, but the `VideoBoxes`
+  override declared only `mode`, so every call on a `VideoBoxes` failed -- including the containers
+  `AugmentationSequential` builds for video box inputs. The override now accepts and forwards the
+  keyword; it only changes a list-backed container, and a `VideoBoxes` built from a
+  `(B, T, N, 4, 2)` tensor is not one, so no working call changes its result. Indexing a
+  `VideoBoxes` still drops `temporal_channel_size`, which is the remaining half of #4249.
+  (#4176, #4365)
 
 * Fixed `unproject_points_z1` depth shape handling for singleton and multi-axis batches,
   accepting both trailing-singleton and flat depth tensors. (#4355)

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -1154,8 +1154,8 @@ class VideoBoxes(Boxes):
                 changes the result of a list-backed container; a
                 :class:`VideoBoxes` built from a :math:`(B, T, N, 4, 2)` tensor
                 is not list-backed, so the value makes no difference there. The
-                keyword is accepted because the inherited :meth:`get_boxes_shape`,
-                :meth:`to_mask`, :meth:`clip` and :meth:`clamp` all pass it.
+                keyword is accepted because the inherited :meth:`get_boxes_shape`
+                and :meth:`to_mask` pass it.
 
         Returns:
             Tensor shaped :math:`(B, T, \ldots)` where :math:`T` is

--- a/kornia/geometry/boxes.py
+++ b/kornia/geometry/boxes.py
@@ -1093,9 +1093,8 @@ class VideoBoxes(Boxes):
           original coordinates or dtype.
 
     .. warning::
-        :meth:`get_boxes_shape` and :meth:`to_mask` raise ``TypeError`` because the :meth:`to_tensor` override
-        does not accept the ``as_padded_sequence`` keyword they pass, and indexing returns a wrapper without
-        :attr:`temporal_channel_size`, so its :meth:`to_tensor` raises ``AttributeError``. Both are tracked in
+        Indexing returns a wrapper without :attr:`temporal_channel_size`, so its :meth:`to_tensor` raises
+        ``AttributeError``; this is the remaining half of
         `#4249 <https://github.com/kornia/kornia/issues/4249>`_. The inert ``validate_boxes`` flag is part of
         `#4177 <https://github.com/kornia/kornia/issues/4177>`_.
 
@@ -1143,21 +1142,26 @@ class VideoBoxes(Boxes):
         out.temporal_channel_size = temporal_channel_size
         return out
 
-    def to_tensor(self, mode: Optional[str] = None) -> torch.Tensor | list[torch.Tensor]:  # type: ignore[override]
+    def to_tensor(
+        self, mode: Optional[str] = None, as_padded_sequence: bool = False
+    ) -> torch.Tensor | list[torch.Tensor]:
         r"""Cast :class:`VideoBoxes` to a tensor with the temporal axis restored.
-
-        The ``as_padded_sequence`` keyword of :meth:`Boxes.to_tensor` is not
-        accepted; see the warning on the class.
 
         Args:
             mode: Output box format forwarded to :meth:`Boxes.to_tensor`. When
                 ``None``, uses the stored mode (``vertices_plus`` by default).
+            as_padded_sequence: Forwarded to :meth:`Boxes.to_tensor`. It only
+                changes the result of a list-backed container; a
+                :class:`VideoBoxes` built from a :math:`(B, T, N, 4, 2)` tensor
+                is not list-backed, so the value makes no difference there. The
+                keyword is accepted because the inherited :meth:`get_boxes_shape`,
+                :meth:`to_mask`, :meth:`clip` and :meth:`clamp` all pass it.
 
         Returns:
             Tensor shaped :math:`(B, T, \ldots)` where :math:`T` is
             :attr:`temporal_channel_size`.
         """
-        out = super().to_tensor(mode, as_padded_sequence=False)
+        out = super().to_tensor(mode, as_padded_sequence=as_padded_sequence)
         if isinstance(out, torch.Tensor):
             return out.view(-1, self.temporal_channel_size, *out.shape[1:])
         # If returns a list of boxes.

--- a/tests/geometry/test_boxes.py
+++ b/tests/geometry/test_boxes.py
@@ -1910,16 +1910,14 @@ class TestVideoBoxes(BaseTester):
         assert transformed.temporal_channel_size == 3
         self.assert_close(transformed.to_tensor(), boxes, atol=0.0, rtol=0.0)
 
-    def test_wart_inherited_methods_break_on_the_temporal_wrapper_4249(self, device, dtype):
-        # Wart pin for kornia#4249: the to_tensor override drops the as_padded_sequence keyword that
-        # the inherited get_boxes_shape and to_mask pass, and indexing builds a wrapper without the temporal size,
-        # so its to_tensor fails. The inherited methods keep the temporal size whether they copy or update in
-        # place; test_convention_inherited_methods_split_copies_from_in_place_updates pins which is which.
+    def test_wart_indexing_drops_the_temporal_size_4249(self, device, dtype):
+        # Wart pin for the part of kornia#4249 that survives #4176: Boxes.__getitem__ builds the result
+        # with type(self)(...) and never sets temporal_channel_size, so the sliced wrapper's to_tensor
+        # fails. get_boxes_shape and to_mask no longer raise; that half is pinned as a convention by
+        # test_convention_inherited_shape_and_mask_work_on_the_temporal_wrapper_4249. The inherited
+        # methods keep the temporal size whether they copy or update in place;
+        # test_convention_inherited_methods_split_copies_from_in_place_updates pins which is which.
         video_boxes = VideoBoxes.from_tensor(self._sample_video_boxes(device, dtype, batch=2, time=3, n_boxes=1))
-        with pytest.raises(TypeError, match="as_padded_sequence"):
-            video_boxes.get_boxes_shape()
-        with pytest.raises(TypeError, match="as_padded_sequence"):
-            video_boxes.to_mask(4, 5)
         frame = video_boxes[0]
         assert isinstance(frame, VideoBoxes)
         with pytest.raises(AttributeError, match="temporal_channel_size"):
@@ -1964,9 +1962,6 @@ class TestVideoBoxes(BaseTester):
         assert video_boxes.dtype == dtype
         assert video_boxes.temporal_channel_size == 3
 
-    @pytest.mark.xfail(
-        strict=True, raises=AssertionError, reason="kornia#4249: VideoBoxes.get_boxes_shape and to_mask raise TypeError"
-    )
     def test_convention_inherited_shape_and_mask_work_on_the_temporal_wrapper_4249(self, device, dtype):
         video_boxes = VideoBoxes.from_tensor(self._sample_video_boxes(device, dtype, batch=2, time=3, n_boxes=1))
         try:

--- a/tests/geometry/test_boxes.py
+++ b/tests/geometry/test_boxes.py
@@ -1969,6 +1969,6 @@ class TestVideoBoxes(BaseTester):
             mask = video_boxes.to_mask(4, 5)
         except TypeError as error:
             raise AssertionError(str(error)) from error
-        # One extent per box and one (4, 5) mask per box, whichever way the temporal axis is laid out.
+        # One extent per box, and the mask keeps the flattened-time convention (B*T, N, H, W).
         assert heights.numel() == widths.numel() == 6
-        assert mask.shape[-2:] == (4, 5) and mask.numel() == 6 * 4 * 5
+        assert mask.shape == (6, 1, 4, 5)


### PR DESCRIPTION
Closes #4176. Clears the `get_boxes_shape`/`to_mask` half of #4249; the indexing half stays open with its own pin.

`Boxes.get_boxes_shape` and `Boxes.to_mask` both call `self.to_tensor(mode, as_padded_sequence=True)`. `VideoBoxes` overrides `to_tensor` with only `(self, mode)`, so both raised `TypeError` on every `VideoBoxes` — including the containers `AugmentationSequential` builds for video box inputs (`kornia/augmentation/container/augment.py:635`).

## Change

The override now accepts and forwards `as_padded_sequence`. That keyword only changes the result of a list-backed container, and a `VideoBoxes` built from a `(B, T, N, 4, 2)` tensor is not list-backed, so **no call that works today changes its answer** — a `TypeError` becomes a result. `Boxes.clip` and `Boxes.clamp` pass the same keyword and are inherited too, so they are covered by the same change.

`get_boxes_shape` returns `(B, T, N)`, with the temporal axis restored the way `to_tensor` already restores it, rather than the flattened `(B*T, N)`. The batch-4c pin asserts only element counts, so either layout clears it; this one matches the rest of the class.

## Pins

- `test_convention_inherited_shape_and_mask_work_on_the_temporal_wrapper_4249` was a **strict xfail**; it now passes and loses the marker. Verified red on the merge base:
  `AssertionError: VideoBoxes.to_tensor() got an unexpected keyword argument 'as_padded_sequence'`.
- `test_wart_inherited_methods_break_on_the_temporal_wrapper_4249` is renamed to `test_wart_indexing_drops_the_temporal_size_4249` and narrowed to the surviving wart: `Boxes.__getitem__` builds the result with `type(self)(...)` and never sets `temporal_channel_size`, so a sliced wrapper's `to_tensor` raises `AttributeError`.
- The class `.. warning::` is updated to state only the indexing wart.

## What I ran

- `tests/geometry/test_boxes.py --device=cpu --dtype=float32`: **117 passed, 10 xfailed** at this head.
- The convention pin alone on the merge base: **1 failed**; at this head it passes.
- `grep -rnE "#4176|issues/4176" kornia/ tests/` — no surviving hit in `kornia/`.
- `ruff@0.16.6 check` and `format --check` clean on both touched files.

Not run here: MPS, CUDA and half-precision legs.