### PR TITLE
docs(camera): cite issues, not private test names, in the batch-5 convention blocks

### DIFF
--- a/docs/source/get-started/camera-conventions.rst
+++ b/docs/source/get-started/camera-conventions.rst
@@ -80,12 +80,7 @@ Kornia's grids are **integer-centre**: :func:`kornia.geometry.grid.create_meshgr
 ``normalized_coordinates=False`` enumerates ``0 .. W-1`` along ``x`` and ``0 .. H-1`` along ``y``, so a centred
 image has its principal point at ``cx = (W - 1) / 2``, ``cy = (H - 1) / 2``. That is what
 :func:`kornia.geometry.camera.perspective.project_points`, :func:`kornia.geometry.depth.depth_to_3d` and the
-rest of the functional camera API assume. The convention is pinned by:
-
-- ``tests/geometry/camera/test_perspective.py``,
-  ``TestProjectPoints::test_convention_integer_pixel_centres_put_the_principal_point_at_w_minus_one_half``
-- ``tests/geometry/test_depth.py``,
-  ``TestDepthTo3d::test_convention_pixel_origin_is_the_integer_centre``
+rest of the functional camera API assume.
 
 .. warning::
 

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -64,8 +64,7 @@ class PinholeCamera:
         `#4265 <https://github.com/kornia/kornia/issues/4265>`_, the batch-size and point-shape limitations
         `#4266 <https://github.com/kornia/kornia/issues/4266>`_, and the rejection of an empty batch
         (:math:`B = 0`) `#4281 <https://github.com/kornia/kornia/issues/4281>`_. The behaviour described here is
-        documented as it is and pinned by the ``test_convention_*`` / ``test_wart_*`` tests in
-        ``tests/geometry/camera/test_pinhole.py``.
+        documented as it is; the issues above track the repairs.
 
     Args:
         intrinsics: torch.Tensor with shape :math:`(B, 4, 4)`

--- a/kornia/geometry/camera/stereo.py
+++ b/kornia/geometry/camera/stereo.py
@@ -88,11 +88,7 @@ class StereoCamera:
         real-data test passes only because its fixture lays a one-row, ten-column strip out as ten rows of one
         column, which the swap cancels; its stored numbers are correct OpenCV output for that strip, so a fix
         corrects the layout and keeps every literal. Tracked as
-        `#4269 <https://github.com/kornia/kornia/issues/4269>`_ and pinned by
-        ``test_wart_reproject_disparity_reads_u_from_the_row_index_4269``,
-        ``test_wart_reproject_disparity_x_varies_with_the_row_and_y_with_the_column_4269`` and the strict
-        ``xfail`` ``test_convention_reproject_disparity_uses_the_column_as_u_4269`` in
-        ``tests/geometry/camera/test_stereo.py``.
+        `#4269 <https://github.com/kornia/kornia/issues/4269>`_.
 
     .. warning::
         Several of the constructor guards do not enforce the contract above. A differing ``cx`` is
@@ -107,12 +103,7 @@ class StereoCamera:
         compares ``shape[:1]`` rather than ``shape[-2:]``, so it can never fire and a :math:`(B, 4, 4)` pair
         is accepted, building the same :math:`(B, 4, 4)` ``Q`` as the :math:`(B, 3, 4)` pair it should have
         required. Tracked as
-        `#4270 <https://github.com/kornia/kornia/issues/4270>`_ and pinned by
-        ``test_wart_stereo_rejects_differing_principal_points_4270``,
-        ``test_wart_stereo_accepts_a_batch_with_one_positive_tx_fx_4270``,
-        ``test_wart_stereo_tx_zero_collapses_every_point_to_the_origin_4270``,
-        ``test_wart_stereo_accepts_a_four_by_four_pair_4270`` and
-        ``test_wart_stereo_rejects_an_empty_batch_4281`` in ``tests/geometry/camera/test_stereo.py``.
+        `#4270 <https://github.com/kornia/kornia/issues/4270>`_.
 
     .. warning::
         The module-level :func:`~kornia.geometry.camera.stereo.reproject_disparity_to_3D` is rendered on

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -88,11 +88,7 @@ def unproject_meshgrid(
         and then raises a ``ShapeError`` further into the body, whose message describes a shape the caller
         never passed rather than the one it did. The same guard admits non-singleton extra leading dimensions,
         which then broadcast against the pixel axes instead of being rejected (above). Tracked as
-        `#4271 <https://github.com/kornia/kornia/issues/4271>`_ and pinned by
-        ``test_wart_unproject_meshgrid_rejects_unbatched_intrinsics_4271``,
-        ``test_wart_unproject_meshgrid_extra_camera_axis_broadcasts_over_columns_4271`` and the strict ``xfail``
-        ``test_convention_unproject_meshgrid_error_names_the_shape_the_caller_passed_4271`` in
-        ``tests/geometry/test_depth.py``.
+        `#4271 <https://github.com/kornia/kornia/issues/4271>`_.
 
     Args:
         height: height of image.
@@ -419,17 +415,14 @@ def warp_frame_depth(
         frame this function calls ``dst`` (the one holding the depth) is that class's ``src``, and the image it
         calls ``image_src`` is that class's ``patch_dst``. The Convention block on
         :class:`~kornia.geometry.depth.DepthWarper` states the mapping in full. Tracked as
-        `#4273 <https://github.com/kornia/kornia/issues/4273>`_ and pinned by
-        ``test_wart_warp_frame_depth_and_depth_warper_name_the_depth_frame_oppositely_4273`` in
-        ``tests/geometry/test_depth.py``.
+        `#4273 <https://github.com/kornia/kornia/issues/4273>`_.
 
     .. warning::
         An empty batch (:math:`B = 0`) raises ``ZeroDivisionError`` from ``transform_points`` -- its
         batch-repeat count is ``0 // 0`` -- before any sampling runs, rather than returning an empty result,
         although the shape guards on the way in accept it and
         :func:`~kornia.geometry.depth.depth_to_3d` -- the same unprojection in the other layout -- returns an
-        empty point cloud. Tracked as `#4281 <https://github.com/kornia/kornia/issues/4281>`_ and pinned by
-        ``test_wart_warp_frame_depth_rejects_an_empty_batch_4281`` in ``tests/geometry/test_depth.py``.
+        empty point cloud. Tracked as `#4281 <https://github.com/kornia/kornia/issues/4281>`_.
 
     Args:
         image_src: image tensor in the source frame with shape :math:`(B,D,H,W)`.
@@ -514,20 +507,15 @@ class DepthWarper(nn.Module):
         -- so the grid, and with it the resampled image, can differ in the last bits. Where the two grids come
         out bit-identical, so do the images. Wherever the transformed points keep a camera-frame ``z`` away
         from zero, the two agree at the working dtype's tolerance in float32 and float64; in float16 and
-        bfloat16 the gap is wider than that tolerance, which is why the pin below states the claim for the two
+        bfloat16 the gap is wider than that tolerance, which is why the agreement is claimed for the two
         single- and double-precision dtypes only. At ``z = 0`` the two split outright, because their two
         projection routes guard the singularity differently:
         :func:`~kornia.geometry.camera.perspective.project_points` skips the homogeneous divide when
         ``abs(z) <= 1e-8``, so :func:`~kornia.geometry.depth.warp_frame_depth` samples ``image_src`` at the
         undivided ``(x, y)`` and returns image content, while ``cam2pixel`` divides by ``z + 1e-12`` and sends
         the same pixel to a coordinate of order ``1e12``, far outside the image. That split is one instance of
-        `#4267 <https://github.com/kornia/kornia/issues/4267>`_, the namespace-wide ``z = 0`` conflict, and is
-        pinned by ``test_wart_warp_frame_depth_and_depth_warper_split_at_zero_transformed_depth_4267``. The
-        naming conflict is tracked as `#4273 <https://github.com/kornia/kornia/issues/4273>`_ and pinned by
-        ``test_wart_warp_frame_depth_and_depth_warper_name_the_depth_frame_oppositely_4273``; the agreement away
-        from ``z = 0`` is pinned by
-        ``test_convention_warp_frame_depth_matches_depth_warper_without_being_bitwise_equal``. All three pins are in
-        ``tests/geometry/test_depth.py``.
+        `#4267 <https://github.com/kornia/kornia/issues/4267>`_, the namespace-wide ``z = 0`` conflict. The
+        naming conflict is tracked as `#4273 <https://github.com/kornia/kornia/issues/4273>`_.
 
     Args:
         pinhole_dst: the pinhole model for the destination frame.
@@ -813,9 +801,7 @@ def depth_from_disparity(
         ``5e9`` for a baseline of ``0.5`` and a focal length of ``100``, a value set by the epsilon as much as
         by the camera and one no caller can threshold against. In float16 the ``1e-8`` itself rounds to zero,
         so the same call divides by zero and returns ``inf`` after all. Tracked as
-        `#4272 <https://github.com/kornia/kornia/issues/4272>`_ and pinned by
-        ``test_wart_zero_disparity_gives_a_finite_depth_4272`` and
-        ``test_wart_depth_from_disparity_rejects_a_batched_baseline_4272`` in ``tests/geometry/test_depth.py``.
+        `#4272 <https://github.com/kornia/kornia/issues/4272>`_.
 
     Args:
         disparity: Disparity tensor of shape :math:`(*, H, W)`.

--- a/kornia/sensors/camera/camera_model.py
+++ b/kornia/sensors/camera/camera_model.py
@@ -167,9 +167,7 @@ class CameraModelBase:
         distortion placeholders ``BrownConradyTransform`` and ``KannalaBrandtK3Transform``, the projection
         placeholder ``OrthographicProjection``, and ``CameraModelBase.matrix``, which those three classes do
         not override. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_; the behaviour is
-        documented as it is and pinned by
-        ``test_wart_the_three_non_pinhole_models_construct_and_then_raise_4284`` in
-        ``tests/sensors/camera/test_camera_model.py``.
+        documented as it is.
 
     Example:
         >>> params = torch.Tensor([328., 328., 320., 240.])
@@ -381,10 +379,7 @@ class PinholeModel(CameraModelBase):
             (floating for a floating-point factor) where the constructor took python integers -- a python
             ``int`` keeps ``int`` fields and a python ``float`` gives ``float`` ones. Both are tracked in
             `#4263 <https://github.com/kornia/kornia/issues/4263>`_, the second in its comment thread; they
-            are documented as they are and pinned by
-            ``test_wart_scale_rescales_the_principal_point_by_the_half_pixel_rule_4263`` and
-            ``test_wart_scale_turns_the_image_size_fields_into_tensors_4263`` in
-            ``tests/sensors/camera/test_camera_model.py``.
+            are documented as they are.
 
         Args:
             scale_factor: Scale factor to scale the camera model.
@@ -416,9 +411,7 @@ class BrownConradyModel(CameraModelBase):
         :meth:`~kornia.sensors.camera.CameraModelBase.unproject` then raise ``NotImplementedError`` with an
         empty message inside ``BrownConradyTransform``, and
         :meth:`~kornia.sensors.camera.CameraModelBase.matrix` inside ``CameraModelBase.matrix``, which this
-        class does not override. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_ and
-        pinned by ``test_wart_the_three_non_pinhole_models_construct_and_then_raise_4284`` in
-        ``tests/sensors/camera/test_camera_model.py``.
+        class does not override. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_.
     """
 
     def __init__(self, image_size: ImageSize, params: torch.Tensor) -> None:
@@ -443,9 +436,7 @@ class KannalaBrandtK3(CameraModelBase):
         :meth:`~kornia.sensors.camera.CameraModelBase.unproject` then raise ``NotImplementedError`` with an
         empty message inside ``KannalaBrandtK3Transform``, and
         :meth:`~kornia.sensors.camera.CameraModelBase.matrix` inside ``CameraModelBase.matrix``, which this
-        class does not override. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_ and
-        pinned by ``test_wart_the_three_non_pinhole_models_construct_and_then_raise_4284`` in
-        ``tests/sensors/camera/test_camera_model.py``.
+        class does not override. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_.
     """
 
     def __init__(self, image_size: ImageSize, params: torch.Tensor) -> None:
@@ -469,9 +460,7 @@ class Orthographic(CameraModelBase):
         :meth:`~kornia.sensors.camera.CameraModelBase.unproject` then raise ``NotImplementedError`` with an
         empty message inside ``OrthographicProjection``, and
         :meth:`~kornia.sensors.camera.CameraModelBase.matrix` inside ``CameraModelBase.matrix``, which this
-        class does not override. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_ and
-        pinned by ``test_wart_the_three_non_pinhole_models_construct_and_then_raise_4284`` in
-        ``tests/sensors/camera/test_camera_model.py``.
+        class does not override. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_.
     """
 
     def __init__(self, image_size: ImageSize, params: torch.Tensor) -> None:

--- a/kornia/sensors/camera/distortion_model.py
+++ b/kornia/sensors/camera/distortion_model.py
@@ -103,9 +103,7 @@ class BrownConradyTransform:
         Both methods are placeholders: :meth:`distort` and :meth:`undistort` raise
         ``NotImplementedError`` with an empty message, which is what makes
         :class:`~kornia.sensors.camera.BrownConradyModel` unusable in either direction. Tracked in
-        `#4284 <https://github.com/kornia/kornia/issues/4284>`_ and pinned by
-        ``test_wart_brown_conrady_and_kannala_brandt_transforms_are_placeholders_4284`` in
-        ``tests/sensors/camera/test_distortion_model.py``.
+        `#4284 <https://github.com/kornia/kornia/issues/4284>`_.
         :func:`~kornia.geometry.calibration.distort_points` is the implemented Brown-Conrady model, in
         pixel space with a separate ``K`` and coefficient vector rather than one packed parameter vector.
 
@@ -165,9 +163,7 @@ class KannalaBrandtK3Transform:
         Both methods are placeholders: :meth:`distort` and :meth:`undistort` raise
         ``NotImplementedError`` with an empty message, which is what makes
         :class:`~kornia.sensors.camera.KannalaBrandtK3` unusable in either direction. Tracked in
-        `#4284 <https://github.com/kornia/kornia/issues/4284>`_ and pinned by
-        ``test_wart_brown_conrady_and_kannala_brandt_transforms_are_placeholders_4284`` in
-        ``tests/sensors/camera/test_distortion_model.py``.
+        `#4284 <https://github.com/kornia/kornia/issues/4284>`_.
         :func:`~kornia.geometry.camera.distort_points_kannala_brandt` is the implemented equivalent, on the
         same normalized input and the same packed parameter vector.
     """

--- a/kornia/sensors/camera/projection_model.py
+++ b/kornia/sensors/camera/projection_model.py
@@ -41,9 +41,7 @@ class Z1Projection:
         .. warning::
             That :math:`z = 0` answer is one of several that the projection entry points of kornia give for
             the same input; they are collected in `#4267 <https://github.com/kornia/kornia/issues/4267>`_.
-            The behaviour above is documented as it is and pinned by
-            ``test_wart_project_divides_by_z_with_no_guard_4267`` in
-            ``tests/sensors/camera/test_projection_model.py``.
+            The behaviour above is documented as it is.
 
         Args:
             points: Vector3 representing the points to project.
@@ -105,9 +103,7 @@ class OrthographicProjection:
     .. warning::
         Both methods are placeholders: :meth:`project` and :meth:`unproject` raise ``NotImplementedError``
         with an empty message, which is what makes :class:`~kornia.sensors.camera.Orthographic` unusable in
-        either direction. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_ and pinned by
-        ``test_wart_orthographic_projection_is_a_placeholder_4284`` in
-        ``tests/sensors/camera/test_projection_model.py``.
+        either direction. Tracked in `#4284 <https://github.com/kornia/kornia/issues/4284>`_.
         :func:`~kornia.geometry.camera.project_points_orthographic` is the implemented equivalent.
     """
 


### PR DESCRIPTION
## What

Docs-only. The five batch-5 convention files and the camera conventions page cited their pins by private test function name and `tests/...` path — 26 exact names and 17 paths across `kornia/geometry/camera/pinhole.py`, `stereo.py`, `kornia/geometry/depth.py`, `kornia/sensors/camera/{camera_model,distortion_model,projection_model}.py`, plus two on `docs/source/get-started/camera-conventions.rst`. This PR replaces each of those clauses with the issue link that was already in the same sentence, so every warning ends "Tracked in `#NNNN`" the way the batch-3 and batch-4 files do.

## Why

- A reader on Read the Docs cannot follow a `tests/` path, and the name of a private test is not part of any contract.
- A test rename silently falsifies the docstring — it happened twice during the batch-5 review rounds — and nothing checks the names.
- The pins stay discoverable: every wart and convention pin carries its issue number as a `_NNNN` suffix, and the `AGENTS.md` issue-number grep is the check that already runs before a fix merges.

Nothing is removed from `tests/`; no pin changes. One dangling phrase ("the pin below states the claim") in the `DepthWarper` block was reworded since the pin is no longer named. The `#4281` link in the `StereoCamera` guards warning survives through its existing parenthetical.

Decided at the batch-5 close-out (#4262).

## Verification

- `kornia/` change is docstring-only: the six modules' ASTs with docstrings stripped are identical to `origin/main` (`147ecc4e`).
- `grep -rnE 'test_(wart|convention)_|tests/'` over the six files: 0 hits; the three rendered pages (`camera-conventions`, `geometry.depth`, `sensors.camera`) contain no test name.
- `sphinx -W -b html` from this branch: exit 0, zero warnings.
- Doctests of the six modules: 22 passed. `tests/geometry/camera`, `tests/geometry/test_depth.py`, `tests/sensors/camera` at cpu float32: 357 passed, 19 skipped, 2 xfailed.
- pre-commit on the changed files: 12 hooks passed. The three lines over 120 columns in `camera-conventions.rst` are pre-existing (URLs).
- No CHANGELOG entry: the warnings keep their meaning and their issue links; only the citation form changes.

Posted on behalf of @ducha-aiki by Claude (Fable 5.1).
