### PR TITLE
fix(contrib): let diamond_square generate sides below 3 px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `kornia.contrib.diamond_square` generates fractals with a spatial side below 3 px. A 1 px side raised
+  `ValueError: math domain error` and a 2 px side a `TypeError` from a float in the `torch.rand` size, so
+  `RandomPlasmaBrightness`, `RandomPlasmaContrast` and `RandomPlasmaShadow` failed on such images. A small
+  side is now drawn on the 3 px grid and sliced; outputs for sides of 3 px and more are bit-identical.
+  (#4472, #4488)
+
 * `RandomMosaic` now preserves `(H, W)` for non-square inputs when `output_size=None`; it previously
   returned `(W, H)`. `start_ratio_range` now scales x by width and y by height; it previously scaled
   x by height and y by width. (#4459)

--- a/kornia/contrib/diamond_square.py
+++ b/kornia/contrib/diamond_square.py
@@ -206,9 +206,11 @@ def diamond_square(
     for x in output_size[:-2]:
         num_samples *= x
 
-    # compute the image seed
-    p2_width: float = 2 ** math.ceil(math.log2(width - 1)) + 1
-    p2_height: float = 2 ** math.ceil(math.log2(height - 1)) + 1
+    # compute the image seed. The smallest grid the algorithm builds is 3 px per side (two corners
+    # and a midpoint), so a smaller side is generated at 3 px and sliced down below: a 1 or 2 px
+    # side is just its corner draws. Sizes from 3 px up are unaffected.
+    p2_width: int = 2 ** math.ceil(math.log2(max(width, 3) - 1)) + 1
+    p2_height: int = 2 ** math.ceil(math.log2(max(height, 3) - 1)) + 1
     recursion_depth: int = int(min(math.log2(p2_width - 1) - 1, math.log2(p2_height - 1) - 1))
     seed_width: int = (p2_width - 1) // 2**recursion_depth + 1
     seed_height: int = (p2_height - 1) // 2**recursion_depth + 1

--- a/tests/contrib/test_diamond_square.py
+++ b/tests/contrib/test_diamond_square.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import pytest
 import torch
 
 import kornia
@@ -46,3 +47,18 @@ class TestDiamondSquare(BaseTester):
         )
         self.assert_close(out.min(), expected_min)
         self.assert_close(out.max(), expected_max)
+
+    @pytest.mark.parametrize("spatial_size", [(1, 1), (2, 2), (2, 3), (3, 2), (1, 5), (2, 17)])
+    def test_spatial_sizes_below_three(self, spatial_size, device, dtype):
+        # Sides under 3 px used to fail with `math domain error` or a float in the `rand` size
+        # (kornia#4472).
+        torch.manual_seed(0)
+        output_size = (2, 3, *spatial_size)
+        out = kornia.contrib.diamond_square(output_size, device=device, dtype=dtype)
+        assert out.shape == output_size
+        assert torch.isfinite(out).all()
+
+    def test_plasma_augmentation_on_a_two_pixel_image(self, device, dtype):
+        img = torch.rand(1, 1, 2, 2, device=device, dtype=dtype)
+        out = kornia.augmentation.RandomPlasmaBrightness(p=1.0)(img)
+        assert out.shape == img.shape


### PR DESCRIPTION
## What does this pull request do?

`kornia.contrib.diamond_square` failed for any spatial side below 3 px:

```text
(1, 1, 1, 1)  ValueError: math domain error                  # log2(1 - 1)
(1, 1, 2, 2)  TypeError: rand(): argument 'size' failed ...  # depth -1, seed size 3.0
```

The seed grid size came from `2 ** ceil(log2(side - 1)) + 1`. At 1 px that is `log2(0)`. At 2 px it gives a grid of 2, a recursion depth of `-1`, and a float seed size.

It now uses `max(side, 3)`, the smallest grid the algorithm builds (two corners and a midpoint). The existing `img[..., :width, :height]` slice then cuts it to the requested size, so a 1 or 2 px side is just its corner draws, as the issue suggested. For a side of 3 px or more, `max(side, 3) == side`, so the arithmetic, the random draws and the output are unchanged.

## Related issue or discussion

Closes #4472 (found in the #4462 review; relevant once #4460 passes the true patch shape).

## What did you check?

- `test_spatial_sizes_below_three` over `(1, 1)`, `(2, 2)`, `(2, 3)`, `(3, 2)`, `(1, 5)`, `(2, 17)`: shape and finiteness.
- `test_plasma_augmentation_on_a_two_pixel_image`: `RandomPlasmaBrightness(p=1.0)` on a `(1, 1, 2, 2)` image.
- **Unchanged outputs for sides ≥ 3 px:** with `torch.manual_seed(0)` and `(B, C) = (2, 3)`, `diamond_square` on `main` and on this branch are `torch.equal` for `(3, 3)`, `(3, 4)`, `(4, 3)`, `(5, 9)`, `(9, 5)`, `(16, 17)`, `(33, 20)` and `(64, 64)`.

```text
$ python -m pytest tests/contrib/test_diamond_square.py --device=cpu --dtype=float32
main: 7 failed, 2 passed
head: 9 passed            # 18 passed across float32 + float64
```

`ruff@0.16.6` check and format are clean. No CUDA/MPS run.

## How did AI help?

I used Claude Code to trace the arithmetic for 1 and 2 px sides, draft the change and tests, and write this description. I ran the tests above and the main-versus-branch output comparison myself.
