### PR TITLE
fix(auto): refuse an inverse the drawn sub-policy cannot undo

### DIFF
--- a/kornia/augmentation/auto/base.py
+++ b/kornia/augmentation/auto/base.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 import torch
 from torch import nn
 
+from kornia.augmentation._2d.geometric.base import GeometricAugmentationBase2D
 from kornia.augmentation.auto.operations.base import OperationBase
 from kornia.augmentation.auto.operations.policy import PolicySequential
 from kornia.augmentation.container.base import ImageSequentialBase, TransformMatrixMinIn
@@ -118,6 +119,58 @@ class PolicyAugmentBase(ImageSequentialBase, TransformMatrixMinIn):
             if not module.is_intensity_only():
                 return False
         return True
+
+    def _non_invertible_ops(self, params: List[ParamItem]) -> List[str]:
+        """Name every drawn operation that :meth:`inverse` cannot undo.
+
+        Args:
+            params: Parameters recorded by a forward pass.
+
+        Returns:
+            Class names of the drawn operations that are not geometric, in execution order.
+        """
+        names: List[str] = []
+        for (_, module), param in zip(self.get_forward_sequence(params), params):
+            subpolicy = cast(PolicySequential, module)
+            subparams = cast(Optional[List[ParamItem]], param.data)
+            for _, operation in subpolicy.get_forward_sequence(subparams):
+                operation = cast(OperationBase, operation)
+                if not isinstance(operation.op, GeometricAugmentationBase2D):
+                    names.append(operation.op.__class__.__name__)
+        return names
+
+    def inverse(
+        self, input: torch.Tensor, params: Optional[List[ParamItem]] = None, extra_args: Optional[Dict[str, Any]] = None
+    ) -> torch.Tensor:
+        """Undo the drawn sub-policy, or refuse when it cannot be undone.
+
+        Only geometric operations are invertible. A policy draw that contains an intensity operation is
+        not round-trippable, and inverting it would return a tensor that still carries that operation --
+        for a draw with no geometry at all, the input unchanged. This raises instead, as
+        :meth:`kornia.augmentation.MixAugmentationBaseV2.inverse` already does for the mix classes.
+
+        Args:
+            input: Tensor produced by a forward pass.
+            params: Parameters used during that forward pass. Defaults to the cached ones.
+            extra_args: Optional per-input-type overrides.
+
+        Returns:
+            The inverse-transformed tensor.
+
+        Raises:
+            RuntimeError: The drawn sub-policy contains a non-invertible operation.
+        """
+        if params is None:
+            params = self._params
+        if params is not None:
+            non_invertible = self._non_invertible_ops(params)
+            if non_invertible:
+                raise RuntimeError(
+                    f"Inverse for {self.__class__.__name__} is not supported: the drawn sub-policy applied "
+                    f"{', '.join(non_invertible)}, which cannot be inverted. Only geometric operations are "
+                    "invertible, and the sub-policy is redrawn on every forward pass."
+                )
+        return super().inverse(input, params, extra_args=extra_args)
 
     def forward_parameters(self, batch_shape: torch.Size) -> List[ParamItem]:
         """Generate per-module parameters for one policy forward pass.

--- a/tests/augmentation/test_auto_operation.py
+++ b/tests/augmentation/test_auto_operation.py
@@ -215,3 +215,62 @@ def test_operation_preserves_input_dtype(device, low_dtype):
         assert out.dtype == low_dtype, f"{type(op).__name__}: {out.dtype} != {low_dtype}"
         checked += 1
     assert checked, f"no op could run in {low_dtype} on this build"
+
+
+# AutoAugment sub-policies are ``(name, probability, magnitude_bin)``; the other two are
+# ``(name, min_magnitude, max_magnitude)``. RandAugment and TrivialAugment allow only one
+# operation per sub-policy, so a mixed draw has to come from two of them -- and cannot
+# happen at all under TrivialAugment, which draws exactly one operation.
+_AA_GEOMETRIC, _AA_INTENSITY = ("translate_x", 1.0, 5), ("solarize", 1.0, 5)
+_GEOMETRIC, _INTENSITY = ("translate_x", -0.5, 0.5), ("solarize", 0.0, 1.0)
+
+
+@pytest.mark.parametrize(
+    ("intensity_only", "mixed", "geometry_only"),
+    [
+        (
+            lambda: AutoAugment(policy=[[_AA_INTENSITY]]),
+            lambda: AutoAugment(policy=[[_AA_GEOMETRIC, _AA_INTENSITY]]),
+            lambda: AutoAugment(policy=[[_AA_GEOMETRIC]]),
+        ),
+        (
+            lambda: RandAugment(n=1, m=15, policy=[[_INTENSITY]]),
+            lambda: RandAugment(n=2, m=15, policy=[[_GEOMETRIC], [_INTENSITY]]),
+            lambda: RandAugment(n=1, m=15, policy=[[_GEOMETRIC]]),
+        ),
+        (
+            lambda: TrivialAugment(policy=[[_INTENSITY]]),
+            None,
+            lambda: TrivialAugment(policy=[[_GEOMETRIC]]),
+        ),
+    ],
+    ids=["AutoAugment", "RandAugment", "TrivialAugment"],
+)
+def test_inverse_refuses_a_non_invertible_draw(intensity_only, mixed, geometry_only, device, dtype):
+    # ``inverse`` can only undo geometric operations. The sub-policy is redrawn on every
+    # forward pass, so a draw holding an intensity operation used to come back through
+    # ``inverse`` with that operation still applied -- and on a draw with no geometry at
+    # all, as the input unchanged, with no error and no warning. It refuses now, the way
+    # ``MixAugmentationBaseV2.inverse`` already does.
+    x = torch.rand(2, 3, 8, 6, device=device, dtype=dtype)
+
+    aug = intensity_only()
+    with pytest.raises(RuntimeError, match="is not supported"):
+        aug.inverse(aug(x))
+
+    if mixed is not None:
+        # half-undoing a mixed draw is the same trap, so it is refused too
+        aug = mixed()
+        with pytest.raises(RuntimeError, match="is not supported"):
+            aug.inverse(aug(x))
+
+    # a geometry-only draw still inverts, unchanged
+    aug = geometry_only()
+    aug.inverse(aug(x))
+
+
+def test_inverse_without_a_forward_pass_still_reports_missing_params(device, dtype):
+    # the refusal must not shadow the pre-existing error for an un-run policy
+    x = torch.rand(2, 3, 8, 6, device=device, dtype=dtype)
+    with pytest.raises(ValueError, match="No parameters available"):
+        RandAugment(n=1, m=5).inverse(x)


### PR DESCRIPTION
Closes #4442.

`AutoAugment`, `RandAugment` and `TrivialAugment` inherit `inverse` from `ImageSequentialBase`, which undoes the geometric part of the drawn sub-policy and leaves everything else alone. `auto` policies are dominated by intensity operations and the sub-policy is redrawn on every forward pass, so many draws hold no invertible geometry at all — and for those, `inverse` returned its argument unchanged, reporting neither an error nor a warning.

The issue's repro makes the reading unambiguous by printing the forward displacement beside the round-trip error: when the two are equal to the last digit, `inverse` returned exactly what it was given. On `main`, 3 of its 6 rows do that.

## Change

Refuse instead, matching what the neighbouring APIs already do — the five mix classes raise `RuntimeError: Inverse for <class> is not supported.`, and the three crop classes in `cropping_mode="slice"` raise rather than fake an inverse. This is the issue's recommended outcome (1).

The guard sits on `PolicyAugmentBase.inverse`, where all three composers get the method:

```
RuntimeError: Inverse for RandAugment is not supported: the drawn sub-policy applied
RandomSolarize, RandomSharpness, which cannot be inverted. Only geometric operations
are invertible, and the sub-policy is redrawn on every forward pass.
```

A mixed draw is refused too: undoing only its geometry is the same trap, one digit closer to the input and no more round-trippable.

## What does not change

- **A geometry-only draw still inverts.** Verified byte-identical to `main`: nine round trips across the three composers and three seeds, `torch.equal(patched, main) == True`.
- **The nested path is untouched.** `AugmentationSequential` reaches a child composer through `InputSequentialOps.inverse` → `inverse_inputs`, not through `inverse`, so `test_sequential` and the container suite are unaffected. The container-level rule is the broader question the issue raises; this PR is scoped to the three `auto` classes that advertise the method.
- **The un-run policy error is preserved.** `inverse` before any forward pass still raises the original `ValueError: No parameters available for inversing, ...`, not the new refusal.

## Verification

```
tests/augmentation/test_auto_operation.py -k inverse
  on main:      3 failed, 1 passed   (DID NOT RAISE RuntimeError, one per composer)
  with the fix: 4 passed

tests/augmentation/container + tests/augmentation/test_auto_operation.py
  539 passed, 51 skipped
```

`ruff check` and `ruff format --check` clean; `mypy` reports no error in the changed module.
