### PR TITLE
ci: run the dynamo leg over tests/models at PR time

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -157,6 +157,10 @@ jobs:
   # `tests` matrix deselects (KORNIA_TEST_OPTIMIZER=""). Keeps the compile-clean core a
   # defended floor at PR time. Scoped to a single config and `-k dynamo or compile` so the
   # extra CI cost is small (only the compile-marked tests actually build inductor graphs).
+  # The directory list has to name every tree whose compile tests should gate a PR: one it
+  # omits is still collected, but with the `torch_optimizer` fixture deselected, so its
+  # `test_dynamo` cases pass as identity no-ops and a compile regression there reaches
+  # `main` before the post-merge `coverage.yml` dynamo job is the first to compile it.
   dynamo:
     needs: [pre-tests]
     uses: ./.github/workflows/tests.yml
@@ -166,7 +170,7 @@ jobs:
       pytorch-version: '["2.14.0"]'
       pytorch-dtype: float32
       optimizer: inductor
-      pytest-extra: 'tests/augmentation tests/enhance tests/feature tests/filters tests/color tests/geometry tests/losses tests/morphology -k "dynamo or compile"'
+      pytest-extra: 'tests/augmentation tests/enhance tests/feature tests/filters tests/color tests/geometry tests/losses tests/morphology tests/models -k "dynamo or compile"'
       cache-path: weights/
       cache-key: model-weights-${{ needs.pre-tests.outputs.hash }}
       cache-restore-keys: |


### PR DESCRIPTION
Fixes #4311.

The PR-time dynamo job names its trees explicitly and `tests/models` was not among them. Those files are still collected, but with the `torch_optimizer` fixture deselected, so every `test_dynamo` there passes as an identity no-op on a pull request — nothing compiles them until the post-merge `coverage.yml` job, by which point a regression is on `main`.

Fifteen tests are affected today: `test_rrdbnet`, `test_small_sr`, `test_dexined`, `test_tiny_vit`, `test_sam`, `test_prompter`, `test_rt_detr`, `test_siglip2`, `test_kimi_vl`.

**On the wall-clock question.** Selection goes from 255 tests to 270. I could not time a compiled run locally — no C++ compiler here, so inductor bails at codegen — and the question was about the runners anyway, so from recent runs:

| job | tests | duration |
|---|---|---|
| PR `dynamo` (current) | 255 | 10.6 – 13.1 min |
| post-merge `coverage / dynamo` (whole suite) | 279 | 17.3 – 17.4 min |

+24 tests ≈ +5 min between those two, so the model tests are indeed the heavy ones and this should land between the two figures. This PR's own run is the real measurement.

I took the narrower of the two options in the issue. Replacing the list with the coverage job's whole-suite `-k` selection stops the legs drifting again, at 279 tests rather than 270 — happy to switch to that if the extra minutes are worth not maintaining the list.
