### PR TITLE
fix(augmentation): sample same number of drops in RandomRain when same_on_batch=True (#4448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,7 +378,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* `RandomRain` with `same_on_batch=True` now samples the same number of rain drops for all samples in the batch. (#4448)
+* `RandomRain` with `same_on_batch=True` now samples the same number of rain drops for all samples in the batch. (#4453)
 * `pixel2cam` now validates the full `Bx4x4` shape of `intrinsics_inv`, rejecting invalid matrix sizes
   before they cause unrelated transformation errors or return the wrong number of coordinate components. (#4381)
 * `Boxes.to_mask` leaves list-padding channels empty, including after coordinate transforms,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `RandomRain` with `same_on_batch=True` now samples the same number of rain drops for all samples in the batch. (#4448)
 * `pixel2cam` now validates the full `Bx4x4` shape of `intrinsics_inv`, rejecting invalid matrix sizes
   before they cause unrelated transformation errors or return the wrong number of coordinate components. (#4381)
 * `Boxes.to_mask` leaves list-padding channels empty, including after coordinate transforms,

--- a/kornia/augmentation/random_generator/_2d/random_rain.py
+++ b/kornia/augmentation/random_generator/_2d/random_rain.py
@@ -70,7 +70,7 @@ class RainGenerator(RandomGeneratorBase):
         _common_param_check(batch_size, same_on_batch)
         _device, _dtype = _extract_device_dtype([self.drop_width, self.drop_height, self.number_of_drops])
         # self.ksize_factor.expand((batch_size, -1))
-        number_of_drops_factor = _adapted_rsampling((batch_size,), self.number_of_drops_sampler).to(
+        number_of_drops_factor = _adapted_rsampling((batch_size,), self.number_of_drops_sampler, same_on_batch).to(
             device=_device, dtype=torch.long
         )
         drop_height_factor = _adapted_rsampling((batch_size,), self.drop_height_sampler, same_on_batch).to(

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5364,6 +5364,18 @@ class TestRandomRain(BaseTester):
         aug = RandomRain(p=0.0, drop_height=(2, 3), drop_width=(2, 3), number_of_drops=(1, 3))
         aug(input_data)
 
+    def test_same_on_batch(self, device, dtype):
+        aug = RandomRain(p=1.0, drop_height=(2, 3), drop_width=(2, 3), number_of_drops=(5, 10), same_on_batch=True)
+        input = torch.rand(1, 3, 10, 10, device=device, dtype=dtype).repeat(4, 1, 1, 1)
+        output = aug(input)
+        self.assert_close(output[0], output[1])
+        self.assert_close(output[1], output[2])
+        self.assert_close(output[2], output[3])
+        assert (aug._params["number_of_drops_factor"] == aug._params["number_of_drops_factor"][0]).all()
+        assert (aug._params["drop_height_factor"] == aug._params["drop_height_factor"][0]).all()
+        assert (aug._params["drop_width_factor"] == aug._params["drop_width_factor"][0]).all()
+        self.assert_close(aug._params["coordinates_factor"][0], aug._params["coordinates_factor"][1])
+
 
 class TestMultiprocessing:
     torch.manual_seed(0)  # for random reproductibility


### PR DESCRIPTION
## What does this pull request do?

Fixes `RandomRain` with `same_on_batch=True` to draw the same number of rain drops across all samples in the batch.
Previously, `RainGenerator.forward` omitted `same_on_batch` when calling `_adapted_rsampling` for `number_of_drops_factor`, causing each sample in the batch to receive a different drop count despite `same_on_batch=True`.

## Related issue or discussion

Fixes #4448

## What did you check?

Added `test_same_on_batch` in `TestRandomRain` to verify that `number_of_drops_factor`, `drop_height_factor`, `drop_width_factor`, `coordinates_factor`, and batch outputs are identical across the batch when `same_on_batch=True`.

```text
$ pytest tests/augmentation/test_augmentation.py -k "TestRandomRain"
10 passed, 395 deselected in 4.23s
$ ruff check kornia/augmentation/random_generator/_2d/random_rain.py tests/augmentation/test_augmentation.py
All checks passed!
$ ruff format --check kornia/augmentation/random_generator/_2d/random_rain.py tests/augmentation/test_augmentation.py
2 files already formatted