### PR TITLE
fix: validate PinholeCamera batch and point shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,6 +390,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrapped silently onto a reversed range. Out-of-range bins now name the operation and the
   valid range. Operations that ignore the magnitude entirely keep accepting any bin. (#4447)
 
+* `PinholeCamera.project` now reports rank-1 inputs with the same explicit `ValueError` used by the point-conversion
+  helpers instead of an internal `IndexError`. Refs #4266. (#4450)
 * `pixel2cam` now validates the full `Bx4x4` shape of `intrinsics_inv`, rejecting invalid matrix sizes
   before they cause unrelated transformation errors or return the wrong number of coordinate components. (#4381)
 * `Boxes.to_mask` leaves list-padding channels empty, including after coordinate transforms,

--- a/kornia/geometry/camera/perspective.py
+++ b/kornia/geometry/camera/perspective.py
@@ -40,8 +40,7 @@ def project_points(point_3d: torch.Tensor, camera_matrix: torch.Tensor) -> torch
           undivided point, giving ``fx x + cx``. A point behind the camera is projected just as silently.
 
     .. warning::
-        The unbatched-input contract is `#4266 <https://github.com/kornia/kornia/issues/4266>`_ and the ``z = 0`` answer
-        `#4267 <https://github.com/kornia/kornia/issues/4267>`_.
+        The ``z = 0`` answer is tracked in `#4267 <https://github.com/kornia/kornia/issues/4267>`_.
 
     Args:
         point_3d: tensor containing the 3d points to be projected

--- a/kornia/geometry/camera/pinhole.py
+++ b/kornia/geometry/camera/pinhole.py
@@ -61,9 +61,9 @@ class PinholeCamera:
         that remains on :meth:`scale_` and the setters is
         `#4264 <https://github.com/kornia/kornia/issues/4264>`_, the in-place :meth:`scale_` failure on an
         integer ``height`` / ``width`` with a floating-point scale factor
-        `#4265 <https://github.com/kornia/kornia/issues/4265>`_, the batch-size and point-shape limitations
-        `#4266 <https://github.com/kornia/kornia/issues/4266>`_. The behaviour described here is
-        documented as it is; the issues above track the repairs.
+        `#4265 <https://github.com/kornia/kornia/issues/4265>`_, the direct projection limitation for
+        :math:`(B, N, 4, 4)` camera storage `#4266 <https://github.com/kornia/kornia/issues/4266>`_. The behaviour
+        described here is documented as it is; the issues above track the repairs.
 
     Args:
         intrinsics: torch.Tensor with shape :math:`(B, 4, 4)`
@@ -399,18 +399,18 @@ class PinholeCamera:
         See the Convention block on :class:`~kornia.geometry.camera.pinhole.PinholeCamera`.
 
         Convention:
-            - ``point_3d`` must be at least rank 2: an unbatched :math:`(3,)` point raises :class:`IndexError`
-              although the shape below reads :math:`(*, 3)`. An empty point set returns an empty result.
+            - ``point_3d`` must be at least rank 2. An unbatched :math:`(3,)` point raises :class:`ValueError`.
+              An empty point set returns an empty result.
             - a point whose **camera-frame** ``z`` is 0 does not raise: ``K`` is applied first and the
               perspective divide is then skipped, so the result is the undivided ``K (R X + t)``.
 
         .. warning::
-            The unbatched-input contract is `#4266 <https://github.com/kornia/kornia/issues/4266>`_ and the
-            ``z = 0`` answer `#4267 <https://github.com/kornia/kornia/issues/4267>`_.
+            The ``z = 0`` answer is tracked in `#4267 <https://github.com/kornia/kornia/issues/4267>`_.
 
         Args:
             point_3d: torch.Tensor containing the 3d points to be projected
-                to the camera plane. The shape of the torch.Tensor can be :math:`(*, 3)`.
+                to the camera plane. The shape of the torch.Tensor can be :math:`(*, 3)` with at least two
+                dimensions.
 
         Returns:
             torch.Tensor of (u, v) cam coordinates with shape :math:`(*, 2)`.
@@ -427,6 +427,8 @@ class PinholeCamera:
             tensor([[5.6088, 8.6827]])
 
         """
+        if len(point_3d.shape) < 2:
+            raise ValueError(f"Input must be at least a 2D tensor. Got {point_3d.shape}")
         P = self.intrinsics @ self.extrinsics
         return convert_points_from_homogeneous(transform_points(P, point_3d))
 
@@ -439,7 +441,8 @@ class PinholeCamera:
 
         Args:
             point_2d: torch.Tensor containing the 2d to be projected to
-                world coordinates. The shape of the torch.Tensor can be :math:`(*, 2)`.
+                world coordinates. The shape of the torch.Tensor can be :math:`(*, 2)` with at least two
+                dimensions.
             depth: torch.Tensor containing the depth value of each 2d
                 points. The torch.Tensor shape must be equal to point2d :math:`(*, 1)`.
 

--- a/tests/geometry/camera/test_pinhole.py
+++ b/tests/geometry/camera/test_pinhole.py
@@ -865,13 +865,7 @@ class TestPinholeCamera(BaseTester):
         points = torch.tensor([[1.0, 2.0, 4.0]], device=device, dtype=dtype)
         self.assert_close(cameras.get_pinhole(1).project(points), cam.project(points))
 
-    def test_wart_project_rejects_an_unbatched_point_with_indexerror_4266(self, device, dtype):
-        # Wart pin for kornia#4266: PinholeCamera.project documents ``(*, 3)``
-        # and raises a bare IndexError("tuple index out of range") on a (3,) point, while the free function
-        # project_points raises ValueError("Input must be at least a 2D tensor") on the same input -- two
-        # exception types for one documented contract, and neither is the documented shape.
-        # Snippet used to generate expected: both calls executed 2026-09-05 (torch 2.14.0, every dtype).
-        # Pins the CURRENT behavior; NOT a contract; delete when #4266 is repaired.
+    def test_project_and_unproject_reject_rank_one_points_4266(self, device, dtype):
         cam = kornia.geometry.camera.PinholeCamera(
             _k44(device, dtype),
             _e44(device, dtype, tx=1.0),
@@ -879,10 +873,19 @@ class TestPinholeCamera(BaseTester):
             torch.tensor([8], device=device),
         )
         point = torch.tensor([1.0, 2.0, 4.0], device=device, dtype=dtype)
-        with pytest.raises(IndexError, match="tuple index out of range"):
+        with pytest.raises(ValueError) as cam_error:
             cam.project(point)
-        with pytest.raises(ValueError, match="at least a 2D tensor"):
+        with pytest.raises(ValueError) as function_error:
             kornia.geometry.camera.project_points(point, _k44(device, dtype)[:, :3, :3].contiguous())
+        assert (
+            str(cam_error.value)
+            == str(function_error.value)
+            == "Input must be at least a 2D tensor. Got torch.Size([3])"
+        )
+
+        point_2d = torch.tensor([1.0, 2.0], device=device, dtype=dtype)
+        with pytest.raises(ValueError, match=r"Input must be at least a 2D tensor\. Got torch\.Size\(\[2\]\)"):
+            cam.unproject(point_2d, torch.tensor([4.0], device=device, dtype=dtype))
 
     def test_constructor_accepts_an_empty_batch_4281(self, device, dtype):
         # Regression for kornia#4281: a consistent empty camera batch is valid.


### PR DESCRIPTION
## What does this pull request do?

After rebasing on current `main`, this PR preserves the constructor batch handling already delivered by #4386: mismatched parameter batches are rejected, while consistent empty batches are valid. The remaining behavior change makes a rank-1 `PinholeCamera.project` input raise the same explicit `ValueError` as `project_points` instead of exposing an internal `IndexError`.

The `project`/`unproject` shape documentation and focused regression coverage are updated accordingly. `PinholeCamerasList` keeps its `(B, N, 4, 4)` storage behavior, while direct projection from that rank-4 storage remains deferred under #4266.

## Related issue or discussion

Refs #4266

## What did you check?

The focused #4266/#4281/rank-four selection passed 98 tests and the complete pinhole module passed 185 tests with 1 skip on CPU float32/float64; all pre-commit hooks passed on the previously changed files, while the repository-wide all-files run is blocked only by unrelated existing `=======` RST title underlines in documentation. For the documentation follow-up, pre-commit passed for `kornia/geometry/camera/perspective.py` and `tests/geometry/camera/test_perspective.py` passed 32 CPU float32/float64 tests; replacement hosted CI is running for published head `c214ae6257cf6db4ce8c0d571a91b93c6622c887`, with no failing hosted check currently reported and several matrix jobs still pending.

```text
$ pixi run test-module tests/geometry/camera/test_pinhole.py --dtype=float32,float64 --device=cpu -k "4266 or 4281 or camera_list_preserves_rank_four_parameters"
$ pixi run test-module tests/geometry/camera/test_pinhole.py --dtype=float32,float64 --device=cpu
$ pixi run uv run pre-commit run --files CHANGELOG.md kornia/geometry/camera/pinhole.py tests/geometry/camera/test_pinhole.py
$ pixi run uv run pre-commit run --files kornia/geometry/camera/perspective.py
$ pixi run test-module tests/geometry/camera/test_perspective.py --dtype=float32,float64 --device=cpu
```

## How did AI help?

AI assisted with resolving the rebase conflicts, preserving #4386's empty-batch and batch-mismatch behavior, narrowing the #4450 changelog entry to the remaining rank-1 projection fix, removing the stale #4266 reference from `project_points` documentation, and running the local verification above.