### PR TITLE
fix(augmentation): accept zero scale in RandomThinPlateSpline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,7 +380,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `RandomThinPlateSpline(scale=0.0)` now generates zero control-point displacement instead of
-  raising an error when constructing a degenerate uniform distribution.
+  raising an error when constructing a degenerate uniform distribution. (#4463)
 
 * `RandAugment`'s `m` guard is exclusive at both ends, but its docstring and its error message
   both named the closed interval `[0, 30]`, so a user who asked for the maximum strength the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,6 +379,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `RandomThinPlateSpline(scale=0.0)` now generates zero control-point displacement instead of
+  raising an error when constructing a degenerate uniform distribution.
+
 * `RandAugment`'s `m` guard is exclusive at both ends, but its docstring and its error message
   both named the closed interval `[0, 30]`, so a user who asked for the maximum strength the
   message advertised got an exception saying `30` was in range. Both now read `(0, 30)`; the

--- a/kornia/augmentation/_2d/geometric/thin_plate_spline.py
+++ b/kornia/augmentation/_2d/geometric/thin_plate_spline.py
@@ -31,7 +31,8 @@ class RandomThinPlateSpline(AugmentationBase2D):
     .. image:: _static/img/RandomThinPlateSpline.png
 
     Args:
-        scale: the scale factor to apply to the destination points.
+        scale: the non-negative scale factor to apply to the destination points.
+            Zero leaves the control points unchanged.
         align_corners: Interpolation flag used by ``grid_sample``.
         mode: Interpolation mode used by `grid_sample`. Either 'bilinear' or 'nearest'.
         same_on_batch: apply the same transformation across the batch.
@@ -69,7 +70,7 @@ class RandomThinPlateSpline(AugmentationBase2D):
             "align_corners": align_corners,
             "padding_mode": SamplePadding.get(padding_mode),
         }
-        self.dist = torch.distributions.Uniform(-scale, scale)
+        self.dist = None if scale == 0 else torch.distributions.Uniform(-scale, scale)
 
     def generate_parameters(self, shape: Tuple[int, ...]) -> Dict[str, torch.Tensor]:
         B, _, _, _ = shape
@@ -84,7 +85,9 @@ class RandomThinPlateSpline(AugmentationBase2D):
             dtype=dtype,
         ).expand(B, 5, 2)
 
-        if self.same_on_batch:
+        if self.dist is None:
+            noise = torch.zeros_like(src)
+        elif self.same_on_batch:
             noise = self.dist.rsample((1, 5, 2)).to(device=device, dtype=dtype)
             noise = noise.expand(B, 5, 2)
         else:

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -5502,6 +5502,35 @@ class TestRandomThinPlateSpline(CommonTests):
 
         assert any(d > 0 for d in diffs)
 
+    @pytest.mark.parametrize("batch_size", [0, 1, 4])
+    @pytest.mark.parametrize("same_on_batch", [False, True])
+    def test_zero_scale_parameters(self, batch_size, same_on_batch, device, dtype):
+        aug = self._augmentation_cls(scale=0.0, same_on_batch=same_on_batch, p=1.0)
+        aug.set_rng_device_and_dtype(device=device, dtype=dtype)
+
+        params = aug.generate_parameters((batch_size, 3, 6, 8))
+
+        assert params["dst"].shape == (batch_size, 5, 2)
+        assert params["dst"].device == device
+        assert params["dst"].dtype == dtype
+        self.assert_close(params["dst"], params["src"], atol=0, rtol=0)
+
+    @pytest.mark.parametrize("same_on_batch", [False, True])
+    def test_zero_scale_identity(self, same_on_batch, device, dtype):
+        if dtype == torch.float16:
+            pytest.skip("get_tps_transform is numerically unstable in float16 (produces NaN)")
+        # align_corners=False has a separate sampling-grid defect tracked in #3928.
+        aug = self._augmentation_cls(scale=0.0, align_corners=True, same_on_batch=same_on_batch, p=1.0)
+        image = torch.arange(48, device=device, dtype=dtype).reshape(1, 1, 6, 8) / 48
+        image = image.expand(2, 1, 6, 8).clone().requires_grad_()
+
+        output = aug(image)
+
+        self.assert_close(output, image)
+        self.assert_close(aug(image, params=aug._params), output)
+        output.sum().backward()
+        self.assert_close(image.grad, torch.ones_like(image))
+
     @pytest.mark.slow
     def _test_gradcheck_implementation(self, params):
         # RandomThinPlateSpline generates fresh random control points on every forward call,


### PR DESCRIPTION
## What does this pull request do?

`RandomThinPlateSpline(scale=0.0)` raises while constructing `Uniform(-0.0, 0.0)`, before an image or parameters can be processed. Handle this endpoint with zero control-point displacement, preserving the existing sampling path for nonzero scales.

The regression tests cover empty/single/multiple batches, both `same_on_batch` settings, parameter dtype/device, image identity with `align_corners=True`, parameter replay, and the identity image gradient. The docstring and changelog describe the newly accepted endpoint.

This is limited to the parameter-generation failure. The separate `align_corners=False` sampling-grid issue remains tracked in #3928 and PR #3944; accepting zero displacement does not repair that grid. The identity test follows the existing TPS tests in skipping float16 because `get_tps_transform` already produces NaN weights for coincident control points in that dtype. Zero-displacement parameter tests still run for float16.

## Related issue or discussion

Fixes #4416.

## What did you check?

Windows, Python 3.13.5, PyTorch 2.10.0, kornia_rs 0.1.14. Used a local virtual environment and direct Python commands because Pixi is not installed.

```text
# Before the fix: all 16 new float32/float64 cases fail at Uniform(-0.0, 0.0).
python -m pytest tests/augmentation/test_augmentation.py -k "RandomThinPlateSpline and zero_scale" --device=cpu --dtype=float32,float64
16 failed

# After the fix:
python -m pytest tests/augmentation/test_augmentation.py -k RandomThinPlateSpline --device=cpu --dtype=float32,float64
34 passed, 16 skipped, 708 deselected

python -m pytest tests/augmentation/test_augmentation.py -k "RandomThinPlateSpline and zero_scale" --device=cpu --dtype=float16,bfloat16
14 passed, 2 skipped, 742 deselected

ty check kornia/augmentation/_2d/geometric/thin_plate_spline.py
All checks passed!

python -m pre_commit run --all-files
All 12 hooks passed.

git diff --cached --check
No output.
```

The existing class-scoped fixture emits one Pytest deprecation warning on pytest 9.1.1. Full-repository `ty check kornia` emits 144 diagnostics in this environment; its concise output is byte-for-byte identical on the base revision and this branch. A baseline worktree also confirmed the existing float16 identity NaNs. With seed 123, the positive-scale generated parameters were byte-identical between base and branch, and negative scale still raises the existing `ValueError`.

## How did AI help?

Codex investigated the issue, implemented the patch and regression tests, ran the reported checks, and compared behavior against a separate baseline worktree. A separate Codex agent reviewed the diff.
