### PR TITLE
fix(augmentation): make the RandAugment and AutoAugment range guards say what they enforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `RandAugment`'s `m` guard is exclusive at both ends, but its docstring and its error message
+  both named the closed interval `[0, 30]`, so a user who asked for the maximum strength the
+  message advertised got an exception saying `30` was in range. Both now read `(0, 30)`; the
+  accepted values are unchanged. `n` was validated nowhere: `n=0` constructed a `RandAugment`
+  that applied nothing, and `n` above the policy length was silently clamped, because the
+  sampler draws without replacement. It is now checked against the policy. `AutoAugment`'s
+  magnitude bin indexes two adjacent points of an 11-point scale, so `9` is the last usable
+  bin; a larger one raised a raw `IndexError` naming an internal tensor, and a negative one
+  wrapped silently onto a reversed range. Out-of-range bins now name the operation and the
+  valid range. Operations that ignore the magnitude entirely keep accepting any bin. (#4443)
+
 * `pixel2cam` now validates the full `Bx4x4` shape of `intrinsics_inv`, rejecting invalid matrix sizes
   before they cause unrelated transformation errors or return the wrong number of coordinate components. (#4381)
 * `Boxes.to_mask` leaves list-padding channels empty, including after coordinate transforms,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,7 +388,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   magnitude bin indexes two adjacent points of an 11-point scale, so `9` is the last usable
   bin; a larger one raised a raw `IndexError` naming an internal tensor, and a negative one
   wrapped silently onto a reversed range. Out-of-range bins now name the operation and the
-  valid range. Operations that ignore the magnitude entirely keep accepting any bin. (#4443)
+  valid range. Operations that ignore the magnitude entirely keep accepting any bin. (#4447)
 
 * `pixel2cam` now validates the full `Bx4x4` shape of `intrinsics_inv`, rejecting invalid matrix sizes
   before they cause unrelated transformation errors or return the wrong number of coordinate components. (#4381)

--- a/kornia/augmentation/auto/autoaugment/ops.py
+++ b/kornia/augmentation/auto/autoaugment/ops.py
@@ -17,6 +17,8 @@
 
 """AutoAugment operation wrapper."""
 
+from typing import Tuple
+
 import torch
 
 from kornia.augmentation.auto.operations import (
@@ -38,13 +40,38 @@ from kornia.augmentation.auto.operations import (
 )
 
 
+def _magnitude_bin(magnitudes: torch.Tensor, magnitude: int, name: str) -> Tuple[float, float]:
+    """Return the magnitude range that bin ``magnitude`` selects from ``magnitudes``.
+
+    A bin indexes two adjacent points, so the last usable bin is two short of the end.
+    Indexing directly would let a negative bin wrap silently onto a reversed range, and
+    an over-large one surface an ``IndexError`` naming an internal tensor rather than the
+    policy entry the caller wrote.
+
+    Args:
+        magnitudes: The op's magnitude scale.
+        magnitude: Bin index into that scale.
+        name: Operation name, for the error message.
+
+    Returns:
+        The ``(low, high)`` range for that bin.
+
+    Raises:
+        ValueError: If ``magnitude`` is not a usable bin index.
+    """
+    last_bin = magnitudes.shape[0] - 2
+    if not 0 <= magnitude <= last_bin:
+        raise ValueError(f"Expect magnitude bin for `{name}` in [0, {last_bin}]. Got {magnitude}.")
+    return magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()
+
+
 def shear_x(probability: float, magnitude: int) -> OperationBase:
     """Return ShearX op."""
     magnitudes = torch.linspace(-0.3, 0.3, 11) * 180.0
     return ShearX(
         None,
         probability,
-        magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()),
+        magnitude_range=_magnitude_bin(magnitudes, magnitude, "shear_x"),
         symmetric_megnitude=False,
     )
 
@@ -55,7 +82,7 @@ def shear_y(probability: float, magnitude: int) -> OperationBase:
     return ShearY(
         None,
         probability,
-        magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()),
+        magnitude_range=_magnitude_bin(magnitudes, magnitude, "shear_y"),
         symmetric_megnitude=False,
     )
 
@@ -66,7 +93,7 @@ def translate_x(probability: float, magnitude: int) -> OperationBase:
     return TranslateX(
         None,
         probability,
-        magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()),
+        magnitude_range=_magnitude_bin(magnitudes, magnitude, "translate_x"),
         symmetric_megnitude=False,
     )
 
@@ -77,7 +104,7 @@ def translate_y(probability: float, magnitude: int) -> OperationBase:
     return TranslateY(
         None,
         probability,
-        magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()),
+        magnitude_range=_magnitude_bin(magnitudes, magnitude, "translate_y"),
         symmetric_megnitude=False,
     )
 
@@ -88,7 +115,7 @@ def rotate(probability: float, magnitude: int) -> OperationBase:
     return Rotate(
         None,
         probability,
-        magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()),
+        magnitude_range=_magnitude_bin(magnitudes, magnitude, "rotate"),
         symmetric_megnitude=False,
     )
 
@@ -111,40 +138,34 @@ def equalize(probability: float, _: int) -> OperationBase:
 def solarize(probability: float, magnitude: int) -> OperationBase:
     """Return solarize op."""
     magnitudes = torch.linspace(0, 255, 11) / 255.0
-    return Solarize(None, probability, magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()))
+    return Solarize(None, probability, magnitude_range=_magnitude_bin(magnitudes, magnitude, "solarize"))
 
 
 def posterize(probability: float, magnitude: int) -> OperationBase:
     """Return posterize op."""
     magnitudes = torch.linspace(4, 8, 11)
-    return Posterize(
-        None, probability, magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item())
-    )
+    return Posterize(None, probability, magnitude_range=_magnitude_bin(magnitudes, magnitude, "posterize"))
 
 
 def contrast(probability: float, magnitude: int) -> OperationBase:
     """Return contrast op."""
     magnitudes = torch.linspace(0.1, 1.9, 11)
-    return Contrast(None, probability, magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()))
+    return Contrast(None, probability, magnitude_range=_magnitude_bin(magnitudes, magnitude, "contrast"))
 
 
 def brightness(probability: float, magnitude: int) -> OperationBase:
     """Return brightness op."""
     magnitudes = torch.linspace(0.1, 1.9, 11)
-    return Brightness(
-        None, probability, magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item())
-    )
+    return Brightness(None, probability, magnitude_range=_magnitude_bin(magnitudes, magnitude, "brightness"))
 
 
 def sharpness(probability: float, magnitude: int) -> OperationBase:
     """Return sharpness op."""
     magnitudes = torch.linspace(0.1, 1.9, 11)
-    return Sharpness(
-        None, probability, magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item())
-    )
+    return Sharpness(None, probability, magnitude_range=_magnitude_bin(magnitudes, magnitude, "sharpness"))
 
 
 def color(probability: float, magnitude: int) -> OperationBase:
     """Return color op."""
     magnitudes = torch.linspace(0.1, 1.9, 11)
-    return Saturate(None, probability, magnitude_range=(magnitudes[magnitude].item(), magnitudes[magnitude + 1].item()))
+    return Saturate(None, probability, magnitude_range=_magnitude_bin(magnitudes, magnitude, "color"))

--- a/kornia/augmentation/auto/rand_augment/rand_augment.py
+++ b/kornia/augmentation/auto/rand_augment/rand_augment.py
@@ -51,8 +51,10 @@ class RandAugment(PolicyAugmentBase):
     """Apply RandAugment :cite:`cubuk2020randaugment` augmentation strategies.
 
     Args:
-        n: the number of augmentations to apply sequentially.
-        m: magnitude for all the augmentations, ranged from [0, 30].
+        n: the number of augmentations to apply sequentially. Must be at least ``1`` and at
+            most the number of sub-policies in ``policy``, since they are sampled without
+            replacement.
+        m: magnitude for all the augmentations, ranged from (0, 30) exclusive.
         policy: candidate transformations. If None, a default candidate list will be used.
         transformation_matrix_mode: computation mode for the chained transformation matrix, via `.transform_matrix`
                                     attribute.
@@ -79,12 +81,17 @@ class RandAugment(PolicyAugmentBase):
         transformation_matrix_mode: str = "silent",
     ) -> None:
         if m <= 0 or m >= 30:
-            raise ValueError(f"Expect `m` in [0, 30]. Got {m}.")
+            raise ValueError(f"Expect `m` in (0, 30). Got {m}.")
 
         if policy is None:
             _policy = default_policy
         else:
             _policy = policy
+
+        # `rand_selector` samples without replacement, so more operations than there are
+        # sub-policies cannot be honoured, and `n <= 0` silently applies nothing at all.
+        if not 1 <= n <= len(_policy):
+            raise ValueError(f"Expect `n` in [1, {len(_policy)}], the number of sub-policies. Got {n}.")
 
         super().__init__(_policy, transformation_matrix_mode=transformation_matrix_mode)
         self.n = n

--- a/tests/augmentation/test_auto_operation.py
+++ b/tests/augmentation/test_auto_operation.py
@@ -90,6 +90,25 @@ class TestAutoAugment(BaseTester):
     def test_sequential(augment_method, device, dtype):
         _test_sequential(AutoAugment(), device=device, dtype=dtype)
 
+    @pytest.mark.parametrize("magnitude", [10, 11, -1, -2])
+    def test_magnitude_bin_out_of_range_names_the_op(self, magnitude):
+        """A bin indexes two adjacent points, so 9 is the last usable one.
+
+        Over-large bins raised a raw IndexError naming an internal tensor, and negative
+        ones wrapped silently onto a reversed range.
+        """
+        with pytest.raises(ValueError, match=r"Expect magnitude bin for `rotate` in \[0, 9\]"):
+            AutoAugment(policy=[[("rotate", 1.0, magnitude)]])
+
+    @pytest.mark.parametrize("name", ["auto_contrast", "invert", "equalize"])
+    def test_ops_that_ignore_magnitude_are_not_gated(self, name):
+        """These take `_: int` and never index the scale, so any bin stays legal."""
+        AutoAugment(policy=[[(name, 1.0, 10)]])
+
+    def test_magnitude_bin_endpoints_are_accepted(self):
+        AutoAugment(policy=[[("rotate", 1.0, 0)]])
+        AutoAugment(policy=[[("rotate", 1.0, 9)]])
+
 
 class TestRandAugment(BaseTester):
     @pytest.mark.parametrize("policy", [None, [[("translate_y", -0.5, 0.5)]]])
@@ -126,6 +145,28 @@ class TestRandAugment(BaseTester):
 
     def test_sequential(augment_method, device, dtype):
         _test_sequential(RandAugment(n=3, m=15), device=device, dtype=dtype)
+
+    @pytest.mark.parametrize("m", [1, 15, 29])
+    def test_m_accepts_the_interval_its_message_names(self, m):
+        """The guard is exclusive at both ends, and the message says so."""
+        RandAugment(n=2, m=m)
+
+    @pytest.mark.parametrize("m", [-1, 0, 30, 31])
+    def test_m_outside_the_open_interval_is_rejected(self, m):
+        with pytest.raises(ValueError, match=r"Expect `m` in \(0, 30\)"):
+            RandAugment(n=2, m=m)
+
+    @pytest.mark.parametrize("n", [0, -1, len(randaug_config) + 1])
+    def test_n_outside_the_policy_length_is_rejected(self, n):
+        """`n=0` applied nothing and `n > len(policy)` was silently clamped."""
+        with pytest.raises(ValueError, match=r"Expect `n` in \[1, 15\]"):
+            RandAugment(n=n, m=10)
+
+    def test_n_is_bounded_by_the_supplied_policy(self):
+        policy = [[("translate_y", -0.5, 0.5)], [("translate_x", -0.5, 0.5)]]
+        RandAugment(n=2, m=10, policy=policy)
+        with pytest.raises(ValueError, match=r"Expect `n` in \[1, 2\]"):
+            RandAugment(n=3, m=10, policy=policy)
 
 
 class TestTrivialAugment(BaseTester):


### PR DESCRIPTION
Fixes #4443.

Reproduced the issue's script verbatim on `d6a2c138` (the commit it cites), then again after the change. Every value that constructed before still constructs.

## `m`

The guard is `m <= 0 or m >= 30`; the docstring and the message both named `[0, 30]`. Both now read `(0, 30)`. The guard itself is untouched, so this is a documentation and message fix with no behaviour change — the direction the issue prefers. Widening the guard to admit `0` and `30` is the other reasonable contract, and I have not taken it; say the word if you would rather have that and I will swap them.

## `n`

Now checked against the policy actually in use, so a caller-supplied two-entry policy reports `[1, 2]` rather than the default's `[1, 15]`.

```
n= 0  ValueError: Expect `n` in [1, 15], the number of sub-policies. Got 0.
n=20  ValueError: Expect `n` in [1, 15], the number of sub-policies. Got 20.
n= 1..15  unchanged
```

## `AutoAugment`'s magnitude bin

Two findings here changed how I implemented it, and both are worth your eye.

**A guard at the dispatch point would have broken working calls.** `auto_contrast`, `invert` and `equalize` take the magnitude as `_` and never index the scale. `("equalize", 1.0, 10)` works today. Gating every op in `compose_subpolicy_sequential` would reject it, which the issue's own "none of these change a currently successful call" rules out. So the check lives where the magnitude is consumed: one `_magnitude_bin` helper in `autoaugment/ops.py`, used by the eleven ops that index a scale. The three that ignore it stay ungated, and there is a test pinning that.

**Negative bins were silently wrong, which the issue does not mention.** Python indexing wraps, so on `main`:

```
rotate bin  -1  -> magnitude_range (30.0, -30.0), reversed; fails later inside
                   RandomRotation with "degrees[0] should be smaller than degrees[1]"
rotate bin  -2  -> constructs fine, silently a different range
rotate bin -11  -> constructs fine, silently a different range
rotate bin -12  -> IndexError
```

A wrong augmentation range with no error is worse than the reported `IndexError`. `0 <= bin <= last` catches all of it in one rule:

```
AutoAugment bin  10 -> ValueError: Expect magnitude bin for `rotate` in [0, 9]. Got 10.
AutoAugment bin  -1 -> ValueError: Expect magnitude bin for `rotate` in [0, 9]. Got -1.
```

The bound is derived as `magnitudes.shape[0] - 2` rather than hardcoded to 9, so an op with a different scale length reports its own bound.

## Tests

Seven new tests, 19 cases, in `TestRandAugment` and `TestAutoAugment`:

- `m` accepted at 1/15/29 and rejected at -1/0/30/31, matching on the new message
- `n` rejected at 0, -1 and `len(policy) + 1`, and bounded by a supplied policy
- magnitude bin rejected at 10, 11, -1, -2, naming the op
- bin endpoints 0 and 9 accepted
- the three magnitude-ignoring ops still accept bin 10

**12 of the 19 fail on `main` and pass here.** The other 7 pass both ways by design — they are the guards proving nothing that worked before stopped working.

## Verification

`tests/augmentation/` gives **160 failed, 2174 passed** both with this change and on clean `main` — byte-identical counts. Those 160 are a pre-existing `OSError: pytest: reading from stdin while output is captured` in `_test_sequential` and friends, unrelated to this change; I stashed and re-ran to confirm rather than assume. `test_auto_operation.py` alone goes from `3 failed, 21 passed` to `3 failed, 40 passed`, the same 3.

`ruff check`, `ruff format --check` and `mypy` clean on all changed files.
