### PR TITLE
fix(geometry): let transform_points take an empty transform batch with points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `transform_points` returns an empty result for an empty transform batch whose points carry a non-empty
+  point axis, such as `(0, 4, 4)` transforms with `(0, 5, 3)` points. It used to raise `ZeroDivisionError`
+  expanding the transforms (`0 // 0`), and `PinholeCamera.project` inherited the crash for an empty camera
+  batch on `(0, N, 3)` points. (#4466, #4487)
+
 * `RandomMosaic` now preserves `(H, W)` for non-square inputs when `output_size=None`; it previously
   returned `(W, H)`. `start_ratio_range` now scales x by width and y by height; it previously scaled
   x by height and y by width. (#4459)

--- a/kornia/geometry/linalg.py
+++ b/kornia/geometry/linalg.py
@@ -220,8 +220,11 @@ def transform_points(trans_01: torch.Tensor, points_1: torch.Tensor) -> torch.Te
     points_1 = points_1.reshape(-1, points_1.shape[-2], points_1.shape[-1])
     trans_01 = trans_01.reshape(-1, trans_01.shape[-2], trans_01.shape[-1])
     # We expand trans_01 to match the dimensions needed for bmm. repeats input division is cast
-    # to integer so onnx doesn't record the value as a tensor and get a device mismatch
-    trans_01 = torch.repeat_interleave(trans_01, repeats=int(points_1.shape[0] // trans_01.shape[0]), dim=0)
+    # to integer so onnx doesn't record the value as a tensor and get a device mismatch. An empty
+    # transform batch has nothing to repeat, and the validation above guarantees an empty point
+    # batch alongside it, so skip the division rather than computing ``0 // 0``.
+    repeats = points_1.shape[0] // trans_01.shape[0] if trans_01.shape[0] > 0 else 0
+    trans_01 = torch.repeat_interleave(trans_01, repeats=int(repeats), dim=0)
     # to homogeneous
     points_1_h = convert_points_to_homogeneous(points_1)  # BxNxD+1
     # `torch.bmm` requires both operands to share a scalar type. Callers may pass coordinate

--- a/tests/geometry/camera/test_pinhole.py
+++ b/tests/geometry/camera/test_pinhole.py
@@ -911,6 +911,16 @@ class TestPinholeCamera(BaseTester):
         )
         assert empty.shape == (0, 1, 2)
 
+    def test_project_an_empty_batch_with_a_point_axis_4466(self, device, dtype):
+        # Regression for kornia#4466: an empty camera batch projected (0, 3) points but raised
+        # ZeroDivisionError on (0, N, 3), inside transform_points.
+        trans = torch.eye(4, device=device, dtype=dtype).expand(0, 4, 4)
+        empty = torch.zeros(0, device=device, dtype=dtype)
+        camera = kornia.geometry.camera.PinholeCamera(trans, trans, empty, empty)
+
+        assert camera.project(torch.zeros(0, 3, device=device, dtype=dtype)).shape == (0, 2)
+        assert camera.project(torch.zeros(0, 1, 3, device=device, dtype=dtype)).shape == (0, 1, 2)
+
     @pytest.mark.parametrize("batch_sizes", [(1, 2, 1, 1), (0, 1, 0, 0)])
     def test_constructor_rejects_mismatched_batch_sizes_4281(self, batch_sizes, device, dtype):
         with pytest.raises(ValueError, match="Arguments shapes must match"):

--- a/tests/geometry/test_linalg.py
+++ b/tests/geometry/test_linalg.py
@@ -63,6 +63,21 @@ class TestTransformPoints(BaseTester):
         assert out.shape == points.shape
         self.assert_close(out, points)
 
+    @pytest.mark.parametrize("num_dims", [2, 3])
+    @pytest.mark.parametrize("points_shape", [(0, 1), (0, 5)])
+    def test_transform_points_empty_batch_with_points(self, num_dims, points_shape, device, dtype):
+        # An empty transform batch with a non-empty point axis divided 0 // 0 while expanding the
+        # transforms (kornia#4466); it must return the same empty shape as a B=1 transform does.
+        points = torch.zeros(*points_shape, num_dims, device=device, dtype=dtype)
+        empty_trans = torch.eye(num_dims + 1, device=device, dtype=dtype).expand(0, -1, -1)
+        single_trans = torch.eye(num_dims + 1, device=device, dtype=dtype)[None]
+
+        out = kgl.transform_points(empty_trans, points)
+
+        assert out.shape == points.shape
+        assert out.dtype == dtype
+        assert out.shape == kgl.transform_points(single_trans, points).shape
+
     def test_gradcheck(self, device):
         # generate input data
         batch_size, num_points, num_dims = 2, 3, 2


### PR DESCRIPTION
## What does this pull request do?

`transform_points` raised `ZeroDivisionError` for an empty transform batch whose points carry a non-empty point axis, for example `(0, 4, 4)` transforms with `(0, 5, 3)` points. Validation accepts the pair, and the early return only covers an empty point *set* (`N == 0`), so the call reached

```python
torch.repeat_interleave(trans_01, repeats=int(points_1.shape[0] // trans_01.shape[0]), dim=0)  # 0 // 0
```

The division is now skipped when the transform batch is empty (`repeats = 0`). Validation already guarantees the point batch is empty too. The rest of the function runs unchanged, so the result is `(0, 5, 3)` in the caller's dtype, the same shape a `B=1` transform already returned for those points. `PinholeCamera.project` inherited the crash for an empty camera batch on `(0, N, 3)` points and now returns `(0, N, 2)`.

I kept the division on the normal path rather than adding a second early return, so the empty-batch output still goes through `bmm` and the dtype restoration like any other call.

## Related issue or discussion

Closes #4466.

## What did you check?

- `tests/geometry/test_linalg.py::TestTransformPoints::test_transform_points_empty_batch_with_points`, parametrized over `D ∈ {2, 3}` and points `(0, 1, D)` / `(0, 5, D)`: shape, dtype, and parity with the `B=1` transform.
- `tests/geometry/camera/test_pinhole.py::...::test_project_an_empty_batch_with_a_point_axis_4466`: `(0, 3)` → `(0, 2)` and `(0, 1, 3)` → `(0, 1, 2)`.

```text
$ python -m pytest tests/geometry/test_linalg.py tests/geometry/camera/test_pinhole.py -k "empty or 4466" --device=cpu --dtype=float32
main: 5 failed, 3 passed      # the 4 new linalg cases + the pinhole case, all ZeroDivisionError
head: 8 passed
$ python -m pytest tests/geometry/test_linalg.py tests/geometry/camera/test_pinhole.py --device=cpu --dtype=float32,float64
347 passed, 1 skipped
```

`ruff@0.16.6` check and format are clean. No CUDA/MPS/ONNX run.

## How did AI help?

I used Claude Code to locate the division, draft the guard and tests, and write this description. I reproduced the crash on `main` with the issue's snippet and ran the tests above on both trees.
