### PR TITLE
fix(tests): keep the RRDB ONNX export inside the coverage timeout

### DIFF
--- a/tests/contrib/test_super_resolution.py
+++ b/tests/contrib/test_super_resolution.py
@@ -80,12 +80,21 @@ class TestSuperResolutionBuilders(BaseTester):
         assert model.output_image_size is None
         assert model.pseudo_image_size is None
 
-    @pytest.mark.parametrize("builder", [SmallSRBuilder, RRDBNetBuilder])
-    def test_to_onnx_exports(self, builder):
+    # The exporter's cost scales with the traced node count, not with the pseudo input size, so
+    # `RRDBNetBuilder`'s 23-block default costs ~4x the 6-block anime variant while traversing the
+    # identical export path. Which variant maps to which architecture is pinned in
+    # tests/models/test_rrdbnet.py::TestRRDBNetBuilder.
+    @pytest.mark.timeout(120)
+    @pytest.mark.parametrize(
+        ("builder", "build_kwargs"),
+        [(SmallSRBuilder, {}), (RRDBNetBuilder, {"model_name": "RealESRGAN_x4plus_anime_6B"})],
+        ids=["SmallSRBuilder", "RRDBNetBuilder"],
+    )
+    def test_to_onnx_exports(self, builder, build_kwargs):
         """Both families export; this fails with ``AttributeError`` if the metadata is unset."""
         pytest.importorskip("onnx")
         pytest.importorskip("onnxscript")
-        builder.build(pretrained=False).to_onnx(save=False)
+        builder.build(pretrained=False, **build_kwargs).to_onnx(save=False)
 
     @pytest.mark.parametrize(("upscale_factor", "image_size"), [(2, 32), (3, None), (4, 64)])
     def test_output_image_size_matches_the_real_forward(self, device, dtype, upscale_factor, image_size):


### PR DESCRIPTION
## What is red

Both `coverage / overall` legs of the post-merge `Tests on CPU (scheduled)` run on `main`
([34476433908](https://github.com/kornia/kornia/actions/runs/34476433908)) fail, deterministically and in
both dtypes:

```
FAILED tests/contrib/test_super_resolution.py::TestSuperResolutionBuilders::test_to_onnx_exports[RRDBNetBuilder]
  - Failed: Timeout (>30.0s) from pytest-timeout.
```

## Root cause

`test_to_onnx_exports[RRDBNetBuilder]` (added in #4335) exports `RRDBNetBuilder.build(pretrained=False)`,
whose default variant is `RealESRNet_x4plus`: 23 RRDB blocks, ~16.7M parameters, ~350 convolutions. The
dynamo ONNX exporter has to trace, decompose, translate and optimize every one of those nodes.

Measured locally (Python 3.11, torch 2.14, CPU):

| what | bare | under `coverage run` |
| --- | --- | --- |
| 23 blocks (current) | 22.25s | **44.75s** |
| 6 blocks | 5.5s | 12.4s |
| `SmallSRBuilder` | 0.9s | 2.1s |

Two things follow from the numbers:

* The cost tracks the **traced node count, not the pseudo input size** — 23 blocks cost 19.91s at the
  default 352px pseudo shape and 19.86s at 64px, and `MKL_NUM_THREADS=1 OMP_NUM_THREADS=1` (what the
  `overall` leg sets) changes nothing. Shrinking the dummy input, the usual lever, would not have helped.
* `coverage run` roughly doubles it, because the exporter is Python-heavy. Only the coverage legs pass
  `--timeout=30` (`.github/actions/coverage/action.yml`), which is why the plain `tests-cpu-*` legs are green.

`coverage.yml` is called from `scheduled_test_cpu.yml` only, never from `pr_test_cpu.yml`, so no PR run can
observe this timeout — #4335 merged green and the failure appeared on the first post-merge run.

## Fix

Two changes to the one test:

* `@pytest.mark.timeout(120)` — the mark every other heavy ONNX export test in the repo already carries
  (`tests/models/test_dexined_onnx.py`, `test_rtdetr_onnx.py`, `test_sam_onnx.py`, `test_object_detector.py`).
  The blanket `--timeout=30` is a hang guard, not a performance budget for a 16.7M-parameter export.
* Export the 6-block `RealESRGAN_x4plus_anime_6B` variant instead of the 23-block default. It traverses the
  identical export path (same `scale=4` branch in `RRDBNet.forward`, same all-`None` ONNX metadata, so the
  same `-1`/352 fallbacks in `SuperResolution.to_onnx`), for a quarter of the graph. Which variant maps to
  which architecture is already pinned by
  `tests/models/test_rrdbnet.py::TestRRDBNetBuilder::test_build_selects_the_vendored_rrdbnet`, so nothing is
  lost. The test id stays `[RRDBNetBuilder]`.

## Verification

* Red state reproduced with the exact CI configuration —
  `coverage run -m pytest <node> --timeout=30` → `1 failed` at 34.21s.
* After the fix, same command: `14 passed in 18.35s`, the RRDB export at 12.42s (was 44.75s).
* The marker really does override the CLI value: the file passes under `--timeout=1` with the marked test
  taking 5.80s.
* `tests/contrib/test_super_resolution.py tests/models/test_rrdbnet.py tests/models/test_small_sr.py`:
  127 passed, 5 skipped.
* `pre-commit` on the changed file: all hooks pass.

No CHANGELOG entry: the change is test-only and not user-visible.

## Follow-up worth considering (not in this PR)

The `--timeout=30` guard exists only in a post-merge workflow, so any future slow test lands green and turns
`main` red afterwards. Either run one coverage leg on PRs or move the timeout into `pr_test_cpu.yml`.

Posted on behalf of @ducha-aiki by Claude (Opus 5).
