### PR TITLE
fix(augmentation): pass RandomBoxBlur's flag to box_blur by keyword and document it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `RandomBoxBlur`'s `normalized` argument is documented as what it does. It was described as "if True, L1 norm
+  of the kernel is set to 1", but it was forwarded positionally into `kornia.filters.box_blur`'s `separable`
+  parameter: it chooses between the separable and the single 2D pass, and the kernel is L1-normalized either
+  way, so `normalized=False` returns window means, not sums. The call now passes `border_type` and
+  `separable` by keyword; outputs are unchanged. (#4433, #4486)
+
 * `RandomMosaic` now preserves `(H, W)` for non-square inputs when `output_size=None`; it previously
   returned `(W, H)`. `start_ratio_range` now scales x by width and y by height; it previously scaled
   x by height and y by width. (#4459)

--- a/kornia/augmentation/_2d/intensity/box_blur.py
+++ b/kornia/augmentation/_2d/intensity/box_blur.py
@@ -32,7 +32,9 @@ class RandomBoxBlur(IntensityAugmentationBase2D):
         kernel_size: the blurring kernel size.
         border_type: the padding mode to be applied before convolving.
           The expected modes are: ``constant``, ``reflect``, ``replicate`` or ``circular``.
-        normalized: if True, L1 norm of the kernel is set to 1.
+        normalized: selects the implementation of :func:`kornia.filters.box_blur`: ``True`` computes the blur
+          as two 1D passes (``separable=True``), ``False`` as one 2D pass. The kernel is L1-normalized either
+          way, so both return the mean of each window, never its sum, and differ only by float rounding.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
@@ -69,4 +71,4 @@ class RandomBoxBlur(IntensityAugmentationBase2D):
     def apply_transform(
         self, input: Tensor, params: Dict[str, Tensor], flags: Dict[str, Any], transform: Optional[Tensor] = None
     ) -> Tensor:
-        return box_blur(input, flags["kernel_size"], flags["border_type"], flags["normalized"])
+        return box_blur(input, flags["kernel_size"], border_type=flags["border_type"], separable=flags["normalized"])

--- a/tests/augmentation/test_augmentation.py
+++ b/tests/augmentation/test_augmentation.py
@@ -4778,11 +4778,30 @@ class TestRandomElasticTransform(BaseTester):
                 assert labels_transformed[to_apply].ne(labels[to_apply]).any()
 
 
-class TestRandomBoxBlur:
+class TestRandomBoxBlur(BaseTester):
     def test_smoke(self, device, dtype):
         img = torch.rand(1, 1, 2, 2, device=device, dtype=dtype)
         aug = RandomBoxBlur(p=1.0)
         assert img.shape == aug(img).shape
+
+    @pytest.mark.parametrize("normalized", [True, False])
+    def test_normalized_selects_the_separable_path(self, normalized, device, dtype):
+        from kornia.filters import box_blur
+
+        torch.manual_seed(0)
+        img = torch.rand(2, 3, 6, 8, device=device, dtype=dtype)
+        out = RandomBoxBlur((3, 3), normalized=normalized, p=1.0)(img.clone())
+
+        expected = box_blur(img, (3, 3), border_type="reflect", separable=normalized)
+        torch.testing.assert_close(out, expected, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("normalized", [True, False])
+    def test_output_is_the_window_mean_for_either_setting(self, normalized, device, dtype):
+        torch.manual_seed(0)
+        img = torch.rand(1, 1, 6, 8, device=device, dtype=dtype)
+        out = RandomBoxBlur((3, 3), normalized=normalized, p=1.0)(img.clone())
+
+        self.assert_close(out[0, 0, 2, 2], img[0, 0, 1:4, 1:4].mean())
 
 
 class TestPadTo(BaseTester):


### PR DESCRIPTION
## What does this pull request do?

`RandomBoxBlur` forwarded its `normalized` flag **positionally** as the fourth argument of `kornia.filters.box_blur`, which is `separable`. So the flag picks the separable or the single 2D pass, the kernel is L1-normalized either way, and `normalized=False` returns window means, not the sums its `Args` entry implies.

This is outcome (2) from the issue, scoped as its disposition describes: one keyword call and the `Args` entry.

- `apply_transform` calls `box_blur(input, kernel_size, border_type=..., separable=flags["normalized"])`, so the parameter lists can no longer silently misalign.
- The `Args` entry says what the flag does: it selects the implementation, and both settings return the window mean and differ only by float rounding.

Outputs are byte-identical. The argument keeps its name; renaming or deprecating it, or making normalization real (outcome 1), is left to the Repair & Deprecation window as the issue says.

## Related issue or discussion

Closes #4433 (tracking #4407).

## What did you check?

Two tests in `TestRandomBoxBlur`, which now uses `BaseTester`:

- `test_normalized_selects_the_separable_path[True|False]`: the class output equals `box_blur(..., separable=normalized)` exactly (`atol=0`).
- `test_output_is_the_window_mean_for_either_setting[True|False]`: the interior pixel equals the 3×3 window mean for both settings.

Both also pass on `main`, since the change keeps behaviour. They pin the contract the new docstring states, so reverting to a sum, or wiring the flag to anything but `separable`, fails them.

```text
$ python -m pytest tests/augmentation/test_augmentation.py -k TestRandomBoxBlur --device=cpu --dtype=float32,float64
10 passed
$ python -m pytest kornia/augmentation/_2d/intensity/box_blur.py --doctest-modules
1 passed
```

`ruff@0.16.6` check and format are clean. `grep -rnE "#4433|issues/4433" kornia/` is empty. No CUDA/MPS run.

## How did AI help?

I used Claude Code to draft the change, tests and description. I checked the `box_blur` signature, ran the tests and doctest above, and confirmed the outputs match `main`.
