### PR TITLE
fix(augmentation): enforce strict RandomRain drop bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `RandomRain` now rejects drop heights equal to the image height and absolute drop widths equal to the image
+  width with the documented validation error, instead of allowing boundary-sized drops to reach an internal
+  `IndexError`. (#4451)
 * `pixel2cam` now validates the full `Bx4x4` shape of `intrinsics_inv`, rejecting invalid matrix sizes
   before they cause unrelated transformation errors or return the wrong number of coordinate components. (#4381)
 * `Boxes.to_mask` leaves list-padding channels empty, including after coordinate transforms,

--- a/kornia/augmentation/_2d/intensity/random_rain.py
+++ b/kornia/augmentation/_2d/intensity/random_rain.py
@@ -32,8 +32,10 @@ class RandomRain(IntensityAugmentationBase2D):
     Args:
         p: probability of applying the transformation.
         number_of_drops: number of drops per image
-        drop_height: height of the drop in image(same for each drops in one image)
-        drop_width: width of the drop in image(same for each drops in one image)
+        drop_height: Height of the drop in the image (same for each drop in one image). Sampled values must be
+            greater than zero and strictly smaller than the input image height.
+        drop_width: Width of the drop in the image (same for each drop in one image). The absolute sampled value
+            must be strictly smaller than the input image width.
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`
         - Output: :math:`(B, C, H, W)`

--- a/kornia/augmentation/_2d/intensity/random_rain.py
+++ b/kornia/augmentation/_2d/intensity/random_rain.py
@@ -74,14 +74,13 @@ class RandomRain(IntensityAugmentationBase2D):
         KORNIA_CHECK(image.shape[1] in {3, 1}, "Number of color channels should be 1 or 3.")
         KORNIA_CHECK(
             bool(
-                torch.all(params["drop_height_factor"] <= image.shape[2])
-                and torch.all(params["drop_height_factor"] > 0)
+                torch.all(params["drop_height_factor"] < image.shape[2]) and torch.all(params["drop_height_factor"] > 0)
             ),
             "Height of drop should be greater than zero and less than image height.",
         )
 
         KORNIA_CHECK(
-            bool(torch.all(torch.abs(params["drop_width_factor"]) <= image.shape[3])),
+            bool(torch.all(torch.abs(params["drop_width_factor"]) < image.shape[3])),
             "Width of drop should be less than image width.",
         )
         modeified_img = image.clone()

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5359,6 +5359,37 @@ class TestRandomRain(BaseTester):
 
             assert err_msg in str(errinfo)
 
+    @pytest.mark.parametrize(
+        "drop_height,drop_width,error_message",
+        [
+            (
+                (5, 5),
+                (1, 1),
+                "Height of drop should be greater than zero and less than image height.",
+            ),
+            ((1, 1), (7, 7), "Width of drop should be less than image width."),
+            ((1, 1), (-7, -7), "Width of drop should be less than image width."),
+        ],
+    )
+    def test_drop_size_boundaries(self, drop_height, drop_width, error_message, device, dtype):
+        from kornia.core.exceptions import BaseError
+
+        input_data = torch.zeros(1, 3, 5, 7, device=device, dtype=dtype)
+        aug = RandomRain(p=1.0, drop_height=drop_height, drop_width=drop_width, number_of_drops=(1, 1))
+
+        with pytest.raises(BaseError) as errinfo:
+            aug(input_data)
+
+        assert str(errinfo.value) == error_message
+
+    def test_drop_size_immediately_inside_boundaries(self, device, dtype):
+        input_data = torch.zeros(1, 3, 5, 7, device=device, dtype=dtype)
+        aug = RandomRain(p=1.0, drop_height=(4, 4), drop_width=(6, 6), number_of_drops=(1, 1))
+
+        output_data = aug(input_data)
+
+        assert output_data.shape == input_data.shape
+
     def test_zero_probability(self, device):
         input_data = torch.rand(10, 3, 8, 8, device=device)
         aug = RandomRain(p=0.0, drop_height=(2, 3), drop_width=(2, 3), number_of_drops=(1, 3))


### PR DESCRIPTION
## What does this pull request do?

Fixes the `RandomRain` drop-size boundary validation reported in #4434.

The existing guards accepted the boundary values:

- `drop_height == H`
- `abs(drop_width) == W`

even though the corresponding error messages describe strict bounds.

Those equality cases could therefore pass validation and fail later during drawing with an internal `IndexError`.

This PR changes the validation so that the implementation matches the documented contract:

- `drop_height < H`
- `abs(drop_width) < W`

The default `RandomRain` sampling behavior remains unchanged.

Regression coverage was added for:

- `drop_height == H`
- `drop_width == W`
- `drop_width == -W`
- a non-square image case to verify height/width orientation
- immediately in-bounds values that must continue to succeed

## Related issue or discussion

Fixes #4434

## What did you check?

Focused `RandomRain` tests:

```text
13 passed
```

Also verified:

- the branch is based directly on the current `upstream/main`
- the worktree is clean
- `git diff --check` passes
- there are no conflict markers
- only the intended `RandomRain` implementation and regression-test files are changed

## How did AI help?

AI tooling assisted with repository analysis, reproducing the boundary behavior, regression-test planning, implementation review, and validation guidance.

I reviewed the resulting changes and ran the focused regression checks locally.