### PR TITLE
fix(camera): handle zero-radius Kannala-Brandt undistortion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   construct and then fail with an `IndexError` from inside `AffineTransform.distort`, naming neither
   `params` nor the camera; a rank-3 `(B, 1, N)` tensor used to construct, project, and silently return a
   `(1, 1, 2)` result. Both now raise `ValueError` from the constructor. (#4316, #4369)
+* `undistort_points_kannala_brandt` no longer collapses representable `float16` points next to the principal point
+  to the origin, and the exact principal-point path now has finite autograd gradients. The zero-radius decision is
+  made from the unsquared normalized coordinates, and the `float16` radius uses `float32` intermediates so its
+  squared value does not underflow; nonzero radial rescaling remains epsilon-free. (#4308, #4370)
 
 * `warp_affine`, `warp_perspective` and `remap` crashed on MPS for an empty destination -- a `dsize` with a
   zero dimension, or zero-sized `remap` maps -- with an internal

--- a/kornia/geometry/camera/distortion_kannala_brandt.py
+++ b/kornia/geometry/camera/distortion_kannala_brandt.py
@@ -163,9 +163,15 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: torch.Tensor, pa
     un = (x - cx) / fx
     vn = (y - cy) / fy
 
-    rth2 = un * un + vn * vn
-    rth = rth2.sqrt()
-    nonzero_radius = rth > 0
+    nonzero_radius = (un != 0) | (vn != 0)
+    safe_un = torch.where(nonzero_radius, un, torch.ones_like(un))
+    safe_vn = torch.where(nonzero_radius, vn, torch.zeros_like(vn))
+    radius_dtype = safe_un.dtype
+    if radius_dtype == torch.float16:
+        safe_un = safe_un.float()
+        safe_vn = safe_vn.float()
+    rth = (safe_un * safe_un + safe_vn * safe_vn).sqrt().to(radius_dtype)
+    rth = torch.where(nonzero_radius, rth, torch.zeros_like(rth))
 
     safe_rth = torch.where(nonzero_radius, rth, torch.ones_like(rth))
     th = safe_rth.sqrt()

--- a/kornia/geometry/camera/distortion_kannala_brandt.py
+++ b/kornia/geometry/camera/distortion_kannala_brandt.py
@@ -119,21 +119,10 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: torch.Tensor, pa
         - the inverse is a fixed number of Gauss-Newton steps rather than a closed form: the step count is not
           a parameter and there is no convergence test, so the round trip through
           :func:`distort_points_kannala_brandt` closes only to the accuracy that iteration has reached. The
-          step count cannot be raised by a caller. In ``float32`` the residual reaches the rounding floor; in
-          ``float64`` it stops at about ``1e-8`` on the normalized plane, because the final radial rescale
-          divides by ``r + 1e-8`` rather than ``r`` and so scales every result by ``1 - 1e-8 / r``. That is the
-          ``float64`` side of `#4308 <https://github.com/kornia/kornia/issues/4308>`_.
-          :func:`~kornia.geometry.camera.undistort_points_affine` is the closed-form contrast.
-        - three small constants guard the Newton start (``1e-16``), Newton denominator (``1e-12``), and final
-          radial rescale (``1e-8``), so a point at the principal point comes back as the origin rather than
-          ``nan`` -- as long as those constants are representable in the dtype of ``params``, which is the
-          dtype the whole body runs in.
-
-    .. warning::
-        All three guard constants underflow to zero in ``float16``. At the principal point the unguarded Newton
-        denominator is one, but the final ``1e-8`` rescale guard then underflows and returns ``nan`` instead of
-        the origin. ``float32``, ``float64`` and ``bfloat16`` are unaffected. Tracked as
-        `#4308 <https://github.com/kornia/kornia/issues/4308>`_.
+          step count cannot be raised by a caller. :func:`~kornia.geometry.camera.undistort_points_affine` is the
+          closed-form contrast.
+        - an exact zero distorted radius is handled structurally and maps to the origin. Nonzero radii use the
+          radius itself for the final radial rescale, without an additive epsilon.
 
     Args:
         distorted_points_in_camera: torch.Tensor representing the points to undistort with shape (..., 2).
@@ -153,7 +142,6 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: torch.Tensor, pa
     KORNIA_CHECK_SHAPE(params, ["*", "8"])
 
     iters = 10
-    eps = 1e-8
     device = distorted_points_in_camera.device
     out_dtype = distorted_points_in_camera.dtype
 
@@ -177,8 +165,11 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: torch.Tensor, pa
 
     rth2 = un * un + vn * vn
     rth = rth2.sqrt()
+    nonzero_radius = rth > 0
 
-    th = rth.clamp(min=1e-16).sqrt()
+    safe_rth = torch.where(nonzero_radius, rth, torch.ones_like(rth))
+    th = safe_rth.sqrt()
+    th = torch.where(nonzero_radius, th, torch.zeros_like(th))
 
     # gauss-newton
     for _ in range(iters):
@@ -190,8 +181,9 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: torch.Tensor, pa
         th = th - step
 
     radius_undistorted = th.tan()
-    denom = rth + eps
+    denom = torch.where(nonzero_radius, rth, torch.ones_like(rth))
     mag = radius_undistorted.abs() / denom
+    mag = torch.where(nonzero_radius, mag, torch.zeros_like(mag))
     undistorted = torch.stack([mag * un, mag * vn], dim=-1)
 
     return undistorted.to(device=device, dtype=out_dtype)

--- a/kornia/geometry/camera/distortion_kannala_brandt.py
+++ b/kornia/geometry/camera/distortion_kannala_brandt.py
@@ -189,7 +189,7 @@ def undistort_points_kannala_brandt(distorted_points_in_camera: torch.Tensor, pa
     radius_undistorted = th.tan()
     denom = torch.where(nonzero_radius, rth, torch.ones_like(rth))
     mag = radius_undistorted.abs() / denom
-    mag = torch.where(nonzero_radius, mag, torch.zeros_like(mag))
+    mag = torch.where(nonzero_radius, mag, torch.ones_like(mag))
     undistorted = torch.stack([mag * un, mag * vn], dim=-1)
 
     return undistorted.to(device=device, dtype=out_dtype)

--- a/tests/geometry/camera/test_distortion.py
+++ b/tests/geometry/camera/test_distortion.py
@@ -363,6 +363,26 @@ class TestDistortionKannalaBrandt(BaseTester):
             torch.tensor([0.5392647981643677, 0.26963239908218384], device=device, dtype=dtype),
         )
 
+    def test_convention_nearest_float16_point_is_not_collapsed_4308(self, device, dtype):
+        if device.type != "cpu" or dtype != torch.float16:
+            pytest.skip("CPU float16 near-origin regression")
+        params = torch.tensor([100.0, 50.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype)
+        point = torch.tensor([4.00390625, 3.0], device=device, dtype=dtype)
+        undistorted = undistort_points_kannala_brandt(point, params)
+        expected_x = (point[0] - params[2]) / params[0]
+        assert undistorted[0] != 0
+        self.assert_close(undistorted, torch.stack([expected_x, torch.zeros_like(expected_x)]), atol=6e-8, rtol=0.0)
+
+    def test_convention_principal_point_has_finite_gradients_4308(self, device, dtype):
+        params = torch.tensor(
+            [100.0, 50.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype, requires_grad=True
+        )
+        principal_point = torch.tensor([4.0, 3.0], device=device, dtype=dtype, requires_grad=True)
+        output = undistort_points_kannala_brandt(principal_point, params)
+        point_grad, params_grad = torch.autograd.grad(output.sum(), (principal_point, params))
+        assert torch.isfinite(point_grad).all()
+        assert torch.isfinite(params_grad).all()
+
     def test_convention_float64_round_trip_precision_4308(self, device, dtype):
         # Regression for kornia#4308: nonzero radii must be rescaled by r itself. An additive 1e-8 denominator
         # guard biases these representative float64 round trips by about 1e-8, well above the dtype's rounding floor.

--- a/tests/geometry/camera/test_distortion.py
+++ b/tests/geometry/camera/test_distortion.py
@@ -374,14 +374,22 @@ class TestDistortionKannalaBrandt(BaseTester):
         self.assert_close(undistorted, torch.stack([expected_x, torch.zeros_like(expected_x)]), atol=6e-8, rtol=0.0)
 
     def test_convention_principal_point_has_finite_gradients_4308(self, device, dtype):
-        params = torch.tensor(
-            [100.0, 50.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype, requires_grad=True
+        params = torch.tensor([100.0, 50.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype)
+        principal_point = torch.tensor([4.0, 3.0], device=device, dtype=dtype)
+        point_jacobian = torch.autograd.functional.jacobian(
+            lambda point: undistort_points_kannala_brandt(point, params), principal_point
         )
-        principal_point = torch.tensor([4.0, 3.0], device=device, dtype=dtype, requires_grad=True)
-        output = undistort_points_kannala_brandt(principal_point, params)
-        point_grad, params_grad = torch.autograd.grad(output.sum(), (principal_point, params))
-        assert torch.isfinite(point_grad).all()
-        assert torch.isfinite(params_grad).all()
+        params_jacobian = torch.autograd.functional.jacobian(
+            lambda camera: undistort_points_kannala_brandt(principal_point, camera), params
+        )
+        expected_point_jacobian = torch.tensor(
+            [[1.0 / params[0], 0.0], [0.0, 1.0 / params[1]]], device=device, dtype=dtype
+        )
+        expected_params_jacobian = torch.zeros(2, 8, device=device, dtype=dtype)
+        expected_params_jacobian[0, 2] = -1.0 / params[0]
+        expected_params_jacobian[1, 3] = -1.0 / params[1]
+        self.assert_close(point_jacobian, expected_point_jacobian)
+        self.assert_close(params_jacobian, expected_params_jacobian)
 
     def test_convention_float64_round_trip_precision_4308(self, device, dtype):
         # Regression for kornia#4308: nonzero radii must be rescaled by r itself. An additive 1e-8 denominator

--- a/tests/geometry/camera/test_distortion.py
+++ b/tests/geometry/camera/test_distortion.py
@@ -315,9 +315,8 @@ class TestDistortionKannalaBrandt(BaseTester):
         # assert_close's dtype tolerance and deliberately states no error bound; the executed residuals are
         # recorded, not enforced. The far-off-axis case is the sibling pin below.
         # Snippet used to generate expected: (undistort_points_kannala_brandt(distort_points_kannala_brandt(p, par),
-        # par) - p).abs().max() executed 2026-09-06 at c0b50ad7 (torch 2.14.0), differenced in the
-        # working dtype -> cpu float32 2.98e-08, float64 9.55e-09, float16 9.77e-04, bfloat16 1.95e-03;
-        # mps float32 2.98e-08, float16 9.77e-04.
+        # par) - p).abs().max(), differenced in the working dtype. Removing the additive radial-rescale epsilon
+        # makes the float64 residual reach the Gauss-Newton rounding floor instead of stopping around 1e-8.
         params = torch.tensor([100.0, 100.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype)
         points = torch.tensor([0.5, 0.25], device=device, dtype=dtype)
         self.assert_close(
@@ -330,9 +329,8 @@ class TestDistortionKannalaBrandt(BaseTester):
         # kornia.geometry.calibration.undistort_points does NOT (kornia#4285). Closure is asserted at
         # assert_close's dtype tolerance, with no error bound.
         # Snippet used to generate expected: (undistort_points_kannala_brandt(distort_points_kannala_brandt(
-        # tensor([3., 0.]), par), par) - tensor([3., 0.])).abs().max() executed 2026-09-06 at c0b50ad7
-        # (torch 2.14.0), differenced in the working dtype -> cpu float32 1.91e-06, float64 2.03e-08,
-        # float16 1.95e-03, bfloat16 6.25e-02; mps float32 1.91e-06, float16 1.95e-03.
+        # tensor([3., 0.]), par), par) - tensor([3., 0.])).abs().max(), differenced in the working dtype. The
+        # float64 result now reaches the rounding floor because the final rescale divides by r rather than r + 1e-8.
         if dtype == torch.bfloat16:
             pytest.skip("bfloat16: the far-off-axis round trip closes only to 6.25e-02, outside the bfloat16 atol")
         params = torch.tensor([100.0, 100.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype)
@@ -340,73 +338,41 @@ class TestDistortionKannalaBrandt(BaseTester):
         self.assert_close(undistort_points_kannala_brandt(distort_points_kannala_brandt(far, params), params), far)
 
     def test_convention_principal_point_undistorts_to_the_origin(self, device, dtype):
-        # Convention pin: small constants that guard the Gauss-Newton denominator and final radial rescale mean the
-        # principal point (cx, cy) undistorts to the EXACT origin instead of the 0/0 that the unguarded
-        # arithmetic would give. The assertion is torch.equal, not assert_close, because the guard makes the
-        # result exactly zero rather than nearly zero.
+        # Convention pin: an exact zero distorted radius is handled structurally, so the principal point (cx, cy)
+        # undistorts to the EXACT origin without relying on a dtype-dependent epsilon. The assertion is torch.equal,
+        # not assert_close, because the masked zero-radius path is exact rather than approximate.
         # cx != cy in these params, so the principal point is off the diagonal and a cx/cy swap would move it.
         # The second, off-centre point is what keeps the pin from being frame-invariant: (54, 28) normalizes to
         # (0.5, 0.25) and undistorts to a value that changes under either swap -- the same params with cx and cy
         # exchanged give [0.5507686734199524, 0.2591852843761444] and with fy halved to 50 they give
         # [0.5658687353134155, 0.5658687353134155].
-        # Snippet used to generate expected: undistort_points_kannala_brandt(tensor([4., 3.]), params) and the
-        # same call on tensor([54., 28.]), executed 2026-09-06 at c0b50ad7 (torch 2.14.0) -> the
-        # principal point gives exactly [0.0, 0.0] on cpu float64/float32/bfloat16 and on mps float32; the
-        # off-centre point gives [0.5392647981643677, 0.26963239908218384] on cpu and mps float32. In float16
-        # the final radial-rescale denominator's 1e-8 guard underflows and the principal point gives [nan, nan]
-        # -- kornia#4308, pinned by
-        # test_wart_principal_point_undistorts_to_nan_in_float16_4308 below.
-        if dtype == torch.float16:
-            pytest.skip("float16: the final radial-rescale guard 1e-8 underflows, making the origin 0/0 (#4308)")
+        # The body computes in params.dtype and casts back to the points dtype, including the mixed float16-points /
+        # float32-params case pinned below.
         params = torch.tensor([100.0, 100.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype)
         principal_point = torch.tensor([4.0, 3.0], device=device, dtype=dtype)
         undistorted = undistort_points_kannala_brandt(principal_point, params)
         assert torch.equal(undistorted, torch.zeros(2, device=device, dtype=dtype))
+        if dtype == torch.float16:
+            wide_params = params.to(torch.float32)
+            mixed = undistort_points_kannala_brandt(principal_point, wide_params)
+            assert mixed.dtype == dtype
+            assert torch.equal(mixed, torch.zeros(2, device=device, dtype=dtype))
         off_centre = torch.tensor([54.0, 28.0], device=device, dtype=dtype)
         self.assert_close(
             undistort_points_kannala_brandt(off_centre, params),
             torch.tensor([0.5392647981643677, 0.26963239908218384], device=device, dtype=dtype),
         )
 
-    def test_wart_principal_point_undistorts_to_nan_in_float16_4308(self, device, dtype):
-        # Wart pin for kornia#4308: in float16, the 1e-8 epsilon added to ``rth`` for the final radial rescale
-        # underflows to zero (the smallest subnormal is about 5.96e-08). At the principal point, both
-        # ``radius_undistorted`` and ``rth`` are zero, so ``mag = 0 / (0 + 0)`` is nan and propagates through
-        # the final multiplication. The 1e-16 Newton-start clamp and 1e-12 Newton-step denominator also
-        # underflow, but they are not the direct source of this result. The body runs in ``params.dtype``;
-        # bfloat16 preserves these values' exponent range, so the wart is specific to float16.
-        # Snippet used to generate expected: undistort_points_kannala_brandt(tensor([4., 3.], dtype=torch.
-        # float16), params.half()) executed 2026-09-06 at c0b50ad7 (torch 2.14.0) -> [nan, nan] on
-        # both cpu and mps. Float16 POINTS with float32
-        # params return [0.0, 0.0], because the body casts the points to params.dtype first.
-        # Pins the CURRENT behavior; NOT a contract; delete when #4308 is repaired.
-        if dtype != torch.float16:
-            pytest.skip("float16-only wart: the radial-rescale epsilon is representable in every other dtype")
-        params = torch.tensor([100.0, 100.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype)
-        principal_point = torch.tensor([4.0, 3.0], device=device, dtype=dtype)
-        assert undistort_points_kannala_brandt(principal_point, params).isnan().all()
-        wide_params = params.to(torch.float32)
-        self.assert_close(
-            undistort_points_kannala_brandt(principal_point, wide_params),
-            torch.zeros(2, device=device, dtype=dtype),
-        )
-
-    def test_wart_rescale_guard_caps_float64_round_trip_4308(self, device, dtype):
-        # Wart pin for kornia#4308, the float64 side of the same constant: the final radial rescale divides by
-        # ``rth + 1e-8`` rather than ``rth``, so every result is scaled by ``1 - 1e-8 / r`` and the float64 round
-        # trip stops at about 1e-8 on the normalized plane instead of the ~1e-16 the ten Gauss-Newton steps reach.
-        # Snippet used to generate expected: (undistort_points_kannala_brandt(distort_points_kannala_brandt(
-        # tensor([3., 0.]), par), par) - tensor([3., 0.])).abs().max() executed 2026-09-08 at d2fe9507 (torch
-        # 2.14.0, cpu float64) -> 2.03e-08; the same body with the guard set to 0.0 -> 0.0. float32's rounding
-        # floor (1.91e-06 here) sits above the bias, so only float64 sees it.
-        # Pins the CURRENT behavior; NOT a contract; delete when #4308 is repaired.
+    def test_convention_float64_round_trip_precision_4308(self, device, dtype):
+        # Regression for kornia#4308: nonzero radii must be rescaled by r itself. An additive 1e-8 denominator
+        # guard biases these representative float64 round trips by about 1e-8, well above the dtype's rounding floor.
         if dtype != torch.float64:
-            pytest.skip("float64-only wart: every other dtype's rounding floor is above the 1e-8 bias")
+            pytest.skip("float64-only precision regression")
         params = torch.tensor([100.0, 100.0, 4.0, 3.0, 0.1, 0.01, 0.001, 0.0001], device=device, dtype=dtype)
-        far = torch.tensor([3.0, 0.0], device=device, dtype=dtype)
-        distorted = distort_points_kannala_brandt(far, params)
-        residual = (undistort_points_kannala_brandt(distorted, params) - far).abs().max().item()
-        assert 1e-9 < residual < 1e-7
+        points = torch.tensor([[0.5, 0.25], [3.0, 0.0], [0.01, 0.0]], device=device, dtype=dtype)
+        distorted = distort_points_kannala_brandt(points, params)
+        residual = (undistort_points_kannala_brandt(distorted, params) - points).abs().max().item()
+        assert residual < 1e-12
 
     def test_wart_dx_distort_points_kannala_brandt_disagrees_with_autograd_4277(self, device, dtype):
         # Wart pin for kornia#4277: the analytic Jacobian is


### PR DESCRIPTION
## What does this pull request do?

<!-- Explain the problem and the change. A few clear sentences are enough. -->

`undistort_points_kannala_brandt` now handles an exact zero distorted radius with a structural mask instead of hardcoded epsilon guards. This makes the principal point return the exact origin in float16 and removes the additive `1e-8` radial-rescale bias that limited float64 round-trip precision, while preserving the existing 10 Gauss-Newton iterations and step denominator.

The convention documentation and regressions were updated accordingly, including mixed float16-points/float32-params behavior and representative float64 round trips.

## Related issue or discussion

<!-- Link one if it exists, for example: Fixes #123. This is optional. -->

Fixes #4308

## What did you check?

<!-- List the tests, examples, or manual checks you ran, and include useful results. -->

The focused principal-point and float64 precision regressions pass on CPU; the full float32/float64 camera-distortion module and both repository CPU half-precision profiles also pass with only their existing manifest xfails. MPS-specific cases were selected but skipped because this Linux host has no MPS device.

```text
$ pixi run --environment default test-module tests/geometry/camera/test_distortion.py --device=cpu --dtype=float16,float32,float64,bfloat16 -k 'principal_point_undistorts_to_the_origin or float64_round_trip_precision_4308'
$ pixi run --environment default test-module tests/geometry/camera/test_distortion.py --device=cpu --dtype=float32,float64
$ pixi run --environment default test-module tests/geometry/camera/test_distortion.py --known-failure-profile=cpu-float16 --xfail-known-failures
$ pixi run --environment default test-module tests/geometry/camera/test_distortion.py --known-failure-profile=cpu-bfloat16 --xfail-known-failures
$ pixi run --environment default typecheck
```

## How did AI help?

<!-- If you used AI, briefly say what it helped with and what you checked or changed afterward. Otherwise, leave this blank. -->

AI was used to inspect the affected implementation, callers, tests, and repository conventions; implement the zero-radius masking change; update the regression coverage and documentation; and run the checks above. The final diff was inspected for scope, compatibility, and unintended files.