### PR TITLE
fix(sensors): validate params in CameraModelBase.__init__ (closes #4316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `CameraModelBase.__init__` now validates `params` against the shape it documents, instead of storing
+  whatever it is given. The typed constructors (`PinholeModel`, `BrownConradyModel`, `KannalaBrandtK3`,
+  `Orthographic`) each apply the same two comparisons, so only the direct-construction path -- which is
+  public, and is what the class docstring's own example uses -- was unguarded. A short vector used to
+  construct and then fail with an `IndexError` from inside `AffineTransform.distort`, naming neither
+  `params` nor the camera; a rank-3 `(B, 1, N)` tensor used to construct, project, and silently return a
+  `(1, 1, 2)` result. Both now raise `ValueError` from the constructor. (#4316, #4369)
+
 * `warp_affine`, `warp_perspective` and `remap` crashed on MPS for an empty destination -- a `dsize` with a
   zero dimension, or zero-sized `remap` maps -- with an internal
   `[srcBuf length] > 0 INTERNAL ASSERT FAILED ... Placeholder tensor is empty!` from PyTorch. The MPS backend

--- a/kornia/sensors/camera/camera_model.py
+++ b/kornia/sensors/camera/camera_model.py
@@ -64,6 +64,41 @@ def get_model_from_type(
 CameraDistortionType = Union[AffineTransform, BrownConradyTransform, KannalaBrandtK3Transform]
 CameraProjectionType = Union[Z1Projection, OrthographicProjection]
 
+# The number of parameters each distortion model reads, which is what fixes the
+# trailing dimension of ``params``. The typed constructors below each spell the
+# same number out; this is the one place that maps it to the distortion, so the
+# base class can enforce the shape its own docstring documents.
+_PARAMS_LEN_FOR_DISTORTION: dict[type, int] = {
+    AffineTransform: 4,
+    BrownConradyTransform: 12,
+    KannalaBrandtK3Transform: 8,
+}
+
+
+def _validate_params(distortion: CameraDistortionType, params: torch.Tensor) -> None:
+    """Check ``params`` against the shape :class:`CameraModelBase` documents.
+
+    ``CameraModelBase`` is public and its docstring states a shape, but only the
+    typed subclasses checked it. Constructing the base directly with a short
+    vector deferred the failure to an ``IndexError`` inside the distortion model,
+    naming neither ``params`` nor the camera; a rank-3 ``(B, 1, N)`` tensor --
+    the shape the subclasses reject, because there is no multi-camera form --
+    was accepted and projected to a silently wrong ``(1, 1, 2)`` result.
+
+    Raises:
+        ValueError: if ``params`` is not of shape :math:`(N,)` or :math:`(B, N)`,
+            with ``N`` the length the distortion model reads.
+
+    """
+    if params.ndim not in (1, 2):
+        raise ValueError(f"params must be of rank 1 or 2, of shape (B, N) or (N,); got shape {tuple(params.shape)}")
+    expected = _PARAMS_LEN_FOR_DISTORTION.get(type(distortion))
+    if expected is not None and params.shape[-1] != expected:
+        raise ValueError(
+            f"params must be of shape (B, {expected}) or ({expected},) for "
+            f"{type(distortion).__name__}; got shape {tuple(params.shape)}"
+        )
+
 
 class CameraModelBase:
     r"""Base class to represent camera models based on distortion and projection types.
@@ -78,7 +113,7 @@ class CameraModelBase:
 
     Example:
         >>> params = torch.Tensor([328., 328., 320., 240.])
-        >>> cam = CameraModelBase(BrownConradyTransform(), Z1Projection(), ImageSize(480, 640), params)
+        >>> cam = CameraModelBase(AffineTransform(), Z1Projection(), ImageSize(480, 640), params)
         >>> cam.params
         tensor([328., 328., 320., 240.])
 
@@ -97,12 +132,17 @@ class CameraModelBase:
             distortion: Distortion type
             projection: Projection type
             image_size: Image size
-            params: Camera parameters of shape :math:`(B, 4)`
-                    for PINHOLE Camera, :math:`(B, 12)`
-                    for Brown Conrady, :math:`(B, 8)`
-                    for Kannala Brandt K3.
+            params: Camera parameters of shape :math:`(B, N)` or :math:`(N,)`, with
+                    :math:`N` fixed by ``distortion``: 4 for
+                    :class:`AffineTransform` (pinhole and orthographic), 12 for
+                    :class:`BrownConradyTransform`, 8 for
+                    :class:`KannalaBrandtK3Transform`.
+
+        Raises:
+            ValueError: if ``params`` does not have that shape.
 
         """
+        _validate_params(distortion, params)
         self.distortion = distortion
         self.projection = projection
         self._image_size = image_size
@@ -322,9 +362,9 @@ class Orthographic(CameraModelBase):
             params: Camera parameters of shape :math:`(B, 4)` of the form :math:`(fx, fy, cx, cy)`.
 
         """
-        super().__init__(AffineTransform(), OrthographicProjection(), image_size, params)
         if params.shape[-1] != 4 or len(params.shape) > 2:
             raise ValueError("params must be of shape B, 4 for ORTHOGRAPHIC Camera")
+        super().__init__(AffineTransform(), OrthographicProjection(), image_size, params)
 
 
 CameraModelVariants = Union[PinholeModel, BrownConradyModel, KannalaBrandtK3, Orthographic]

--- a/tests/sensors/camera/test_camera_model.py
+++ b/tests/sensors/camera/test_camera_model.py
@@ -20,7 +20,14 @@ import torch
 
 from kornia.geometry.vector import Vector3
 from kornia.image import ImageSize
-from kornia.sensors.camera import CameraModel, CameraModelType
+from kornia.sensors.camera import CameraModel, CameraModelBase, CameraModelType
+from kornia.sensors.camera.camera_model import Orthographic
+from kornia.sensors.camera.distortion_model import (
+    AffineTransform,
+    BrownConradyTransform,
+    KannalaBrandtK3Transform,
+)
+from kornia.sensors.camera.projection_model import OrthographicProjection, Z1Projection
 
 from testing.base import BaseTester
 
@@ -111,3 +118,78 @@ class TestPinholeCamera(BaseTester):
         self.assert_close(cam.cy * scale, scaled_cam.cy)
         self.assert_close(cam.width * scale, scaled_cam.width)
         self.assert_close(cam.height * scale, scaled_cam.height)
+
+
+class TestCameraModelBaseParamsValidation:
+    """`CameraModelBase` is public and documents a `params` shape it did not check.
+
+    The typed subclasses each apply the same two comparisons, so only the direct
+    construction path was unguarded -- and that is the path the class docstring's
+    own example uses.
+    """
+
+    image_size = ImageSize(6, 8)
+
+    def test_a_short_params_vector_is_rejected_at_construction(self, device, dtype):
+        # Was: constructed fine, then raised IndexError from inside
+        # AffineTransform.distort, naming neither params nor the camera model.
+        params = torch.ones(3, device=device, dtype=dtype)
+        with pytest.raises(ValueError, match=r"shape \(B, 4\) or \(4,\) for AffineTransform"):
+            CameraModelBase(AffineTransform(), Z1Projection(), self.image_size, params)
+
+    def test_a_rank_three_params_tensor_is_rejected_at_construction(self, device, dtype):
+        # Was: constructed, projected without complaint, and silently returned a
+        # (1, 1, 2) result. There is no (B, N, 4) multi-camera form, which is why
+        # the typed constructors reject exactly this shape.
+        params = torch.ones(1, 1, 4, device=device, dtype=dtype)
+        with pytest.raises(ValueError, match="rank 1 or 2"):
+            CameraModelBase(AffineTransform(), Z1Projection(), self.image_size, params)
+
+    @pytest.mark.parametrize(
+        ("distortion", "length"),
+        [
+            (AffineTransform, 4),
+            (BrownConradyTransform, 12),
+            (KannalaBrandtK3Transform, 8),
+        ],
+    )
+    def test_the_required_length_follows_the_distortion_model(self, distortion, length, device, dtype):
+        """The same lengths the four typed constructors each spell out."""
+        ok = torch.ones(length, device=device, dtype=dtype)
+        CameraModelBase(distortion(), Z1Projection(), self.image_size, ok)
+
+        wrong = torch.ones(length + 1, device=device, dtype=dtype)
+        with pytest.raises(ValueError, match=rf"shape \(B, {length}\)"):
+            CameraModelBase(distortion(), Z1Projection(), self.image_size, wrong)
+
+    @pytest.mark.parametrize("shape", [(4,), (1, 4), (5, 4)])
+    def test_the_documented_shapes_still_construct_and_project(self, shape, device, dtype):
+        """Unbatched and batched both stay valid; this is not a tightening of them."""
+        params = torch.ones(*shape, device=device, dtype=dtype)
+        cam = CameraModelBase(AffineTransform(), Z1Projection(), self.image_size, params)
+        assert tuple(cam.params.shape) == shape
+        point = Vector3(torch.tensor([[1.0, 2.0, 4.0]], device=device, dtype=dtype))
+        assert cam.project(point).data.shape[-1] == 2
+
+    def test_orthographic_still_reports_its_own_message(self, device, dtype):
+        """Orthographic validated after super().__init__, so the base now runs first.
+
+        Moving its guard above the super() call keeps its specific message, and
+        stops it half-building the object before rejecting the arguments.
+        """
+        params = torch.ones(5, device=device, dtype=dtype)
+        with pytest.raises(ValueError, match="ORTHOGRAPHIC"):
+            Orthographic(self.image_size, params)
+
+    def test_the_class_docstring_example_is_consistent(self, device, dtype):
+        """The example paired a Brown-Conrady transform with a 4-element affine vector."""
+        params = torch.tensor([328.0, 328.0, 320.0, 240.0], device=device, dtype=dtype)
+        cam = CameraModelBase(AffineTransform(), Z1Projection(), ImageSize(480, 640), params)
+        assert cam.params.shape == params.shape
+
+    def test_the_orthographic_pair_takes_four(self, device, dtype):
+        """AffineTransform + OrthographicProjection is the other 4-parameter pair."""
+        cam = CameraModelBase(
+            AffineTransform(), OrthographicProjection(), self.image_size, torch.ones(4, device=device, dtype=dtype)
+        )
+        assert tuple(cam.params.shape) == (4,)


### PR DESCRIPTION
Closes #4316.

`CameraModelBase` documents `params` as `(B, 4)` for pinhole, `(B, 12)` for Brown-Conrady and `(B, 8)` for Kannala-Brandt K3, and then stored whatever it was handed. The four typed constructors each apply the same two comparisons, so only the direct-construction path was unguarded — and that path is public: the class is exported from `kornia.sensors.camera.__all__` and its own docstring example constructs one.

## What went wrong

Both cells from the issue, on `main`:

```
short  constructed, params.shape = (3,)
short  project      : IndexError: index 3 is out of bounds for dimension 1 with size 3
rank3  constructed, params.shape = (1, 1, 4)
rank3  project      : (1, 1, 2) [1.25, 1.5]
```

A short vector failed far from the constructor, inside `AffineTransform.distort`, with a message naming neither `params` nor the camera model. A rank-3 `(B, 1, N)` tensor — the shape the typed constructors reject, because there is no `(B, N, 4)` multi-camera form — constructed, projected without complaint, and silently returned a `(1, 1, 2)` result.

## The change

Option 1 from the issue. The length each distortion model reads moves into one map:

```python
_PARAMS_LEN_FOR_DISTORTION: dict[type, int] = {
    AffineTransform: 4,
    BrownConradyTransform: 12,
    KannalaBrandtK3Transform: 8,
}
```

and `CameraModelBase.__init__` checks rank and length against it, so the documented precondition holds on every path:

```
short (3,)       ValueError: params must be of shape (B, 4) or (4,) for AffineTransform; got shape (3,)
rank3 (1,1,4)    ValueError: params must be of rank 1 or 2, of shape (B, N) or (N,); got shape (1, 1, 4)
valid (4,)       project     : [1.25, 1.5]
valid (2,4)      params.shape: (2, 4)
```

The typed constructors keep their own guards and their own messages, so nothing that depends on those changes:

```
typed (3,)        : params must be of shape (B, 4) for PINHOLE Camera
typed (1, 1, 4)   : params must be of shape (B, 4) for PINHOLE Camera
```

## Two things that fell out

**The class docstring example was itself inconsistent.** It paired `BrownConradyTransform()` with `torch.Tensor([328., 328., 320., 240.])` — four values, where that map says twelve. The values are `(fx, fy, cx, cy)`, an affine parameter vector, so the example now uses `AffineTransform()` and is correct rather than merely unchecked. Worth noting `BrownConradyTransform.distort` and `KannalaBrandtK3Transform.distort` are both `NotImplementedError` stubs today, so that example could never have projected either way.

**`Orthographic` validated after `super().__init__`.** It called the base constructor and only then raised, half-building the object first. Its guard moves above the `super()` call; the message is unchanged, and it still wins over the base message.

## Verification

`e8111a61`-equivalent head on current `main` (`8f292308`), torch 2.14.0, cpu.

```
tests/sensors + tests/geometry/camera   186 passed, 19 skipped, 1 xfailed   (float32)
tests/sensors                            30 passed, 16 skipped              (float64)
pytest --doctest-modules kornia/sensors/camera/camera_model.py    7 passed
ruff@0.16.6 check / format               clean (the version pinned in .pre-commit-config.yaml)
```

Isolation — removing only the `_validate_params(distortion, params)` line from the constructor:

```
5 failed, 6 passed
FAILED ...::test_a_short_params_vector_is_rejected_at_construction - Failed: DID NOT RAISE ValueError
FAILED ...::test_a_rank_three_params_tensor_is_rejected_at_construction - Failed: DID NOT RAISE ValueError
FAILED ...::test_the_required_length_follows_the_distortion_model[AffineTransform-4]
FAILED ...::test_the_required_length_follows_the_distortion_model[BrownConradyTransform-12]
FAILED ...::test_the_required_length_follows_the_distortion_model[KannalaBrandtK3Transform-8]
```

The six that still pass are the ones that should: the documented shapes `(4,)`, `(1, 4)`, `(5, 4)` construct and project, and `Orthographic` reports its own message.