### PR TITLE
fix(augmentation): document RandomCutMixV2's cut_size and reject a minimum of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `RandomCutMixV2` and `CutmixGenerator` document `cut_size` as what it is: the `[min, max]` clamp on the
+  Beta-sampled mixing coefficient `lambda`, where the cut side is `floor(sqrt(1 - lambda) * side)`, so a larger
+  `cut_size` gives a smaller cut. It was described as the "minimum and maximum cut ratio". A minimum of `1.0` is
+  now rejected with a `ValueError`: it forced `lambda = 1`, built an inverted zero-size box and silently made the
+  augmentation an identity. (#4439, #4491)
+
 * `RandomMosaic` now preserves `(H, W)` for non-square inputs when `output_size=None`; it previously
   returned `(W, H)`. `start_ratio_range` now scales x by width and y by height; it previously scaled
   x by height and y by width. (#4459)

--- a/kornia/augmentation/_2d/mix/cutmix.py
+++ b/kornia/augmentation/_2d/mix/cutmix.py
@@ -48,8 +48,10 @@ class RandomCutMixV2(MixAugmentationBaseV2):
         num_mix: cut mix times.
         beta: hyperparameter for generating cut size from beta distribution.
             Beta cannot be set to 0 after torch 1.8.0. If None, it will be set to 1.
-        cut_size: controlling the minimum and maximum cut ratio from [0, 1].
-            If None, it will be set to [0, 1], which means no restriction.
+        cut_size: the ``[min, max]`` clamp, within [0, 1], applied to the Beta-sampled mixing coefficient
+            ``lambda``, not the fraction of the image to cut. The cut side is ``floor(sqrt(1 - lambda) * side)``,
+            so a larger ``cut_size`` gives a *smaller* cut, and a minimum of 1 is rejected because it would cut
+            nothing. If None, it will be set to [0, 1], which means no restriction.
         same_on_batch: apply the same transformation across the batch.
             This flag will not maintain permutation order.
         keepdim: whether to keep the output shape the same as input (True) or broadcast it

--- a/kornia/augmentation/random_generator/_2d/cutmix.py
+++ b/kornia/augmentation/random_generator/_2d/cutmix.py
@@ -42,8 +42,10 @@ class CutmixGenerator(RandomGeneratorBase):
         num_mix (int): number of images to mix with. Default is 1.
         beta (torch.Tensor, optional): hyperparameter for generating cut size from beta distribution.
             If None, it will be set to 1.
-        cut_size (torch.Tensor, optional): controlling the minimum and maximum cut ratio from [0, 1].
-            If None, it will be set to [0, 1], which means no restriction.
+        cut_size (torch.Tensor, optional): the ``[min, max]`` clamp, within [0, 1], applied to the
+            Beta-sampled mixing coefficient ``lambda``. The cut side is ``floor(sqrt(1 - lambda) * side)``,
+            so a larger ``cut_size`` gives a *smaller* cut. The minimum must be below 1: at 1, ``lambda`` is
+            always 1 and nothing is cut. If None, it will be set to [0, 1], which means no restriction.
 
     Returns:
         params Dict[str, torch.Tensor]: parameters to be passed for transformation.
@@ -88,6 +90,12 @@ class CutmixGenerator(RandomGeneratorBase):
             self._cut_size = torch.as_tensor(self.cut_size, device=device, dtype=dtype)
 
         _joint_range_check(self._cut_size, "cut_size", bounds=(0, 1))
+        if float(self._cut_size[0]) >= 1.0:
+            raise ValueError(
+                f"`cut_size` clamps the mixing coefficient lambda, and a minimum of 1 forces lambda = 1, which "
+                f"cuts nothing (cut side = floor(sqrt(1 - lambda) * side)). A larger cut_size gives a smaller "
+                f"cut, so lower the minimum. Got {self._cut_size.tolist()}."
+            )
 
         self.beta_sampler = Beta(self._beta, self._beta)
         self.prob_sampler = Bernoulli(torch.tensor(float(self.p), device=device, dtype=dtype))

--- a/tests/augmentation/test_random_generator.py
+++ b/tests/augmentation/test_random_generator.py
@@ -1487,6 +1487,7 @@ class TestRandomCutMixGen(RandomGeneratorBaseTests):
             (200, 200, 1, torch.tensor([0.0, 1.0]), None),
             (200, 200, 1, None, torch.tensor([-1.0, 1.0])),
             (200, 200, 1, None, torch.tensor([0.0, 2.0])),
+            (200, 200, 1, None, torch.tensor([1.0, 1.0])),
         ],
     )
     @pytest.mark.parametrize("same_on_batch", [True, False])
@@ -1498,6 +1499,23 @@ class TestRandomCutMixGen(RandomGeneratorBaseTests):
                 beta=(beta.to(device=device, dtype=dtype) if isinstance(beta, (Tensor)) else beta),
                 cut_size=(cut_size.to(device=device, dtype=dtype) if isinstance(cut_size, (Tensor)) else cut_size),
             )(torch.Size([8, 3, height, width]), same_on_batch=same_on_batch)
+
+    def test_a_minimum_cut_size_of_one_is_rejected_by_name_4439(self, device, dtype):
+        # kornia#4439: cut_size clamps lambda, so (1.0, 1.0) forced lambda = 1 and built an inverted,
+        # zero-size box that silently made the augmentation an identity.
+        with pytest.raises(ValueError, match="forces lambda = 1, which cuts nothing"):
+            CutmixGenerator(cut_size=torch.tensor([1.0, 1.0], device=device, dtype=dtype))
+
+    def test_a_larger_cut_size_gives_a_smaller_cut_4439(self, device, dtype):
+        side = []
+        for cut_size in ((0.1, 0.1), (0.9, 0.9)):
+            torch.manual_seed(0)
+            params = CutmixGenerator(cut_size=torch.tensor(cut_size, device=device, dtype=dtype), p=1.0)(
+                torch.Size([4, 3, 60, 80])
+            )
+            box = params["crop_src"][0, 0]
+            side.append(float(box[:, 0].max() - box[:, 0].min()))
+        assert side[0] > side[1]
 
     def test_random_gen(self, device, dtype):
         torch.manual_seed(42)


### PR DESCRIPTION
## What does this pull request do?

Both halves of #4439.

**Naming (docs).** `cut_size` on `RandomCutMixV2` and `CutmixGenerator` is now documented as the `[min, max]` clamp on the Beta-sampled mixing coefficient `lambda`, with the cut side `floor(sqrt(1 - lambda) * side)`. So a larger `cut_size` gives a **smaller** cut. The argument keeps its name, as the issue recommends.

**Degenerate clamp (validation).** A minimum of `1.0` forces `lambda = 1`, so `cutmix_rate = 0` and the box has `dx = dy = -1` (inverted extents that sometimes sit at negative coordinates), and the augmentation silently becomes an identity. `CutmixGenerator.make_samplers` now raises `ValueError` for `cut_size[0] >= 1`, naming the cause:

```
`cut_size` clamps the mixing coefficient lambda, and a minimum of 1 forces lambda = 1, which cuts nothing
(cut side = floor(sqrt(1 - lambda) * side)). A larger cut_size gives a smaller cut, so lower the minimum. Got [1.0, 1.0].
```

This rejects the clamp at construction, the first of the issue's two options. I didn't clamp box sizes to at least 1 px instead: the same zero-size arithmetic is how non-applied samples (`p` misses, `cutmix_rate = 0`) flow today, so a floor there would change the output of every current call. It also doesn't touch the inclusive `start + size - 1` corner (#3934). The default `[0, 1]` and any minimum below 1 are unaffected; the check uses `float()` once at sampler construction, not per call.

## Related issue or discussion

Closes #4439 (tracking #4407; box arithmetic tracked in #3934).

## What did you check?

`tests/augmentation/test_random_generator.py`:
- `test_invalid_param_combinations` gains `cut_size=[1.0, 1.0]` for both `same_on_batch` values;
- `test_a_minimum_cut_size_of_one_is_rejected_by_name_4439`;
- `test_a_larger_cut_size_gives_a_smaller_cut_4439` pins the documented direction (0.1 cuts wider than 0.9). It passes on `main` too, since it pins the contract the new docstring states.

```text
$ python -m pytest tests/augmentation/test_random_generator.py -k Cutmix --device=cpu --dtype=float32
main: 3 failed, 341 passed      # the [1.0, 1.0] cases (x2) and the named rejection
head: 344 passed                # 688 across float32 + float64
$ python -m pytest tests/augmentation/test_augmentation_mix.py -k CutMix --device=cpu --dtype=float32
8 passed
```

Doctests on both modules pass. `ruff@0.16.6` check and format are clean. No CUDA/MPS run.

## How did AI help?

I used Claude Code to trace `cut_size` through the generator, draft the docstrings, the guard and the tests, and write this description. I reproduced the inverted box on `main` and ran the tests above on both trees.
