### PR TITLE
Fix #4235: elastic_transform2d identity mapping with align_corners=False

### DIFF
--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -124,7 +124,14 @@ def elastic_transform2d(
 
     # Warp image based on displacement matrix
     _, _, h, w = image.shape
-    grid = create_meshgrid(h, w, device=image.device).to(image.dtype)
+    
+    if align_corners:
+        grid = create_meshgrid(h, w, device=image.device).to(image.dtype)
+    else:
+        grid = create_meshgrid(h, w, normalized_coordinates=False, device=image.device).to(image.dtype)
+        grid[..., 0] = (grid[..., 0] + 0.5) * 2.0 / max(w, 1) - 1.0
+        grid[..., 1] = (grid[..., 1] + 0.5) * 2.0 / max(h, 1) - 1.0
+        
     warped = F.grid_sample(
         image, (grid + disp).clamp(-1, 1), align_corners=align_corners, mode=mode, padding_mode=padding_mode
     )

--- a/kornia/geometry/transform/elastic_transform.py
+++ b/kornia/geometry/transform/elastic_transform.py
@@ -124,14 +124,14 @@ def elastic_transform2d(
 
     # Warp image based on displacement matrix
     _, _, h, w = image.shape
-    
+
     if align_corners:
         grid = create_meshgrid(h, w, device=image.device).to(image.dtype)
     else:
         grid = create_meshgrid(h, w, normalized_coordinates=False, device=image.device).to(image.dtype)
         grid[..., 0] = (grid[..., 0] + 0.5) * 2.0 / max(w, 1) - 1.0
         grid[..., 1] = (grid[..., 1] + 0.5) * 2.0 / max(h, 1) - 1.0
-        
+
     warped = F.grid_sample(
         image, (grid + disp).clamp(-1, 1), align_corners=align_corners, mode=mode, padding_mode=padding_mode
     )

--- a/tests/geometry/transform/test_elastic_transform.py
+++ b/tests/geometry/transform/test_elastic_transform.py
@@ -103,13 +103,20 @@ class TestElasticTransform(BaseTester):
         noise = torch.ones(1, 2, 3, 3, device=device, dtype=dtype)
 
         expected = torch.tensor(
-            [[[[0.0005, 0.3795, 0.1905], [0.1034, 0.4235, 0.0702], [0.0259, 0.2007, 0.2193]]]],
+            [[[[0.0062, 0.7506, 0.7487], [0.2058, 0.4235, 0.1397], [0.1036, 0.3996, 0.8693]]]],
             device=device,
             dtype=dtype,
         )
 
         actual = elastic_transform2d(image, noise)
         self.assert_close(actual, expected, atol=1e-3, rtol=1e-3)
+
+    @pytest.mark.parametrize("align_corners", [True, False])
+    def test_identity(self, device, dtype, align_corners):
+        image = torch.arange(16.0, device=device, dtype=dtype).reshape(1, 1, 4, 4)
+        noise = torch.zeros(1, 2, 4, 4, device=device, dtype=dtype)
+        output = elastic_transform2d(image, noise, align_corners=align_corners)
+        self.assert_close(output, image)
 
     @pytest.mark.parametrize("requires_grad", [True, False])
     def test_gradcheck(self, device, dtype, requires_grad):


### PR DESCRIPTION
Fixes #4235

### Description

This PR fixes a bug in `elastic_transform2d` where a zero displacement field does not result in an identity transformation when `align_corners=False`.

The issue was caused by `elastic_transform2d` always using `create_meshgrid(normalized_coordinates=True)` to generate the base grid, which assumes the `align_corners=True` convention (`[-1, 1]` mapped to outer pixel centers). When this grid was passed into `F.grid_sample` with `align_corners=False`, the coordinate meaning shifted, resulting in the image being slightly resampled at shifted coordinates.

I fixed this by explicitly generating the grid according to the selected `align_corners` flag so that it's consistent with `grid_sample` expectations. 

Includes tests that verify identity mappings for both `align_corners=False` and `align_corners=True`.
