### PR TITLE
docs(augmentation): make three Args blocks match their constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* The `Args` blocks of `ColorJitter`, `RandomBrightness` and `RandomGaussianBlur` no longer document a
+  `silence_instantiation_warning` argument that none of them accepts, and `ColorJitter` now documents its
+  `order` argument: a fixed (sub)set of brightness/contrast/saturation/hue indices that makes the transform
+  `torch.compile` fullgraph-safe, with the drawn `_params["order"]` entry ignored when it is set.
+  (#4437, #4490)
+
 * `RandomMosaic` now preserves `(H, W)` for non-square inputs when `output_size=None`; it previously
   returned `(W, H)`. `start_ratio_range` now scales x by width and y by height; it previously scaled
   x by height and y by width. (#4459)

--- a/kornia/augmentation/_2d/intensity/brightness.py
+++ b/kornia/augmentation/_2d/intensity/brightness.py
@@ -35,7 +35,6 @@ class RandomBrightness(IntensityAugmentationBase2D):
     Args:
         brightness: the brightness factor to apply
         clip_output: if true clip output
-        silence_instantiation_warning: if True, silence the warning at instantiation.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it

--- a/kornia/augmentation/_2d/intensity/color_jitter.py
+++ b/kornia/augmentation/_2d/intensity/color_jitter.py
@@ -45,11 +45,14 @@ class ColorJitter(IntensityAugmentationBase2D):
         contrast: The contrast factor to apply.
         saturation: The saturation factor to apply.
         hue: The hue factor to apply.
-        silence_instantiation_warning: if True, silence the warning at instantiation.
         same_on_batch: apply the same transformation across the batch.
         p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
+        order: a fixed application order, as indices into (brightness, contrast, saturation, hue); a subset
+          applies only those. ``None`` (the default) draws a random order on every call. A fixed order makes
+          the transform ``torch.compile`` fullgraph-safe. The parameter generator still draws an ``order``
+          entry into ``_params``, and with a fixed order that entry is ignored, including on replay.
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`
         - Output: :math:`(B, C, H, W)`

--- a/kornia/augmentation/_2d/intensity/gaussian_blur.py
+++ b/kornia/augmentation/_2d/intensity/gaussian_blur.py
@@ -43,7 +43,6 @@ class RandomGaussianBlur(IntensityAugmentationBase2D):
         p: probability of applying the transformation.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it
                  to the batch form (False).
-        silence_instantiation_warning: if True, silence the warning at instantiation.
 
     Shape:
         - Input: :math:`(C, H, W)` or :math:`(B, C, H, W)`, Optional: :math:`(B, 3, 3)`

--- a/tests/augmentation/test_args_docstrings.py
+++ b/tests/augmentation/test_args_docstrings.py
@@ -1,0 +1,39 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import inspect
+import re
+
+import pytest
+
+import kornia.augmentation as K
+
+
+def _documented_args(cls):
+    doc = inspect.getdoc(cls) or ""
+    block = re.search(r"Args:\n(.*?)\n\s*(?:Shape|Returns|Examples?|\.\. note::|Note)", doc, re.S)
+    assert block, f"{cls.__name__} has no Args block"
+    return [match.group(1) for match in re.finditer(r"^\s{4}(\w+):", block.group(1), re.M)]
+
+
+@pytest.mark.parametrize("cls", [K.ColorJitter, K.ColorJiggle, K.RandomBrightness, K.RandomGaussianBlur])
+def test_args_block_matches_the_constructor(cls):
+    # kornia#4437: three classes documented a `silence_instantiation_warning` argument that does not
+    # exist, and ColorJitter did not document its real `order` argument.
+    signature = list(inspect.signature(cls.__init__).parameters)[1:]
+
+    assert sorted(_documented_args(cls)) == sorted(signature)


### PR DESCRIPTION
## What does this pull request do?

The docstring fix from #4437, across all three classes carrying the phantom entry:

- `ColorJitter`, `RandomBrightness` and `RandomGaussianBlur` no longer document `silence_instantiation_warning`. None of them accepts it, and it appeared in no code, so a call written from the docs raised `TypeError`.
- `ColorJitter` now documents `order`: indices into (brightness, contrast, saturation, hue) where a subset applies only those; `None` draws a random order per call; a fixed order makes the transform `torch.compile` fullgraph-safe. It also states the replay trap from the issue: with `order` set, the generator still draws `_params["order"]` and that entry is ignored, including on replay. This takes the issue's recommendation to document the key rather than stop drawing it, since stopping would change RNG consumption.

No code changes.

## Related issue or discussion

Closes #4437 (tracking #4407).

## What did you check?

`tests/augmentation/test_args_docstrings.py` (new) parses each class's `Args` block and asserts it lists exactly the constructor's parameters, for `ColorJitter`, `ColorJiggle` (the sibling the issue uses as the control), `RandomBrightness` and `RandomGaussianBlur`.

```text
$ python -m pytest tests/augmentation/test_args_docstrings.py
main: 3 failed, 1 passed      # ColorJiggle already matched
head: 4 passed
$ python -m pytest kornia/augmentation/_2d/intensity/{color_jitter,brightness,gaussian_blur}.py --doctest-modules
3 passed
```

`grep -rn silence_instantiation_warning kornia/` is empty. `ruff@0.16.6` check and format are clean.

## How did AI help?

I used Claude Code to draft the docstring edits, the test and this description. I checked the `order` handling in `apply_transform` against the new wording and ran the test on both trees.
